### PR TITLE
Fix build on Linux.

### DIFF
--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -eu
 
 git_sha_head() {


### PR DESCRIPTION
Without this change the Linux build fails. Apparently
commit 554ffe6a465d025c5777c23d38faf7202e083842 added the use of a
bash-specific feature.

Signed-off-by: Brian Smith <brian@briansmith.org>