### PR TITLE
Bump install timeout in integration tests

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -90,7 +90,7 @@ func TestInstall(t *testing.T) {
 	}
 
 	// Tests Pods and Deployments
-	err = TestHelper.RetryFor(1*time.Minute, func() error {
+	err = TestHelper.RetryFor(2*time.Minute, func() error {
 		for deploy, replicas := range linkerdDeployReplicas {
 			if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
 				return fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err)


### PR DESCRIPTION
If the linkerd2 docker images haven't been already pulled into the test cluster when the integration tests are run, then the install test must wait for them to be pulled before validating that they're up and running. In the past we've waited 1 minute, but that timeout appears to be too short, based on [sporadic test failures](https://github.com/linkerd/linkerd2/issues/1265#issuecomment-402802200). This branch bumps the timeout to 2 minutes.

Relates to #1265.