### PR TITLE
Name ClusterRole objects to be namespace-specific

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -57,10 +57,10 @@ printf "Testing Conduit version [%s] namespace [%s]\\n" "$conduit_version" "$con
 exit_code=0
 
 run_test "$test_directory/install_test.go" || exit_code=$?
+run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done
-run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
 
 if [ $exit_code -eq 0 ]; then
     printf "\\n=== PASS: all tests passed\\n"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -17,7 +17,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-conduit-controller
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -30,11 +30,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-conduit-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-controller
+  name: conduit-conduit-controller
 subjects:
 - kind: ServiceAccount
   name: conduit-controller
@@ -53,7 +53,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-conduit-prometheus
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -63,11 +63,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-conduit-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-prometheus
+  name: conduit-conduit-prometheus
 subjects:
 - kind: ServiceAccount
   name: conduit-prometheus

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -17,7 +17,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-Namespace-controller
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -30,11 +30,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-Namespace-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-controller
+  name: conduit-Namespace-controller
 subjects:
 - kind: ServiceAccount
   name: conduit-controller
@@ -53,7 +53,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-Namespace-prometheus
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -63,11 +63,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-Namespace-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-prometheus
+  name: conduit-Namespace-prometheus
 subjects:
 - kind: ServiceAccount
   name: conduit-prometheus
@@ -859,7 +859,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-ca
+  name: conduit-Namespace-ca
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -882,11 +882,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-ca
+  name: conduit-Namespace-ca
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-ca
+  name: conduit-Namespace-ca
 subjects:
 - kind: ServiceAccount
   name: conduit-ca

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -20,7 +20,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-{{.Namespace}}-controller
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -33,11 +33,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-controller
+  name: conduit-{{.Namespace}}-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-controller
+  name: conduit-{{.Namespace}}-controller
 subjects:
 - kind: ServiceAccount
   name: conduit-controller
@@ -56,7 +56,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-{{.Namespace}}-prometheus
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -66,11 +66,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-prometheus
+  name: conduit-{{.Namespace}}-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-prometheus
+  name: conduit-{{.Namespace}}-prometheus
 subjects:
 - kind: ServiceAccount
   name: conduit-prometheus
@@ -627,7 +627,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-ca
+  name: conduit-{{.Namespace}}-ca
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -650,11 +650,11 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: conduit-ca
+  name: conduit-{{.Namespace}}-ca
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: conduit-ca
+  name: conduit-{{.Namespace}}-ca
 subjects:
 - kind: ServiceAccount
   name: conduit-ca


### PR DESCRIPTION
The control-plane's `ClusterRole` and `ClusterRoleBinding` objects are
global. Because their names did not vary across multiple control-plane
deployments, it prevented multiple control-planes from coexisting (when
RBAC is enabled).

Modify the `ClusterRole` and `ClusterRoleBinding` objects to include the
control-plane's namespace in their names. Also modify the integration
test to first install two control-planes, and then perform its full
suite of tests, to prevent regression.

Fixes #1292.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>