### PR TITLE
Update version test to block on http server initialization

### DIFF
--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -16,13 +16,13 @@ func TestVersionCheck(t *testing.T) {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "{\"version\": \"v0.3.0\"}")
 	})
-	go http.ListenAndServe("localhost:8080", nil)
+	go http.ListenAndServe("localhost:23456", nil)
 
 	// wait for HTTP server to initialize
 	readyCh := make(chan struct{})
 	go func() {
 		for {
-			_, err := http.Head("http://localhost:8080/")
+			_, err := http.Head("http://localhost:23456/")
 			if err == nil {
 				close(readyCh)
 				break
@@ -40,7 +40,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.3.0"
 		mockPublicApi := createMockPublicApi("v0.3.0")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:23456/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedName := version.VersionSubsystemName
@@ -73,7 +73,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.1.1"
 		mockPublicApi := createMockPublicApi("v0.3.0")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:23456/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedStatus := healthcheckPb.CheckStatus_FAIL
@@ -91,7 +91,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "v0.3.0"
 		mockPublicApi := createMockPublicApi("v0.1.1")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:23456/", "", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		expectedStatus := healthcheckPb.CheckStatus_FAIL
@@ -109,7 +109,7 @@ func TestVersionCheck(t *testing.T) {
 		version.Version = "customversion"
 		mockPublicApi := createMockPublicApi("customversion")
 
-		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:8080/", "customversion", mockPublicApi)
+		versionStatusChecker := version.NewVersionStatusChecker("http://localhost:23456/", "customversion", mockPublicApi)
 		checks := versionStatusChecker.SelfCheck()
 
 		for _, check := range checks {


### PR DESCRIPTION
The `pkg/version/version_test.go` test starts an HTTP server on 8080 and sends requests to it. This is pretty unconventional for a unit test, but probably OK provided nothing else is running on localhost 8080. The test doesn't wait for the server to initialize, however, which is causing some of our test runs to fail if the first test in the file executes before the server is fully initialized. In this branch I'm updating the test to wait for the server to initialize, which should fix the flakiness.

Fixes #1157.