### PR TITLE
Return error if unable to reach tap server

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -211,9 +211,8 @@ func (s *grpcServer) TapByResource(req *pb.TapByResourceRequest, stream pb.Api_T
 	tapStream := stream.(tapServer)
 	tapClient, err := s.tapClient.TapByResource(tapStream.Context(), req)
 	if err != nil {
-		//TODO: why not return the error?
 		log.Errorf("Unexpected error tapping [%v]: %v", req, err)
-		return nil
+		return err
 	}
 	for {
 		select {


### PR DESCRIPTION
If the public-api encounters an error reaching the tap server, it does not return with that error.  Instead, it enters an infinite loop where it repeatedly returns empty tap events which display in the tap client as `unknown proxy=??? src=0.0.0.0:0 dst=0.0.0.0:0 tls=`.

We return the error if we encounter one.  If the tap server cannot be reached, this results in the error message `Error: all SubConns are in TransientFailure` which is one of the most incomprehensible error messages I've ever seen.  However, I'm hesitant to replace this with a generic "Tap server error" message as this could hide other potentially useful error messages.  Matching on the text of the `SubConns` error also seems brittle.  Any suggestions for better error handling and display would be greatly appreciated.

Fixes #1293 

Signed-off-by: Alex Leong <alex@buoyant.io>