### PR TITLE
Update inject cmd to read from folder

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -92,7 +94,7 @@ func TestRunInjectCmd(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
-			exitCode := runInjectCmd(in, errBuffer, outBuffer, testInjectOptions)
+			exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, testInjectOptions)
 			if exitCode != tc.exitCode {
 				t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
 			}
@@ -106,5 +108,100 @@ func TestRunInjectCmd(t *testing.T) {
 			expectedStdErrResult := readOptionalTestFile(t, tc.stdErrGoldenFileName)
 			diffCompare(t, actualStdErrResult, expectedStdErrResult)
 		})
+	}
+}
+
+func TestInjectFilePath(t *testing.T) {
+	var (
+		resourceFolder = filepath.Join("testdata", "inject-filepath", "resources")
+		expectedFolder = filepath.Join("inject-filepath", "expected")
+		options        = newInjectOptions()
+	)
+
+	t.Run("read from files", func(t *testing.T) {
+		testCases := []struct {
+			resource     string
+			resourceFile string
+			expectedFile string
+		}{
+			{resource: "nginx", resourceFile: filepath.Join(resourceFolder, "nginx.yaml"), expectedFile: filepath.Join(expectedFolder, "injected_nginx.yaml")},
+			{resource: "redis", resourceFile: filepath.Join(resourceFolder, "db/redis.yaml"), expectedFile: filepath.Join(expectedFolder, "injected_redis.yaml")},
+		}
+
+		for i, testCase := range testCases {
+			t.Run(fmt.Sprintf("%d %s", i, testCase.resource), func(t *testing.T) {
+				in, err := read(testCase.resourceFile)
+				if err != nil {
+					t.Fatal("Unexpected error: ", err)
+				}
+
+				actual := &bytes.Buffer{}
+				if exitCode := runInjectCmd(in, actual, actual, options); exitCode != 0 {
+					t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
+				}
+
+				expected := readOptionalTestFile(t, testCase.expectedFile)
+				if expected != actual.String() {
+					t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
+				}
+			})
+		}
+	})
+
+	t.Run("read from folder", func(t *testing.T) {
+		in, err := read(resourceFolder)
+		if err != nil {
+			t.Fatal("Unexpected error: ", err)
+		}
+
+		actual := &bytes.Buffer{}
+		if exitCode := runInjectCmd(in, actual, actual, options); exitCode != 0 {
+			t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
+		}
+
+		expected := readOptionalTestFile(t, filepath.Join(expectedFolder, "injected_nginx_redis.yaml"))
+		if expected != actual.String() {
+			t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
+		}
+	})
+}
+
+func TestWalk(t *testing.T) {
+	// create two data files, one in the root folder and the other in a subfolder.
+	// walk should be able to read the content of the two data files recursively.
+	var (
+		tmpFolderRoot = "linkerd-testdata"
+		tmpFolderData = filepath.Join(tmpFolderRoot, "data")
+	)
+
+	if err := os.MkdirAll(tmpFolderData, os.ModeDir|os.ModePerm); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+	defer os.RemoveAll(tmpFolderRoot)
+
+	var (
+		data  = []byte(readOptionalTestFile(t, "inject_gettest_deployment.bad.input.yml"))
+		file1 = filepath.Join(tmpFolderRoot, "root.txt")
+		file2 = filepath.Join(tmpFolderData, "data.txt")
+	)
+	if err := ioutil.WriteFile(file1, data, 0666); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+	if err := ioutil.WriteFile(file2, data, 0666); err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	actual, err := walk(tmpFolderRoot)
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	for _, r := range actual {
+		b := make([]byte, len(data))
+		r.Read(b)
+
+		if string(b) != string(data) {
+			t.Errorf("Content mismatch. Expected %q, but got %q", data, b)
+		}
 	}
 }

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        app: nginx
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: LINKERD2_PROXY_CONTROL_URL
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: LINKERD2_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/linkerd-io/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -1,0 +1,162 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        app: redis
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: redis
+    spec:
+      containers:
+      - image: redis
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: server
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: LINKERD2_PROXY_CONTROL_URL
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: LINKERD2_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/linkerd-io/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        app: nginx
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: nginx
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: LINKERD2_PROXY_CONTROL_URL
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: LINKERD2_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/linkerd-io/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        app: redis
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: redis
+    spec:
+      containers:
+      - image: redis
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: server
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: LINKERD2_PROXY_CONTROL_URL
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: LINKERD2_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/linkerd-io/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-metrics
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/cli/cmd/testdata/inject-filepath/resources/db/redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/resources/db/redis.yaml
@@ -1,0 +1,21 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis
+        ports:
+        - name: server
+          containerPort: 6379
+

--- a/cli/cmd/testdata/inject-filepath/resources/nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/resources/nginx.yaml
@@ -1,0 +1,20 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - name: http
+          containerPort: 80


### PR DESCRIPTION
This PR extends the CLI `inject` command to read from folder. This behaviour matches that of `kubectl create|apply|delete` commands which can read from stdin, files and directories (recursively, if the `-R` option is provided).

Given this `apps` folder:
```
$ ls -R apps
apps:
db  nginx.yaml
apps/db:
redis.yaml
```

Current behaviour:
```
$ linkerd version --client
Client version: v18.7.1
$ linkerd inject apps
Error injecting linkerd proxy: read apps: is a directory
```

With this change:
```
$ bin/go-run cli inject apps
# lots of yaml
# .......
$ bin/go-run cli inject apps | kubectl apply -f -
deployment.apps "redis" created
deployment.apps "nginx" created
```