### PR TITLE
Add more filters to the web UI tap form

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -211,9 +211,8 @@ func (s *grpcServer) TapByResource(req *pb.TapByResourceRequest, stream pb.Api_T
 	tapStream := stream.(tapServer)
 	tapClient, err := s.tapClient.TapByResource(tapStream.Context(), req)
 	if err != nil {
-		//TODO: why not return the error?
 		log.Errorf("Unexpected error tapping [%v]: %v", req, err)
-		return nil
+		return err
 	}
 	for {
 		select {

--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -15,3 +15,9 @@ button.ant-btn-primary {
     border-color: var(--siennared);
   }
 }
+
+button.tap-form-toggle {
+  padding-left: 0;
+  border: none;
+  color: rgba(52, 137, 206, 0.906);
+}

--- a/web/app/js/components/ErrorBanner.jsx
+++ b/web/app/js/components/ErrorBanner.jsx
@@ -6,8 +6,13 @@ import { Col, Row } from 'antd';
 const defaultErrorMsg = "An error has occurred";
 
 class ErrorMessage extends React.Component {
+  static defaultProps = {
+    onHideMessage: _.noop
+  }
+
   static propTypes = {
     message: PropTypes.string.isRequired,
+    onHideMessage: PropTypes.func
   }
 
   constructor(props) {
@@ -25,6 +30,7 @@ class ErrorMessage extends React.Component {
   }
 
   hideMessage() {
+    this.props.onHideMessage();
     this.setState({
       visible: false
     });

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -50,6 +50,7 @@ class Sidebar extends React.Component {
       pendingRequests: false
     };
   }
+
   componentDidMount() {
     this.startServerPolling();
   }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -4,31 +4,86 @@ import PageHeader from './PageHeader.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withContext } from './util/AppContext.jsx';
-import { Button, Form, Icon, Input } from 'antd';
+import {
+  AutoComplete,
+  Button,
+  Col,
+  Form,
+  Icon,
+  Input,
+  Row,
+  Select
+} from 'antd';
 import './../../css/tap.css';
 
+const colSpan = 5;
+const rowGutter = 16;
+const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
+const defaultMaxRps = 1.0;
 class Tap extends React.Component {
   static propTypes = {
+    api: PropTypes.shape({
+      PrefixedLink: PropTypes.func.isRequired,
+    }).isRequired,
     pathPrefix: PropTypes.string.isRequired
   }
 
   constructor(props) {
     super(props);
+    this.api = this.props.api;
+    this.loadFromServer = this.loadFromServer.bind(this);
 
     this.state = {
-      errors: "",
-      resource: "",
-      namespace: "",
+      error: "",
       messages: [],
+      resourcesByNs: {},
+      query: {
+        resource: "",
+        namespace: "",
+        toResource: "",
+        toNamespace: "",
+        method: "",
+        path: "",
+        scheme: "",
+        authority: "",
+        maxRps: defaultMaxRps
+      },
+      autocomplete: {
+        namespace: [],
+        resource: [],
+        toNamespace: [],
+        toResource: [],
+      },
       maxLinesToDisplay: 40,
-      webSocketRequestSent: false
+      webSocketRequestSent: false,
+      showAdvancedForm: false,
+      pollingInterval: 10000,
+      pendingRequests: false
     };
+  }
+
+  componentDidMount() {
+    this.startServerPolling();
   }
 
   componentWillUnmount() {
     this.ws.close(1000);
     this.stopTapStreaming();
     this.stopServerPolling();
+  }
+
+  onWebsocketOpen = () => {
+    let query = this.state.query;
+    query.maxRps = parseFloat(query.maxRps) || defaultMaxRps;
+
+    this.ws.send(JSON.stringify({
+      id: "tap-web",
+      ...query
+    }));
+    this.setState({
+      webSocketRequestSent: true,
+      error: ""
+    });
   }
 
   onWebsocketRecv = e => {
@@ -43,22 +98,37 @@ class Tap extends React.Component {
   onWebsocketClose = e => {
     if (!e.wasClean) {
       this.setState({
-        errors: `Websocket [${e.code}] ${e.reason}`
+        error: `Websocket [${e.code}] ${e.reason}`
       });
     }
+
     this.stopTapStreaming();
   }
 
-  onWebsocketOpen = () => {
-    this.ws.send(JSON.stringify({
-      id: "tap-web",
-      resource: this.state.resource,
-      namespace: this.state.namespace
-    }));
-    this.setState({
-      webSocketRequestSent: true,
-      errors: ""
-    });
+  getResourcesByNs(rsp) {
+    let statTables = _.get(rsp, [0, "ok", "statTables"]);
+    return _.reduce(statTables, (mem, table) => {
+      _.map(table.podGroup.rows, row => {
+        if (!mem[row.resource.namespace]) {
+          mem[row.resource.namespace] = [];
+        }
+
+        if (row.resource.type.toLowerCase() !== "service") {
+          mem[row.resource.namespace].push(`${row.resource.type}/${row.resource.name}`);
+        }
+      });
+      return mem;
+    }, {});
+  }
+
+  startServerPolling() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  stopServerPolling() {
+    window.clearInterval(this.timerId);
+    this.api.cancelCurrentRequests();
   }
 
   startTapSteaming() {
@@ -79,8 +149,12 @@ class Tap extends React.Component {
     this.setState({
       webSocketRequestSent: false
     });
+  }
 
-    window.clearInterval(this.timerId);
+  toggleAdvancedForm = show => {
+    this.setState({
+      showAdvancedForm: show
+    });
   }
 
   handleTapStart = e => {
@@ -92,47 +166,264 @@ class Tap extends React.Component {
     this.ws.close(1000);
   }
 
-  handleFormChange = formVal => {
-    let state = {};
-    return e => {
-      state[formVal] = e.target.value;
+  handleFormChange = (name, scopeResource) => {
+    let state = {
+      query: this.state.query,
+      autocomplete: this.state.autocomplete
+    };
+
+    return formVal => {
+      state.query[name] = formVal;
+      if (!_.isNil(scopeResource)) {
+        // scope the available typeahead resources to the selected namespace
+        state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
+      }
+
       this.setState(state);
     };
   }
 
+  handleFormEvent = name => {
+    let state = {
+      query: this.state.query
+    };
+
+    return event => {
+      state.query[name] = event.target.value;
+      this.setState(state);
+    };
+  }
+
+  autoCompleteData = name => {
+    return _(this.state.autocomplete[name])
+      .filter(d => d.indexOf(this.state.query[name]) !== -1)
+      .sortBy()
+      .value();
+  }
+
+  loadFromServer() {
+    if (this.state.pendingRequests) {
+      return; // don't make more requests if the ones we sent haven't completed
+    }
+    this.setState({
+      pendingRequests: true
+    });
+
+    let url = "/api/tps-reports?resource_type=all&all_namespaces=true";
+    this.api.setCurrentRequests([this.api.fetchMetrics(url)]);
+    this.serverPromise = Promise.all(this.api.getCurrentPromises())
+      .then(rsp => {
+        let resourcesByNs = this.getResourcesByNs(rsp);
+        let namespaces = _.sortBy(_.keys(resourcesByNs));
+        let resourceNames = resourcesByNs[this.state.query.namespace] ||
+          _.uniq(_.flatten(_.values(resourcesByNs)));
+        let toResourceNames = resourcesByNs[this.state.query.toNamespace] ||
+          _.uniq(_.flatten(_.values(resourcesByNs)));
+
+        this.setState({
+          resourcesByNs,
+          autocomplete: {
+            namespace: namespaces,
+            resource: resourceNames,
+            toNamespace: namespaces,
+            toResource: toResourceNames
+          },
+          pendingRequests: false
+        });
+      })
+      .catch(this.handleApiError);
+  }
+
+  handleApiError = e => {
+    if (e.isCanceled) {
+      return;
+    }
+
+    this.setState({
+      pendingRequests: false,
+      error: `Error getting data from server: ${e.message}`
+    });
+  }
+
   renderTapForm = () => {
     return (
-      <Form layout="inline">
-        <Form.Item>
-          <Input placeholder="Resource" onChange={this.handleFormChange("resource")} />
-        </Form.Item>
+      <Form>
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item>
+              <Select
+                showSearch
+                allowClear
+                placeholder="Namespace"
+                optionFilterProp="children"
+                onChange={this.handleFormChange("namespace", "resource")}>
+                {
+                  _.map(this.state.autocomplete.namespace, (n, i) => (
+                    <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
+                  ))
+                }
+              </Select>
+            </Form.Item>
+          </Col>
 
-        <Form.Item>
-          <Input placeholder="Namespace" onChange={this.handleFormChange("namespace")} />
-        </Form.Item>
+          <Col span={colSpan}>
+            <Form.Item>
+              <AutoComplete
+                dataSource={this.autoCompleteData("resource")}
+                onSelect={this.handleFormChange("resource")}
+                onSearch={this.handleFormChange("resource")}
+                placeholder="Resource" />
+            </Form.Item>
+          </Col>
 
-        <Form.Item>
-          { this.state.webSocketRequestSent ?
-            <Button type="primary" className="tap-stop" onClick={this.handleTapStop} disabled={false}>Stop</Button> :
-            <Button type="primary" className="tap-start" onClick={this.handleTapStart} disabled={false}>Start</Button>
-          }
-        </Form.Item>
+          <Col span={colSpan}>
+            <Form.Item>
+              {
+                this.state.webSocketRequestSent ?
+                  <Button type="primary" className="tap-stop" onClick={this.handleTapStop}>Stop</Button> :
+                  <Button type="primary" className="tap-start" onClick={this.handleTapStart}>Start</Button>
+              }
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Button
+          className="tap-form-toggle"
+          onClick={() => this.toggleAdvancedForm(!this.state.showAdvancedForm)}>
+          { this.state.showAdvancedForm ?
+            "Hide filters" : "Show more filters" } <Icon type={this.state.showAdvancedForm ? 'up' : 'down'} />
+        </Button>
+
+        { !this.state.showAdvancedForm ? null : this.renderAdvancedTapForm() }
       </Form>
+    );
+  }
+
+  renderAdvancedTapForm = () => {
+    return (
+      <React.Fragment>
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item>
+              <Select
+                showSearch
+                allowClear
+                placeholder="To Namespace"
+                optionFilterProp="children"
+                onChange={this.handleFormChange("toNamespace", "toResource")}>
+                {
+                  _.map(this.state.autocomplete.toNamespace, (n, i) => (
+                    <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
+                  ))
+                }
+              </Select>
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item>
+              <AutoComplete
+                dataSource={this.autoCompleteData("toResource")}
+                onSelect={this.handleFormChange("toResource")}
+                onSearch={this.handleFormChange("toResource")}
+                placeholder="To Resource" />
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Row gutter={rowGutter}>
+          <Col span={2 * colSpan}>
+            <Form.Item
+              extra="Display requests with this :authority">
+              <Input placeholder="Authority" onChange={this.handleFormEvent("authority")} />
+            </Form.Item>
+          </Col>
+
+          <Col span={2 * colSpan}>
+            <Form.Item
+              extra="Display requests with paths that start with this prefix">
+              <Input placeholder="Path" onChange={this.handleFormEvent("path")} />
+            </Form.Item>
+          </Col>
+
+        </Row>
+
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Display requests with this scheme">
+              <Input placeholder="Scheme" onChange={this.handleFormEvent("scheme")} />
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Maximum requests per second to tap">
+              <Input
+                defaultValue={defaultMaxRps}
+                placeholder="Max RPS"
+                onChange={this.handleFormEvent("maxRps")} />
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Display requests with this HTTP method">
+              <Select
+                allowClear
+                placeholder="HTTP method"
+                onChange={this.handleFormChange("method")}>
+                {
+                  _.map(httpMethods, m =>
+                    <Select.Option key={`method-select-${m}`} value={m}>{m}</Select.Option>
+                  )
+                }
+              </Select>
+            </Form.Item>
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  }
+
+  renderCurrentQuery = () => {
+    let emptyVals =  _.countBy(_.values(this.state.query), v => _.isEmpty(v));
+
+    return (
+      <div className="tap-query">
+        <code>
+          { !emptyVals.false || emptyVals.false === 1 ? null :
+          <div>
+            Current query:
+            {
+              _.map(this.state.query, (query, queryName) => {
+                if (query === "") {
+                  return null;
+                }
+                return <div key={queryName}>{queryName}: {query}</div>;
+              })
+            }
+          </div>
+          }
+        </code>
+      </div>
     );
   }
 
   render() {
     return (
       <div>
-        {!this.state.errors ? null : <ErrorBanner message={this.state.errors} />}
+        {!this.state.error ? null :
+        <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: "" })} />}
 
         <PageHeader header="Tap" />
         {this.renderTapForm()}
+        {this.renderCurrentQuery()}
 
         <div className="tap-display">
           <code>
             { this.state.webSocketRequestSent && _.size(this.state.messages) === 0 ?
-              <div><Icon type="loading" /> Starting tap on {this.state.resource} in namespace {this.state.namespace}</div> : null }
+              <div><Icon type="loading" /> Starting tap query...</div> : null }
             { _.map(this.state.messages, (m, i) => <div key={`message-${i}`}>{m}</div>)}
           </code>
         </div>

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "antd": "^3.1.0",
+    "antd": "^3.7.2",
     "chai": "^4.1.2",
     "d3": "^4.11.0",
     "enzyme": "^3.3.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -338,52 +338,58 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-antd@^3.1.0:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/antd/-/antd-3.4.3.tgz#17c6f6d91da8c15c27704a3e38833d67592a3959"
+antd@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/antd/-/antd-3.7.2.tgz#175c92eebe86fe89465d549bfad6b305c57abb32"
   dependencies:
     array-tree-filter "^2.0.0"
     babel-runtime "6.x"
     classnames "~2.2.0"
     create-react-class "^15.6.0"
+    create-react-context "^0.2.2"
     css-animation "^1.2.5"
     dom-closest "^0.2.0"
     enquire.js "^2.1.1"
+    intersperse "^1.0.0"
     lodash "^4.17.5"
     moment "^2.19.3"
     omit.js "^1.0.0"
     prop-types "^15.5.7"
+    raf "^3.4.0"
     rc-animate "^2.4.1"
     rc-calendar "~9.6.0"
-    rc-cascader "~0.12.0"
+    rc-cascader "~0.14.0"
     rc-checkbox "~2.1.5"
-    rc-collapse "~1.8.0"
+    rc-collapse "~1.9.0"
     rc-dialog "~7.1.0"
-    rc-dropdown "~2.1.0"
+    rc-drawer "~1.6.2"
+    rc-dropdown "~2.2.0"
     rc-editor-mention "^1.0.2"
     rc-form "^2.1.0"
     rc-input-number "~4.0.0"
-    rc-menu "~6.2.0"
-    rc-notification "~3.0.0"
+    rc-menu "~7.0.2"
+    rc-notification "~3.1.1"
     rc-pagination "~1.16.1"
     rc-progress "~2.2.2"
     rc-rate "~2.4.0"
-    rc-select "~7.7.0"
+    rc-select "~8.0.7"
     rc-slider "~8.6.0"
     rc-steps "~3.1.0"
     rc-switch "~1.6.0"
-    rc-table "~6.1.0"
+    rc-table "~6.2.2"
     rc-tabs "~9.2.0"
     rc-time-picker "~3.3.0"
     rc-tooltip "~3.7.0"
-    rc-tree "~1.8.0"
-    rc-tree-select "~1.12.0"
-    rc-upload "~2.4.0"
+    rc-tree "~1.12.0"
+    rc-tree-select "~2.0.5"
+    rc-trigger "^2.5.4"
+    rc-upload "~2.5.0"
     rc-util "^4.0.4"
     react-lazy-load "^3.0.12"
+    react-lifecycles-compat "^3.0.2"
     react-slick "~0.23.1"
     shallowequal "^1.0.1"
-    warning "~3.0.0"
+    warning "~4.0.1"
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -1771,6 +1777,10 @@ classnames@2.x, classnames@^2.2.0, classnames@^2.2.1, classnames@^2.2.3, classna
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 cli-color@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-0.3.3.tgz#12d5bdd158ff8a0b0db401198913c03df069f6f5"
@@ -2107,6 +2117,13 @@ create-react-class@15.x, create-react-class@^15.5.2, create-react-class@^15.5.3,
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+create-react-context@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2717,6 +2734,10 @@ doctrine@^2.0.2:
 dom-align@1.x:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.6.7.tgz#6858138efb6b77405ce99146d0be5e4f7282813f"
+
+dom-align@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.8.0.tgz#c0e89b5b674c6e836cd248c52c2992135f093654"
 
 dom-closest@^0.2.0:
   version "0.2.0"
@@ -3454,6 +3475,18 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -3791,6 +3824,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 hammerjs@^2.0.8:
   version "2.0.8"
@@ -4163,6 +4200,10 @@ internal-ip@1.2.0:
 interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
+intersperse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/intersperse/-/intersperse-1.0.0.tgz#f2561fb1cfef9f5277cc3347a22886b4351a5181"
 
 invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
@@ -5099,7 +5140,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-mini-store@^1.0.2:
+mini-store@^1.0.2, mini-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mini-store/-/mini-store-1.1.0.tgz#4d6b3fb5c89aa0303d9b39475efb3439cd42f04f"
   dependencies:
@@ -6443,6 +6484,13 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, pr
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.5.0:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.2.tgz#6571504f47bb988ec8180253f85dd7e14952bdec"
@@ -6591,13 +6639,35 @@ rc-align@2.x:
     rc-util "^4.0.4"
     shallowequal "^1.0.2"
 
-rc-animate@2.x, rc-animate@^2.0.2, rc-animate@^2.3.0, rc-animate@^2.4.1:
+rc-align@^2.4.0, rc-align@^2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.4.3.tgz#b9b3c2a6d68adae71a8e1d041cd5e3b2a655f99a"
+  dependencies:
+    babel-runtime "^6.26.0"
+    dom-align "^1.7.0"
+    prop-types "^15.5.8"
+    rc-util "^4.0.4"
+
+rc-animate@2.x, rc-animate@^2.3.0, rc-animate@^2.4.1:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.4.4.tgz#a05a784c747beef140d99ff52b6117711bef4b1e"
   dependencies:
     babel-runtime "6.x"
     css-animation "^1.3.2"
     prop-types "15.x"
+
+rc-animate@^3.0.0-rc.1:
+  version "3.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-3.0.0-rc.1.tgz#39703e5be6d35c0c50ae53126a6c2424e5ec9405"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    component-classes "^1.2.6"
+    fbjs "^0.8.16"
+    prop-types "15.x"
+    raf "^3.4.0"
+    rc-util "^4.5.0"
+    react-lifecycles-compat "^3.0.4"
 
 rc-calendar@~9.6.0:
   version "9.6.0"
@@ -6611,15 +6681,16 @@ rc-calendar@~9.6.0:
     rc-trigger "^2.2.0"
     rc-util "^4.1.1"
 
-rc-cascader@~0.12.0:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-0.12.2.tgz#2d08fe44b504364137d3c748f51ac393483e7b3b"
+rc-cascader@~0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/rc-cascader/-/rc-cascader-0.14.0.tgz#a956c99896f10883bf63d46fb894d0cb326842a4"
   dependencies:
     array-tree-filter "^1.0.0"
     prop-types "^15.5.8"
     rc-trigger "^2.2.0"
     rc-util "^4.0.4"
     shallow-equal "^1.0.0"
+    warning "^4.0.1"
 
 rc-checkbox@~2.1.5:
   version "2.1.5"
@@ -6630,9 +6701,9 @@ rc-checkbox@~2.1.5:
     prop-types "15.x"
     rc-util "^4.0.4"
 
-rc-collapse@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.8.0.tgz#107bd9193e36b1ec5381c9ed9ff4f7245a79adb5"
+rc-collapse@~1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.9.3.tgz#d9741db06a823353e1fd1aec3ba4c0f9d8af4b26"
   dependencies:
     classnames "2.x"
     css-animation "1.x"
@@ -6647,13 +6718,22 @@ rc-dialog@~7.1.0:
     rc-animate "2.x"
     rc-util "^4.4.0"
 
-rc-dropdown@~2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-2.1.2.tgz#f99844d2ec17707232f244dda75c8d8a623d0272"
+rc-drawer@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/rc-drawer/-/rc-drawer-1.6.2.tgz#588e819406698c26769bddf271e7de6a2bc3b4e7"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    prop-types "^15.5.0"
+    rc-util "^4.5.1"
+
+rc-dropdown@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rc-dropdown/-/rc-dropdown-2.2.0.tgz#a905067666ce73c0ce26cf0980e7b75b46126825"
   dependencies:
     babel-runtime "^6.26.0"
     prop-types "^15.5.8"
-    rc-trigger "^2.2.2"
+    rc-trigger "^2.5.1"
     react-lifecycles-compat "^3.0.2"
 
 rc-editor-core@~0.8.3:
@@ -6710,23 +6790,35 @@ rc-input-number@~4.0.0:
     prop-types "^15.5.7"
     rmc-feedback "^1.0.0"
 
-rc-menu@^6.1.0, rc-menu@~6.2.0:
-  version "6.2.10"
-  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-6.2.10.tgz#d8a4ce5637ac51c1c539c4c6d0996e0ced5122ec"
+rc-menu@^7.0.2:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-7.2.6.tgz#b18b8da9d637533145c6bc28cae1f29ae55c8dc7"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
-    create-react-class "^15.5.2"
     dom-scroll-into-view "1.x"
-    mini-store "^1.0.2"
+    mini-store "^1.1.0"
     prop-types "^15.5.6"
     rc-animate "2.x"
     rc-trigger "^2.3.0"
     rc-util "^4.1.0"
 
-rc-notification@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-3.0.1.tgz#9ddcb831895ad40943a7e1df34951aa705173bce"
+rc-menu@~7.0.2:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/rc-menu/-/rc-menu-7.0.5.tgz#986b65df5ad227aadf399ea374b98d2313802316"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "2.x"
+    dom-scroll-into-view "1.x"
+    mini-store "^1.1.0"
+    prop-types "^15.5.6"
+    rc-animate "2.x"
+    rc-trigger "^2.3.0"
+    rc-util "^4.1.0"
+
+rc-notification@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/rc-notification/-/rc-notification-3.1.1.tgz#14eac6730db1d59adaf569dad9fe82a2f33cd23a"
   dependencies:
     babel-runtime "6.x"
     classnames "2.x"
@@ -6757,9 +6849,9 @@ rc-rate@~2.4.0:
     prop-types "^15.5.8"
     rc-util "^4.3.0"
 
-rc-select@~7.7.0:
-  version "7.7.8"
-  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-7.7.8.tgz#333c7e4df349986a566b360d62101e4176d772c7"
+rc-select@~8.0.7:
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/rc-select/-/rc-select-8.0.14.tgz#ff1763458a15519bea010ea15fecf6f59095b346"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "2.x"
@@ -6767,9 +6859,10 @@ rc-select@~7.7.0:
     dom-scroll-into-view "1.x"
     prop-types "^15.5.8"
     rc-animate "2.x"
-    rc-menu "^6.1.0"
+    rc-menu "^7.0.2"
     rc-trigger "^2.2.0"
     rc-util "^4.0.4"
+    react-lifecycles-compat "^3.0.2"
     warning "^3.0.0"
 
 rc-slider@~8.6.0:
@@ -6801,11 +6894,12 @@ rc-switch@~1.6.0:
     classnames "^2.2.1"
     prop-types "^15.5.6"
 
-rc-table@~6.1.0:
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-6.1.10.tgz#b2749f127cfb76d7f331fd2e80cfe48c30b6edef"
+rc-table@~6.2.2:
+  version "6.2.8"
+  resolved "https://registry.yarnpkg.com/rc-table/-/rc-table-6.2.8.tgz#c06bf48bfab60754ab3f70102290e41e8b32388e"
   dependencies:
     babel-runtime "6.x"
+    classnames "^2.2.5"
     component-classes "^1.2.6"
     lodash "^4.17.5"
     mini-store "^1.0.2"
@@ -6846,32 +6940,25 @@ rc-tooltip@^3.7.0, rc-tooltip@~3.7.0:
     prop-types "^15.5.8"
     rc-trigger "^2.2.2"
 
-rc-tree-select@~1.12.0:
-  version "1.12.11"
-  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-1.12.11.tgz#6fabf6bee56d422c4408b3b237f358ee33505c80"
+rc-tree-select@~2.0.5:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/rc-tree-select/-/rc-tree-select-2.0.11.tgz#4130acccead2623b6735d060981ae29e4b439f07"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "^2.2.1"
     prop-types "^15.5.8"
-    rc-animate "^2.0.2"
-    rc-tree "~1.7.1"
-    rc-trigger "^2.2.2"
+    raf "^3.4.0"
+    rc-animate "^3.0.0-rc.1"
+    rc-tree "~1.12.2"
+    rc-trigger "^3.0.0-rc.2"
     rc-util "^4.5.0"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.0.2"
+    warning "^4.0.1"
 
-rc-tree@~1.7.1:
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.7.11.tgz#349de6383fc7d22bf4c13b0751794111022adddf"
-  dependencies:
-    babel-runtime "^6.23.0"
-    classnames "2.x"
-    prop-types "^15.5.8"
-    rc-animate "2.x"
-    rc-util "^4.0.4"
-    warning "^3.0.0"
-
-rc-tree@~1.8.0:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.8.3.tgz#2875e83bc951b5ed7577c1038490f8245d79a37f"
+rc-tree@~1.12.0, rc-tree@~1.12.2:
+  version "1.12.6"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.12.6.tgz#53bd6a567b41418a125a6d8c129a8730698f1933"
   dependencies:
     babel-runtime "^6.23.0"
     classnames "2.x"
@@ -6890,9 +6977,32 @@ rc-trigger@^2.2.0, rc-trigger@^2.2.2, rc-trigger@^2.3.0:
     rc-animate "2.x"
     rc-util "^4.4.0"
 
-rc-upload@~2.4.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-2.4.4.tgz#28e1e6a3e44d1b1f92e57e21927cfa2763ac2a21"
+rc-trigger@^2.5.1, rc-trigger@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-2.5.4.tgz#9088a24ba5a811b254f742f004e38a9e2f8843fb"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.6"
+    prop-types "15.x"
+    rc-align "^2.4.0"
+    rc-animate "2.x"
+    rc-util "^4.4.0"
+
+rc-trigger@^3.0.0-rc.2:
+  version "3.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-3.0.0-rc.3.tgz#35842df1674d25315e1426a44882a4c97652258b"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.6"
+    prop-types "15.x"
+    raf "^3.4.0"
+    rc-align "^2.4.1"
+    rc-animate "^3.0.0-rc.1"
+    rc-util "^4.4.0"
+
+rc-upload@~2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/rc-upload/-/rc-upload-2.5.1.tgz#7ae0c9038d98ba8750e9466d8f969e1b4bc9f0e0"
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.5"
@@ -6902,6 +7012,15 @@ rc-upload@~2.4.0:
 rc-util@^4.0.4, rc-util@^4.1.0, rc-util@^4.1.1, rc-util@^4.3.0, rc-util@^4.4.0, rc-util@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.5.0.tgz#3183e6ec806f382efb2d3e85770d95875fa6180f"
+  dependencies:
+    add-dom-event-listener "1.x"
+    babel-runtime "6.x"
+    prop-types "^15.5.10"
+    shallowequal "^0.2.2"
+
+rc-util@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.5.1.tgz#0e435057174c024901c7600ba8903dd03da3ab39"
   dependencies:
     add-dom-event-listener "1.x"
     babel-runtime "6.x"
@@ -6938,6 +7057,10 @@ react-lazy-load@^3.0.12:
 react-lifecycles-compat@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz#7279047275bd727a912e25f734c0559527e84eff"
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -8144,7 +8267,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
@@ -8368,9 +8491,15 @@ warning@2.x:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^3.0.0, warning@~3.0.0:
+warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1, warning@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.1.tgz#66ce376b7fbfe8a887c22bdf0e7349d73d397745"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
This branch
- upgrades our minor version of ant
- adds a callback prop to the ErrorBanner so we can dismiss messages permanently
- adds more form fields to the web UI tap form
- adds namespace dropdowns and resource autocompletes for the tap form

For the form help text, I've added what we have in the cli help. 

I think a clear button will come in handy for the larger form, I'll probably add that next.

<img width="1035" alt="screen shot 2018-07-26 at 5 50 10 pm" src="https://user-images.githubusercontent.com/549258/43291561-dacea7fc-90ff-11e8-8479-cf524844edd0.png">

<img width="577" alt="screen shot 2018-07-26 at 6 16 38 pm" src="https://user-images.githubusercontent.com/549258/43291601-1272fd84-9100-11e8-9859-c32fe1a7c82a.png">


I still get occasional 1006 websocket errors when opening and closing connections. I'm looking into it.