### PR TITLE
bin/test-cleanup: Delete test namespaces in paralllel.

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -64,7 +64,6 @@ cluster. Prior to running the test suite, verify that:
 
 - The Linkerd docker images you're trying to test have been built and are
   accessible to the Kubernetes cluster to which you are deploying
-- `kubectl version` reports the client version as v1.11.1 or later.
 - The `kubectl` CLI has been configured to talk to that Kubernetes cluster
 - The namespace where the tests will install Linkerd does not already exist;
   by default the namespace `linkerd` is used

--- a/TEST.md
+++ b/TEST.md
@@ -64,6 +64,7 @@ cluster. Prior to running the test suite, verify that:
 
 - The Linkerd docker images you're trying to test have been built and are
   accessible to the Kubernetes cluster to which you are deploying
+- `kubectl version` reports the client version as v1.11.1 or later.
 - The `kubectl` CLI has been configured to talk to that Kubernetes cluster
 - The namespace where the tests will install Linkerd does not already exist;
   by default the namespace `linkerd` is used

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -9,7 +9,4 @@ fi
 
 echo "cleaning up namespace [${linkerd_namespace}] and associated test namespaces"
 
-kubectl delete ns "$linkerd_namespace"
-for ns in $(kubectl get ns | grep "^$linkerd_namespace-" | cut -f1 -d ' '); do
-  kubectl delete ns "$ns"
-done
+kubectl get ns | grep "^$linkerd_namespace-" | cut -f1 -d ' ' | xargs kubectl delete ns "$linkerd_namespace"

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 linkerd_namespace=$1
 
 if [ -z "$linkerd_namespace" ]; then
@@ -9,4 +11,6 @@ fi
 
 echo "cleaning up namespace [${linkerd_namespace}] and associated test namespaces"
 
-kubectl get ns | grep "^$linkerd_namespace-" | cut -f1 -d ' ' | xargs kubectl delete ns "$linkerd_namespace"
+# `kubectl delete ns` will fail if there are no matching matching namespaces,
+# causing this script to exit with an error status.
+kubectl get ns | cut -f1 -d ' ' | grep -E "^$linkerd_namespace(-|$)" | xargs kubectl delete ns

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -13,4 +13,9 @@ echo "cleaning up namespace [${linkerd_namespace}] and associated test namespace
 
 # `kubectl delete ns` will fail if there are no matching matching namespaces,
 # causing this script to exit with an error status.
-kubectl get ns | cut -f1 -d ' ' | grep -E "^$linkerd_namespace(-|$)" | xargs kubectl delete ns
+if ! namespaces=$(kubectl get ns | cut -f1 -d ' ' | grep -E "^$linkerd_namespace(-|$)"); then
+  echo "no namespaces found for [$linkerd_namespace]" >&2
+  exit 1
+else
+  kubectl delete ns $namespaces
+fi

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -11,11 +11,9 @@ fi
 
 echo "cleaning up namespace [${linkerd_namespace}] and associated test namespaces"
 
-# `kubectl delete ns` will fail if there are no matching matching namespaces,
-# causing this script to exit with an error status.
-if ! namespaces=$(kubectl get ns | cut -f1 -d ' ' | grep -E "^$linkerd_namespace(-|$)"); then
+if ! namespaces=$(kubectl get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
   echo "no namespaces found for [$linkerd_namespace]" >&2
   exit 1
 else
-  kubectl delete ns $namespaces
+  kubectl delete $namespaces
 fi


### PR DESCRIPTION
My kubectl (1.11.1) waits until the `kubectl delete` operation completes,
unlike previous versions which issue the deletion request and then
immediate return. As a result of this change, bin/test-cleanup become
much slower than it used to be in my configuration. Fix this by issuing
all the deletions in parallel with a single `kubectl delete`.

Also, make bin/test-cleanup exit with a failure status code if no
namespaces are deleted. Previously, with kubectl 1.11.1, the script
would exit with a success error code when no namespaces were
deleted.

Signed-off-by: Brian Smith <brian@briansmith.org>