### PR TITLE
Add flag that skips `dep ensure` to bin/fast-build

### DIFF
--- a/bin/fast-build
+++ b/bin/fast-build
@@ -2,12 +2,6 @@
 
 set -eu
 
-if [[ "${1:-}" = "--no-dep" ]]; then
-dep_ensure=
-else
-dep_ensure=1
-fi
-
 cd "$(pwd -P)"
 
 # Builds CLI binary for current platform only and outside docker to speed up things. Suitable for local development.
@@ -27,7 +21,7 @@ fi
 
 (
     cd $rootdir
-    if [ ! -z ${dep_ensure} ]; then
+    if [ -z "${LINKERD_SKIP_DEP:-}" ]; then
       $bindir/dep ensure -vendor-only -v
     fi
     target="target/cli/${host_platform}/linkerd"

--- a/bin/fast-build
+++ b/bin/fast-build
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -eu
-
 cd "$(pwd -P)"
 
 # Builds CLI binary for current platform only and outside docker to speed up things. Suitable for local development.

--- a/bin/fast-build
+++ b/bin/fast-build
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 set -eu
+
+if [[ "${1:-}" = "--no-dep" ]]; then
+dep_ensure=
+else
+dep_ensure=1
+fi
+
 cd "$(pwd -P)"
 
 # Builds CLI binary for current platform only and outside docker to speed up things. Suitable for local development.
@@ -20,7 +27,9 @@ fi
 
 (
     cd $rootdir
-    $bindir/dep ensure -vendor-only -v
+    if [ ! -z ${dep_ensure} ]; then
+      $bindir/dep ensure -vendor-only -v
+    fi
     target="target/cli/${host_platform}/linkerd"
     CGO_ENABLED=0 go build -installsuffix cgo -o $target -ldflags "-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=$($bindir/root-tag)" ./cli
     echo "$target"


### PR DESCRIPTION
bin/fast-build is supposed to be fast. `dep ensure -vendor-only` is too slow
to meet this goal. Add a `LINKERD_SKIP_DEP` flag to allow skipping it. The
default behavior is kept as-is to reduce new users' confusion.

The difference in speed isn't too notable now because the bin/docker-build
step drowns out the win currently. But if/when the bin/docker-build step is
replaced, this matters a lot.

Signed-off-by: Brian Smith <brian@briansmith.org>