### PR TITLE
Read all bytes of message length header

### DIFF
--- a/controller/api/public/proto_over_http.go
+++ b/controller/api/public/proto_over_http.go
@@ -119,11 +119,14 @@ func serializeAsPayload(messageContentsInBytes []byte) ([]byte, error) {
 
 func deserializePayloadFromReader(reader *bufio.Reader) ([]byte, error) {
 	messageLengthAsBytes := make([]byte, numBytesForMessageLength)
-	reader.Read(messageLengthAsBytes)
+	_, err := io.ReadFull(reader, messageLengthAsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error while reading message length: %v", err)
+	}
 	messageLength := int(binary.LittleEndian.Uint32(messageLengthAsBytes))
 
 	messageContentsAsBytes := make([]byte, messageLength)
-	_, err := io.ReadFull(reader, messageContentsAsBytes)
+	_, err = io.ReadFull(reader, messageContentsAsBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error while reading bytes from message: %v", err)
 	}


### PR DESCRIPTION
The `reader.Read` method only reads as many bytes as are currently available from reader.  When reading the 4 byte message length header, if not all 4 of those bytes are available, `Read` will only read the available bytes and return.  This causes alignment issues when the message body is read and there are still unread header bytes in the reader.  These bytes will appear at the beginning of the message body and cause a crash when the message is unmarshalled.

Use `io.ReadFull` to ensure that we read all 4 of the message length header bytes.

Fixes #1287 

Signed-off-by: Alex Leong <alex@buoyant.io>