### PR TITLE
Enable Tap from the Web UI 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,6 +106,12 @@
   revision = "104e2578924bb3b211150c19414d0144b82165bb"
 
 [[projects]]
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
   packages = ["."]
   revision = "6b7015e65d366bf3f19b2b2a000a831940f0f7e0"
@@ -636,6 +642,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "54e0dd7c4513ef8ceddf3cbb7e4d20a7b868c4a850b8c5efce81065181e2b745"
+  inputs-digest = "51bf169451e7cef474b4402438cb4a0cf0cf43159a08fc5bdf29498c46031dc1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,6 +48,9 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
   name = "github.com/prometheus/client_golang"
   revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
 
+[[constraint]]
+  name = "github.com/gorilla/websocket"
+  version = "1.2.0"
 #
 # k8s.io/kubernetes dependency fixes
 # taken from https://github.com/kubernetes/kubernetes/blob/master/Godeps/Godeps.json

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:baf323e4 as golang
+FROM gcr.io/linkerd-io/go-deps:766a0983 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/linkerd/linkerd2/controller/api/public"
+	"github.com/linkerd/linkerd2/controller/api/util"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -19,17 +20,15 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 	t.Run("Should render busy response if everything went well", func(t *testing.T) {
 		resourceType := k8s.Pods
 		targetName := "pod-666"
-		options := &tapOptions{
-			scheme:    "https",
-			method:    "GET",
-			authority: "localhost",
-			path:      "/some/path",
+		params := util.TapRequestParams{
+			Resource:  resourceType + "/" + targetName,
+			Scheme:    "https",
+			Method:    "GET",
+			Authority: "localhost",
+			Path:      "/some/path",
 		}
 
-		req, err := buildTapByResourceRequest(
-			[]string{resourceType, targetName},
-			options,
-		)
+		req, err := util.BuildTapByResourceRequest(params)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -41,8 +40,8 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 						Id: &pb.TapEvent_Http_StreamId{
 							Base: 1,
 						},
-						Authority: options.authority,
-						Path:      options.path,
+						Authority: params.Authority,
+						Path:      params.Path,
 					},
 				},
 			},
@@ -98,17 +97,15 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {
 		resourceType := k8s.Pods
 		targetName := "pod-666"
-		options := &tapOptions{
-			scheme:    "https",
-			method:    "GET",
-			authority: "localhost",
-			path:      "/some/path",
+		params := util.TapRequestParams{
+			Resource:  resourceType + "/" + targetName,
+			Scheme:    "https",
+			Method:    "GET",
+			Authority: "localhost",
+			Path:      "/some/path",
 		}
 
-		req, err := buildTapByResourceRequest(
-			[]string{resourceType, targetName},
-			options,
-		)
+		req, err := util.BuildTapByResourceRequest(params)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -139,17 +136,15 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 		t.SkipNow()
 		resourceType := k8s.Pods
 		targetName := "pod-666"
-		options := &tapOptions{
-			scheme:    "https",
-			method:    "GET",
-			authority: "localhost",
-			path:      "/some/path",
+		params := util.TapRequestParams{
+			Resource:  resourceType + "/" + targetName,
+			Scheme:    "https",
+			Method:    "GET",
+			Authority: "localhost",
+			Path:      "/some/path",
 		}
 
-		req, err := buildTapByResourceRequest(
-			[]string{resourceType, targetName},
-			options,
-		)
+		req, err := util.BuildTapByResourceRequest(params)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -218,7 +213,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "req id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -235,7 +230,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "rsp id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :status=200 latency=999µs"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -256,7 +251,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= grpc-status=OK duration=888µs response-length=111B"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -277,7 +272,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= reset-error=123 duration=888µs response-length=111B"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -296,7 +291,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= duration=888µs response-length=111B"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -314,7 +309,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= duration=888µs response-length=111B"
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -324,7 +319,7 @@ func TestEventToString(t *testing.T) {
 		event := toTapEvent(&pb.TapEvent_Http{})
 
 		expectedOutput := "unknown proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls="
-		output := renderTapEvent(event)
+		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:baf323e4 as golang
+FROM gcr.io/linkerd-io/go-deps:766a0983 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:baf323e4 as golang
+FROM gcr.io/linkerd-io/go-deps:766a0983 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:baf323e4 as golang
+FROM gcr.io/linkerd-io/go-deps:766a0983 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY web web
 COPY controller controller

--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -1,0 +1,17 @@
+@import 'styles.css';
+
+.tap-display {
+  font-size: 10px;
+  margin-top: calc(4 * var(--base-width));
+}
+
+button.ant-btn-primary {
+  &.tap-start {
+    background-color: var(--green);
+    border-color: var(--green);
+  }
+  &.tap-stop {
+    background-color: var(--siennared);
+    border-color: var(--siennared);
+  }
+}

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -161,6 +161,13 @@ class Sidebar extends React.Component {
               </PrefixedLink>
             </Menu.Item>
 
+            <Menu.Item className="sidebar-menu-item" key="/tap">
+              <PrefixedLink to="/tap">
+                <Icon type="coffee" />
+                <span>Tap</span>
+              </PrefixedLink>
+            </Menu.Item>
+
             {
               _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {
                 return (

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -161,12 +161,12 @@ class Sidebar extends React.Component {
               </PrefixedLink>
             </Menu.Item>
 
-            <Menu.Item className="sidebar-menu-item" key="/tap">
+            {/* <Menu.Item className="sidebar-menu-item" key="/tap">
               <PrefixedLink to="/tap">
                 <Icon type="coffee" />
                 <span>Tap</span>
               </PrefixedLink>
-            </Menu.Item>
+            </Menu.Item> */}
 
             {
               _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -26,7 +26,21 @@ class Tap extends React.Component {
   }
 
   componentWillUnmount() {
+    this.ws.close(1000);
     this.stopTapStreaming();
+    this.stopServerPolling();
+  }
+
+  onWebsocketOpen = () => {
+    this.ws.send(JSON.stringify({
+      id: "tap-web",
+      resource: this.state.query.resource,
+      namespace: this.state.query.namespace,
+    }));
+    this.setState({
+      webSocketRequestSent: true,
+      errors: ""
+    });
   }
 
   onWebsocketRecv = e => {
@@ -77,7 +91,6 @@ class Tap extends React.Component {
       webSocketRequestSent: false
     });
 
-    this.ws.close();
     window.clearInterval(this.timerId);
   }
 
@@ -87,7 +100,7 @@ class Tap extends React.Component {
   }
 
   handleTapStop = () => {
-    this.stopTapStreaming();
+    this.ws.close(1000);
   }
 
   handleFormChange = formVal => {

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -1,0 +1,151 @@
+import _ from 'lodash';
+import ErrorBanner from './ErrorBanner.jsx';
+import PageHeader from './PageHeader.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withContext } from './util/AppContext.jsx';
+import { Button, Form, Icon, Input } from 'antd';
+import './../../css/tap.css';
+
+class Tap extends React.Component {
+  static propTypes = {
+    pathPrefix: PropTypes.string.isRequired
+  }
+
+  constructor(props) {
+    super(props);
+    this.loadFromServer = this.loadFromServer.bind(this);
+
+    this.state = {
+      errors: "",
+      pollingInterval: 2000,
+      resource: "",
+      namespace: "",
+      messages: [],
+      maxLinesToDisplay: 40,
+      websocketRequestSent: false,
+      tapUnderway: false
+    };
+  }
+
+  componentWillUnmount() {
+    this.stopTapPolling();
+  }
+
+  onWebsocketRecv = e => {
+    this.setState({
+      messages: _(this.state.messages)
+        .push(e.data)
+        .takeRight(this.state.maxLinesToDisplay)
+        .value()
+    });
+  }
+
+  onWebsocketClose = e => {
+    if (!e.wasClean) {
+      this.setState({
+        errors: `Websocket [${e.code}] ${e.reason}`
+      });
+    }
+    this.stopTapPolling();
+  }
+
+  startTapPolling() {
+    this.setState({
+      messages: [],
+      tapUnderway: true
+    });
+
+    let tapWebSocket = `ws://${window.location.host}${this.props.pathPrefix}/api/tap`;
+    this.ws = new WebSocket(tapWebSocket);
+    this.ws.onmessage = this.onWebsocketRecv;
+    this.ws.onclose = this.onWebsocketClose;
+
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  stopTapPolling() {
+    this.setState({
+      websocketRequestSent: false,
+      tapUnderway: false
+    });
+
+    this.ws.close();
+    window.clearInterval(this.timerId);
+  }
+
+  loadFromServer = () => {
+    if (this.state.websocketRequestSent) {
+      return;
+    }
+
+    if (this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        id: "tap-web",
+        resource: this.state.resource,
+        namespace: this.state.namespace
+      }));
+      this.setState({ websocketRequestSent: true });
+    }
+  }
+
+  handleTapStart = e => {
+    e.preventDefault();
+    this.startTapPolling();
+  }
+
+  handleTapStop = () => {
+    this.stopTapPolling();
+  }
+
+  handleFormChange = formVal => {
+    let state = {};
+    return e => {
+      state[formVal] = e.target.value;
+      this.setState(state);
+    };
+  }
+
+  renderTapForm = () => {
+    return (
+      <Form layout="inline">
+        <Form.Item>
+          <Input placeholder="Resource" onChange={this.handleFormChange("resource")} />
+        </Form.Item>
+
+        <Form.Item>
+          <Input placeholder="Namespace" onChange={this.handleFormChange("namespace")} />
+        </Form.Item>
+
+        <Form.Item>
+          { this.state.tapUnderway ?
+            <Button type="primary" className="tap-stop" onClick={this.handleTapStop} disabled={false}>Stop</Button> :
+            <Button type="primary" className="tap-start" onClick={this.handleTapStart} disabled={false}>Start</Button>
+          }
+        </Form.Item>
+      </Form>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {!this.state.errors ? null : <ErrorBanner message={this.state.errors} />}
+
+        <PageHeader header="Tap" />
+        {this.renderTapForm()}
+
+        <div className="tap-display">
+          <code>
+            { this.state.tapUnderway && _.size(this.state.messages) === 0 ?
+              <div><Icon type="loading" /> Starting tap on {this.state.resource} in namespace {this.state.namespace}</div> : null }
+            { _.map(this.state.messages, (m, i) => <div key={`message-${i}`}>{m}</div>)}
+          </code>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default withContext(Tap);

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -31,18 +31,6 @@ class Tap extends React.Component {
     this.stopServerPolling();
   }
 
-  onWebsocketOpen = () => {
-    this.ws.send(JSON.stringify({
-      id: "tap-web",
-      resource: this.state.query.resource,
-      namespace: this.state.query.namespace,
-    }));
-    this.setState({
-      webSocketRequestSent: true,
-      errors: ""
-    });
-  }
-
   onWebsocketRecv = e => {
     this.setState({
       messages: _(this.state.messages)
@@ -68,7 +56,8 @@ class Tap extends React.Component {
       namespace: this.state.namespace
     }));
     this.setState({
-      webSocketRequestSent: true
+      webSocketRequestSent: true,
+      errors: ""
     });
   }
 

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -63,7 +63,9 @@ class Tap extends React.Component {
       messages: []
     });
 
-    let tapWebSocket = `ws://${window.location.host}${this.props.pathPrefix}/api/tap`;
+    let protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    let tapWebSocket = `${protocol}://${window.location.host}${this.props.pathPrefix}/api/tap`;
+
     this.ws = new WebSocket(tapWebSocket);
     this.ws.onmessage = this.onWebsocketRecv;
     this.ws.onclose = this.onWebsocketClose;

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom';
 import ResourceList from './components/ResourceList.jsx';
 import ServiceMesh from './components/ServiceMesh.jsx';
 import Sidebar from './components/Sidebar.jsx';
+import Tap from './components/Tap.jsx';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import './../css/styles.css';
 
@@ -39,6 +40,7 @@ let applicationHtml = (
                 <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
                 <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
                 <Route path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
+                <Route path={`${pathPrefix}/tap`} component={Tap} />
                 <Route
                   path={`${pathPrefix}/namespaces`}
                   render={() => <ResourceList resource="namespace" />} />

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -125,16 +125,22 @@ func (h *handler) handleApiTap(w http.ResponseWriter, req *http.Request, p httpr
 	}
 	defer ws.Close()
 
-	var requestParams util.TapRequestParams
 	messageType, message, err := ws.ReadMessage()
-	if messageType == websocket.TextMessage {
-		err := json.Unmarshal(message, &requestParams)
-		if err != nil {
-			ws.WriteMessage(websocket.CloseMessage, []byte(err.Error()))
-			return
-		}
-	} else {
+	if err != nil {
+		ws.WriteMessage(websocket.CloseMessage, []byte(err.Error()))
+		return
+	}
+
+	if messageType != websocket.TextMessage {
 		ws.WriteMessage(websocket.CloseMessage, []byte("MessageType not supported"))
+		return
+	}
+
+	var requestParams util.TapRequestParams
+	err = json.Unmarshal(message, &requestParams)
+	if err != nil {
+		ws.WriteMessage(websocket.CloseMessage, []byte(err.Error()))
+		return
 	}
 
 	if requestParams.MaxRps == 0.0 {

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -90,6 +90,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 	server.router.GET("/replicationcontrollers", handler.handleIndex)
 	server.router.GET("/pods", handler.handleIndex)
 	server.router.GET("/authorities", handler.handleIndex)
+	server.router.GET("/tap", handler.handleIndex)
 	server.router.ServeFiles(
 		"/dist/*filepath", // add catch-all parameter to match all files in dir
 		filesonly.FileSystem(server.staticDir))
@@ -98,6 +99,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 	server.router.GET("/api/version", handler.handleApiVersion)
 	server.router.GET("/api/tps-reports", handler.handleApiStat)
 	server.router.GET("/api/pods", handler.handleApiPods)
+	server.router.GET("/api/tap", handler.handleApiTap)
 
 	return httpServer
 }


### PR DESCRIPTION
Adds a tap endpoint in the web api that communicates with the dashboard via websockets. I've moved a bunch of code from the cli `tap.go` into utils so that the code can be shared between web and CLI. I think we should consider making the display more suited to web, but in the short term, reusing the CLI's rendering of tap events works.

Adds a Tap page in the Web UI that you can use to make tap requests. The form currently only allows you to enter a resource and namespace, but I plan to add in the other filters in a follow-up branch.

Go deps need to be updated for this branch, so I'll need to build and push them, changing the shas in this branch.

![screen shot 2018-07-19 at 1 43 52 pm](https://user-images.githubusercontent.com/549258/42975758-d9ebf7a0-8b72-11e8-9db4-da17e77d2f47.png)

Future plans for this:
- display the tap events in a more UI friendly way (not like the CLI output)
- add namespace and resource autocompletes 
- add form options for --to-resource and the other tap flags
