### PR TITLE
Allow docker-build-proxy to override the proxy version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 *.iml
 bin
 !bin/dep
+!bin/fetch-proxy
 !bin/web
 **/Dockerfile*
 Dockerfile*

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -5,11 +5,11 @@ RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy
 ARG PROXY_VERSION
-RUN bin/fetch-proxy $PROXY_VERSION
+RUN bin/fetch-proxy $PROXY_VERSION > version.txt
 
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
 COPY --from=fetch /build/target/proxy/linkerd2-proxy ./linkerd2-proxy
-COPY --from=fetch /build/target/proxy/version.txt ./linkerd2-proxy-version.txt
+COPY --from=fetch /build/version.txt ./linkerd2-proxy-version.txt
 ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info
 ENTRYPOINT ["./linkerd2-proxy"]

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -5,11 +5,14 @@ RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy
 ARG PROXY_VERSION
-RUN bin/fetch-proxy $PROXY_VERSION > version.txt
+RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION); \
+    version=$(basename "$proxy" | sed 's/linkerd2-proxy-//'); \
+    mv "$proxy" linkerd2-proxy; \
+    echo "$version" >version.txt)
 
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
-COPY --from=fetch /build/target/proxy/linkerd2-proxy ./linkerd2-proxy
+COPY --from=fetch /build/linkerd2-proxy ./linkerd2-proxy
 COPY --from=fetch /build/version.txt ./linkerd2-proxy-version.txt
 ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info
 ENTRYPOINT ["./linkerd2-proxy"]

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,23 +1,15 @@
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2017-10-30.01
 
-# Fetches the latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt
 FROM gcr.io/linkerd-io/base:2017-10-30.01 as fetch
 RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
-RUN (curl -vsLO https://build.l5d.io/linkerd2-proxy/latest.txt ; \
-    latest=$(awk '{print $2}' latest.txt) ; \
-    version=${latest%%.tar.gz} ; version=${version##linkerd2-proxy-} ; \
-    latest_sha=$(awk '{print $1}' latest.txt) ; \
-    curl -vsLO "https://build.l5d.io/linkerd2-proxy/${latest}" ; \
-    sha=$(sha256sum $latest | awk '{print $1}') ; \
-    if [ "$sha" != "$latest_sha" ]; then echo "sha mismatch" >&2 ; exit 1 ; fi ; \
-    tar -zxvf ${latest} ; \
-    mv "linkerd2-proxy-${version}/bin/linkerd2-proxy" . ; \
-    echo "$version" >version.txt)
+COPY bin/fetch-proxy bin/fetch-proxy
+ARG PROXY_VERSION
+RUN bin/fetch-proxy $PROXY_VERSION
 
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
-COPY --from=fetch /build/linkerd2-proxy ./linkerd2-proxy
-COPY --from=fetch /build/version.txt ./linkerd2-proxy-version.txt
+COPY --from=fetch /build/target/proxy/linkerd2-proxy ./linkerd2-proxy
+COPY --from=fetch /build/target/proxy/version.txt ./linkerd2-proxy-version.txt
 ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info
 ENTRYPOINT ["./linkerd2-proxy"]

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -13,4 +13,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy
+PROXY_VERSION="${PROXY_VERSION:-latest}"
+
+docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # If the first argument to this script is "latest" or unset, it fetches the
-# latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt. If it's set
-# to a 7-character commit sha from the master branch of the linkerd2-proxy repo,
-# it will fetch that binary instead.
+# latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt. If it's set to
+# a commit sha from the master branch of the linkerd2-proxy repo, it will fetch
+# the binary matching that sha instead.
 
 set -eu
 
@@ -23,8 +23,10 @@ fi
 filename="linkerd2-proxy-${version}.tar.gz"
 archive="$builddir/$filename"
 
-mkdir -p "$builddir"
-curl -vsL "$builddir" "https://build.l5d.io/linkerd2-proxy/$filename" > "$archive"
+if [ ! -f "$archive" ]; then
+  mkdir -p "$builddir"
+  curl -vsL "$builddir" "https://build.l5d.io/linkerd2-proxy/$filename" > "$archive"
+fi
 
 if [ -n "$latest_sha" ]; then
   sha=$(sha256sum "$archive" | awk '{print $1}')
@@ -34,6 +36,7 @@ if [ -n "$latest_sha" ]; then
   fi
 fi
 
-tar -C "$builddir" -zxvf "$archive"
+tar -C "$builddir" -zxvf "$archive" >&2
 mv "$builddir/linkerd2-proxy-$version/bin/linkerd2-proxy" "$builddir"
-echo "$version" > "$builddir/version.txt"
+rm -r "$archive" "$builddir/linkerd2-proxy-$version"
+echo "$version"

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -39,4 +39,5 @@ fi
 tar -C "$builddir" -zxvf "$archive" >&2
 mv "$builddir/linkerd2-proxy-$version/bin/linkerd2-proxy" "$builddir"
 rm -r "$archive" "$builddir/linkerd2-proxy-$version"
-echo "$version"
+mv "$builddir/linkerd2-proxy" "$builddir/linkerd2-proxy-$version"
+echo "$builddir/linkerd2-proxy-$version"

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# If the first argument to this script is "latest" or unset, it fetches the
+# latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt. If it's set
+# to a 7-character commit sha from the master branch of the linkerd2-proxy repo,
+# it will fetch that binary instead.
+
+set -eu
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+builddir="$rootdir/target/proxy"
+
+version="${1:-latest}"
+latest_sha=""
+
+if [ "$version" == "latest" ]; then
+  out=$(curl -vsL https://build.l5d.io/linkerd2-proxy/latest.txt)
+  version=$(echo $out | awk '{print $2}' | sed 's/^linkerd2-proxy-//' | sed 's/\.tar\.gz//')
+  latest_sha=$(echo $out | awk '{print $1}')
+fi
+
+filename="linkerd2-proxy-${version}.tar.gz"
+archive="$builddir/$filename"
+
+mkdir -p "$builddir"
+curl -vsL "$builddir" "https://build.l5d.io/linkerd2-proxy/$filename" > "$archive"
+
+if [ -n "$latest_sha" ]; then
+  sha=$(sha256sum "$archive" | awk '{print $1}')
+  if [ "$sha" != "$latest_sha" ]; then
+    echo "sha mismatch" >&2
+    exit 1
+  fi
+fi
+
+tar -C "$builddir" -zxvf "$archive"
+mv "$builddir/linkerd2-proxy-$version/bin/linkerd2-proxy" "$builddir"
+echo "$version" > "$builddir/version.txt"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -11,7 +11,7 @@ ENV ROOT $GOPATH/src/$PROJECT
 ENV PACKAGEDIR $GOPATH/src/$PACKAGE
 
 COPY web/app $PACKAGEDIR
-COPY bin $ROOT/bin
+COPY bin/web $ROOT/bin/web
 WORKDIR $PACKAGEDIR
 
 # node dependencies


### PR DESCRIPTION
This branch adds support for the `PROXY_VERSION` environment variable in the `bin/docker-build-proxy` script. This environment variable can be used to specify a specific proxy revision, instead of using the latest revision. The latest revision is still the default if `PROXY_VERSION` is unset.

This change was necessary to track down the regression introduced in https://github.com/linkerd/linkerd2-proxy/pull/8#issuecomment-404916344. As part of this change I've also moved the code for fetching the proxy binary into a separate script so that it can also be run locally.