### PR TITLE
rfc: Add "proxy fundamentals" to the docs

### DIFF
--- a/doc/proxy-fundamentals.md
+++ b/doc/proxy-fundamentals.md
@@ -27,28 +27,29 @@ telemetry, and routing.
 > than at the transport layer?**
 > A number of Linkerd 2's primary features inherently require a protocol-aware
 > proxy. For example:
-> + **Request/response telemetry**: In order to expose telemetry information
->   about protocol level concepts (such as HTTP requests and responses, HTTP
->   status codes, gRPC status codes, et cetera), the proxy must --- by
->   definition --- be aware of these application layer protocol concepts.
+> + **Request/response telemetry**: In order to expose protocol-specific
+>   telemetry (such as HTTP requests and responses, HTTP status codes, gRPC
+>   status codes, et cetera), the proxy must understand those protocols.
 > + **Latency-aware load balancing**: Similarly, for the proxy to use load
 >   balancing algorithms that incorporate latency data, it must be aware of
 >   protocol-level requests and responses so that latencies can be measured.
+>   Furthermore, the load balancer must be aware of the target origin of a
+>   request, in order to find servers that are capable of serving that request.
 > + **Retries**: In order to determine whether requests can be retried, we
 >   need to be aware of protocol-level failure semantics. For example, some
->   HTTP verbs are safe to retry, while others are not.
+>   HTTP verbs are safe to retry, while others are not. Although Linkerd 2 does
+>   not currently implement retry policies, when this feature is added, it will
+>   require protocol awareness.
 
 ### How it Works
 
-There are essentially two ways for a proxy to be made protocol-aware: either it
-can be configured with some prior knowledge describing what protocols to expect
-from what traffic (the approach used by Linkerd 1), or it can detect the protocol
-of incoming connections as they are accepted. Since Linkerd 2 is designed to
-require as little as possible configuration by the user, it automatically detects
-protocols. The proxy does this by peeking at the data received on an incoming
-connection until it finds a pattern of bytes that uniquely identifies a particular
-protocol. If no protocol was identified after peeking up to a set number of bytes,
-the connection is treated as raw TCP traffic.
+Since Linkerd 2 is designed to require as little configuration by the user as
+possible, it automatically detects protocols. The proxy does this by peeking at
+the data received on an incoming connection until it finds a pattern of bytes
+that uniquely identifies a particular protocol. For example, all HTTP/2
+messages begin with the bytes `PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n` If no protocol
+was identified after peeking up to a set number of bytes, the connection is
+treated as raw TCP traffic.
 
 ### What This Means
 

--- a/doc/proxy-fundamentals.md
+++ b/doc/proxy-fundamentals.md
@@ -35,11 +35,6 @@ telemetry, and routing.
 >   protocol-level requests and responses so that latencies can be measured.
 >   Furthermore, the load balancer must be aware of the target origin of a
 >   request, in order to find servers that are capable of serving that request.
-> + **Retries**: In order to determine whether requests can be retried, we
->   need to be aware of protocol-level failure semantics. For example, some
->   HTTP verbs are safe to retry, while others are not. Although Linkerd 2 does
->   not currently implement retry policies, when this feature is added, it will
->   require protocol awareness.
 
 ### How it Works
 
@@ -62,7 +57,7 @@ it will fail to proxy data for these protocols.
 
 Among the most common server-speaks-first protocols are MySQL and SMTP.
 When using their default ports, Linkerd's protocol detection is disabled by
-default. For other server-speaks-first protocols, or MySQL or SMTP traffi
+default. For other server-speaks-first protocols, or MySQL or SMTP traffic
 on other ports, Linkerd has to be configured to disable its protocol detection.
 See the ["Adding Your Service"] section of the documentation for more information.
 

--- a/doc/proxy-fundamentals.md
+++ b/doc/proxy-fundamentals.md
@@ -8,7 +8,12 @@ docpage = true
 As Linkerd's proxy layer is configured automatically by the control plane,
 detailed knowledge of the proxy's internals is not necessary to use and
 operate it. However, a basic understanding of the high-level level principles
-behind the proxy can be valuable for avoiding some pitfalls.
+behind the proxy can be valuable for avoiding some pitfalls. This document will
+highlight some of the core principles behind the proxy's operation, and discuss
+how they can interact with your application. Additionally, we'll shine some
+light on the design decisions behind why the proxy works the way it does.
+
+____
 
 ## Protocol Detection
 
@@ -17,6 +22,23 @@ at the level of application layer protocols (HTTP/1, HTTP/2, and gRPC), rather
 than forwarding raw TCP traffic at the transport layer. This protocol awareness
 unlocks functionality such as intelligent load balancing, protocol-level
 telemetry, and routing.
+
+> **Why is it important for a proxy to operate at the application layer, rather
+> than at the transport layer?**
+> A number of Linkerd 2's primary features inherently require a protocol-aware
+> proxy. For example:
+> + **Request/response telemetry**: In order to expose telemetry information
+>   about protocol level concepts (such as HTTP requests and responses, HTTP
+>   status codes, gRPC status codes, et cetera), the proxy must --- by
+>   definition --- be aware of these application layer protocol concepts.
+> + **Latency-aware load balancing**: Similarly, for the proxy to use load
+>   balancing algorithms that incorporate latency data, it must be aware of
+>   protocol-level requests and responses so that latencies can be measured.
+> + **Retries**: In order to determine whether requests can be retried, we
+>   need to be aware of protocol-level failure semantics. For example, some
+>   HTTP verbs are safe to retry, while others are not.
+
+### How it Works
 
 There are essentially two ways for a proxy to be made protocol-aware: either it
 can be configured with some prior knowledge describing what protocols to expect
@@ -44,3 +66,5 @@ on other ports, Linkerd has to be configured to disable its protocol detection.
 See the ["Adding Your Service"] section of the documentation for more information.
 
 ["Adding Your Service"]: /adding-your-service#server-speaks-first-protocols
+
+____

--- a/doc/proxy-fundamentals.md
+++ b/doc/proxy-fundamentals.md
@@ -1,0 +1,46 @@
++++
+title = "Proxy fundamentals"
+docpage = true
+[menu.docs]
+  parent = "docs"
++++
+
+As Linkerd's proxy layer is configured automatically by the control plane,
+detailed knowledge of the proxy's internals is not necessary to use and
+operate it. However, a basic understanding of the high-level level principles
+behind the proxy can be valuable for avoiding some pitfalls.
+
+## Protocol Detection
+
+The Linkerd proxy is *protocol-aware* --- when possible, it proxies traffic
+at the level of application layer protocols (HTTP/1, HTTP/2, and gRPC), rather
+than forwarding raw TCP traffic at the transport layer. This protocol awareness
+unlocks functionality such as intelligent load balancing, protocol-level
+telemetry, and routing.
+
+There are essentially two ways for a proxy to be made protocol-aware: either it
+can be configured with some prior knowledge describing what protocols to expect
+from what traffic (the approach used by Linkerd 1), or it can detect the protocol
+of incoming connections as they are accepted. Since Linkerd 2 is designed to
+require as little as possible configuration by the user, it automatically detects
+protocols. The proxy does this by peeking at the data received on an incoming
+connection until it finds a pattern of bytes that uniquely identifies a particular
+protocol. If no protocol was identified after peeking up to a set number of bytes,
+the connection is treated as raw TCP traffic.
+
+### What This Means
+
+The primary impact of the proxy's protocol detection is that it can interfere
+with *server-speaks-first protocols*. These are protocols where clients
+open connections to a server, but wait for the server to send the first bytes
+of data. Because the Linkerd proxy detects protocols by peeking at the first
+bytes of data sent by the client before opening a connection to the server,
+it will fail to proxy data for these protocols.
+
+Among the most common server-speaks-first protocols are MySQL and SMTP.
+When using their default ports, Linkerd's protocol detection is disabled by
+default. For other server-speaks-first protocols, or MySQL or SMTP traffi
+on other ports, Linkerd has to be configured to disable its protocol detection.
+See the ["Adding Your Service"] section of the documentation for more information.
+
+["Adding Your Service"]: /adding-your-service#server-speaks-first-protocols


### PR DESCRIPTION
This branch adds a new "Proxy fundamentals" section to the docs, as I
initially described in issue #1345. The intention behind this doc page
is to discuss the basics of how the proxy works. While I don't think
it's necessary to provide a detailed description of proxy internals, I
_do_ thik we ought to summarise the important details about its
behaviour --- how it interacts with the injected application, how
requests are routed, et cetera, and some of the the potential effects of
these behaviours (e.g. "don't rewrite host headers or your requests may
not go where you expect them to" and so on).

Currently, I've added a brief discussion of how protocol detection works,
and why this can interfere with server-speaks-first protocols. Next, (in
a subsequent branch) I also intend to add a section on how requests are
routed by authority, and what this means (see #1345).

Consider this branch to be a bit of an RFC --- if anyone has opinions on
how these docs ought to be written, where in the docs this information
belongs, or anything else, I'd welcome your input!