### PR TITLE
Continue to remove conduit branding from /web

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -93,7 +93,7 @@ ul.ant-menu.ant-menu-sub {
   }
 }
 
-.ant-layout .ant-layout-sider .ant-layout-sider-trigger {
+.ant-layout .ant-layout-sider, .ant-layout .ant-layout-sider .ant-layout-sider-trigger {
   /* override ant color */
   background: var(--sider-black);
 }

--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -1,5 +1,9 @@
 @import 'styles.css';
 
+ul.ant-menu.ant-menu-sub {
+  background: var(--sider-black);
+}
+
 .sidebar {
   background: var(--header-black);
   color: white;
@@ -91,5 +95,5 @@
 
 .ant-layout .ant-layout-sider .ant-layout-sider-trigger {
   /* override ant color */
-  background: #343838;
+  background: var(--sider-black);
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -3,6 +3,7 @@
 :root {
   --white: #fff;
   --header-black: #1e2322;
+  --sider-black: #343838;
   --royalblue: #2F80ED;
   --darkblue: #071E3C;
   --curiousblue: #2D9CDB;

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -313,7 +313,7 @@ class ServiceMesh extends React.Component {
     if (numUnadded === 0) {
       return (
         <div className="mesh-completion-message">
-          All namespaces have a conduit install.
+          All namespaces have a {this.props.productName} install.
         </div>
       );
     } else {

--- a/web/app/test/ServiceMeshTest.jsx
+++ b/web/app/test/ServiceMeshTest.jsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import Adapter from 'enzyme-adapter-react-16';
-import podFixtures from './fixtures/podRollup.json';
 import { expect } from 'chai';
 import nsFixtures from './fixtures/namespaces.json';
+import podFixtures from './fixtures/podRollup.json';
 import { routerWrap } from './testHelpers.jsx';
 import ServiceMesh from '../js/components/ServiceMesh.jsx';
 import sinon from 'sinon';
@@ -197,7 +197,7 @@ describe('ServiceMesh', () => {
       component = mount(routerWrap(ServiceMesh));
 
       return withPromise(() => {
-        expect(component.html()).to.include("All namespaces have a conduit install.");
+        expect(component.html()).to.include("All namespaces have a ShinyProductName install.");
       });
     });
   });

--- a/web/app/test/fixtures/allRollup.json
+++ b/web/app/test/fixtures/allRollup.json
@@ -35,7 +35,7 @@
           "rows": [
             {
               "resource": {
-                "namespace": "conduit",
+                "namespace": "shiny-product",
                 "type": "pods",
                 "name": "web-5f97578cf6-597sr"
               },
@@ -52,7 +52,7 @@
             },
             {
               "resource": {
-                "namespace": "conduit-other",
+                "namespace": "shiny-product-other",
                 "type": "pods",
                 "name": "controller-795dd8df6-tjdt6"
               },
@@ -69,7 +69,7 @@
             },
             {
               "resource": {
-                "namespace": "not-conduit",
+                "namespace": "not-shiny-product",
                 "type": "pods",
                 "name": "prometheus-595785446-r7rlq"
               },
@@ -80,7 +80,7 @@
             },
             {
               "resource": {
-                "namespace": "conduit-other",
+                "namespace": "shiny-product-other",
                 "type": "pods",
                 "name": "grafana-78cdb656bf-v8lsj"
               },

--- a/web/app/test/fixtures/namespaces.json
+++ b/web/app/test/fixtures/namespaces.json
@@ -8,7 +8,7 @@
               "resource": {
                 "namespace": "",
                 "type": "namespaces",
-                "name": "conduit"
+                "name": "shiny-product"
               },
               "timeWindow": "1m",
               "meshedPodCount": "4",

--- a/web/app/test/fixtures/podRollup.json
+++ b/web/app/test/fixtures/podRollup.json
@@ -6,7 +6,7 @@
           "rows": [
             {
               "resource": {
-                "namespace": "conduit",
+                "namespace": "shiny-product",
                 "type": "pods",
                 "name": "web-5f97578cf6-597sr"
               },
@@ -23,7 +23,7 @@
             },
             {
               "resource": {
-                "namespace": "conduit",
+                "namespace": "shiny-product",
                 "type": "pods",
                 "name": "controller-795dd8df6-tjdt6"
               },
@@ -40,7 +40,7 @@
             },
             {
               "resource": {
-                "namespace": "conduit",
+                "namespace": "shiny-product",
                 "type": "pods",
                 "name": "prometheus-595785446-r7rlq"
               },
@@ -51,7 +51,7 @@
             },
             {
               "resource": {
-                "namespace": "conduit",
+                "namespace": "shiny-product",
                 "type": "pods",
                 "name": "grafana-78cdb656bf-v8lsj"
               },

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -6,7 +6,7 @@ import { Route, Router } from 'react-router';
 
 const componentDefaultProps = {
   api: ApiHelpers(''),
-  controllerNamespace: 'conduit',
+  controllerNamespace: 'shiny-controller-ns',
   productName: 'ShinyProductName',
   releaseVersion: ''
 };


### PR DESCRIPTION
This PR adjusts the colour of a popup in the sidebar, as well as removes references 
to conduit in the frontend test fixtures.

All that's left in the Web UI code now is a few references to the conduit sites / githubs, as well as the CLI name. These should be fairly easy to move over.

Again, no user-visible word changes, so can me merged anytime.

Before (popup is blue):
![screen shot 2018-07-06 at 3 51 54 pm](https://user-images.githubusercontent.com/549258/42403241-ab98c8ee-8134-11e8-9ea8-befe9b61e1b8.png)



<img width="315" alt="screen shot 2018-07-09 at 10 54 04 am" src="https://user-images.githubusercontent.com/549258/42467464-d68342e4-8366-11e8-8431-7bcc943cefaf.png">


After:
![screen shot 2018-07-06 at 3 37 46 pm](https://user-images.githubusercontent.com/549258/42403243-aded03e4-8134-11e8-98f9-cdbc0f1ca306.png)

<img width="445" alt="screen shot 2018-07-09 at 10 54 27 am" src="https://user-images.githubusercontent.com/549258/42467479-e0348186-8366-11e8-8bd6-f7d2f0b244de.png">
