### PR TITLE
Build version tags in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ sudo: false
 branches:
   only:
     - master
+    - /^v\d+\.\d+\.[\w-]+$/ # build version tags
 
 stages:
   - name: test
   - name: docker-deploy
-    if: branch = master AND type != pull_request
+    if: type != pull_request
   - name: integration-test
-    if: branch = master AND type != pull_request
+    if: type != pull_request
 
 jobs:
   include:
@@ -144,7 +145,7 @@ jobs:
           (. bin/_gcp.sh ; get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER")
         - |
           # Install linkerd cli.
-          version="git-$(git rev-parse --short=8 HEAD)"
+          version="$(CI_FORCE_CLEAN=1 bin/root-tag)"
           image="gcr.io/linkerd-io/cli-bin:$version"
           id=$(docker create $image)
           docker cp "$id:/out/linkerd-linux" "./linkerd"

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -11,7 +11,11 @@ go_deps_sha() {
 }
 
 clean_head() {
-    git diff-index --quiet HEAD --
+    if [ -n "${CI_FORCE_CLEAN:-}" ]; then
+        true
+    else
+        git diff-index --quiet HEAD --
+    fi
 }
 
 named_tag() {

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -11,11 +11,7 @@ go_deps_sha() {
 }
 
 clean_head() {
-    if [ -n "${CI_FORCE_CLEAN:-}" ]; then
-        true
-    else
-        git diff-index --quiet HEAD --
-    fi
+    [ -n "${CI_FORCE_CLEAN:-}" ] || git diff-index --quiet HEAD --
 }
 
 named_tag() {


### PR DESCRIPTION
This branch updates our travis CI config to start publishing docker images when new version tags are created in the linkerd2 repo, provided that the tags match the regex `/^v\d+\.\d+\.[\w-]+$/`. This change works because travis does not distinguish between a tag and a branch -- it treats all tags and branches as branches.

As part of this change I also had to add a CI-specific environment variable in order for integration tests to pass -- `CI_FORCE_CLEAN` -- since our integration tests don't run in a clean repo checkout and I've never been able to figure out why.

I tested this branch by naming the branch in a way that matches the version tag regex, and validating that docker images were published and integration tests passed: https://travis-ci.org/linkerd/linkerd2/builds/407820373

Fixes #1364.