### PR TITLE
Tap: Make use of the Web UI to render tap events in a table

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -23,7 +23,6 @@
   --font-weight-bold: 700;
   --font-weight-extra-bold: 900;
   --base-width: 8px;
-  --tap-bg-opacity: 0.1;
 }
 
 .hide {

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -23,6 +23,7 @@
   --font-weight-bold: 700;
   --font-weight-extra-bold: 900;
   --base-width: 8px;
+  --tap-bg-opacity: 0.1;
 }
 
 .hide {
@@ -58,7 +59,7 @@ h2, h3, h4, h5, h6 {
 }
 
 .main-content {
-  max-width: 1164px;
+  max-width: 100%;
   width: 100%;
   padding: 40px;
   float: left;

--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -1,23 +1,20 @@
 @import 'styles.css';
 
-.tap-display {
-  font-size: 10px;
-  margin-top: calc(4 * var(--base-width));
-}
-
-button.ant-btn-primary {
-  &.tap-start {
-    background-color: var(--green);
-    border-color: var(--green);
+.tap-form {
+  & button.ant-btn-primary {
+    &.tap-start {
+      background-color: var(--green);
+      border-color: var(--green);
+    }
+    &.tap-stop {
+      background-color: var(--siennared);
+      border-color: var(--siennared);
+    }
   }
-  &.tap-stop {
-    background-color: var(--siennared);
-    border-color: var(--siennared);
-  }
-}
 
-button.tap-form-toggle {
-  padding-left: 0;
-  border: none;
-  color: rgba(52, 137, 206, 0.906);
+  & button.tap-form-toggle {
+    padding-left: 0;
+    border: none;
+    color: rgba(52, 137, 206, 0.906);
+  }
 }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -3,6 +3,7 @@ import ErrorBanner from './ErrorBanner.jsx';
 import PageHeader from './PageHeader.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
+import TapEventTable from './TapEventTable.jsx';
 import { withContext } from './util/AppContext.jsx';
 import {
   AutoComplete,
@@ -68,7 +69,9 @@ class Tap extends React.Component {
   }
 
   componentWillUnmount() {
-    this.ws.close(1000);
+    if (this.ws) {
+      this.ws.close(1000);
+    }
     this.stopTapStreaming();
     this.stopServerPolling();
   }
@@ -260,7 +263,7 @@ class Tap extends React.Component {
 
   renderTapForm = () => {
     return (
-      <Form>
+      <Form className="tap-form">
         <Row gutter={rowGutter}>
           <Col span={colSpan}>
             <Form.Item>
@@ -296,8 +299,15 @@ class Tap extends React.Component {
                   <Button type="primary" className="tap-stop" onClick={this.handleTapStop}>Stop</Button> :
                   <Button type="primary" className="tap-start" onClick={this.handleTapStart}>Start</Button>
               }
+              {
+                this.state.awaitingWebSocketConnection ?
+                  <Icon type="loading" style={{ paddingLeft: rowGutter, fontSize: 20, color: '#08c' }} /> : null
+              }
             </Form.Item>
+
           </Col>
+
+
         </Row>
 
         <Button
@@ -432,17 +442,7 @@ class Tap extends React.Component {
         <PageHeader header="Tap" />
         {this.renderTapForm()}
         {this.renderCurrentQuery()}
-
-        <div className="tap-display">
-          <code>
-            { this.state.awaitingWebSocketConnection ?
-              <div><Icon type="loading" /> Starting tap query...</div> : null }
-            { _.isEmpty(this.state.messages) && this.state.webSocketRequestSent
-              && !this.state.awaitingWebSocketConnection
-              ? <div>No messages to display</div> : null }
-            { _.map(this.state.messages, (m, i) => <div key={`message-${i}`}>{m}</div>)}
-          </code>
-        </div>
+        <TapEventTable data={this.state.messages} />
       </div>
     );
   }

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -115,6 +115,7 @@ const expandedRowRender = d => {
     </div>
   );
 };
+
 export default class TapEventTable extends BaseTable {
   constructor(props) {
     super(props);

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,0 +1,190 @@
+import _ from 'lodash';
+import BaseTable from './BaseTable.jsx';
+import { publicAddressToString } from './util/Utils.js';
+import React from 'react';
+import { Col, Icon, Row } from 'antd';
+
+let tapColumns = [
+  {
+    title: "ID",
+    dataIndex: "base.id"
+  },
+  {
+    title: "Direction",
+    dataIndex: "base.proxyDirection"
+  },
+  {
+    title: "Source",
+    dataIndex: "base.source",
+    render: d => !d ? null : <span>{publicAddressToString(_.get(d, "ip.ipv4"), d.port)}</span>
+  },
+  {
+    title: "Destination",
+    dataIndex: "base.destination",
+    render: d => !d ? null : <span>{publicAddressToString(_.get(d, "ip.ipv4"), d.port)}</span>
+  },
+  {
+    title: "TLS",
+    dataIndex: "base.tls"
+  },
+  {
+    title: "Request Init",
+    children: [
+      {
+        title: "Authority",
+        key: "authority",
+        dataIndex: "req.http.requestInit",
+        render: d => !d ? <Icon type="loading" /> : d.authority
+      },
+      {
+        title: "Path",
+        key: "path",
+        dataIndex: "req.http.requestInit",
+        render: d => !d ? <Icon type="loading" /> : d.path
+      },
+      {
+        title: "Scheme",
+        key: "scheme",
+        dataIndex: "req.http.requestInit",
+        render: d => !d ? <Icon type="loading" /> : _.get(d, "scheme.registered")
+      },
+      {
+        title: "Method",
+        key: "method",
+        dataIndex: "req.http.requestInit",
+        render: d => !d ? <Icon type="loading" /> : _.get(d, "method.registered")
+      }
+    ]
+  },
+  {
+    title: "Response Init",
+    children: [
+      {
+        title: "HTTP status",
+        key: "http-status",
+        dataIndex: "rsp.http.responseInit",
+        render: d => !d ? <Icon type="loading" /> : d.httpStatus
+      },
+      {
+        title: "Latency",
+        key: "rsp-latency",
+        dataIndex: "rsp.http.responseInit",
+        render: d => !d ? <Icon type="loading" /> : d.sinceRequestInit
+      },
+    ]
+  },
+  {
+    title: "Response End",
+    children: [
+      {
+        title: "GRPC status",
+        key: "grpc-status",
+        dataIndex: "end.http.responseEnd",
+        render: d => !d ? <Icon type="loading" /> : _.get(d, "eos.grpcStatusCode")
+      },
+      {
+        title: "Latency",
+        key: "end-latency",
+        dataIndex: "end.http.responseEnd",
+        render: d => !d ? <Icon type="loading" /> : d.sinceResponseInit
+      },
+      {
+        title: "Response Length (B)",
+        key: "rsp-length",
+        dataIndex: "end.http.responseEnd",
+        render: d => !d ? <Icon type="loading" /> : d.responseBytes
+      },
+    ]
+
+  }
+];
+
+// hide verbose information
+const expandedRowRender = d => {
+  return (
+    <div>
+      <p style={{ margin: 0 }}>Destination Meta</p>
+      {
+        _.map(_.get(d, "base.destinationMeta.labels", []), (v, k) => (
+          <Row key={k}>
+            <Col span={6}>{k}</Col>
+            <Col cpan={6}>{v}</Col>
+          </Row>
+        ))
+      }
+    </div>
+  );
+};
+export default class TapEventTable extends BaseTable {
+  constructor(props) {
+    super(props);
+    this.requestsById = {};
+  }
+
+  indexRequest = req => {
+    if (_.isNil(this.requestsById[req.id])) {
+      this.requestsById[req.id] = {};
+    }
+    this.requestsById[req.id][req.eventType] = req;
+    // assumption: requests of a given id all share the same high level metadata
+    this.requestsById[req.id]["base"] = req;
+  }
+
+  processRowData = data => {
+    // we could do more efficient things here, like not go through all
+    // the rows on the addition of each row
+    _.each(data, datum => {
+      let d = JSON.parse(datum);
+      let rowData = {
+        tls: "",
+        id: "",
+        eventType: ""
+      };
+
+      switch (d.proxyDirection) {
+        case "INBOUND":
+          rowData.tls = _.get(d, "sourceMeta.labels.tls", "");
+          break;
+        case "OUTBOUND":
+          rowData.tls = _.get(d, "destinationMeta.labels.tls", "");
+          break;
+        default:
+          // too old for TLS
+      }
+
+      if (_.isNil(d.http)) {
+        this.setState({ error: "Undefined request type"});
+      } else {
+        if (!_.isNil(d.http.requestInit)) {
+          rowData.eventType = "req";
+          rowData.id = `${_.get(d, "http.requestInit.id.base")}:${_.get(d, "http.requestInit.id.stream")} `;
+        } else if (!_.isNil(d.http.responseInit)) {
+          rowData.eventType = "rsp";
+          rowData.id = `${_.get(d, "http.responseInit.id.base")}:${_.get(d, "http.responseInit.id.stream")} `;
+        } else if (!_.isNil(d.http.responseEnd)) {
+          rowData.eventType = "end";
+          rowData.id = `${_.get(d, "http.responseEnd.id.base")}:${_.get(d, "http.responseEnd.id.stream")} `;
+        }
+      }
+
+      this.indexRequest(_.merge({}, d, rowData));
+    });
+
+    return _.reverse(_.values(this.requestsById));
+  }
+
+  render() {
+    let rows = this.processRowData(this.props.data);
+
+    return (
+      <BaseTable
+        dataSource={rows}
+        columns={tapColumns}
+        expandedRowRender={expandedRowRender}
+        rowKey={r => r.base.id}
+        pagination={false}
+        className="tap-event-table"
+        size="middle" />
+    );
+  }
+}

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
-import { publicAddressToString } from './util/Utils.js';
 import React from 'react';
 import { Col, Icon, Row } from 'antd';
+import { formatLatency, publicAddressToString } from './util/Utils.js';
 
 let tapColumns = [
   {
@@ -69,7 +69,7 @@ let tapColumns = [
         title: "Latency",
         key: "rsp-latency",
         dataIndex: "rsp.http.responseInit",
-        render: d => !d ? <Icon type="loading" /> : d.sinceRequestInit
+        render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceRequestInit)
       },
     ]
   },
@@ -86,7 +86,7 @@ let tapColumns = [
         title: "Latency",
         key: "end-latency",
         dataIndex: "end.http.responseEnd",
-        render: d => !d ? <Icon type="loading" /> : d.sinceResponseInit
+        render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceResponseInit)
       },
       {
         title: "Response Length (B)",
@@ -98,6 +98,11 @@ let tapColumns = [
 
   }
 ];
+
+let formatTapLatency = str => {
+  let millis = parseFloat(str.replace("s", "")) * 1000;
+  return formatLatency(millis);
+};
 
 // hide verbose information
 const expandedRowRender = d => {

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -14,7 +14,7 @@ const successRateFormatter = d3.format(".2%");
 const latencySecFormatter = d3.format(".3f");
 const latencyFormatter = d3.format(",");
 
-const formatLatency = m => {
+export const formatLatency = m => {
   if (_.isNil(m)) {
     return "---";
   } else if (m < 1000) {

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -108,3 +108,24 @@ export const friendlyTitle = resource => {
   }
   return titles;
 };
+
+/*
+  produce octets given an ip address
+*/
+const decodeIPToOctets = ip => {
+  ip = parseInt(ip, 10);
+  return [
+    ip >> 24 & 255,
+    ip >> 16 & 255,
+    ip >> 8 & 255,
+    ip & 255
+  ];
+};
+
+/*
+  converts an address to an ipv4 formatted host:port pair
+*/
+export const publicAddressToString = (ipv4, port) => {
+  let octets = decodeIPToOctets(ipv4);
+  return octets.join(".") + ":" + port;
+};


### PR DESCRIPTION
- Return JSON tap events instead of the command line output
- Experiment with a different way of rendering the EventList

I changed the default width back to 100% of the screen because this table does *not* look great squished. But we can decide we only want 100% width for this page, or do other squishing if we want.

![screen shot 2018-07-31 at 5 53 54 pm](https://user-images.githubusercontent.com/549258/43495145-3fc21baa-94eb-11e8-9ae6-7a41da594761.png)
