### PR TITLE
Update prometheus to only scrape proxies in the same mesh

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -625,8 +625,9 @@ data:
       - source_labels:
         - __meta_kubernetes_pod_container_name
         - __meta_kubernetes_pod_container_port_name
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics$
+        regex: ^linkerd-proxy;linkerd-metrics;linkerd$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -647,9 +648,6 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
-      # __meta_kubernetes_pod_label_foo=bar => foo=bar
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
 
 ### Grafana ###
 ---

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -628,8 +628,9 @@ data:
       - source_labels:
         - __meta_kubernetes_pod_container_name
         - __meta_kubernetes_pod_container_port_name
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics$
+        regex: ^linkerd-proxy;linkerd-metrics;Namespace$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -650,9 +651,6 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
-      # __meta_kubernetes_pod_label_foo=bar => foo=bar
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
 
 ### Grafana ###
 ---

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -451,8 +451,9 @@ data:
       - source_labels:
         - __meta_kubernetes_pod_container_name
         - __meta_kubernetes_pod_container_port_name
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics$
+        regex: ^linkerd-proxy;linkerd-metrics;{{.Namespace}}$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -473,9 +474,6 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
-      # __meta_kubernetes_pod_label_foo=bar => foo=bar
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
 
 ### Grafana ###
 ---

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -505,7 +505,7 @@ func (s *grpcServer) getPodStats(obj runtime.Object) (*podStats, error) {
 			meshCount.failed++
 		} else {
 			meshCount.total++
-			if isInMesh(pod) {
+			if k8s.IsMeshed(pod, s.controllerNamespace) {
 				meshCount.inMesh++
 			}
 		}
@@ -556,11 +556,6 @@ func checkContainerErrors(containerStatuses []apiv1.ContainerStatus, containerNa
 		}
 	}
 	return errors
-}
-
-func isInMesh(pod *apiv1.Pod) bool {
-	_, ok := pod.Annotations[k8s.ProxyVersionAnnotation]
-	return ok
 }
 
 func isInvalidServiceRequest(req *pb.StatSummaryRequest) bool {

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -180,8 +180,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `, `
@@ -202,8 +201,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Completed
 `,
@@ -241,8 +239,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -287,8 +284,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -336,8 +332,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -391,8 +386,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -446,8 +440,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `, `
@@ -458,8 +451,7 @@ metadata:
   namespace: totallydifferent
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -513,8 +505,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `, `
@@ -525,8 +516,7 @@ metadata:
   namespace: totallydifferent
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -605,8 +595,7 @@ metadata:
   namespace: not-right-emojivoto-namespace
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `, `
@@ -617,8 +606,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -915,8 +903,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Succeeded
 `, `
@@ -927,8 +914,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Failed
 `},
@@ -976,8 +962,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `, `
@@ -998,8 +983,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Failed
 `, `
@@ -1010,8 +994,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Succeeded
 `},
@@ -1049,8 +1032,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -1092,8 +1074,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,
@@ -1142,8 +1123,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
-  annotations:
-    linkerd.io/proxy-version: testinjectversion
+    linkerd.io/control-plane-ns: linkerd
 status:
   phase: Running
 `,

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -158,7 +158,7 @@ func (c *CertificateController) syncSecret(key string) error {
 
 func (c *CertificateController) handlePodAdd(obj interface{}) {
 	pod := obj.(*v1.Pod)
-	if c.isInjectedPod(pod) {
+	if pkgK8s.IsMeshed(pod, c.namespace) {
 		log.Debugf("enqueuing update of CA bundle configmap in %s", pod.Namespace)
 		c.queue.Add(pod.Namespace)
 
@@ -171,8 +171,4 @@ func (c *CertificateController) handlePodAdd(obj interface{}) {
 
 func (c *CertificateController) handlePodUpdate(oldObj, newObj interface{}) {
 	c.handlePodAdd(newObj)
-}
-
-func (c *CertificateController) isInjectedPod(pod *v1.Pod) bool {
-	return pkgK8s.GetControllerNs(pod) == c.namespace
 }

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -93,7 +93,7 @@ func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]strin
 		labels[ownerKind] = ownerName
 	}
 
-	if controllerNS := GetControllerNs(pod); controllerNS != "" {
+	if controllerNS := pod.Labels[ControllerNSLabel]; controllerNS != "" {
 		labels["linkerd_io_control_plane_ns"] = controllerNS
 	}
 
@@ -104,8 +104,8 @@ func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]strin
 	return labels
 }
 
-func GetControllerNs(pod *coreV1.Pod) string {
-	return pod.Labels[ControllerNSLabel]
+func IsMeshed(pod *coreV1.Pod, controllerNS string) bool {
+	return pod.Labels[ControllerNSLabel] == controllerNS
 }
 
 // TLSIdentity is the identity of a pod owner (Deployment, Pod,


### PR DESCRIPTION
Our previous prometheus scrape config was setup to scrape proxies in all injected pods, regardless of which controller namespace they were using. This meant that we were double collecting data in clusters with multiple linkerd installs.

In this branch I'm changing the scrape configs to only scrape proxies that are injected to use the same controller namespace where prometheus is running. I'm also removing a scrape config rule that was setup to collect arbitrary pod labels.

As part of this change I tried to clean up a few spots in the codebase where we determine if a pod is meshed or not, but creating a new `IsMeshed` func in the k8s package that requires that a pod be in the right controller namespace in order for us to consider that pod to be meshed.

Relates to #1332.