### PR TITLE
Ensure destination service always sends pod metadata

### DIFF
--- a/controller/destination/endpoints_watcher_test.go
+++ b/controller/destination/endpoints_watcher_test.go
@@ -216,7 +216,7 @@ spec:
 
 			actualAddresses := make([]string, 0)
 			for _, add := range listener.added {
-				actualAddresses = append(actualAddresses, addr.ProxyAddressToString(&add))
+				actualAddresses = append(actualAddresses, addr.ProxyAddressToString(add.address))
 			}
 			sort.Strings(actualAddresses)
 

--- a/controller/destination/endpoints_watcher_test.go
+++ b/controller/destination/endpoints_watcher_test.go
@@ -40,10 +40,49 @@ metadata:
 subsets:
 - addresses:
   - ip: 172.17.0.12
+    targetRef:
+      kind: Pod
+      name: name1-1
+      namespace: ns
   - ip: 172.17.0.19
+    targetRef:
+      kind: Pod
+      name: name1-2
+      namespace: ns
   - ip: 172.17.0.20
+    targetRef:
+      kind: Pod
+      name: name1-3
+      namespace: ns
   ports:
   - port: 8989`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-1
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.12`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-2
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.19`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-3
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.20`,
 			},
 			service: &serviceId{namespace: "ns", name: "name1"},
 			port:    uint32(8989),
@@ -55,7 +94,61 @@ subsets:
 			expectedNoEndpoints:              false,
 			expectedNoEndpointsServiceExists: false,
 		},
-
+		{
+			serviceType: "local services with missing pods",
+			k8sConfigs: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: name1
+  namespace: ns
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8989`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: name1
+  namespace: ns
+subsets:
+- addresses:
+  - ip: 172.17.0.23
+    targetRef:
+      kind: Pod
+      name: name1-1
+      namespace: ns
+  - ip: 172.17.0.24
+    targetRef:
+      kind: Pod
+      name: name1-2
+      namespace: ns
+  - ip: 172.17.0.25
+    targetRef:
+      kind: Pod
+      name: name1-3
+      namespace: ns
+  ports:
+  - port: 8989`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-3
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.25`,
+			},
+			service: &serviceId{namespace: "ns", name: "name1"},
+			port:    uint32(8989),
+			expectedAddresses: []string{
+				"172.17.0.25:8989",
+			},
+			expectedNoEndpoints:              false,
+			expectedNoEndpointsServiceExists: false,
+		},
 		{
 			serviceType: "local services with no endpoints",
 			k8sConfigs: []string{`

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -3,17 +3,15 @@ package destination
 import (
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	net "github.com/linkerd/linkerd2-proxy-api/go/net"
-	"github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type podsByIpFn func(string) ([]*coreV1.Pod, error)
 type ownerKindAndNameFn func(*coreV1.Pod) (string, string)
 
 type updateListener interface {
-	Update(add []net.TcpAddress, remove []net.TcpAddress)
+	Update(add map[net.TcpAddress]*coreV1.Pod, remove []net.TcpAddress)
 	ClientClose() <-chan struct{}
 	ServerClose() <-chan struct{}
 	NoEndpoints(exists bool)
@@ -24,7 +22,6 @@ type updateListener interface {
 // implements the updateListener interface
 type endpointListener struct {
 	stream           pb.Destination_GetServer
-	podsByIp         podsByIpFn
 	ownerKindAndName ownerKindAndNameFn
 	labels           map[string]string
 	enableTLS        bool
@@ -33,13 +30,11 @@ type endpointListener struct {
 
 func newEndpointListener(
 	stream pb.Destination_GetServer,
-	podsByIp podsByIpFn,
 	ownerKindAndName ownerKindAndNameFn,
 	enableTLS bool,
 ) *endpointListener {
 	return &endpointListener{
 		stream:           stream,
-		podsByIp:         podsByIp,
 		ownerKindAndName: ownerKindAndName,
 		labels:           make(map[string]string),
 		enableTLS:        enableTLS,
@@ -68,7 +63,7 @@ func (l *endpointListener) SetServiceId(id *serviceId) {
 	}
 }
 
-func (l *endpointListener) Update(add []net.TcpAddress, remove []net.TcpAddress) {
+func (l *endpointListener) Update(add map[net.TcpAddress]*coreV1.Pod, remove []net.TcpAddress) {
 	if len(add) > 0 {
 		update := &pb.Update{
 			Update: &pb.Update_Add{
@@ -104,10 +99,10 @@ func (l *endpointListener) NoEndpoints(exists bool) {
 	l.stream.Send(update)
 }
 
-func (l *endpointListener) toWeightedAddrSet(endpoints []net.TcpAddress) *pb.WeightedAddrSet {
+func (l *endpointListener) toWeightedAddrSet(endpoints map[net.TcpAddress]*coreV1.Pod) *pb.WeightedAddrSet {
 	addrs := make([]*pb.WeightedAddr, 0)
-	for _, address := range endpoints {
-		addrs = append(addrs, l.toWeightedAddr(address))
+	for address, pod := range endpoints {
+		addrs = append(addrs, l.toWeightedAddr(address, pod))
 	}
 
 	return &pb.WeightedAddrSet{
@@ -116,35 +111,15 @@ func (l *endpointListener) toWeightedAddrSet(endpoints []net.TcpAddress) *pb.Wei
 	}
 }
 
-func (l *endpointListener) toWeightedAddr(address net.TcpAddress) *pb.WeightedAddr {
-	var tlsIdentity *pb.TlsIdentity
-	metricLabelsForPod := map[string]string{}
-	ipAsString := addr.ProxyIPToString(address.Ip)
-
-	resultingPods, err := l.podsByIp(ipAsString)
-	if err != nil {
-		log.Errorf("Error while finding pod for IP [%s], this IP will be sent with no metric labels: %v", ipAsString, err)
-	} else {
-		podFound := false
-		for _, pod := range resultingPods {
-			if pod.Status.Phase == coreV1.PodRunning {
-				podFound = true
-				metricLabelsForPod = pkgK8s.GetOwnerLabels(pod.ObjectMeta)
-				metricLabelsForPod["pod"] = pod.Name
-				tlsIdentity = l.toTlsIdentity(pod)
-				break
-			}
-		}
-		if !podFound {
-			log.Errorf("Could not find running pod for IP [%s], this IP will be sent with no metric labels.", ipAsString)
-		}
-	}
+func (l *endpointListener) toWeightedAddr(address net.TcpAddress, pod *coreV1.Pod) *pb.WeightedAddr {
+	metricLabelsForPod := pkgK8s.GetOwnerLabels(pod.ObjectMeta)
+	metricLabelsForPod["pod"] = pod.Name
 
 	return &pb.WeightedAddr{
 		Addr:         &address,
 		Weight:       1,
 		MetricLabels: metricLabelsForPod,
-		TlsIdentity:  tlsIdentity,
+		TlsIdentity:  l.toTlsIdentity(pod),
 	}
 }
 

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -167,7 +167,6 @@ func TestEndpointListener(t *testing.T) {
 
 		add := map[net.TcpAddress]*v1.Pod{
 			addedAddress1: podForAddedAddress1,
-			addedAddress2: pod2,
 		}
 		listener.Update(add, nil)
 

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -20,17 +20,17 @@ type podExpected struct {
 }
 
 var (
-	addedAddress1 = net.TcpAddress{
+	addedAddress1 = &net.TcpAddress{
 		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 1}},
 		Port: 1,
 	}
 
-	addedAddress2 = net.TcpAddress{
+	addedAddress2 = &net.TcpAddress{
 		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 2}},
 		Port: 2,
 	}
 
-	removedAddress1 = net.TcpAddress{
+	removedAddress1 = &net.TcpAddress{
 		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 100}},
 		Port: 100,
 	}
@@ -49,12 +49,14 @@ var (
 		},
 	}
 
-	add = map[net.TcpAddress]*v1.Pod{
-		addedAddress1: pod1,
-		addedAddress2: pod2,
+	add = []*updateAddress{
+		&updateAddress{address: addedAddress1, pod: pod1},
+		&updateAddress{address: addedAddress2, pod: pod2},
 	}
 
-	remove = []net.TcpAddress{removedAddress1}
+	remove = []*updateAddress{
+		&updateAddress{address: removedAddress1},
+	}
 )
 
 func defaultOwnerKindAndName(pod *v1.Pod) (string, string) {
@@ -103,11 +105,11 @@ func TestEndpointListener(t *testing.T) {
 			t.Fatalf("Expecting [%d] addresses to be removed, got [%d]: %v", expectedNumberOfRemoved, actualNumberOfRemoved, addressesRemoved)
 		}
 
-		checkAddress(t, addressesAdded[0], &addedAddress1)
-		checkAddress(t, addressesAdded[1], &addedAddress2)
+		checkAddress(t, addressesAdded[0], addedAddress1)
+		checkAddress(t, addressesAdded[1], addedAddress2)
 
 		actualAddressRemoved := addressesRemoved[0]
-		expectedAddressRemoved := &removedAddress1
+		expectedAddressRemoved := removedAddress1
 		if !reflect.DeepEqual(actualAddressRemoved, expectedAddressRemoved) {
 			t.Fatalf("Expected remove address to be [%s], but it was [%s]", expectedAddressRemoved, actualAddressRemoved)
 		}
@@ -165,8 +167,8 @@ func TestEndpointListener(t *testing.T) {
 			stream: mockGetServer,
 		}
 
-		add := map[net.TcpAddress]*v1.Pod{
-			addedAddress1: podForAddedAddress1,
+		add := []*updateAddress{
+			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 
@@ -221,8 +223,8 @@ func TestEndpointListener(t *testing.T) {
 			enableTLS:        true,
 		}
 
-		add := map[net.TcpAddress]*v1.Pod{
-			addedAddress1: podForAddedAddress1,
+		add := []*updateAddress{
+			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 
@@ -267,8 +269,8 @@ func TestEndpointListener(t *testing.T) {
 			stream:           mockGetServer,
 		}
 
-		add := map[net.TcpAddress]*v1.Pod{
-			addedAddress1: podForAddedAddress1,
+		add := []*updateAddress{
+			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -7,7 +7,6 @@ import (
 
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	"github.com/linkerd/linkerd2-proxy-api/go/net"
-	"github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,16 +19,43 @@ type podExpected struct {
 	phase                 v1.PodPhase
 }
 
-type listenerExpected struct {
-	pods           []podExpected
-	address        net.TcpAddress
-	listenerLabels map[string]string
-	addressLabels  map[string]string
-}
+var (
+	addedAddress1 = net.TcpAddress{
+		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 1}},
+		Port: 1,
+	}
 
-func noPodsByIp(ip string) ([]*v1.Pod, error) {
-	return make([]*v1.Pod, 0), nil
-}
+	addedAddress2 = net.TcpAddress{
+		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 2}},
+		Port: 2,
+	}
+
+	removedAddress1 = net.TcpAddress{
+		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 100}},
+		Port: 100,
+	}
+
+	pod1 = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "ns",
+		},
+	}
+
+	pod2 = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "ns",
+		},
+	}
+
+	add = map[net.TcpAddress]*v1.Pod{
+		addedAddress1: pod1,
+		addedAddress2: pod2,
+	}
+
+	remove = []net.TcpAddress{removedAddress1}
+)
 
 func defaultOwnerKindAndName(pod *v1.Pod) (string, string) {
 	return "", ""
@@ -41,15 +67,10 @@ func TestEndpointListener(t *testing.T) {
 
 		listener := &endpointListener{
 			stream:           mockGetServer,
-			podsByIp:         noPodsByIp,
 			ownerKindAndName: defaultOwnerKindAndName,
 		}
 
-		addedAddress1 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 1}}, Port: 1}
-		addedAddress2 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 2}}, Port: 2}
-		removedAddress1 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 100}}, Port: 100}
-
-		listener.Update([]net.TcpAddress{addedAddress1, addedAddress2}, []net.TcpAddress{removedAddress1})
+		listener.Update(add, remove)
 
 		expectedNumUpdates := 2
 		actualNumUpdates := len(mockGetServer.updatesReceived)
@@ -63,15 +84,10 @@ func TestEndpointListener(t *testing.T) {
 
 		listener := &endpointListener{
 			stream:           mockGetServer,
-			podsByIp:         noPodsByIp,
 			ownerKindAndName: defaultOwnerKindAndName,
 		}
 
-		addedAddress1 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 1}}, Port: 1}
-		addedAddress2 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 2}}, Port: 2}
-		removedAddress1 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 100}}, Port: 100}
-
-		listener.Update([]net.TcpAddress{addedAddress1, addedAddress2}, []net.TcpAddress{removedAddress1})
+		listener.Update(add, remove)
 
 		addressesAdded := mockGetServer.updatesReceived[0].GetAdd().Addrs
 		actualNumberOfAdded := len(addressesAdded)
@@ -102,7 +118,6 @@ func TestEndpointListener(t *testing.T) {
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}, contextToReturn: context}
 		listener := &endpointListener{
 			stream:           mockGetServer,
-			podsByIp:         noPodsByIp,
 			ownerKindAndName: defaultOwnerKindAndName,
 		}
 
@@ -127,8 +142,6 @@ func TestEndpointListener(t *testing.T) {
 		expectedNamespace := "this-namespace"
 		expectedReplicationControllerName := "rc-name"
 
-		addedAddress1 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 666}}, Port: 1}
-		ipForAddr1 := addr.ProxyIPToString(addedAddress1.Ip)
 		podForAddedAddress1 := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
@@ -141,14 +154,9 @@ func TestEndpointListener(t *testing.T) {
 				Phase: v1.PodRunning,
 			},
 		}
-		addedAddress2 := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 222}}, Port: 22}
-		podIndex := func(ip string) ([]*v1.Pod, error) {
-			return map[string][]*v1.Pod{ipForAddr1: []*v1.Pod{podForAddedAddress1}}[ip], nil
-		}
 
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
 		listener := &endpointListener{
-			podsByIp:         podIndex,
 			ownerKindAndName: defaultOwnerKindAndName,
 			labels: map[string]string{
 				"service":   expectedServiceName,
@@ -157,7 +165,11 @@ func TestEndpointListener(t *testing.T) {
 			stream: mockGetServer,
 		}
 
-		listener.Update([]net.TcpAddress{addedAddress1, addedAddress2}, nil)
+		add := map[net.TcpAddress]*v1.Pod{
+			addedAddress1: podForAddedAddress1,
+			addedAddress2: pod2,
+		}
+		listener.Update(add, nil)
 
 		actualGlobalMetricLabels := mockGetServer.updatesReceived[0].GetAdd().MetricLabels
 		expectedGlobalMetricLabels := map[string]string{"namespace": expectedNamespace, "service": expectedServiceName}
@@ -185,9 +197,7 @@ func TestEndpointListener(t *testing.T) {
 			ControllerNs: "conduit-namespace",
 		}
 
-		addedAddress := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 666}}, Port: 1}
-		ipForAddr := addr.ProxyIPToString(addedAddress.Ip)
-		podForAddedAddress := &v1.Pod{
+		podForAddedAddress1 := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
@@ -201,23 +211,21 @@ func TestEndpointListener(t *testing.T) {
 			},
 		}
 
-		podIndex := func(ip string) ([]*v1.Pod, error) {
-			return map[string][]*v1.Pod{ipForAddr: []*v1.Pod{podForAddedAddress}}[ip], nil
-		}
-
 		ownerKindAndName := func(pod *v1.Pod) (string, string) {
 			return "deployment", expectedPodDeployment
 		}
 
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
 		listener := &endpointListener{
-			podsByIp:         podIndex,
 			ownerKindAndName: ownerKindAndName,
 			stream:           mockGetServer,
 			enableTLS:        true,
 		}
 
-		listener.Update([]net.TcpAddress{addedAddress}, nil)
+		add := map[net.TcpAddress]*v1.Pod{
+			addedAddress1: podForAddedAddress1,
+		}
+		listener.Update(add, nil)
 
 		addrs := mockGetServer.updatesReceived[0].GetAdd().GetAddrs()
 		if len(addrs) != 1 {
@@ -236,9 +244,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedConduitNamespace := "conduit-namespace"
 		expectedPodDeployment := "pod-deployment"
 
-		addedAddress := net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 666}}, Port: 1}
-		ipForAddr := addr.ProxyIPToString(addedAddress.Ip)
-		podForAddedAddress := &v1.Pod{
+		podForAddedAddress1 := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
@@ -252,22 +258,20 @@ func TestEndpointListener(t *testing.T) {
 			},
 		}
 
-		podIndex := func(ip string) ([]*v1.Pod, error) {
-			return map[string][]*v1.Pod{ipForAddr: []*v1.Pod{podForAddedAddress}}[ip], nil
-		}
-
 		ownerKindAndName := func(pod *v1.Pod) (string, string) {
 			return "deployment", expectedPodDeployment
 		}
 
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
 		listener := &endpointListener{
-			podsByIp:         podIndex,
 			ownerKindAndName: ownerKindAndName,
 			stream:           mockGetServer,
 		}
 
-		listener.Update([]net.TcpAddress{addedAddress}, nil)
+		add := map[net.TcpAddress]*v1.Pod{
+			addedAddress1: podForAddedAddress1,
+		}
+		listener.Update(add, nil)
 
 		addrs := mockGetServer.updatesReceived[0].GetAdd().GetAddrs()
 		if len(addrs) != 1 {
@@ -276,103 +280,6 @@ func TestEndpointListener(t *testing.T) {
 
 		if addrs[0].TlsIdentity != nil {
 			t.Fatalf("Expected no TlsIdentity to be sent, but got [%v]", addrs[0].TlsIdentity)
-		}
-	})
-
-	t.Run("It only returns pods in a running state", func(t *testing.T) {
-		expectations := []listenerExpected{
-			listenerExpected{
-				pods: []podExpected{
-					podExpected{
-						pod:                   "pod1",
-						namespace:             "this-namespace",
-						replicationController: "rc-name",
-						phase: v1.PodPending,
-					},
-				},
-				address: net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 666}}, Port: 1},
-				listenerLabels: map[string]string{
-					"service":   "service-name",
-					"namespace": "this-namespace",
-				},
-				addressLabels: map[string]string{},
-			},
-			listenerExpected{
-				pods: []podExpected{
-					podExpected{
-						pod:                   "pod1",
-						namespace:             "this-namespace",
-						replicationController: "rc-name",
-						phase: v1.PodPending,
-					},
-					podExpected{
-						pod:                   "pod2",
-						namespace:             "this-namespace",
-						replicationController: "rc-name",
-						phase: v1.PodRunning,
-					},
-					podExpected{
-						pod:                   "pod3",
-						namespace:             "this-namespace",
-						replicationController: "rc-name",
-						phase: v1.PodSucceeded,
-					},
-				},
-				address: net.TcpAddress{Ip: &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 666}}, Port: 1},
-				listenerLabels: map[string]string{
-					"service":   "service-name",
-					"namespace": "this-namespace",
-				},
-				addressLabels: map[string]string{
-					"pod": "pod2",
-					"replication_controller": "rc-name",
-				},
-			},
-		}
-
-		for _, exp := range expectations {
-			backingMap := map[string][]*v1.Pod{}
-
-			for _, pod := range exp.pods {
-				ipForAddr := addr.ProxyIPToString(exp.address.Ip)
-				podForAddedAddress := &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      pod.pod,
-						Namespace: pod.namespace,
-						Labels: map[string]string{
-							pkgK8s.ProxyReplicationControllerLabel: pod.replicationController,
-						},
-					},
-					Status: v1.PodStatus{
-						Phase: pod.phase,
-					},
-				}
-
-				backingMap[ipForAddr] = append(backingMap[ipForAddr], podForAddedAddress)
-			}
-			podIndex := func(ip string) ([]*v1.Pod, error) {
-				return backingMap[ip], nil
-			}
-
-			mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
-			listener := &endpointListener{
-				podsByIp:         podIndex,
-				ownerKindAndName: defaultOwnerKindAndName,
-				labels:           exp.listenerLabels,
-				stream:           mockGetServer,
-			}
-
-			listener.Update([]net.TcpAddress{exp.address}, nil)
-
-			actualGlobalMetricLabels := mockGetServer.updatesReceived[0].GetAdd().MetricLabels
-			if !reflect.DeepEqual(actualGlobalMetricLabels, exp.listenerLabels) {
-				t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", exp.listenerLabels, actualGlobalMetricLabels)
-			}
-
-			actualAddedAddressMetricLabels := mockGetServer.updatesReceived[0].GetAdd().Addrs[0].MetricLabels
-			if !reflect.DeepEqual(actualAddedAddressMetricLabels, exp.addressLabels) {
-				t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", exp.addressLabels, actualAddedAddressMetricLabels)
-			}
 		}
 	})
 }

--- a/controller/destination/test_helper.go
+++ b/controller/destination/test_helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/linkerd/linkerd2-proxy-api/go/net"
+	"k8s.io/api/core/v1"
 )
 
 // implements the updateListener interface
@@ -16,8 +17,10 @@ type collectUpdateListener struct {
 	stopCh            chan struct{}
 }
 
-func (c *collectUpdateListener) Update(add []net.TcpAddress, remove []net.TcpAddress) {
-	c.added = append(c.added, add...)
+func (c *collectUpdateListener) Update(add map[net.TcpAddress]*v1.Pod, remove []net.TcpAddress) {
+	for a := range add {
+		c.added = append(c.added, a)
+	}
 	c.removed = append(c.removed, remove...)
 }
 

--- a/controller/destination/test_helper.go
+++ b/controller/destination/test_helper.go
@@ -2,25 +2,20 @@ package destination
 
 import (
 	"context"
-
-	"github.com/linkerd/linkerd2-proxy-api/go/net"
-	"k8s.io/api/core/v1"
 )
 
 // implements the updateListener interface
 type collectUpdateListener struct {
-	added             []net.TcpAddress
-	removed           []net.TcpAddress
+	added             []*updateAddress
+	removed           []*updateAddress
 	noEndpointsCalled bool
 	noEndpointsExists bool
 	context           context.Context
 	stopCh            chan struct{}
 }
 
-func (c *collectUpdateListener) Update(add map[net.TcpAddress]*v1.Pod, remove []net.TcpAddress) {
-	for a := range add {
-		c.added = append(c.added, a)
-	}
+func (c *collectUpdateListener) Update(add, remove []*updateAddress) {
+	c.added = append(c.added, add...)
 	c.removed = append(c.removed, remove...)
 }
 

--- a/pkg/addr/addr.go
+++ b/pkg/addr/addr.go
@@ -90,36 +90,3 @@ func decodeIPToOctets(ip uint32) [4]uint8 {
 		uint8(ip & 255),
 	}
 }
-
-func DiffProxyAddresses(oldAddrs []pb.TcpAddress, newAddrs []pb.TcpAddress) ([]pb.TcpAddress, []pb.TcpAddress) {
-	addSet := make(map[string]pb.TcpAddress)
-	removeSet := make(map[string]pb.TcpAddress)
-
-	for _, addr := range newAddrs {
-		key := ProxyAddressToString(&addr)
-		addSet[key] = addr
-	}
-
-	for _, addr := range oldAddrs {
-		key := ProxyAddressToString(&addr)
-		delete(addSet, key)
-		removeSet[key] = addr
-	}
-
-	for _, addr := range newAddrs {
-		key := ProxyAddressToString(&addr)
-		delete(removeSet, key)
-	}
-
-	add := make([]pb.TcpAddress, 0)
-	for _, addr := range addSet {
-		add = append(add, addr)
-	}
-
-	remove := make([]pb.TcpAddress, 0)
-	for _, addr := range removeSet {
-		remove = append(remove, addr)
-	}
-
-	return add, remove
-}


### PR DESCRIPTION
The destination service previously used an in-memory index of pods by IP to return pod metadata as part of address updates streamed back to the proxies. This meant that if we couldn't find a pod by IP, we'd end up sending back an address without any metadata, which is problematic for stats collection and TLS.

It turns out the pod IP index was extraneous, since the endpoints update event that the destination service receives from the Kubernetes API contains a pod owner reference in addition to the pod's IP. In this branch I'm removing the index by IP, and updating the endpoint watcher to also find the associated pods when an endpoints update is received. If a pod cannot be found, then it is skipped until the next endpoints update. Testing locally I haven't observed any instances where the pod cannot be found, which suggests to me that the primary pod index is more reliable than the secondary index by IP that we were previously using.

Fixes #783.
Fixes #1264.