### PR TITLE
Use stable version for linkerd2-proxy-api dep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,7 +170,8 @@
     "go/net",
     "go/tap"
   ]
-  revision = "a9f0b9f267bd027be5648b87389fe46abc38c59e"
+  revision = "b0543809839fd0e6bc7cb8e4a644ce48df88b27d"
+  version = "v0.1.1"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -689,6 +690,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "18912fda7c049e609c570f382dabd369045d7e10883353fda18f42d13e013a8f"
+  inputs-digest = "771d4a9ac32fe84b400577444ceb014a105cc6ce0b5adbf85952a596026b5158"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,7 +6,7 @@ required = ["github.com/golang/protobuf/protoc-gen-go"]
 
 [[constraint]]
   name = "github.com/linkerd/linkerd2-proxy-api"
-  revision = "a9f0b9f267bd027be5648b87389fe46abc38c59e" # not published yet
+  version = "v0.1.1"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:0f0f2e2d as golang
+FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:0f0f2e2d as golang
+FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:0f0f2e2d as golang
+FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:0f0f2e2d as golang
+FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY web web
 COPY controller controller


### PR DESCRIPTION
As of linkerd/linkerd2-proxy-api#7, we can switch to stable versions for the linkerd2-proxy-api dependency, instead of relying on arbitrary revisions.