### PR TITLE
Introduce kube-state-metrics, ReplicaSet dashboard

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -478,11 +478,33 @@ metadata:
   annotations:
     conduit.io/created-by: conduit/cli undefined
 data:
+  prometheus.rules: |-
+    groups:
+    - name: conduit-rules
+      rules:
+      - record: request_total:irate30s
+        expr: irate(request_total[30s])
+      - record: response_total:irate30s
+        expr: irate(response_total[30s])
+      - record: response_latency_ms_bucket:irate30s
+        expr: irate(response_latency_ms_bucket[30s])
+      - record: tcp_close_total:irate30s
+        expr: irate(tcp_close_total[30s])
+      - record: tcp_open_total:irate30s
+        expr: irate(tcp_open_total[30s])
+      - record: tcp_read_bytes_total:irate30s
+        expr: irate(tcp_read_bytes_total[30s])
+      - record: tcp_write_bytes_total:irate30s
+        expr: irate(tcp_write_bytes_total[30s])
+
   prometheus.yml: |-
     global:
       scrape_interval: 10s
       scrape_timeout: 10s
       evaluation_interval: 10s
+
+    rule_files:
+    - /etc/prometheus/prometheus.rules
 
     scrape_configs:
     - job_name: 'prometheus'
@@ -530,6 +552,39 @@ data:
         regex: '^/system\.slice/(.+)\.service$'
         target_label: systemd_service_name
         replacement: '${1}'
+
+    # For kube-state-metrics, from:
+    # https://github.com/prometheus/prometheus/blob/85a3c974b760642bbce00d795db231326a09edb9/documentation/examples/prometheus-kubernetes.yml#L131-L171
+    - job_name: 'kubernetes-service-endpoints'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
 
     - job_name: 'conduit-controller'
       kubernetes_sd_configs:
@@ -751,4 +806,237 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: conduit-top-line
+
+### kube-state-metrics ###
+### from https://github.com/kubernetes/kube-state-metrics/tree/0e1535b40e30c149372da9ca727ffbe0ce725d56/kubernetes ###
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: conduit
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: conduit
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: conduit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: conduit
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: conduit
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: kube-state-metrics
+  namespace: conduit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        conduit.io/created-by: conduit/cli undefined
+        conduit.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        conduit.io/control-plane-ns: conduit
+        conduit.io/proxy-deployment: kube-state-metrics
+        k8s-app: kube-state-metrics
+    spec:
+      containers:
+      - image: quay.io/coreos/kube-state-metrics:v1.3.1
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources: {}
+      - command:
+        - /pod_nanny
+        - --container=kube-state-metrics
+        - --cpu=100m
+        - --extra-cpu=1m
+        - --memory=100Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=kube-state-metrics
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: k8s.gcr.io/addon-resizer:1.7
+        name: addon-resizer
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+      - env:
+        - name: CONDUIT_PROXY_LOG
+          value: warn,conduit_proxy=info
+        - name: CONDUIT_PROXY_CONTROL_URL
+          value: tcp://proxy-api.conduit.svc.cluster.local:8086
+        - name: CONDUIT_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: CONDUIT_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: CONDUIT_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: CONDUIT_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: CONDUIT_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/runconduit/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: conduit-proxy
+        ports:
+        - containerPort: 4143
+          name: conduit-proxy
+        - containerPort: 4191
+          name: conduit-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/runconduit/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: conduit-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+      serviceAccountName: kube-state-metrics
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: conduit
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
 ---

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -482,8 +482,67 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: kube_dst_pod_owner
-        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
+      # copy pod/namespace/owner_kind/owner_name labels to dst_* equivalents for easier matching with outbound metrics
+      - record: kube_pod_owner_ex
+        expr: |
+          label_replace(
+            label_replace(
+              label_replace(
+                label_replace(
+                  kube_pod_owner,
+                  "dst_pod", "$1", "pod", "(.*)"
+                ),
+                "dst_namespace", "$1", "namespace", "(.*)"
+              ),
+              "dst_owner_kind", "$1", "owner_kind", "(.*)"
+            ),
+            "dst_owner_name", "$1", "owner_name", "(.*)"
+          )
+      # copy owner_kind and owner_name into request_total metric,
+      # if owner_kind="ReplicaSet", infer Deployment name in "ksm_deployment" label
+      # nest for dst_* info
+      - record: request_total_ex
+        expr: |
+          # this drops metrics that satisfy request_total{pod=""}, how is that possible?
+          label_replace(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner{owner_kind="ReplicaSet"},
+            "ksm_deployment", "$1", "owner_name", "(.*)-.*"
+          )
+          or on (namespace, pod)(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner
+          )
 
   prometheus.yml: |-
     global:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -482,20 +482,8 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: request_total:irate30s
-        expr: irate(request_total[30s])
-      - record: response_total:irate30s
-        expr: irate(response_total[30s])
-      - record: response_latency_ms_bucket:irate30s
-        expr: irate(response_latency_ms_bucket[30s])
-      - record: tcp_close_total:irate30s
-        expr: irate(tcp_close_total[30s])
-      - record: tcp_open_total:irate30s
-        expr: irate(tcp_open_total[30s])
-      - record: tcp_read_bytes_total:irate30s
-        expr: irate(tcp_read_bytes_total[30s])
-      - record: tcp_write_bytes_total:irate30s
-        expr: irate(tcp_write_bytes_total[30s])
+      - record: kube_dst_pod_owner
+        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
 
   prometheus.yml: |-
     global:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -485,20 +485,8 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: request_total:irate30s
-        expr: irate(request_total[30s])
-      - record: response_total:irate30s
-        expr: irate(response_total[30s])
-      - record: response_latency_ms_bucket:irate30s
-        expr: irate(response_latency_ms_bucket[30s])
-      - record: tcp_close_total:irate30s
-        expr: irate(tcp_close_total[30s])
-      - record: tcp_open_total:irate30s
-        expr: irate(tcp_open_total[30s])
-      - record: tcp_read_bytes_total:irate30s
-        expr: irate(tcp_read_bytes_total[30s])
-      - record: tcp_write_bytes_total:irate30s
-        expr: irate(tcp_write_bytes_total[30s])
+      - record: kube_dst_pod_owner
+        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
 
   prometheus.yml: |-
     global:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -481,11 +481,33 @@ metadata:
   annotations:
     CreatedByAnnotation: CliVersion
 data:
+  prometheus.rules: |-
+    groups:
+    - name: conduit-rules
+      rules:
+      - record: request_total:irate30s
+        expr: irate(request_total[30s])
+      - record: response_total:irate30s
+        expr: irate(response_total[30s])
+      - record: response_latency_ms_bucket:irate30s
+        expr: irate(response_latency_ms_bucket[30s])
+      - record: tcp_close_total:irate30s
+        expr: irate(tcp_close_total[30s])
+      - record: tcp_open_total:irate30s
+        expr: irate(tcp_open_total[30s])
+      - record: tcp_read_bytes_total:irate30s
+        expr: irate(tcp_read_bytes_total[30s])
+      - record: tcp_write_bytes_total:irate30s
+        expr: irate(tcp_write_bytes_total[30s])
+
   prometheus.yml: |-
     global:
       scrape_interval: 10s
       scrape_timeout: 10s
       evaluation_interval: 10s
+
+    rule_files:
+    - /etc/prometheus/prometheus.rules
 
     scrape_configs:
     - job_name: 'prometheus'
@@ -533,6 +555,39 @@ data:
         regex: '^/system\.slice/(.+)\.service$'
         target_label: systemd_service_name
         replacement: '${1}'
+
+    # For kube-state-metrics, from:
+    # https://github.com/prometheus/prometheus/blob/85a3c974b760642bbce00d795db231326a09edb9/documentation/examples/prometheus-kubernetes.yml#L131-L171
+    - job_name: 'kubernetes-service-endpoints'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+        action: replace
+        target_label: __scheme__
+        regex: (https?)
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+        action: replace
+        target_label: __address__
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
 
     - job_name: 'conduit-controller'
       kubernetes_sd_configs:
@@ -755,4 +810,237 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: conduit-top-line
+
+### kube-state-metrics ###
+### from https://github.com/kubernetes/kube-state-metrics/tree/0e1535b40e30c149372da9ca727ffbe0ce725d56/kubernetes ###
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: Namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: Namespace
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: Namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: Namespace
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: kube-state-metrics
+  namespace: Namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        conduit.io/created-by: conduit/cli undefined
+        conduit.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        conduit.io/control-plane-ns: Namespace
+        conduit.io/proxy-deployment: kube-state-metrics
+        k8s-app: kube-state-metrics
+    spec:
+      containers:
+      - image: quay.io/coreos/kube-state-metrics:v1.3.1
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources: {}
+      - command:
+        - /pod_nanny
+        - --container=kube-state-metrics
+        - --cpu=100m
+        - --extra-cpu=1m
+        - --memory=100Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=kube-state-metrics
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: k8s.gcr.io/addon-resizer:1.7
+        name: addon-resizer
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+      - env:
+        - name: CONDUIT_PROXY_LOG
+          value: warn,conduit_proxy=info
+        - name: CONDUIT_PROXY_CONTROL_URL
+          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+        - name: CONDUIT_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: CONDUIT_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: CONDUIT_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: CONDUIT_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: CONDUIT_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/runconduit/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: conduit-proxy
+        ports:
+        - containerPort: 4143
+          name: conduit-proxy
+        - containerPort: 4191
+          name: conduit-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/runconduit/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: conduit-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+      serviceAccountName: kube-state-metrics
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: Namespace
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
 ---

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -485,8 +485,67 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: kube_dst_pod_owner
-        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
+      # copy pod/namespace/owner_kind/owner_name labels to dst_* equivalents for easier matching with outbound metrics
+      - record: kube_pod_owner_ex
+        expr: |
+          label_replace(
+            label_replace(
+              label_replace(
+                label_replace(
+                  kube_pod_owner,
+                  "dst_pod", "$1", "pod", "(.*)"
+                ),
+                "dst_namespace", "$1", "namespace", "(.*)"
+              ),
+              "dst_owner_kind", "$1", "owner_kind", "(.*)"
+            ),
+            "dst_owner_name", "$1", "owner_name", "(.*)"
+          )
+      # copy owner_kind and owner_name into request_total metric,
+      # if owner_kind="ReplicaSet", infer Deployment name in "ksm_deployment" label
+      # nest for dst_* info
+      - record: request_total_ex
+        expr: |
+          # this drops metrics that satisfy request_total{pod=""}, how is that possible?
+          label_replace(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner{owner_kind="ReplicaSet"},
+            "ksm_deployment", "$1", "owner_name", "(.*)-.*"
+          )
+          or on (namespace, pod)(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner
+          )
 
   prometheus.yml: |-
     global:

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -322,8 +322,67 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: kube_dst_pod_owner
-        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
+      # copy pod/namespace/owner_kind/owner_name labels to dst_* equivalents for easier matching with outbound metrics
+      - record: kube_pod_owner_ex
+        expr: |
+          label_replace(
+            label_replace(
+              label_replace(
+                label_replace(
+                  kube_pod_owner,
+                  "dst_pod", "$1", "pod", "(.*)"
+                ),
+                "dst_namespace", "$1", "namespace", "(.*)"
+              ),
+              "dst_owner_kind", "$1", "owner_kind", "(.*)"
+            ),
+            "dst_owner_name", "$1", "owner_name", "(.*)"
+          )
+      # copy owner_kind and owner_name into request_total metric,
+      # if owner_kind="ReplicaSet", infer Deployment name in "ksm_deployment" label
+      # nest for dst_* info
+      - record: request_total_ex
+        expr: |
+          # this drops metrics that satisfy request_total{pod=""}, how is that possible?
+          label_replace(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner{owner_kind="ReplicaSet"},
+            "ksm_deployment", "$1", "owner_name", "(.*)-.*"
+          )
+          or on (namespace, pod)(
+            (
+              # this drops metrics that satisfy request_total{direction="outbound", dst_pod=""}, how is that possible?
+              label_replace(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex{dst_owner_kind="ReplicaSet"},
+                "ksm_dst_deployment", "$1", "dst_owner_name", "(.*)-.*"
+              )
+              or on (dst_namespace, dst_pod)(
+                request_total{direction="outbound"}
+                * on(dst_namespace, dst_pod) group_left(dst_owner_kind, dst_owner_name)
+                kube_pod_owner_ex
+              )
+              or request_total{direction="inbound"}
+            )
+            * on(namespace, pod) group_left(owner_kind, owner_name)
+            kube_pod_owner
+          )
 
   prometheus.yml: |-
     global:

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -322,20 +322,8 @@ data:
     groups:
     - name: conduit-rules
       rules:
-      - record: request_total:irate30s
-        expr: irate(request_total[30s])
-      - record: response_total:irate30s
-        expr: irate(response_total[30s])
-      - record: response_latency_ms_bucket:irate30s
-        expr: irate(response_latency_ms_bucket[30s])
-      - record: tcp_close_total:irate30s
-        expr: irate(tcp_close_total[30s])
-      - record: tcp_open_total:irate30s
-        expr: irate(tcp_open_total[30s])
-      - record: tcp_read_bytes_total:irate30s
-        expr: irate(tcp_read_bytes_total[30s])
-      - record: tcp_write_bytes_total:irate30s
-        expr: irate(tcp_write_bytes_total[30s])
+      - record: kube_dst_pod_owner
+        expr: label_replace(kube_pod_owner, "dst_pod", "$1", "pod", "(.*)")
 
   prometheus.yml: |-
     global:

--- a/grafana/dashboards/replica-set.json
+++ b/grafana/dashboards/replica-set.json
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(response_total:irate30s{direction=\"inbound\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
+          "expr": "sum(irate(response_total{direction=\"inbound\", classification=\"success\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(request_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
+          "expr": "sum(irate(request_total{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -421,7 +421,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(response_total:irate30s{direction=\"inbound\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
+          "expr": "sum(irate(response_total{direction=\"inbound\", classification=\"success\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -507,7 +507,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(request_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
+          "expr": "sum(irate(request_total{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -593,7 +593,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -601,14 +601,14 @@
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p95 rs/{{owner_name}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction=\"inbound\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "p99 rs/{{owner_name}}",
@@ -1003,7 +1003,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
+              "expr": "sum(irate(response_total{direction=\"outbound\", dst_pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", dst_pod=~\"$pod\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -1097,7 +1097,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
+              "expr": "sum(irate(response_total{direction=\"outbound\", dst_pod=~\"$pod\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "rs/{{owner_name}}",
@@ -1189,7 +1189,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction=\"outbound\", dst_pod=~\"$pod\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1197,14 +1197,14 @@
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", dst_pod=~\"$pod\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 rs/{{owner_name}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction=\"outbound\", dst_pod=~\"$pod\"}[30s]) * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 rs/{{owner_name}}",
@@ -1322,7 +1322,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+          "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1408,7 +1408,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(request_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+          "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1493,7 +1493,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (le, owner_name))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1874,7 +1874,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+              "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "rs/{{owner_name}}",
@@ -1959,7 +1959,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(request_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+              "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -2044,21 +2044,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 rs/{{owner_name}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 rs/{{owner_name}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 rs/{{owner_name}}",

--- a/grafana/dashboards/replica-set.json
+++ b/grafana/dashboards/replica-set.json
@@ -1322,7 +1322,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
+          "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1408,7 +1408,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
+          "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (owner_name)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1493,7 +1493,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (le, owner_name))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}) by (le, owner_name))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1874,7 +1874,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
+              "expr": "sum(irate(response_total{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)\n/\nsum(irate(response_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "rs/{{owner_name}}",
@@ -1959,7 +1959,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
+              "expr": "sum(irate(request_total{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (owner_name)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -2044,21 +2044,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P50 rs/{{owner_name}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P95 rs/{{owner_name}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_dst_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
+              "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction=\"outbound\", pod=~\"$pod\"}[30s]) * on(namespace, dst_pod) group_left (owner_kind, owner_name) kube_pod_owner_ex{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}) by (le, owner_name))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "P99 rs/{{owner_name}}",

--- a/grafana/dashboards/replica-set.json
+++ b/grafana/dashboards/replica-set.json
@@ -1,0 +1,2297 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1526425998083,
+  "links": [],
+  "panels": [
+    {
+      "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://conduit.io/favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">rs/$replica_set</span>\n</div>",
+      "gridPos": {
+        "h": 2.4,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 20,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "prometheus",
+      "decimals": null,
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 1,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 2.4
+      },
+      "id": 5,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(response_total:irate30s{direction=\"inbound\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.9,.99",
+      "title": "SUCCESS RATE",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 2.4
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": " RPS",
+      "postfixFontSize": "100%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(request_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "REQUEST RATE",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "decimals": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 2.4
+      },
+      "id": 11,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "100%",
+      "prefix": "",
+      "prefixFontSize": "100%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(count(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=~\"$inbound\"}) by (owner_name))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "INBOUND REPLICA SETS",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 2.4
+      },
+      "id": 15,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "100%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(count(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=~\"$outbound\"}) by (owner_name))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "OUTBOUND REPLICA SETS",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND TRAFFIC</span>\n</div>",
+      "gridPos": {
+        "h": 2.2,
+        "w": 24,
+        "x": 0,
+        "y": 6.4
+      },
+      "id": 17,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 8.600000000000001
+      },
+      "id": 67,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(response_total:irate30s{direction=\"inbound\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)\n",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "rs/{{owner_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SUCCESS RATE",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": "",
+          "logBase": 1,
+          "max": "1",
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 8.600000000000001
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(request_total:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (owner_name)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "rs/{{owner_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "REQUEST RATE",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "rps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 8.600000000000001
+      },
+      "id": 68,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "p50 rs/{{owner_name}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p95 rs/{{owner_name}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"inbound\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}) by (le, owner_name))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p99 rs/{{owner_name}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "LATENCY",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15.600000000000001
+      },
+      "id": 148,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 16.6
+          },
+          "id": 167,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tcp_close_total{namespace=\"$namespace\", pod=~\"$pod\", direction=\"inbound\",classification=\"failure\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{peer}} {{classification}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TCP CONNECTION FAILURES",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 16.6
+          },
+          "id": 168,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tcp_open_connections{namespace=\"$namespace\", pod=~\"$pod\", direction=\"inbound\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{peer}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TCP CONNECTIONS OPEN",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 16.6
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 169,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "targets": [
+            {
+              "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", pod=~\"$pod\", direction=\"inbound\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A"
+            }
+          ],
+          "title": "TCP CONNECTION DURATION",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurationms",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "title": "Inbound TCP Metrics",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16.6
+      },
+      "id": 152,
+      "panels": [],
+      "title": "",
+      "type": "row"
+    },
+    {
+      "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND REPLICA SETS</span>\n</div>",
+      "gridPos": {
+        "h": 2.2,
+        "w": 24,
+        "x": 0,
+        "y": 17.6
+      },
+      "id": 76,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19.8
+      },
+      "id": 59,
+      "panels": [
+        {
+          "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">rs/$inbound</span>\n</div>",
+          "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 20.8
+          },
+          "id": 39,
+          "links": [],
+          "mode": "html",
+          "scopedVars": {
+            "inbound": {
+              "selected": false,
+              "text": "vote-bot-66667b6494",
+              "value": "vote-bot-66667b6494"
+            }
+          },
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 22.8
+          },
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "inbound": {
+              "selected": false,
+              "text": "vote-bot-66667b6494",
+              "value": "vote-bot-66667b6494"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\", classification=\"success\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "rs/{{owner_name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SUCCESS RATE",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1",
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 22.8
+          },
+          "id": 22,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "inbound": {
+              "selected": false,
+              "text": "vote-bot-66667b6494",
+              "value": "vote-bot-66667b6494"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(response_total:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (owner_name)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "rs/{{owner_name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "REQUEST RATE",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "rps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 22.8
+          },
+          "id": 29,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "scopedVars": {
+            "inbound": {
+              "selected": false,
+              "text": "vote-bot-66667b6494",
+              "value": "vote-bot-66667b6494"
+            }
+          },
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "P50 rs/{{owner_name}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "P95 rs/{{owner_name}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", dst_pod=~\"$pod\"} * on(namespace, pod) group_left (owner_kind, owner_name) kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$inbound\"}) by (le, owner_name))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "P99 rs/{{owner_name}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "LATENCY",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "repeat": "inbound",
+      "title": "rs/$inbound",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20.8
+      },
+      "id": 34,
+      "panels": [],
+      "repeat": null,
+      "title": "",
+      "type": "row"
+    },
+    {
+      "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND TRAFFIC</span>\n</div>",
+      "gridPos": {
+        "h": 2.2,
+        "w": 24,
+        "x": 0,
+        "y": 21.8
+      },
+      "id": 32,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 77,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "rs/{{owner_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "SUCCESS RATE",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "percentunit",
+          "label": "",
+          "logBase": 1,
+          "max": "1",
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 78,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(request_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "rs/{{owner_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "REQUEST RATE",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "rps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 79,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "P95 rs/{{owner_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "P95 LATENCY",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 154,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 39
+          },
+          "id": 157,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tcp_close_total{namespace=\"$namespace\", pod=~\"$pod\", direction=\"outbound\",classification=\"failure\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{peer}} {{classification}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TCP CONNECTION FAILURES",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 39
+          },
+          "id": 166,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tcp_open_connections{namespace=\"$namespace\", pod=~\"$pod\", direction=\"outbound\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{peer}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "TCP CONNECTIONS OPEN",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateOranges",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": null,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 39
+          },
+          "heatmap": {},
+          "highlightCards": true,
+          "id": 160,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "targets": [
+            {
+              "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", pod=~\"$pod\", direction=\"outbound\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "TCP CONNECTION DURATION",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurationms",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "title": "Outbound TCP Metrics",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 156,
+      "panels": [],
+      "title": "",
+      "type": "row"
+    },
+    {
+      "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND REPLICA SETS</span>\n</div>",
+      "gridPos": {
+        "h": 2.2,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 80,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35.2
+      },
+      "id": 27,
+      "panels": [
+        {
+          "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://conduit.io/favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">rs/$outbound</span>\n</div>",
+          "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 36.2
+          },
+          "id": 40,
+          "links": [],
+          "mode": "html",
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 38.2
+          },
+          "id": 28,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\", classification=\"success\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)\n/\nsum(response_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "rs/{{owner_name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "SUCCESS RATE",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": "1",
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 38.2
+          },
+          "id": 35,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(request_total:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (owner_name)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "rs/{{owner_name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "REQUEST RATE",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rps",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 38.2
+          },
+          "id": 41,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "P50 rs/{{owner_name}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "P95 rs/{{owner_name}}",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(response_latency_ms_bucket:irate30s{direction=\"outbound\", pod=~\"$pod\"} * on(namespace, dst_pod) group_left (owner_kind, owner_name) label_replace(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$outbound\"}, \"dst_pod\", \"$1\", \"pod\", \"(.*)\")) by (le, owner_name))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "P99 rs/{{owner_name}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "LATENCY",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "repeat": "outbound",
+      "title": "rs/$outbound",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [
+    "conduit"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(request_total{conduit_io_control_plane_component=\"\"}, namespace)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Replica Set",
+        "multi": false,
+        "name": "replica_set",
+        "options": [],
+        "query": "label_values(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\"}, owner_name)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", owner_name=\"$replica_set\"}, pod)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "inboundpod",
+        "options": [],
+        "query": "label_values(request_total{dst_pod=~\"$pod\"}, pod)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "outboundpod",
+        "options": [],
+        "query": "label_values(request_total{pod=~\"$pod\"}, dst_pod)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "inbound",
+        "options": [],
+        "query": "label_values(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", pod=~\"$inboundpod\"}, owner_name)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "prometheus",
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "outbound",
+        "options": [],
+        "query": "label_values(kube_pod_owner{namespace=\"$namespace\", owner_kind=\"ReplicaSet\", pod=~\"$outboundpod\"}, owner_name)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Conduit Replica Set",
+  "uid": "K5xp4Yniz",
+  "version": 3
+}


### PR DESCRIPTION
The telemetry pipeline leverages denormalized kubernetes data to
identify source and destinations pods.

This change introduces kube-state-metrics into the conduit install, and
a ReplicaSet Grafana dashboard to prove out this approach.
kube-state-metrics listens to the Kubernetes API, generates metrics
about the state of objects, and serves those metrics to Prometheus.

By joining kube-state-metrics with conduit-proxy metrics, we may be able
to normalize all condiut metrics data. This could include removal of
self-identifying information added at inject time, and also destination
info added at destination lookup time.

Relates to #741.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<img width="1252" alt="screen shot 2018-05-15 at 4 59 56 pm" src="https://user-images.githubusercontent.com/236915/40090156-ee1f632e-5864-11e8-97e3-9efc2006e59f.png">
