### PR TITLE
Fix annoying flickering if image asset isn't present

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -59,6 +59,7 @@ ul.ant-menu.ant-menu-sub {
   }
 
   & .sidebar-menu-header {
+    height: 80px;
     padding: calc(var(--base-width)*2) 14px;
 
     &.collapsed {


### PR DESCRIPTION
Fix the height we reserve for the logo in the sidebar. This prevents the rest of the sidebar from moving up and down in spacing if for some reason we can't get the image asset for the logo.

(You can reproduce this effect by doing `rm -fr web/app/dist` and then running `webpack-dev-server` and observing how the sidebar behaves when it can't find the asset).