### PR TITLE
Increase outbound router capacity for Prometheus pod's proxy

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -225,6 +225,24 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		},
 	}
 
+	// Special case if the caller specifies that
+	// CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY be set on the pod.
+	// We key off of any container image in the pod. Ideally we would instead key
+	// off of something at the top-level of the PodSpec, but there is nothing
+	// easily identifiable at that level.
+	// This is currently only used by the Prometheus pod in the control-plane.
+	for _, container := range t.Containers {
+		if capacity, ok := options.proxyOutboundCapacity[container.Image]; ok {
+			sidecar.Env = append(sidecar.Env,
+				v1.EnvVar{
+					Name:  "CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY",
+					Value: fmt.Sprintf("%d", capacity),
+				},
+			)
+			break
+		}
+	}
+
 	if options.enableTLS() {
 		yes := true
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -226,7 +226,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	}
 
 	// Special case if the caller specifies that
-	// CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY be set on the pod.
+	// LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY be set on the pod.
 	// We key off of any container image in the pod. Ideally we would instead key
 	// off of something at the top-level of the PodSpec, but there is nothing
 	// easily identifiable at that level.
@@ -235,7 +235,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		if capacity, ok := options.proxyOutboundCapacity[container.Image]; ok {
 			sidecar.Env = append(sidecar.Env,
 				v1.EnvVar{
-					Name:  "CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY",
+					Name:  "LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY",
 					Value: fmt.Sprintf("%d", capacity),
 				},
 			)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -42,6 +42,8 @@ type installOptions struct {
 	*proxyConfigOptions
 }
 
+const prometheusProxyOutboundCapacity = 10000
+
 func newInstallOptions() *installOptions {
 	return &installOptions{
 		controllerReplicas: 1,
@@ -64,6 +66,7 @@ func newCmdInstall() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
 			return render(*config, os.Stdout, options)
 		},
 	}
@@ -124,6 +127,10 @@ func render(config installConfig, w io.Writer, options *installOptions) error {
 	}
 	injectOptions := newInjectOptions()
 	injectOptions.proxyConfigOptions = options.proxyConfigOptions
+
+	// Special case for conduit-proxy running in the Prometheus pod.
+	injectOptions.proxyOutboundCapacity[config.PrometheusImage] = prometheusProxyOutboundCapacity
+
 	return InjectYAML(buf, w, injectOptions)
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -76,18 +76,19 @@ func newPublicAPIClient() (pb.ApiClient, error) {
 }
 
 type proxyConfigOptions struct {
-	linkerdVersion   string
-	proxyImage       string
-	initImage        string
-	dockerRegistry   string
-	imagePullPolicy  string
-	proxyUID         int64
-	proxyLogLevel    string
-	proxyBindTimeout string
-	proxyAPIPort     uint
-	proxyControlPort uint
-	proxyMetricsPort uint
-	tls              string
+	linkerdVersion        string
+	proxyImage            string
+	initImage             string
+	dockerRegistry        string
+	imagePullPolicy       string
+	proxyUID              int64
+	proxyLogLevel         string
+	proxyBindTimeout      string
+	proxyAPIPort          uint
+	proxyControlPort      uint
+	proxyMetricsPort      uint
+	proxyOutboundCapacity map[string]uint
+	tls                   string
 }
 
 const (
@@ -97,18 +98,19 @@ const (
 
 func newProxyConfigOptions() *proxyConfigOptions {
 	return &proxyConfigOptions{
-		linkerdVersion:   version.Version,
-		proxyImage:       defaultDockerRegistry + "/proxy",
-		initImage:        defaultDockerRegistry + "/proxy-init",
-		dockerRegistry:   defaultDockerRegistry,
-		imagePullPolicy:  "IfNotPresent",
-		proxyUID:         2102,
-		proxyLogLevel:    "warn,linkerd2_proxy=info",
-		proxyBindTimeout: "10s",
-		proxyAPIPort:     8086,
-		proxyControlPort: 4190,
-		proxyMetricsPort: 4191,
-		tls:              "",
+		linkerdVersion:        version.Version,
+		proxyImage:            defaultDockerRegistry + "/proxy",
+		initImage:             defaultDockerRegistry + "/proxy-init",
+		dockerRegistry:        defaultDockerRegistry,
+		imagePullPolicy:       "IfNotPresent",
+		proxyUID:              2102,
+		proxyLogLevel:         "warn,linkerd2_proxy=info",
+		proxyBindTimeout:      "10s",
+		proxyAPIPort:          8086,
+		proxyControlPort:      4190,
+		proxyMetricsPort:      4191,
+		proxyOutboundCapacity: map[string]uint{},
+		tls: "",
 	}
 }
 

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -503,7 +503,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+        - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -503,6 +503,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+          value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-proxy

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -506,7 +506,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+        - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -506,6 +506,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CONDUIT_PROXY_OUTBOUND_ROUTER_CAPACITY
+          value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-proxy


### PR DESCRIPTION
Currently, when a cluster has over 100 pods injected with the Linkerd2
proxy, Prometheus metrics are not collected correctly. This is because
Prometheus appears to be making more concurrent requests than its'
proxy's outbound router cache can handle See issue #1322 for further 
details.

This branch introduces a workaround for this issue, by increasing the
outbound router cache capacity to 10000 routes for the Prometheus pod's
proxy only. The router capacity limit of 100 active routes is primarily
due to the limitation of the number of active Destination service 
lookups, so increasing the capacity for the Prometheus pod specifically
is probably okay, as the scrape requests are made to IP addresses 
directly and therefore will not cause service discovery lookups. 

This change was originally implemented and tested in @siggy's PR #1228.
I've rebased his branch onto the current `master`, and updated the code
to reflect the project name change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
Co-authored-by: Andrew Seigner <siggy@buoyant.io>