### PR TITLE
Update location of emojivoto kubernetes config

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -135,7 +135,7 @@ bin/linkerd check --expected-version $(bin/root-tag)
 bin/linkerd dashboard
 
 # install the demo app
-curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | bin/linkerd inject - | kubectl apply -f -
+curl https://raw.githubusercontent.com/BuoyantIO/emojivoto/master/emojivoto.yml | bin/linkerd inject - | kubectl apply -f -
 
 # view demo app
 minikube -n emojivoto service web-svc

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -196,7 +196,7 @@ Finally, it’s time to install a demo application and add it to the service mes
 
 ### To install a local version of this demo locally and add it to Linkerd, run:
 
-#### `curl https://raw.githubusercontent.com/runconduit/conduit-examples/master/emojivoto/emojivoto.yml | linkerd inject - | kubectl apply -f -`
+#### `curl https://raw.githubusercontent.com/BuoyantIO/emojivoto/master/emojivoto.yml | linkerd inject - | kubectl apply -f -`
 
 ### Which should display:
 


### PR DESCRIPTION
The emojivoto app has moved to the https://github.com/BuoyantIO/emojivoto repo. This branch updates the emojivoto install instructions in this repo accordingly.