### PR TITLE
Merge controller executables into one executable.

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -139,6 +139,7 @@ spec:
     spec:
       containers:
       - args:
+        - linkerd-controller
         - public-api
         - -prometheus-url=http://prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
@@ -163,6 +164,7 @@ spec:
             port: 9995
         resources: {}
       - args:
+        - linkerd-controller
         - destination
         - -enable-tls=false
         - -log-level=info
@@ -186,6 +188,7 @@ spec:
             port: 9999
         resources: {}
       - args:
+        - linkerd-controller
         - proxy-api
         - -addr=:8086
         - -log-level=info
@@ -209,6 +212,7 @@ spec:
             port: 9996
         resources: {}
       - args:
+        - linkerd-controller
         - tap
         - -log-level=info
         image: gcr.io/linkerd-io/controller:undefined

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -140,6 +140,7 @@ spec:
     spec:
       containers:
       - args:
+        - linkerd-controller
         - public-api
         - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
         - -controller-namespace=Namespace
@@ -164,6 +165,7 @@ spec:
             port: 9995
         resources: {}
       - args:
+        - linkerd-controller
         - destination
         - -enable-tls=true
         - -log-level=ControllerLogLevel
@@ -187,6 +189,7 @@ spec:
             port: 9999
         resources: {}
       - args:
+        - linkerd-controller
         - proxy-api
         - -addr=:123
         - -log-level=ControllerLogLevel
@@ -210,6 +213,7 @@ spec:
             port: 9996
         resources: {}
       - args:
+        - linkerd-controller
         - tap
         - -log-level=ControllerLogLevel
         image: ControllerImage
@@ -917,6 +921,7 @@ spec:
     spec:
       containers:
       - args:
+        - linkerd-controller
         - ca
         - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -145,6 +145,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "linkerd-controller"
         - "public-api"
         - "-prometheus-url=http://prometheus.{{.Namespace}}.svc.cluster.local:9090"
         - "-controller-namespace={{.Namespace}}"
@@ -168,6 +169,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "linkerd-controller"
         - "destination"
         - "-enable-tls={{.EnableTLS}}"
         - "-log-level={{.ControllerLogLevel}}"
@@ -190,6 +192,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "linkerd-controller"
         - "proxy-api"
         - "-addr=:{{.ProxyAPIPort}}"
         - "-log-level={{.ControllerLogLevel}}"
@@ -212,6 +215,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "linkerd-controller"
         - "tap"
         - "-log-level={{.ControllerLogLevel}}"
         livenessProbe:
@@ -685,6 +689,7 @@ spec:
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
+        - "linkerd-controller"
         - "ca"
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,13 +1,13 @@
 ## compile controller services
 FROM gcr.io/linkerd-io/go-deps:766a0983 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
+
 COPY controller/gen controller/gen
 COPY pkg pkg
-COPY controller controller
-
-# use `install` so that we produce multiple binaries
 RUN CGO_ENABLED=0 GOOS=linux go install ./pkg/...
-RUN CGO_ENABLED=0 GOOS=linux go install ./controller/cmd/...
+
+COPY controller controller
+RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/linkerd-controller ./controller/
 
 ## package runtime
 FROM scratch

--- a/controller/cmd/ca/main.go
+++ b/controller/cmd/ca/main.go
@@ -1,4 +1,4 @@
-package main
+package ca_main
 
 import (
 	"flag"
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	metricsAddr := flag.String("metrics-addr", ":9997", "address to serve scrapable metrics on")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -1,4 +1,4 @@
-package main
+package destination_main
 
 import (
 	"flag"
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	addr := flag.String("addr", "127.0.0.1:8089", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -1,4 +1,4 @@
-package main
+package proxy_api_main
 
 import (
 	"flag"
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	addr := flag.String("addr", ":8086", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	destinationAddr := flag.String("destination-addr", "127.0.0.1:8089", "address of destination service")

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -1,4 +1,4 @@
-package main
+package public_api_main
 
 import (
 	"context"
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	addr := flag.String("addr", ":8085", "address to serve on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	prometheusUrl := flag.String("prometheus-url", "http://127.0.0.1:9090", "prometheus url")

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -1,4 +1,4 @@
-package main
+package tap_main
 
 import (
 	"flag"
@@ -13,7 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func main() {
+func Main() {
 	addr := flag.String("addr", "127.0.0.1:8088", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")

--- a/controller/main.go
+++ b/controller/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+	"os"
+	"github.com/linkerd/linkerd2/controller/cmd/ca"
+	"github.com/linkerd/linkerd2/controller/cmd/destination"
+	"github.com/linkerd/linkerd2/controller/cmd/public-api"
+	"github.com/linkerd/linkerd2/controller/cmd/proxy-api"
+	"github.com/linkerd/linkerd2/controller/cmd/tap"
+	"strings"
+)
+
+func main() {
+	// Especially because all of the commands use client-go which ends up
+	// making the executable huge, it is much more efficient for link time,
+	// executable size, and container image size to have them all in one
+	// executable.
+	if len(os.Args) < 2 || strings.HasPrefix(os.Args[1], "-") {
+		log.Fatal("no command given; it must be the first argument")
+	}
+	// All the commands' Main() functions are written as though they are
+	// main.main(). They use the flag package that doesn't tolerate non-flag
+	// arguments, so remove the command from os.Args before calling Main().
+	cmd := os.Args[1]
+	copy(os.Args[1:], os.Args[2:]) // Remove os.Args[1]
+	switch cmd {
+	case "ca":
+		ca_main.Main()
+	case "destination":
+		destination_main.Main()
+	case "proxy-api":
+		proxy_api_main.Main()
+	case "public-api":
+		public_api_main.Main()
+	case "tap":
+		tap_main.Main()
+	default:
+		log.Fatalf("unrecognized command: %s", os.Args[1])
+	}
+}


### PR DESCRIPTION
The link stage of `go build` is one of the slowest parts of the build,
so speed it up by linking only once instead of 5 times. Every executable
that contains client-go is huge (39-44MB) so this shrinks the
controller's size to a little more than 1/5 its current size, to ~44MB.
This speeds up the installation by reducing the download size and also
reduces resource consumption at runtime.

Also, improve Docker's caching of pkg/ build results by putting the
`COPY controller controller` in the right place.

There are no functional changes here.

Signed-off-by: Brian Smith <brian@briansmith.org>