### PR TITLE
Update top-level docs to reflect repo rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Conduit #
+# Contributing to Linkerd2 #
 
 :balloon: Thanks for your help improving the project!
 
 ## Getting Help ##
 
-If you have a question about Conduit or have encountered problems using it,
+If you have a question about Linkerd2 or have encountered problems using it,
 start by [asking a question in the forums][discourse] or join us in the
-[#conduit Slack channel][slack].
+(yet-to-be-renamed) [#conduit Slack channel][slack].
 
 ## Certificate of Origin ##
 
@@ -35,8 +35,8 @@ Do you have an improvement?
 3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 4. Submit a pull request against this repo's `master` branch.
 5. Your branch may be merged once all configured checks pass, including:
-    - 2 code review approvals, at least 1 of which is from a [runconduit organization member][members].
     - The branch has passed tests in CI.
+    - A review from appropriate maintainers (see [MAINTAINERS.md](MAINTAINERS.md) and [GOVERNANCE.md](GOVERNANCE.md))
 
 ## Committing ##
 
@@ -99,5 +99,4 @@ changes should include before- and after- benchmark results.
 
 [discourse]: https://discourse.linkerd.io/c/conduit
 [issue]: https://github.com/linkerd/linkerd2/issues/new
-[members]: https://github.com/orgs/runconduit/people
 [slack]: http://slack.linkerd.io/

--- a/TEST.md
+++ b/TEST.md
@@ -1,9 +1,9 @@
-# Conduit Test Guide
+# Linkerd2 Test Guide
 
-This document covers how to run all of the tests that are present in the Conduit
-repo. Most of these tests are run in CI, but you can use the instructions here
-to run the tests from source. For more information about working in this repo,
-see the [BUILD.md](BUILD.md) guide.
+This document covers how to run all of the tests that are present in the
+Linkerd2 repo. Most of these tests are run in CI, but you can use the
+instructions here to run the tests from source. For more information about
+working in this repo, see the [BUILD.md](BUILD.md) guide.
 
 Note that all shell commands in this guide are expected to be run from the root
 of this repo, unless otherwise indicated by a `cd` command.
@@ -11,7 +11,6 @@ of this repo, unless otherwise indicated by a `cd` command.
 # Table of contents
 
 - [Unit tests](#unit-tests)
-  - [Rust](#rust)
   - [Go](#go)
   - [Javascript](#javascript)
 - [Integration tests](#integration-tests)
@@ -21,25 +20,6 @@ of this repo, unless otherwise indicated by a `cd` command.
 - [Integration tests: proxy-init](#integration-tests-proxy-init)
 
 # Unit tests
-
-Conduit is primarily written in Rust, Go, and Javascript, and each entails a
-different set of unit tests, described below.
-
-## Rust
-
-Rust dependencies are managed via [cargo](https://github.com/rust-lang/cargo).
-To build the Rust code and run tests, run:
-
-```bash
-cargo test
-```
-
-To analyze the Rust code and report errors, without building object files or
-running tests, run:
-
-```bash
-cargo check
-```
 
 ## Go
 
@@ -74,7 +54,7 @@ NODE_ENV=test yarn karma start --single-run
 
 # Integration tests
 
-The `test/` directory contains a test suite that can be run to validate Conduit
+The `test/` directory contains a test suite that can be run to validate Linkerd
 functionality via a series of end-to-end tests.
 
 ## Prerequisites
@@ -82,30 +62,29 @@ functionality via a series of end-to-end tests.
 The integration test suite operates on your currently configured Kubernetes
 cluster. Prior to running the test suite, verify that:
 
-- The Conduit docker images you're trying to test have been built and are
+- The Linkerd docker images you're trying to test have been built and are
   accessible to the Kubernetes cluster to which you are deploying
 - The `kubectl` CLI has been configured to talk to that Kubernetes cluster
-- The Kubernetes cluster automatically provisions external IPs for external load
-  balanced services (e.g. GKE), or the cluster is running in minikube
-- The `conduit` namespace that you're testing does not already exist
+- The namespace where the tests will install Linkerd does not already exist;
+  by default the namespace `linkerd` is used
 - The repo's Go dependencies have been downloaded by running `bin/dep ensure`
 
 ## Running tests
 
 You can use the `bin/test-run` script to run the full suite of tests.
 
-The `bin/test-run` script requires an absolute path to a Conduit binary to test
-as the first argument. You can optionally pass the namespace where Conduit will
-be installed as the second argument.
+The `bin/test-run` script requires an absolute path to a `linkerd` binary to
+test as the first argument. You can optionally pass the namespace where Linkerd
+will be installed as the second argument.
 
 ```bash
 $ bin/test-run
-usage: test-run /path/to/conduit [namespace]
+usage: test-run /path/to/linkerd [namespace]
 ```
 
 It's also possible to run tests individually, using the `go test` command. All
 of the tests are located in the `test/` directory, either at the root or in
-subdirectories. The root `test/install_test.go` test installs Conduit, so that
+subdirectories. The root `test/install_test.go` test installs Linkerd, so that
 must be run before any of the subdirectory tests (the `bin/test-run` script does
 this for you). The subdirectory tests are intended to be run independently of
 each other, and in the future they may be run in parallel.
@@ -114,18 +93,18 @@ To run an individual test (e.g. the "get" test), first run the root test, and
 then run the subdirectory test. For instance:
 
 ```bash
-$ go test -v ./test -integration-tests -conduit /path/to/conduit
-$ go test -v ./test/get -integration-tests -conduit /path/to/conduit
+$ go test -v ./test -integration-tests -linkerd /path/to/linkerd
+$ go test -v ./test/get -integration-tests -linkerd /path/to/linkerd
 ```
 
 ### Testing against the installed version of the CLI
 
-You can run tests using your installed version of the `conduit` CLI. For
+You can run tests using your installed version of the `linkerd` CLI. For
 example, to run the full suite of tests using your installed CLI in the
 "specialtest" namespace, run:
 
 ```bash
-$ bin/test-run `which conduit` specialtest
+$ bin/test-run `which linkerd` specialtest
 ```
 
 That will create multiple namespaces in your Kubernetes cluster:
@@ -146,43 +125,43 @@ $ bin/test-cleanup specialtest
 
 ### Testing against a locally-built version of the CLI
 
-You can also test a locally-built version of the `conduit` CLI. Note, however,
-that this requires that you build the corresponding Conduit docker images and
+You can also test a locally-built version of the `linkerd` CLI. Note, however,
+that this requires that you build the corresponding Linkerd docker images and
 publish them to a docker registry that's accessible from the Kubernetes cluster
 where you're running the tests. As a result, local testing mostly applies to
 [minikube](https://github.com/kubernetes/minikube), since you can build the
 images directly into minikube's local docker registry, as described below.
 
-To test your current branch on minikube, first build all of the Conduit images
+To test your current branch on minikube, first build all of the Linkerd images
 in your minikube environment, by running:
 
 ```bash
 $ DOCKER_TRACE=1 bin/mkube bin/docker-build
 ```
 
-That command also copies the corresponding `conduit` binaries into the
-`target/cli` directory, and you can use the `bin/conduit` script to load those
+That command also copies the corresponding `linkerd` binaries into the
+`target/cli` directory, and you can use the `bin/linkerd` script to load those
 binaries when running tests. To run tests using your local binary, run:
 
 ```bash
-$ bin/test-run `pwd`/bin/conduit
+$ bin/test-run `pwd`/bin/linkerd
 ```
 
 That will create multiple namespaces in your Kubernetes cluster:
 
 ```bash
-$ kubectl get ns | grep conduit
+$ kubectl get ns | grep linkerd
 NAME                  STATUS    AGE
-conduit               Active    4m
-conduit-egress-test   Active    4m
-conduit-get-test      Active    3m
+linkerd               Active    4m
+linkerd-egress-test   Active    4m
+linkerd-get-test      Active    3m
 ...
 ```
 
 To cleanup the namespaces after the test has finished, run:
 
 ```bash
-$ bin/test-cleanup conduit
+$ bin/test-cleanup linkerd
 ```
 
 ## Writing tests

--- a/bin/fast-build
+++ b/bin/fast-build
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -eu
-cd "$(pwd -P)"
 
 # Builds CLI binary for current platform only and outside docker to speed up things. Suitable for local development.
 
@@ -20,6 +19,7 @@ fi
 
 (
     cd $rootdir
+    cd "$(pwd -P)"
     if [ -z "${LINKERD_SKIP_DEP:-}" ]; then
       $bindir/dep ensure -vendor-only -v
     fi

--- a/bin/go-run
+++ b/bin/go-run
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+cd "$(pwd -P)"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
This branch updates BUILD.md, CONTRIBUTING.md, and TEST.md to reflect the repo rename. README.md was updated in #1328.

As part of this change I've also included a small fix for building the `linkerd` CLI that I noticed when vetting the BUILD.md docs.

Fixes #1317.