### PR TITLE
Add transport-level metrics to simulate-proxy

### DIFF
--- a/controller/script/simulate-proxy/main.go
+++ b/controller/script/simulate-proxy/main.go
@@ -253,7 +253,7 @@ func (p *proxyMetricCollectors) generateTCPStats(randomCount int) {
 	if connectClosedCount >= 2 {
 		connectFailedCount = rand.Intn(connectClosedCount / 2)
 		connectClosedCount -= connectFailedCount
-		p.tcpAcceptCloseTotal.With(failLabels).Add(float64(connectFailedCount))
+		p.tcpConnectCloseTotal.With(failLabels).Add(float64(connectFailedCount))
 	}
 
 	p.tcpConnectCloseTotal.With(closeLabels).Add(float64(connectClosedCount))


### PR DESCRIPTION
This PR adds the transport-level metrics described in #742 to the `simulate-proxy` script. This will be useful while adding these metrics to the Grafana dashboard and/or CLI.

Closes #793
