### PR TITLE
Remove conduit references from proxy-init codebase

### DIFF
--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -34,10 +34,10 @@ func NewRootCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "proxy-init",
-		Short: "Adds a Kubernetes pod to the Conduit Service Mesh",
-		Long: `proxy-init Adds a Kubernetes pod to the Conduit Service Mesh.
+		Short: "proxy-init adds a Kubernetes pod to the Linkerd service mesh",
+		Long: `proxy-init adds a Kubernetes pod to the Linkerd service mesh.
 
-Find more information at https://conduit.io/.`,
+Find more information at https://linkerd.io/.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, err := buildFirewallConfiguration(options)
 			if err != nil {

--- a/proxy-init/cmd/root.go
+++ b/proxy-init/cmd/root.go
@@ -35,9 +35,7 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "proxy-init",
 		Short: "proxy-init adds a Kubernetes pod to the Linkerd service mesh",
-		Long: `proxy-init adds a Kubernetes pod to the Linkerd service mesh.
-
-Find more information at https://linkerd.io/.`,
+		Long:  "proxy-init adds a Kubernetes pod to the Linkerd service mesh.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			config, err := buildFirewallConfiguration(options)
 			if err != nil {

--- a/proxy-init/integration_test/iptables/Dockerfile-tester
+++ b/proxy-init/integration_test/iptables/Dockerfile-tester
@@ -4,4 +4,4 @@ ADD iptables/ /go
 # Kubernetes Jobs will be retried until they return status 0,
 # so we need to output the status for processing but make sure
 # that the container exits with 0
-ENTRYPOINT cd /go && (go test -v ; echo "status:$?")
+ENTRYPOINT cd /go && (go test -v -integration-tests; echo "status:$?")

--- a/proxy-init/integration_test/run_tests.sh
+++ b/proxy-init/integration_test/run_tests.sh
@@ -82,8 +82,6 @@ spec:
       - name: tester
         image: buoyantio/iptables-tester:v1
         env:
-          - name: CONDUIT_INTEGRATION_TESTS_ENABLED
-            value: "1"
           - name: POD_REDIRECTS_ALL_PORTS_IP
             value: ${POD_REDIRECTS_ALL_PORTS_IP}
           - name: POD_WITH_NO_RULES_IP


### PR DESCRIPTION
This branch removes the remaining conduit references from the proxy-init directory (fixes #1313). As part of this change I'm modifying the proxy-init integration test setup to more closely resemble our main integration test setup (fixes #623).