### PR TITLE
Add script to extract binaries from prebuilt cli-bin image

### DIFF
--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -eq 1 ]; then
+    tag="${1:-}"
+else
+    echo "usage: $(basename $0) tag" >&2
+    exit 64
+fi
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+. $bindir/_docker.sh
+
+workdir="$rootdir/target/release"
+mkdir -p "$workdir"
+
+shorttag="$tag"
+if [ "${tag:0:1}" == "v" ]; then
+  shorttag="${tag:1}"
+fi
+
+# create the cli-bin container in order to extract the binaries
+id=$(docker create "$(docker_repo cli-bin):$tag")
+
+for os in darwin linux windows ; do
+  ext="$os"
+  if [ "$os" == "windows" ]; then
+    ext="windows.exe"
+  fi
+  filepath="$workdir/linkerd2-cli-$shorttag-$ext"
+  docker cp "$id:/out/linkerd-$os" "$filepath"
+  openssl dgst -sha256 "$filepath" | awk '{print $2}' > "$filepath.sha256"
+  echo "$filepath"
+done
+
+# cleanup the cli-bin container when finished
+docker rm "$id" > /dev/null


### PR DESCRIPTION
As of #1365, CI is setup to publish the docker images when a release tag is created. When we create the release in GitHub, we need to attach the binaries from the `cli-bin` image that was published by CI.

This branch adds a script that pulls a `cli-bin` image by tag name and extracts the binaries so that we can attach them to the release. The script also automatically generates checksums for all of the binaries, so that we can start including those with the release as well (relates to #1379).

Here's an example of the script extracting the binaries from the latest release tag:

```
$ ./bin/docker-pull-binaries v18.7.2
/Users/kl/workspace/linkerd2/target/release/linkerd2-cli-18.7.2-darwin
/Users/kl/workspace/linkerd2/target/release/linkerd2-cli-18.7.2-linux
/Users/kl/workspace/linkerd2/target/release/linkerd2-cli-18.7.2-windows.exe
$ ls -l target/release
total 137688
-rwxr-xr-x  1 kl  staff  25230800 Jul 24 13:42 linkerd2-cli-18.7.2-darwin
-rw-r--r--  1 kl  staff        65 Jul 31 14:41 linkerd2-cli-18.7.2-darwin.sha256
-rwxr-xr-x  1 kl  staff  22518336 Jul 24 13:42 linkerd2-cli-18.7.2-linux
-rw-r--r--  1 kl  staff        65 Jul 31 14:41 linkerd2-cli-18.7.2-linux.sha256
-rwxr-xr-x  1 kl  staff  22732288 Jul 24 13:42 linkerd2-cli-18.7.2-windows.exe
-rw-r--r--  1 kl  staff        65 Jul 31 14:41 linkerd2-cli-18.7.2-windows.exe.sha256
```