### PR TITLE
Remove remaining conduit references in codebase

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -135,7 +135,7 @@ bin/linkerd check --expected-version $(bin/root-tag)
 bin/linkerd dashboard
 
 # install the demo app
-curl https://raw.githubusercontent.com/BuoyantIO/emojivoto/master/emojivoto.yml | bin/linkerd inject - | kubectl apply -f -
+curl https://run.linkerd.io/emojivoto.yml | bin/linkerd inject - | kubectl apply -f -
 
 # view demo app
 minikube -n emojivoto service web-svc

--- a/BUILD.md
+++ b/BUILD.md
@@ -112,7 +112,7 @@ and run Linkerd2:
 
 This configuration builds all Linkerd2 components in Docker images, and deploys
 them onto Minikube. This setup most closely parallels our recommended production
-installation, documented at https://conduit.io/getting-started/.
+installation, documented at https://linkerd.io/2/getting-started/.
 
 These commands assume a working
 [Minikube](https://github.com/kubernetes/minikube) environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,6 @@ Describe the modifications you've made.
 Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.
 
-[discourse]: https://discourse.linkerd.io/c/conduit
+[discourse]: https://discourse.linkerd.io/c/linkerd2
 [issue]: https://github.com/linkerd/linkerd2/issues/new
 [slack]: http://slack.linkerd.io/

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 
 :balloon: Welcome to Linkerd2! :wave:
 
-Note: this project is currently in the middle of a migration from the old name
-(Conduit) to the new name (Linkerd2). While this transition is ongoing, there
-will be references to Conduit that don't make a lot of sense. Not to worry,
-we're working on it! For more information, check out the
-[announcement][announcement].
-
 Linkerd2 is an ultralight *service mesh*, designed to make modern applications
 safe and sane by transparently adding service discovery, load balancing, failure
 handling, instrumentation, and routing to all inter-service communication.
@@ -41,17 +35,17 @@ Linkerd is hosted by the Cloud Native Computing Foundation ([CNCF][cncf]).
   mailing list.
 * [Announcements mailing list][linkerd-announce]: Linkerd2 announcements only
   (low volume).
-* Follow [@runconduit][twitter] on Twitter.
+* Follow [@linkerd][twitter] on Twitter.
 * Join the #linkerd2 channel on the [Linkerd Slack][slack].
 
 ## Documentation
 
 View [Linkerd2 docs][linkerd-docs] for more a more comprehensive guide to
-getting started, or view the full [Linkerd2 roadmap][roadmap].
+getting started, or use the instructions below.
 
 ## Getting started with Linkerd2
 
-1. Install the Linkerd2 CLI with `curl https://run.conduit.io/install | sh `.
+1. Install the Linkerd2 CLI with `curl https://run.linkerd.io/install | sh`.
 
 1. Add `$HOME/.linkerd2/bin` to your `PATH`.
 
@@ -102,25 +96,22 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 <!-- refs -->
-[announcement]: https://blog.conduit.io/2018/07/06/conduit-0-5-and-the-future/
 [ci]: https://travis-ci.org/linkerd/linkerd2
 [ci-badge]: https://travis-ci.org/linkerd/linkerd2.svg?branch=master
 [cncf]: https://www.cncf.io/
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [linkerd-announce]: https://groups.google.com/forum/#!forum/conduit-announce
-[linkerd-demo]: https://conduit.io/getting-started/#install-the-demo-app
+[linkerd-demo]: https://linkerd.io/2/getting-started/#step-3-install-the-demo-app
 [linkerd-dev]: https://groups.google.com/forum/#!forum/conduit-dev
-[linkerd-inject]: https://conduit.io/adding-your-service/
-[linkerd-docs]: https://conduit.io/docs/
+[linkerd-inject]: https://linkerd.io/2/adding-your-service/
+[linkerd-docs]: https://linkerd.io/2/overview/
 [linkerd-users]: https://groups.google.com/forum/#!forum/conduit-users
 [golang]: https://golang.org/
 [license-badge]: https://img.shields.io/github/license/linkerd/linkerd.svg
 [logo]: https://user-images.githubusercontent.com/9226/33582867-3e646e02-d90c-11e7-85a2-2e238737e859.png
 [proxy]: https://github.com/linkerd/linkerd2-proxy
 [proxy-api]: https://github.com/linkerd/linkerd2-proxy-api
-[roadmap]: https://conduit.io/roadmap
-[releases]: https://github.com/linkerd/linkerd2/releases
 [rust]: https://www.rust-lang.org/
 [slack-badge]: http://slack.linkerd.io/badge.svg
 [slack]: http://slack.linkerd.io
-[twitter]: https://twitter.com/runconduit/
+[twitter]: https://twitter.com/linkerd

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -20,7 +20,7 @@ const (
 	okStatus        = "[ok]"
 	failStatus      = "[FAIL]"
 	errorStatus     = "[ERROR]"
-	versionCheckURL = "https://versioncheck.conduit.io/version.json"
+	versionCheckURL = "https://versioncheck.linkerd.io/version.json"
 )
 
 type checkOptions struct {

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -76,7 +76,7 @@ class Sidebar extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    let versionUrl = `https://versioncheck.conduit.io/version.json?version=${this.props.releaseVersion}?uuid=${this.props.uuid}`;
+    let versionUrl = `https://versioncheck.linkerd.io/version.json?version=${this.props.releaseVersion}?uuid=${this.props.uuid}`;
     this.api.setCurrentRequests([
       ApiHelpers("").fetch(versionUrl),
       this.api.fetchMetrics(this.api.urlsForResource("namespace"))
@@ -203,7 +203,7 @@ class Sidebar extends React.Component {
             </Menu.SubMenu>
 
             <Menu.Item className="sidebar-menu-item" key="/docs">
-              <Link to="https://conduit.io/docs/" target="_blank">
+              <Link to="https://linkerd.io/2/overview/" target="_blank">
                 <Icon type="file-text" />
                 <span>Documentation</span>
               </Link>
@@ -211,7 +211,7 @@ class Sidebar extends React.Component {
 
             { this.state.isLatest ? null : (
               <Menu.Item className="sidebar-menu-item" key="/update">
-                <Link to="https://versioncheck.conduit.io/update" target="_blank">
+                <Link to="https://versioncheck.linkerd.io/update" target="_blank">
                   <Icon type="exclamation-circle-o" className="update" />
                   <span>Update {this.props.productName}</span>
                 </Link>

--- a/web/app/js/components/SocialLinks.jsx
+++ b/web/app/js/components/SocialLinks.jsx
@@ -45,7 +45,7 @@ export default class SocialLinks extends React.Component {
       <div className="social-links">
         <Link target="_blank" to="https://github.com/linkerd/linkerd2"><Github /></Link>
         <Link target="_blank" to="https://slack.linkerd.io/"><Slack /></Link>
-        <Link target="_blank" to="https://twitter.com/runconduit"><Twitter /></Link>
+        <Link target="_blank" to="https://twitter.com/linkerd"><Twitter /></Link>
       </div>
     );
   }

--- a/web/app/js/components/Version.jsx
+++ b/web/app/js/components/Version.jsx
@@ -37,7 +37,7 @@ class Version extends React.Component {
       <div>
         A new version ({latestVersion}) is available<br />
         <Link
-          to="https://versioncheck.conduit.io/update"
+          to="https://versioncheck.linkerd.io/update"
           className="button primary"
           target="_blank">
           Update Now


### PR DESCRIPTION
This branch removes all remaining conduit references from the codebase, except:

* The mailing lists, which haven't been updated yet
* The `doc` directory, which is going to be dropped
* Previous releases in the changelog, which we are not going to update

Fixes #1316.
Fixes #1347.