### PR TITLE
Update prometheus labels to match k8s resource names

### DIFF
--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -38,7 +38,7 @@ Only pod resources (aka pods, po) are supported.`,
   # get pods from namespace linkerd
   linkerd get pods --namespace linkerd`,
 		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{k8s.Pods},
+		ValidArgs: []string{k8s.Pod},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("please specify a resource type")
@@ -51,8 +51,8 @@ Only pod resources (aka pods, po) are supported.`,
 			friendlyName := args[0]
 			resourceType, err := k8s.CanonicalResourceNameFromFriendlyName(friendlyName)
 
-			if err != nil || resourceType != k8s.Pods {
-				return fmt.Errorf("invalid resource type %s, only %s are allowed as resource types", friendlyName, k8s.Pods)
+			if err != nil || resourceType != k8s.Pod {
+				return fmt.Errorf("invalid resource type %s, valid types: %s", friendlyName, k8s.Pod)
 			}
 			client, err := newPublicAPIClient()
 			if err != nil {

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -204,7 +204,7 @@ func writeStatsToBuffer(resp *pb.StatSummaryResponse, reqResourceType string, w 
 			}
 
 			meshedCount := fmt.Sprintf("%d/%d", r.MeshedPodCount, r.RunningPodCount)
-			if resourceKey == k8s.Authorities {
+			if resourceKey == k8s.Authority {
 				meshedCount = "-"
 			}
 			statTables[resourceKey][key] = &row{

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 )
 
 func TestStat(t *testing.T) {
@@ -16,7 +17,7 @@ func TestStat(t *testing.T) {
 			FailedPods:  0,
 		}
 
-		response := public.GenStatSummaryResponse("emoji", "namespaces", "emojivoto", counts)
+		response := public.GenStatSummaryResponse("emoji", k8s.Namespace, "emojivoto", counts)
 
 		mockClient.StatSummaryResponseToReturn = &response
 

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRequestTapByResourceFromAPI(t *testing.T) {
 	t.Run("Should render busy response if everything went well", func(t *testing.T) {
-		resourceType := k8s.Pods
+		resourceType := k8s.Pod
 		targetName := "pod-666"
 		options := &tapOptions{
 			scheme:    "https",
@@ -96,7 +96,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 	})
 
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {
-		resourceType := k8s.Pods
+		resourceType := k8s.Pod
 		targetName := "pod-666"
 		options := &tapOptions{
 			scheme:    "https",
@@ -137,7 +137,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 
 	t.Run("Should return error if stream returned error", func(t *testing.T) {
 		t.SkipNow()
-		resourceType := k8s.Pods
+		resourceType := k8s.Pod
 		targetName := "pod-666"
 		options := &tapOptions{
 			scheme:    "https",

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -19,7 +19,7 @@ spec:
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd
-        linkerd.io/proxy-stateful-set: web
+        linkerd.io/proxy-statefulset: web
     spec:
       containers:
       - env:

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -258,7 +258,7 @@ func (s *grpcServer) nonK8sResourceQuery(ctx context.Context, req *pb.StatSummar
 }
 
 func isNonK8sResourceQuery(resourceType string) bool {
-	return resourceType == k8s.Authorities
+	return resourceType == k8s.Authority
 }
 
 // get the list of objects for which we want to return results
@@ -289,7 +289,7 @@ func getResultKeys(
 func promGroupByLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{namespaceLabel}
 
-	if resource.Type != k8s.Namespaces {
+	if resource.Type != k8s.Namespace {
 		names = append(names, promResourceType(resource))
 	}
 	return names
@@ -302,7 +302,7 @@ func promDstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
 
 	if isNonK8sResourceQuery(resource.GetType()) {
 		names = append(names, promResourceType(resource))
-	} else if resource.Type != k8s.Namespaces {
+	} else if resource.Type != k8s.Namespace {
 		names = append(names, "dst_"+promResourceType(resource))
 	}
 	return names
@@ -339,7 +339,7 @@ func promDstQueryLabels(resource *pb.Resource) model.LabelSet {
 
 // determine if we should add "namespace=<namespace>" to a named query
 func shouldAddNamespaceLabel(resource *pb.Resource) bool {
-	return resource.Type != k8s.Namespaces && resource.Namespace != ""
+	return resource.Type != k8s.Namespace && resource.Namespace != ""
 }
 
 // query for inbound or outbound requests
@@ -350,7 +350,7 @@ func promDirectionLabels(direction string) model.LabelSet {
 }
 
 func promResourceType(resource *pb.Resource) model.LabelName {
-	return model.LabelName(k8s.ResourceTypesToProxyLabels[resource.Type])
+	return model.LabelName(resource.Type)
 }
 
 func buildRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labelNames model.LabelNames) {
@@ -566,9 +566,9 @@ func isInMesh(pod *apiv1.Pod) bool {
 func isInvalidServiceRequest(req *pb.StatSummaryRequest) bool {
 	fromResource := req.GetFromResource()
 	if fromResource != nil {
-		return fromResource.Type == k8s.Services
+		return fromResource.Type == k8s.Service
 	} else {
-		return req.Selector.Resource.Type == k8s.Services
+		return req.Selector.Resource.Type == k8s.Service
 	}
 }
 

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -213,12 +213,12 @@ status:
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Deployments,
+							Type:      pkgK8s.Deployment,
 						},
 					},
 					TimeWindow: "1m",
 				},
-				expectedResponse: GenStatSummaryResponse("emoji", "deployments", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emoji", pkgK8s.Deployment, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 2,
 					FailedPods:  0,
@@ -253,7 +253,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "emojivoto-1",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -264,7 +264,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (le, namespace, pod))`,
 					`sum(increase(response_total{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", pkgK8s.Pod, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -299,7 +299,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "emojivoto-1",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -307,7 +307,7 @@ status:
 						FromResource: &pb.Resource{
 							Name:      "emojivoto-2",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 				},
@@ -350,7 +350,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "emojivoto-1",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -358,7 +358,7 @@ status:
 						ToResource: &pb.Resource{
 							Name:      "emojivoto-2",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 				},
@@ -368,7 +368,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="outbound", dst_namespace="emojivoto", dst_pod="emojivoto-2", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (le, namespace, pod))`,
 					`sum(increase(response_total{direction="outbound", dst_namespace="emojivoto", dst_pod="emojivoto-2", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", pkgK8s.Pod, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -405,7 +405,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "emojivoto-1",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -413,7 +413,7 @@ status:
 						ToResource: &pb.Resource{
 							Name:      "emojivoto-2",
 							Namespace: "totallydifferent",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 				},
@@ -423,7 +423,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="outbound", dst_namespace="totallydifferent", dst_pod="emojivoto-2", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (le, namespace, pod))`,
 					`sum(increase(response_total{direction="outbound", dst_namespace="totallydifferent", dst_pod="emojivoto-2", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", pkgK8s.Pod, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -472,7 +472,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -480,7 +480,7 @@ status:
 						FromResource: &pb.Resource{
 							Name:      "emojivoto-2",
 							Namespace: "",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 				},
@@ -490,7 +490,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="outbound", pod="emojivoto-2"}[1m])) by (le, dst_namespace, dst_pod))`,
 					`sum(increase(response_total{direction="outbound", pod="emojivoto-2"}[1m])) by (dst_namespace, dst_pod, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", pkgK8s.Pod, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -539,7 +539,7 @@ status:
 						Resource: &pb.Resource{
 							Name:      "emojivoto-1",
 							Namespace: "emojivoto",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 					TimeWindow: "1m",
@@ -547,7 +547,7 @@ status:
 						FromResource: &pb.Resource{
 							Name:      "emojivoto-2",
 							Namespace: "totallydifferent",
-							Type:      pkgK8s.Pods,
+							Type:      pkgK8s.Pod,
 						},
 					},
 				},
@@ -557,7 +557,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="outbound", namespace="totallydifferent", pod="emojivoto-2"}[1m])) by (le, dst_namespace, dst_pod))`,
 					`sum(increase(response_total{direction="outbound", namespace="totallydifferent", pod="emojivoto-2"}[1m])) by (dst_namespace, dst_pod, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("emojivoto-1", "pods", "emojivoto", &PodCounts{
+				expectedResponse: GenStatSummaryResponse("emojivoto-1", pkgK8s.Pod, "emojivoto", &PodCounts{
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -651,7 +651,7 @@ status:
 												&pb.StatTable_PodGroup_Row{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
-														Type:      "authorities",
+														Type:      pkgK8s.Authority,
 													},
 													TimeWindow: "1m",
 													Stats: &pb.BasicStats{
@@ -674,7 +674,7 @@ status:
 												&pb.StatTable_PodGroup_Row{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
-														Type:      "deployments",
+														Type:      pkgK8s.Deployment,
 														Name:      "emoji-deploy",
 													},
 													Stats: &pb.BasicStats{
@@ -700,7 +700,7 @@ status:
 												&pb.StatTable_PodGroup_Row{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
-														Type:      "pods",
+														Type:      pkgK8s.Pod,
 														Name:      "emojivoto-pod-2",
 													},
 													TimeWindow:      "1m",
@@ -718,7 +718,7 @@ status:
 												&pb.StatTable_PodGroup_Row{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
-														Type:      "services",
+														Type:      pkgK8s.Service,
 														Name:      "emoji-svc",
 													},
 													TimeWindow:      "1m",
@@ -757,21 +757,21 @@ status:
 				},
 			},
 			statSumExpected{
-				err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: deployment"),
+				err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: deployments"),
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "deployment",
+							Type: "deployments",
 						},
 					},
 				},
 			},
 			statSumExpected{
-				err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: pod"),
+				err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: po"),
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "pod",
+							Type: "po",
 						},
 					},
 				},
@@ -819,7 +819,7 @@ status:
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "services",
+							Type: pkgK8s.Service,
 						},
 					},
 				},
@@ -828,12 +828,12 @@ status:
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "services",
+							Type: pkgK8s.Service,
 						},
 					},
 					Outbound: &pb.StatSummaryRequest_ToResource{
 						ToResource: &pb.Resource{
-							Type: "pods",
+							Type: pkgK8s.Pod,
 						},
 					},
 				},
@@ -842,12 +842,12 @@ status:
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "pods",
+							Type: pkgK8s.Pod,
 						},
 					},
 					Outbound: &pb.StatSummaryRequest_FromResource{
 						FromResource: &pb.Resource{
-							Type: "services",
+							Type: pkgK8s.Service,
 						},
 					},
 				},
@@ -867,12 +867,12 @@ status:
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "pods",
+							Type: pkgK8s.Pod,
 						},
 					},
 					Outbound: &pb.StatSummaryRequest_ToResource{
 						ToResource: &pb.Resource{
-							Type: "services",
+							Type: pkgK8s.Service,
 						},
 					},
 				},
@@ -881,12 +881,12 @@ status:
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
-							Type: "services",
+							Type: pkgK8s.Service,
 						},
 					},
 					Outbound: &pb.StatSummaryRequest_FromResource{
 						FromResource: &pb.Resource{
-							Type: "pods",
+							Type: pkgK8s.Pod,
 						},
 					},
 				},
@@ -937,7 +937,7 @@ status:
 						Selector: &pb.ResourceSelection{
 							Resource: &pb.Resource{
 								Namespace: "emojivoto",
-								Type:      pkgK8s.Pods,
+								Type:      pkgK8s.Pod,
 							},
 						},
 					},
@@ -1020,12 +1020,12 @@ status:
 						Selector: &pb.ResourceSelection{
 							Resource: &pb.Resource{
 								Namespace: "emojivoto",
-								Type:      pkgK8s.Deployments,
+								Type:      pkgK8s.Deployment,
 							},
 						},
 						TimeWindow: "1m",
 					},
-					expectedResponse: GenStatSummaryResponse("emoji", "deployments", "emojivoto", &PodCounts{
+					expectedResponse: GenStatSummaryResponse("emoji", pkgK8s.Deployment, "emojivoto", &PodCounts{
 						MeshedPods:  1,
 						RunningPods: 2,
 						FailedPods:  1,
@@ -1062,7 +1062,7 @@ status:
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
 							Namespace: "linkerd",
-							Type:      pkgK8s.Authorities,
+							Type:      pkgK8s.Authority,
 						},
 					},
 					TimeWindow: "1m",
@@ -1073,7 +1073,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="inbound", namespace="linkerd"}[1m])) by (le, namespace, authority))`,
 					`sum(increase(response_total{direction="inbound", namespace="linkerd"}[1m])) by (namespace, authority, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", "authorities", "linkerd", nil),
+				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", pkgK8s.Authority, "linkerd", nil),
 			},
 		}
 
@@ -1105,7 +1105,7 @@ status:
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
 							Namespace: "linkerd",
-							Type:      pkgK8s.Authorities,
+							Type:      pkgK8s.Authority,
 						},
 					},
 					TimeWindow: "1m",
@@ -1113,7 +1113,7 @@ status:
 						FromResource: &pb.Resource{
 							Name:      "emojivoto",
 							Namespace: "",
-							Type:      pkgK8s.Deployments,
+							Type:      pkgK8s.Deployment,
 						},
 					},
 				},
@@ -1123,7 +1123,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{deployment="emojivoto", direction="outbound"}[1m])) by (le, dst_namespace, authority))`,
 					`sum(increase(response_total{deployment="emojivoto", direction="outbound"}[1m])) by (dst_namespace, authority, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", "authorities", "", nil),
+				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", pkgK8s.Authority, "", nil),
 			},
 		}
 
@@ -1155,7 +1155,7 @@ status:
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
 							Namespace: "linkerd",
-							Type:      pkgK8s.Authorities,
+							Type:      pkgK8s.Authority,
 							Name:      "10.1.1.239:9995",
 						},
 					},
@@ -1167,7 +1167,7 @@ status:
 					`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{authority="10.1.1.239:9995", direction="inbound", namespace="linkerd"}[1m])) by (le, namespace, authority))`,
 					`sum(increase(response_total{authority="10.1.1.239:9995", direction="inbound", namespace="linkerd"}[1m])) by (namespace, authority, classification, tls)`,
 				},
-				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", "authorities", "linkerd", nil),
+				expectedResponse: GenStatSummaryResponse("10.1.1.239:9995", pkgK8s.Authority, "linkerd", nil),
 			},
 		}
 

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -26,22 +26,22 @@ var (
 	// target resource on an outbound 'to' query
 	// destination resource on an outbound 'from' query
 	ValidTargets = []string{
-		k8s.Deployments,
-		k8s.Namespaces,
-		k8s.Pods,
-		k8s.ReplicationControllers,
-		k8s.Authorities,
+		k8s.Deployment,
+		k8s.Namespace,
+		k8s.Pod,
+		k8s.ReplicationController,
+		k8s.Authority,
 	}
 
 	// ValidDestinations specifies resource types allowed as a destination:
 	// destination resource on an outbound 'to' query
 	// target resource on an outbound 'from' query
 	ValidDestinations = []string{
-		k8s.Deployments,
-		k8s.Namespaces,
-		k8s.Pods,
-		k8s.ReplicationControllers,
-		k8s.Services,
+		k8s.Deployment,
+		k8s.Namespace,
+		k8s.Pod,
+		k8s.ReplicationController,
+		k8s.Service,
 	}
 )
 
@@ -183,7 +183,7 @@ func validateFromResourceType(resourceType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if name == k8s.Authorities {
+	if name == k8s.Authority {
 		return "", errors.New("cannot query traffic --from an authority")
 	}
 	return name, nil
@@ -220,7 +220,7 @@ func buildResource(namespace string, resType string, name string) (pb.Resource, 
 	if err != nil {
 		return pb.Resource{}, err
 	}
-	if canonicalType == k8s.Namespaces {
+	if canonicalType == k8s.Namespace {
 		// ignore --namespace flags if type is namespace
 		namespace = ""
 	}

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -40,12 +40,12 @@ func TestGRPCError(t *testing.T) {
 func TestBuildStatSummaryRequest(t *testing.T) {
 	t.Run("Maps Kubernetes friendly names to canonical names", func(t *testing.T) {
 		expectations := map[string]string{
-			"deployments": k8s.Deployments,
-			"deployment":  k8s.Deployments,
-			"deploy":      k8s.Deployments,
-			"pods":        k8s.Pods,
-			"pod":         k8s.Pods,
-			"po":          k8s.Pods,
+			"deployments": k8s.Deployment,
+			"deployment":  k8s.Deployment,
+			"deploy":      k8s.Deployment,
+			"pods":        k8s.Pod,
+			"pod":         k8s.Pod,
+			"po":          k8s.Pod,
 		}
 
 		for friendly, canonical := range expectations {
@@ -74,7 +74,7 @@ func TestBuildStatSummaryRequest(t *testing.T) {
 			statSummaryRequest, err := BuildStatSummaryRequest(
 				StatSummaryRequestParams{
 					TimeWindow:   timeWindow,
-					ResourceType: k8s.Deployments,
+					ResourceType: k8s.Deployment,
 				},
 			)
 			if err != nil {
@@ -143,7 +143,7 @@ func TestBuildResource(t *testing.T) {
 				args:      []string{"deployments"},
 				resource: pb.Resource{
 					Namespace: "test-ns",
-					Type:      k8s.Deployments,
+					Type:      k8s.Deployment,
 					Name:      "",
 				},
 			},
@@ -152,7 +152,7 @@ func TestBuildResource(t *testing.T) {
 				args:      []string{"deploy/foo"},
 				resource: pb.Resource{
 					Namespace: "",
-					Type:      k8s.Deployments,
+					Type:      k8s.Deployment,
 					Name:      "foo",
 				},
 			},
@@ -161,7 +161,7 @@ func TestBuildResource(t *testing.T) {
 				args:      []string{"po", "foo"},
 				resource: pb.Resource{
 					Namespace: "foo-ns",
-					Type:      k8s.Pods,
+					Type:      k8s.Pod,
 					Name:      "foo",
 				},
 			},
@@ -170,7 +170,7 @@ func TestBuildResource(t *testing.T) {
 				args:      []string{"ns", "foo-ns2"},
 				resource: pb.Resource{
 					Namespace: "",
-					Type:      k8s.Namespaces,
+					Type:      k8s.Namespace,
 					Name:      "foo-ns2",
 				},
 			},
@@ -179,7 +179,7 @@ func TestBuildResource(t *testing.T) {
 				args:      []string{"ns/foo-ns2"},
 				resource: pb.Resource{
 					Namespace: "",
-					Type:      k8s.Namespaces,
+					Type:      k8s.Namespace,
 					Name:      "foo-ns2",
 				},
 			},

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -174,5 +174,5 @@ func (c *CertificateController) handlePodUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *CertificateController) isInjectedPod(pod *v1.Pod) bool {
-	return pkgK8s.GetControllerNs(pod.ObjectMeta) == c.namespace
+	return pkgK8s.GetControllerNs(pod) == c.namespace
 }

--- a/controller/destination/listener_test.go
+++ b/controller/destination/listener_test.go
@@ -148,18 +148,19 @@ func TestEndpointListener(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedNamespace,
-				Labels: map[string]string{
-					pkgK8s.ProxyReplicationControllerLabel: expectedReplicationControllerName,
-				},
 			},
 			Status: v1.PodStatus{
 				Phase: v1.PodRunning,
 			},
 		}
 
+		ownerKindAndName := func(pod *v1.Pod) (string, string) {
+			return "replicationcontroller", expectedReplicationControllerName
+		}
+
 		mockGetServer := &mockDestination_GetServer{updatesReceived: []*pb.Update{}}
 		listener := &endpointListener{
-			ownerKindAndName: defaultOwnerKindAndName,
+			ownerKindAndName: ownerKindAndName,
 			labels: map[string]string{
 				"service":   expectedServiceName,
 				"namespace": expectedNamespace,
@@ -181,7 +182,7 @@ func TestEndpointListener(t *testing.T) {
 		actualAddedAddress1MetricLabels := mockGetServer.updatesReceived[0].GetAdd().Addrs[0].MetricLabels
 		expectedAddedAddress1MetricLabels := map[string]string{
 			"pod": expectedPodName,
-			"replication_controller": expectedReplicationControllerName,
+			"replicationcontroller": expectedReplicationControllerName,
 		}
 		if !reflect.DeepEqual(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -174,15 +174,15 @@ func (api *API) CM() coreinformers.ConfigMapInformer {
 // If name is an empty string, match all objects of the given type.
 func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, error) {
 	switch restype {
-	case k8s.Namespaces:
+	case k8s.Namespace:
 		return api.getNamespaces(name)
-	case k8s.Deployments:
+	case k8s.Deployment:
 		return api.getDeployments(namespace, name)
-	case k8s.Pods:
+	case k8s.Pod:
 		return api.getPods(namespace, name)
-	case k8s.ReplicationControllers:
+	case k8s.ReplicationController:
 		return api.getRCs(namespace, name)
-	case k8s.Services:
+	case k8s.Service:
 		return api.getServices(namespace, name)
 	default:
 		// TODO: ReplicaSet

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -68,7 +68,7 @@ func TestGetObjects(t *testing.T) {
 			getObjectsExpected{
 				err:       nil,
 				namespace: "my-ns",
-				resType:   k8s.Pods,
+				resType:   k8s.Pod,
 				name:      "my-pod",
 				k8sResResults: []string{`
 apiVersion: v1
@@ -87,7 +87,7 @@ status:
 			getObjectsExpected{
 				err:           errors.New("pod \"my-pod\" not found"),
 				namespace:     "not-my-ns",
-				resType:       k8s.Pods,
+				resType:       k8s.Pod,
 				name:          "my-pod",
 				k8sResResults: []string{},
 				k8sResMisc: []string{`
@@ -101,7 +101,7 @@ metadata:
 			getObjectsExpected{
 				err:       nil,
 				namespace: "",
-				resType:   k8s.ReplicationControllers,
+				resType:   k8s.ReplicationController,
 				name:      "",
 				k8sResResults: []string{`
 apiVersion: v1
@@ -115,7 +115,7 @@ metadata:
 			getObjectsExpected{
 				err:       nil,
 				namespace: "my-ns",
-				resType:   k8s.Deployments,
+				resType:   k8s.Deployment,
 				name:      "",
 				k8sResResults: []string{`
 apiVersion: apps/v1beta2
@@ -161,7 +161,7 @@ metadata:
 				getObjectsExpected{
 					err:       nil,
 					namespace: "my-ns",
-					resType:   k8s.Pods,
+					resType:   k8s.Pod,
 					name:      "my-pod",
 					k8sResResults: []string{`
 apiVersion: v1
@@ -179,7 +179,7 @@ status:
 				getObjectsExpected{
 					err:       nil,
 					namespace: "my-ns",
-					resType:   k8s.Pods,
+					resType:   k8s.Pod,
 					name:      "my-pod",
 					k8sResResults: []string{`
 apiVersion: v1
@@ -218,7 +218,7 @@ status:
 				getObjectsExpected{
 					err:       nil,
 					namespace: "my-ns",
-					resType:   k8s.Pods,
+					resType:   k8s.Pod,
 					name:      "my-pod",
 					k8sResResults: []string{`
 apiVersion: v1
@@ -236,7 +236,7 @@ status:
 				getObjectsExpected{
 					err:       nil,
 					namespace: "my-ns",
-					resType:   k8s.Pods,
+					resType:   k8s.Pod,
 					name:      "my-pod",
 					k8sResResults: []string{`
 apiVersion: v1

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -223,9 +223,9 @@ func makeByResourceMatch(match *public.TapByResourceRequest_Match) (*proxy.Obser
 func destinationLabels(resource *public.Resource) map[string]string {
 	dstLabels := map[string]string{}
 	if resource.Name != "" {
-		dstLabels[pkgK8s.ResourceTypesToProxyLabels[resource.Type]] = resource.Name
+		dstLabels[resource.Type] = resource.Name
 	}
-	if resource.Type != pkgK8s.Namespaces && resource.Namespace != "" {
+	if resource.Type != pkgK8s.Namespace && resource.Namespace != "" {
 		dstLabels["namespace"] = resource.Namespace
 	}
 	return dstLabels

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -7,6 +7,7 @@ import (
 
 	public "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 )
 
 type tapExpected struct {
@@ -44,7 +45,7 @@ status:
 					Target: &public.ResourceSelection{
 						Resource: &public.Resource{
 							Namespace: "emojivoto",
-							Type:      "pods",
+							Type:      pkgK8s.Pod,
 							Name:      "emojivoto-meshed",
 						},
 					},
@@ -88,14 +89,14 @@ status:
 					Target: &public.ResourceSelection{
 						Resource: &public.Resource{
 							Namespace: "emojivoto",
-							Type:      "pods",
+							Type:      pkgK8s.Pod,
 							Name:      "emojivoto-meshed-not-found",
 						},
 					},
 				},
 			},
 			tapExpected{
-				msg: "rpc error: code = NotFound desc = no pods found for ResourceSelection: {Resource:namespace:\"emojivoto\" type:\"pods\" name:\"emojivoto-meshed\"  LabelSelector:}",
+				msg: "rpc error: code = NotFound desc = no pods found for ResourceSelection: {Resource:namespace:\"emojivoto\" type:\"pod\" name:\"emojivoto-meshed\"  LabelSelector:}",
 				k8sRes: []string{`
 apiVersion: v1
 kind: Pod
@@ -114,7 +115,7 @@ status:
 					Target: &public.ResourceSelection{
 						Resource: &public.Resource{
 							Namespace: "emojivoto",
-							Type:      "pods",
+							Type:      pkgK8s.Pod,
 							Name:      "emojivoto-meshed",
 						},
 					},
@@ -143,7 +144,7 @@ status:
 					Target: &public.ResourceSelection{
 						Resource: &public.Resource{
 							Namespace: "emojivoto",
-							Type:      "pods",
+							Type:      pkgK8s.Pod,
 							Name:      "emojivoto-meshed",
 						},
 					},

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -64,11 +64,11 @@ The following labels are only applicable if `direction=outbound`.
 
 * `dst_deployment`: The deployment to which this request is being sent.
 * `dst_k8s_job`: The job to which this request is being sent.
-* `dst_replica_set`: The replica set to which this request is being sent.
-* `dst_daemon_set`: The daemon set to which this request is being sent.
-* `dst_stateful_set`: The stateful set to which this request is being sent.
-* `dst_replication_controller`: The replication controller to which this request
-                                is being sent.
+* `dst_replicaset`: The replica set to which this request is being sent.
+* `dst_daemonset`: The daemon set to which this request is being sent.
+* `dst_statefulset`: The stateful set to which this request is being sent.
+* `dst_replicationcontroller`: The replication controller to which this request
+                               is being sent.
 * `dst_namespace`: The namespace to which this request is being sent.
 * `dst_service`: The service to which this request is being sent.
 * `dst_pod_template_hash`: The [pod-template-hash][pod-template-hash] of the pod
@@ -103,13 +103,13 @@ Kubernetes labels prefixed with `linkerd.io/` are added to your application at
 `linkerd inject` time. More specifically, Kubernetes labels prefixed with
 `linkerd.io/proxy-*` will correspond to these Prometheus labels:
 
-* `daemon_set`: The daemon set that the pod belongs to (if applicable).
+* `daemonset`: The daemon set that the pod belongs to (if applicable).
 * `deployment`: The deployment that the pod belongs to (if applicable).
 * `k8s_job`: The job that the pod belongs to (if applicable).
-* `replica_set`: The replica set that the pod belongs to (if applicable).
-* `replication_controller`: The replication controller that the pod belongs to
-                            (if applicable).
-* `stateful_set`: The stateful set that the pod belongs to (if applicable).
+* `replicaset`: The replica set that the pod belongs to (if applicable).
+* `replicationcontroller`: The replication controller that the pod belongs to
+                           (if applicable).
+* `statefulset`: The stateful set that the pod belongs to (if applicable).
 
 ### Example
 

--- a/grafana/dashboards/replicationcontroller.json
+++ b/grafana/dashboards/replicationcontroller.json
@@ -20,7 +20,7 @@
   "links": [],
   "panels": [
     {
-      "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">rc/$replication_controller</span>\n</div>",
+      "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">rc/$replicationcontroller</span>\n</div>",
       "gridPos": {
         "h": 2.4,
         "w": 24,
@@ -96,7 +96,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s]))",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -180,7 +180,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s]))",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -264,7 +264,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(count(request_total{dst_namespace=\"$namespace\", replication_controller!=\"\", dst_replication_controller!=\"\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}) by (namespace, replication_controller))",
+          "expr": "count(count(request_total{dst_namespace=\"$namespace\", replicationcontroller!=\"\", dst_replicationcontroller!=\"\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}) by (namespace, replicationcontroller))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -346,7 +346,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(count(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}) by (namespace, dst_replication_controller))",
+          "expr": "count(count(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}) by (namespace, dst_replicationcontroller))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -419,10 +419,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (replication_controller)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) by (replicationcontroller) / sum(irate(response_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) by (replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{replication_controller}}",
+          "legendFormat": "rc/{{replicationcontroller}}",
           "refId": "A"
         }
       ],
@@ -504,17 +504,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\", tls=\"true\"}[30s])) by (replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\", tls=\"true\"}[30s])) by (replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "🔒rc/{{replication_controller}}",
+          "legendFormat": "🔒rc/{{replicationcontroller}}",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\", tls!=\"true\"}[30s])) by (replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\", tls!=\"true\"}[30s])) by (replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{replication_controller}}",
+          "legendFormat": "rc/{{replicationcontroller}}",
           "refId": "B"
         }
       ],
@@ -596,25 +596,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) by (le, replicationcontroller))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 rc/{{replication_controller}}",
+          "legendFormat": "p50 rc/{{replicationcontroller}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) by (le, replicationcontroller))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "p95 rc/{{replication_controller}}",
+          "legendFormat": "p95 rc/{{replicationcontroller}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"inbound\"}[30s])) by (le, replication_controller))",
+          "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"inbound\"}[30s])) by (le, replicationcontroller))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p99 rc/{{replication_controller}}",
+          "legendFormat": "p99 rc/{{replicationcontroller}}",
           "refId": "C"
         }
       ],
@@ -736,7 +736,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (replication_controller, pod) / sum(irate(response_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (replication_controller, pod)",
+              "expr": "sum(irate(response_total{classification=\"success\", replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (replicationcontroller, pod) / sum(irate(response_total{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (replicationcontroller, pod)",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 1,
@@ -822,14 +822,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\", tls=\"true\"}[30s])) by (replication_controller, pod)",
+              "expr": "sum(irate(request_total{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\", tls=\"true\"}[30s])) by (replicationcontroller, pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "🔒po/{{pod}}",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(request_total{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (replication_controller, pod)",
+              "expr": "sum(irate(request_total{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (replicationcontroller, pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "po/{{pod}}",
@@ -914,24 +914,24 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (le, replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P50 rc/{{replication_controller}}",
+              "legendFormat": "P50 rc/{{replicationcontroller}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (le, replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P95 rc/{{replication_controller}}",
+              "legendFormat": "P95 rc/{{replicationcontroller}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{replication_controller!=\"\", replication_controller=\"$inbound\", dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, replication_controller))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{replicationcontroller!=\"\", replicationcontroller=\"$inbound\", dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (le, replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P99 rc/{{replication_controller}}",
+              "legendFormat": "P99 rc/{{replicationcontroller}}",
               "refId": "C"
             }
           ],
@@ -1046,10 +1046,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (dst_replication_controller)",
+          "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (dst_replicationcontroller) / sum(irate(response_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (dst_replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{dst_replication_controller}}",
+          "legendFormat": "rc/{{dst_replicationcontroller}}",
           "refId": "A"
         }
       ],
@@ -1131,17 +1131,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "🔒rc/{{dst_replication_controller}}",
+          "legendFormat": "🔒rc/{{dst_replicationcontroller}}",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replication_controller)",
+          "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replicationcontroller)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "rc/{{dst_replication_controller}}",
+          "legendFormat": "rc/{{dst_replicationcontroller}}",
           "refId": "B"
         }
       ],
@@ -1222,10 +1222,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
+          "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", direction=\"outbound\"}[30s])) by (le, dst_replicationcontroller))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "P95 rc/{{dst_replication_controller}}",
+          "legendFormat": "P95 rc/{{dst_replicationcontroller}}",
           "refId": "A"
         }
       ],
@@ -1346,10 +1346,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replication_controller) / sum(irate(response_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replication_controller)",
+              "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replicationcontroller) / sum(irate(response_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replicationcontroller)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "rc/{{dst_replication_controller}}",
+              "legendFormat": "rc/{{dst_replicationcontroller}}",
               "refId": "A"
             }
           ],
@@ -1431,17 +1431,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replication_controller)",
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replicationcontroller)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "🔒rc/{{dst_replication_controller}}",
+              "legendFormat": "🔒rc/{{dst_replicationcontroller}}",
               "refId": "A"
             },
             {
-              "expr": "sum(irate(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replication_controller)",
+              "expr": "sum(irate(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replicationcontroller)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "rc/{{dst_replication_controller}}",
+              "legendFormat": "rc/{{dst_replicationcontroller}}",
               "refId": "B"
             }
           ],
@@ -1522,24 +1522,24 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P50 rc/{{dst_replication_controller}}",
+              "legendFormat": "P50 rc/{{dst_replicationcontroller}}",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P95 rc/{{dst_replication_controller}}",
+              "legendFormat": "P95 rc/{{dst_replicationcontroller}}",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replication_controller=\"$replication_controller\", dst_replication_controller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replication_controller))",
+              "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\", dst_replicationcontroller=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicationcontroller))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "P99 rc/{{dst_replication_controller}}",
+              "legendFormat": "P99 rc/{{dst_replicationcontroller}}",
               "refId": "C"
             }
           ],
@@ -1607,7 +1607,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(request_total{replication_controller!=\"\"}, namespace)",
+        "query": "label_values(request_total{replicationcontroller!=\"\"}, namespace)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1623,11 +1623,11 @@
         "datasource": "prometheus",
         "hide": 0,
         "includeAll": false,
-        "label": "Replication Controller",
+        "label": "ReplicationController",
         "multi": false,
-        "name": "replication_controller",
+        "name": "replicationcontroller",
         "options": [],
-        "query": "label_values(request_total{namespace=\"$namespace\"}, replication_controller)",
+        "query": "label_values(request_total{namespace=\"$namespace\"}, replicationcontroller)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1647,7 +1647,7 @@
         "multi": false,
         "name": "inbound",
         "options": [],
-        "query": "label_values(request_total{dst_namespace=\"$namespace\", dst_replication_controller=\"$replication_controller\"}, replication_controller)",
+        "query": "label_values(request_total{dst_namespace=\"$namespace\", dst_replicationcontroller=\"$replicationcontroller\"}, replicationcontroller)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1667,7 +1667,7 @@
         "multi": false,
         "name": "outbound",
         "options": [],
-        "query": "label_values(request_total{namespace=\"$namespace\", replication_controller=\"$replication_controller\"}, dst_replication_controller)",
+        "query": "label_values(request_total{namespace=\"$namespace\", replicationcontroller=\"$replicationcontroller\"}, dst_replicationcontroller)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1709,7 +1709,7 @@
     ]
   },
   "timezone": "",
-  "title": "Linkerd Replication Controller",
+  "title": "Linkerd ReplicationController",
   "uid": "eIYYYkGmz",
   "version": 1
 }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -9,33 +9,22 @@ import (
 )
 
 const (
-	Deployments            = "deployments"
-	Namespaces             = "namespaces"
-	Pods                   = "pods"
-	ReplicationControllers = "replicationcontrollers"
-	Services               = "services"
-	All                    = "all"
-	Authorities            = "authorities"
+	All                   = "all"
+	Authority             = "authority"
+	Deployment            = "deployment"
+	Namespace             = "namespace"
+	Pod                   = "pod"
+	ReplicationController = "replicationcontroller"
+	Service               = "service"
 )
-
-// ResourceTypesToProxyLabels maps resource type names to keys
-// understood by the proxy, specifically Destination and Prometheus labels.
-var ResourceTypesToProxyLabels = map[string]string{
-	Deployments: "deployment",
-	Namespaces:  "namespace",
-	Pods:        "pod",
-	ReplicationControllers: "replication_controller",
-	Services:               "service",
-	Authorities:            "authority", // non k8s
-}
 
 // resources to query in StatSummary when Resource.Type is "all"
 var StatAllResourceTypes = []string{
-	Deployments,
-	ReplicationControllers,
-	Pods,
-	Services,
-	Authorities,
+	Deployment,
+	ReplicationController,
+	Pod,
+	Service,
+	Authority,
 }
 
 func generateKubernetesApiBaseUrlFor(schemeHostAndPort string, namespace string, extraPathStartingWithSlash string) (*url.URL, error) {
@@ -83,17 +72,17 @@ func getConfig(fpath string) (*rest.Config, error) {
 func CanonicalResourceNameFromFriendlyName(friendlyName string) (string, error) {
 	switch friendlyName {
 	case "deploy", "deployment", "deployments":
-		return Deployments, nil
+		return Deployment, nil
 	case "ns", "namespace", "namespaces":
-		return Namespaces, nil
+		return Namespace, nil
 	case "po", "pod", "pods":
-		return Pods, nil
+		return Pod, nil
 	case "rc", "replicationcontroller", "replicationcontrollers":
-		return ReplicationControllers, nil
+		return ReplicationController, nil
 	case "svc", "service", "services":
-		return Services, nil
+		return Service, nil
 	case "au", "authority", "authorities":
-		return Authorities, nil
+		return Authority, nil
 	case "all":
 		return All, nil
 	}
@@ -105,17 +94,17 @@ func CanonicalResourceNameFromFriendlyName(friendlyName string) (string, error) 
 // Essentially the reverse of CanonicalResourceNameFromFriendlyName
 func ShortNameFromCanonicalResourceName(canonicalName string) string {
 	switch canonicalName {
-	case Deployments:
+	case Deployment:
 		return "deploy"
-	case Namespaces:
+	case Namespace:
 		return "ns"
-	case Pods:
+	case Pod:
 		return "po"
-	case ReplicationControllers:
+	case ReplicationController:
 		return "rc"
-	case Services:
+	case Service:
 		return "svc"
-	case Authorities:
+	case Authority:
 		return "au"
 	default:
 		return ""

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -82,12 +82,12 @@ func TestGetConfig(t *testing.T) {
 func TestCanonicalResourceNameFromFriendlyName(t *testing.T) {
 	t.Run("Returns canonical name for all known variants", func(t *testing.T) {
 		expectations := map[string]string{
-			"po":          Pods,
-			"pod":         Pods,
-			"deployment":  Deployments,
-			"deployments": Deployments,
-			"au":          Authorities,
-			"authorities": Authorities,
+			"po":          Pod,
+			"pod":         Pod,
+			"deployment":  Deployment,
+			"deployments": Deployment,
+			"au":          Authority,
+			"authorities": Authority,
 		}
 
 		for input, expectedName := range expectations {

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { friendlyTitle } from './util/Utils.js';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Icon, Modal, Switch } from 'antd';
@@ -131,7 +132,7 @@ export default class ErrorModal extends React.Component {
         <Icon type="warning" className="controller-error-icon" onClick={this.showModal} />
         <Modal
           className="controller-pod-error-modal"
-          title={`Errors in ${this.props.resourceType} ${this.props.resourceName}`}
+          title={`Errors in ${friendlyTitle(this.props.resourceType).singular} ${this.props.resourceName}`}
           visible={this.state.visible}
           onOk={this.handleOk}
           onCancel={this.handleCancel}

--- a/web/app/js/components/GrafanaLink.jsx
+++ b/web/app/js/components/GrafanaLink.jsx
@@ -2,12 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const GrafanaLink = ({PrefixedLink, name, namespace, resource}) => {
-  let resourceVariableName = resource.toLowerCase().replace(" ", "_");
-  let dashboardName = resource.toLowerCase().replace(" ", "-");
-
   return (
     <PrefixedLink
-      to={`/dashboard/db/linkerd-${dashboardName}?var-namespace=${namespace}&var-${resourceVariableName}=${name}`}
+      to={`/dashboard/db/linkerd-${resource}?var-namespace=${namespace}&var-${resource}=${name}`}
       deployment="grafana"
       targetBlank={true}>
       {name}&nbsp;&nbsp;<i className="fa fa-external-link" />

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -61,7 +61,7 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
 
   let columns = [
     {
-      title: formatTitle(resource),
+      title: formatTitle(friendlyTitle(resource).singular),
       key: "name",
       defaultSortOrder: 'ascend',
       sorter: (a, b) => (a.name || "").localeCompare(b.name),
@@ -209,7 +209,7 @@ export class MetricsTableBase extends BaseTable {
       return { text: ns, value: ns };
     });
 
-    let resource = this.props.resource.toLowerCase();
+    let resource = this.props.resource;
 
     let showNsColumn = this.props.showNamespaceColumn;
     if (resource === "namespace") {

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -123,8 +123,8 @@ class Namespaces extends React.Component {
 
   render() {
     const {metrics} = this.state;
-    let noMetrics = _.isEmpty(this.state.metrics.pods);
-    let deploymentsWithMetrics = _.filter(this.state.metrics.deployments, "requestRate");
+    let noMetrics = _.isEmpty(metrics.pod);
+    let deploymentsWithMetrics = _.filter(metrics.deployment, "requestRate");
 
     return (
       <div className="page-content">
@@ -134,11 +134,11 @@ class Namespaces extends React.Component {
             <PageHeader header={`Namespace: ${this.state.ns}`} />
             { noMetrics ? <div>No resources detected.</div> : null}
             { _.isEmpty(deploymentsWithMetrics) ? null :
-            <NetworkGraph namespace={this.state.ns} deployments={metrics.deployments} />}
-            {this.renderResourceSection("Deployment", metrics.deployments)}
-            {this.renderResourceSection("Replication Controller", metrics.replicationcontrollers)}
-            {this.renderResourceSection("Pod", metrics.pods)}
-            {this.renderResourceSection("Authority", metrics.authorities)}
+            <NetworkGraph namespace={this.state.ns} deployments={metrics.deployment} />}
+            {this.renderResourceSection("deployment", metrics.deployment)}
+            {this.renderResourceSection("replicationcontroller", metrics.replicationcontroller)}
+            {this.renderResourceSection("pod", metrics.pod)}
+            {this.renderResourceSection("authority", metrics.authority)}
           </div>
         )}
       </div>);

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -47,7 +47,7 @@ export class ResourceListBase extends React.Component {
 
     return (
       <MetricsTable
-        resource={friendlyTitle(this.props.resource).singular}
+        resource={this.props.resource}
         metrics={processedMetrics} />
     );
   }

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -83,10 +83,6 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   };
 
   const urlsForResource = (type, namespace) => {
-    if (type === "replication_controller") {
-      type = "replicationcontroller";
-    }
-
     let baseUrl = '/api/tps-reports?resource_type=' + type;
     return !namespace ? baseUrl + '&all_namespaces=true' : baseUrl + '&namespace=' + namespace;
   };

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -96,8 +96,12 @@ export const numericSort = (a, b) => (_.isNil(a) ? -1 : a) - (_.isNil(b) ? -1 : 
   Nicely readable names for the stat resources
 */
 export const friendlyTitle = resource => {
-  let titles = { singular: _.startCase(resource) };
-  if (resource.toLowerCase() === "authority") {
+  let singular = _.startCase(resource);
+  if (resource === "replicationcontroller") {
+    singular = _.startCase("replication controller");
+  }
+  let titles = { singular: singular };
+  if (resource === "authority") {
     titles.plural = "Authorities";
   } else {
     titles.plural = titles.singular + "s";

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -48,7 +48,7 @@ let applicationHtml = (
                   render={() => <ResourceList resource="deployment" />} />
                 <Route
                   path={`${pathPrefix}/replicationcontrollers`}
-                  render={() => <ResourceList resource="replication_controller" />} />
+                  render={() => <ResourceList resource="replicationcontroller" />} />
                 <Route
                   path={`${pathPrefix}/pods`}
                   render={() => <ResourceList resource="pod" />} />

--- a/web/app/test/GrafanaLinkTest.jsx
+++ b/web/app/test/GrafanaLinkTest.jsx
@@ -14,16 +14,16 @@ describe('GrafanaLink', () => {
   it('makes a link', () => {
     let api = ApiHelpers('');
     let linkProps = {
-      resource: "Replication Controller",
+      resource: "replicationcontroller",
       name: "aldksf-3409823049823",
       namespace: "myns",
       PrefixedLink: api.PrefixedLink
     };
     let component = mount(routerWrap(GrafanaLink, linkProps));
 
-    let expectedDashboardNameStr = "/linkerd-replication-controller";
+    let expectedDashboardNameStr = "/linkerd-replicationcontroller";
     let expectedNsStr = "var-namespace=myns";
-    let expectedVarNameStr = "var-replication_controller=aldksf-3409823049823";
+    let expectedVarNameStr = "var-replicationcontroller=aldksf-3409823049823";
 
     expect(component.find("GrafanaLink")).to.have.length(1);
     expect(component.html()).to.contain(expectedDashboardNameStr);

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -54,9 +54,9 @@ describe('MetricUtils', () => {
       let result = processMultiResourceRollup(multiResourceRollupFixtures);
       expect(_.size(result)).to.equal(2);
 
-      expect(result["deployments"]).to.have.length(1);
-      expect(result["pods"]).to.have.length(4);
-      expect(result["replicationcontrollers"]).to.be.undefined;
+      expect(result["deployment"]).to.have.length(1);
+      expect(result["pod"]).to.have.length(4);
+      expect(result["replicationcontroller"]).to.be.undefined;
     });
   });
 });

--- a/web/app/test/ResourceListTest.jsx
+++ b/web/app/test/ResourceListTest.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Adapter from 'enzyme-adapter-react-16';
 import deployRollup from './fixtures/deployRollup.json';
 import ErrorBanner from '../js/components/ErrorBanner.jsx';
@@ -82,7 +81,7 @@ describe('Tests for <ResourceListBase>', () => {
     expect(component.find(Spin)).to.have.length(0);
     expect(metrics).to.have.length(1);
 
-    expect(metrics.props().resource).to.equal(_.startCase(resource));
+    expect(metrics.props().resource).to.equal(resource);
     expect(metrics.props().metrics).to.have.length(1);
   });
 });

--- a/web/app/test/ServiceMeshTest.jsx
+++ b/web/app/test/ServiceMeshTest.jsx
@@ -142,10 +142,10 @@ describe('ServiceMesh', () => {
     it("displays a message if >1 resource has not been added to the mesh", () => {
       let nsAllResourcesAdded = _.cloneDeep(nsFixtures);
       nsAllResourcesAdded.ok.statTables[0].podGroup.rows.push({
-        "resource":{
-          "namespace":"",
-          "type":"namespaces",
-          "name":"test-1"
+        "resource": {
+          "namespace": "",
+          "type": "namespace",
+          "name": "test-1"
         },
         "timeWindow": "1m",
         "meshedPodCount": "0",

--- a/web/app/test/fixtures/allRollup.json
+++ b/web/app/test/fixtures/allRollup.json
@@ -9,7 +9,7 @@
               "resource": {
                 "name": "voting",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "15",
@@ -36,7 +36,7 @@
             {
               "resource": {
                 "namespace": "shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "web-5f97578cf6-597sr"
               },
               "timeWindow": "1m",
@@ -53,7 +53,7 @@
             {
               "resource": {
                 "namespace": "shiny-product-other",
-                "type": "pods",
+                "type": "pod",
                 "name": "controller-795dd8df6-tjdt6"
               },
               "timeWindow": "1m",
@@ -70,7 +70,7 @@
             {
               "resource": {
                 "namespace": "not-shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "prometheus-595785446-r7rlq"
               },
               "timeWindow": "1m",
@@ -81,7 +81,7 @@
             {
               "resource": {
                 "namespace": "shiny-product-other",
-                "type": "pods",
+                "type": "pod",
                 "name": "grafana-78cdb656bf-v8lsj"
               },
               "timeWindow": "1m",

--- a/web/app/test/fixtures/deployRollup.json
+++ b/web/app/test/fixtures/deployRollup.json
@@ -9,7 +9,7 @@
               "resource": {
                 "name": "voting",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "15",

--- a/web/app/test/fixtures/emojivotoPods.json
+++ b/web/app/test/fixtures/emojivotoPods.json
@@ -8,7 +8,7 @@
               {
                 "resource": {
                   "namespace": "emojivoto",
-                  "type": "deployments",
+                  "type": "deployment",
                   "name": "web"
                 },
                 "timeWindow": "1m",
@@ -51,7 +51,7 @@
               {
                 "resource": {
                   "namespace": "emojivoto",
-                  "type": "deployments",
+                  "type": "deployment",
                   "name": "web"
                 },
                 "timeWindow": "1m",
@@ -83,7 +83,7 @@
               {
                 "resource": {
                   "namespace": "emojivoto",
-                  "type": "deployments",
+                  "type": "deployment",
                   "name": "vote-bot"
                 },
                 "timeWindow": "1m",

--- a/web/app/test/fixtures/multiDeployRollup.json
+++ b/web/app/test/fixtures/multiDeployRollup.json
@@ -9,7 +9,7 @@
               "resource": {
                 "name": "voting",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "10",
@@ -26,7 +26,7 @@
               "resource": {
                 "name": "emoji",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "0",
@@ -43,7 +43,7 @@
               "resource": {
                 "name": "vote-bot",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "0",
@@ -60,7 +60,7 @@
               "resource": {
                 "name": "web",
                 "namespace": "emojivoto",
-                "type": "deployments"
+                "type": "deployment"
               },
               "stats": {
                 "failureCount": "11",

--- a/web/app/test/fixtures/namespaces.json
+++ b/web/app/test/fixtures/namespaces.json
@@ -7,7 +7,7 @@
             {
               "resource": {
                 "namespace": "",
-                "type": "namespaces",
+                "type": "namespace",
                 "name": "shiny-product"
               },
               "timeWindow": "1m",
@@ -24,7 +24,7 @@
             {
               "resource": {
                 "namespace": "",
-                "type": "namespaces",
+                "type": "namespace",
                 "name": "kube-system"
               },
               "timeWindow": "1m",
@@ -35,7 +35,7 @@
             {
               "resource": {
                 "namespace": "",
-                "type": "namespaces",
+                "type": "namespace",
                 "name": "default"
               },
               "timeWindow": "1m",
@@ -46,7 +46,7 @@
             {
               "resource": {
                 "namespace": "",
-                "type": "namespaces",
+                "type": "namespace",
                 "name": "kube-public"
               },
               "timeWindow": "1m",

--- a/web/app/test/fixtures/podRollup.json
+++ b/web/app/test/fixtures/podRollup.json
@@ -7,7 +7,7 @@
             {
               "resource": {
                 "namespace": "shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "web-5f97578cf6-597sr"
               },
               "timeWindow": "1m",
@@ -24,7 +24,7 @@
             {
               "resource": {
                 "namespace": "shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "controller-795dd8df6-tjdt6"
               },
               "timeWindow": "1m",
@@ -41,7 +41,7 @@
             {
               "resource": {
                 "namespace": "shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "prometheus-595785446-r7rlq"
               },
               "timeWindow": "1m",
@@ -52,7 +52,7 @@
             {
               "resource": {
                 "namespace": "shiny-product",
-                "type": "pods",
+                "type": "pod",
                 "name": "grafana-78cdb656bf-v8lsj"
               },
               "timeWindow": "1m",

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/linkerd/linkerd2/controller/api/util"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,7 +20,7 @@ type (
 )
 
 var (
-	defaultResourceType = "deployments"
+	defaultResourceType = k8s.Deployment
 	pbMarshaler         = jsonpb.Marshaler{EmitDefaults: true}
 )
 


### PR DESCRIPTION
Our prometheus labels for replication controllers, daemonsets, statefulsets, and replicasets included underscores, which isn't consistent with how kubectl handles these types (no underscores). In this branch I'm removing the underscores.

As part of this change, I'm also changing all resource types used in our APIs to be singular. We were using a mix of singular and plural resource types, which meant that we had a lot of code for converting from singular to plural and back, so this hopefully simplifies things.

This is a big diff, but the meat of the change happens in `pkg/k8s/labels.go`.

Fixes #740.