### PR TITLE
Restore linkerd_io_control_plane* labels

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -648,6 +648,10 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_linkerd_io_foo=bar =>
+      # foo=bar
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_linkerd_io_(.+)
 
 ### Grafana ###
 ---

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -651,6 +651,10 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_linkerd_io_foo=bar =>
+      # foo=bar
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_linkerd_io_(.+)
 
 ### Grafana ###
 ---

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -474,6 +474,10 @@ data:
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
+      # __meta_kubernetes_pod_label_linkerd_io_foo=bar =>
+      # foo=bar
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_linkerd_io_(.+)
 
 ### Grafana ###
 ---

--- a/doc/prometheus.md
+++ b/doc/prometheus.md
@@ -33,8 +33,9 @@ rich telemetry data to your cluster.  Simply add the following item to your
       - source_labels:
         - __meta_kubernetes_pod_container_name
         - __meta_kubernetes_pod_container_port_name
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics$
+        regex: ^linkerd-proxy;linkerd-metrics;linkerd$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -55,9 +56,10 @@ rich telemetry data to your cluster.  Simply add the following item to your
       # drop all labels that we just made copies of in the previous labelmap
       - action: labeldrop
         regex: __meta_kubernetes_pod_label_linkerd_io_proxy_(.+)
-      # __meta_kubernetes_pod_label_foo=bar => foo=bar
+      # __meta_kubernetes_pod_label_linkerd_io_foo=bar =>
+      # foo=bar
       - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
+        regex: __meta_kubernetes_pod_label_linkerd_io_(.+)
 ```
 
 That's it!  Your Prometheus cluster is now configured to scrape Linkerd's

--- a/doc/proxy-metrics.md
+++ b/doc/proxy-metrics.md
@@ -133,7 +133,7 @@ request_total{
   pod="vote-bot-5b7f5657f6-xbjjw",
   namespace="emojivoto",
   app="vote-bot",
-  linkerd_io_control_plane_ns="linkerd",
+  control_plane_ns="linkerd",
   deployment="vote-bot",
   pod_template_hash="3957278789",
   test="vote-bot-test",

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -71,14 +71,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_virtual_memory_bytes{linkerd_io_control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
+          "expr": "process_virtual_memory_bytes{control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}}/{{pod}}/virtual",
           "refId": "A"
         },
         {
-          "expr": "process_resident_memory_bytes{linkerd_io_control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
+          "expr": "process_resident_memory_bytes{control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}}/{{pod}}/resident",
@@ -162,7 +162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(process_cpu_seconds_total{linkerd_io_control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}[20s])) by (namespace, pod)",
+          "expr": "sum(irate(process_cpu_seconds_total{control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}[20s])) by (namespace, pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}}/{{pod}}",
@@ -246,7 +246,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_open_fds{linkerd_io_control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
+          "expr": "process_open_fds{control_plane_ns=\"$namespace\", job=\"linkerd-proxy\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{namespace}}/{{pod}}",
@@ -1699,7 +1699,7 @@
         "multi": false,
         "name": "deployment",
         "options": [],
-        "query": "label_values(request_total{linkerd_io_control_plane_component!=\"\"}, deployment)",
+        "query": "label_values(request_total{control_plane_component!=\"\"}, deployment)",
         "refresh": 2,
         "regex": "",
         "sort": 1,
@@ -1739,7 +1739,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(request_total{linkerd_io_control_plane_ns!=\"\"},  linkerd_io_control_plane_ns)",
+        "query": "label_values(request_total{control_plane_ns!=\"\"},  control_plane_ns)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -94,7 +94,7 @@ func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]strin
 	}
 
 	if controllerNS := pod.Labels[ControllerNSLabel]; controllerNS != "" {
-		labels["linkerd_io_control_plane_ns"] = controllerNS
+		labels["control_plane_ns"] = controllerNS
 	}
 
 	if pth := pod.Labels[appsV1.DefaultDeploymentUniqueLabelKey]; pth != "" {

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -25,10 +25,10 @@ func TestGetPodLabels(t *testing.T) {
 		ownerName := "test-deployment"
 
 		expectedLabels := map[string]string{
-			"linkerd_io_control_plane_ns": "linkerd-namespace",
-			"deployment":                  "test-deployment",
-			"pod":                         "test-pod",
-			"pod_template_hash":           "test-pth",
+			"control_plane_ns":  "linkerd-namespace",
+			"deployment":        "test-deployment",
+			"pod":               "test-pod",
+			"pod_template_hash": "test-pth",
 		}
 
 		podLabels := GetPodLabels(ownerKind, ownerName, pod)


### PR DESCRIPTION
In #1402, I inadvertently removed a relabel config that we were relying on for the Linkerd Health grafana dashboard. Specifically, we were using this rule to produce the `linkerd_io_control_plane_ns` and `linkerd_io_control_plane_component` labels:

```
      # __meta_kubernetes_pod_label_foo=bar => foo=bar
      - action: labelmap
        regex: __meta_kubernetes_pod_label_(.+)
```

In this branch I'm re-adding the rule but scoping it to only operate on labels that are prefixed with "linkerd.io/", as follows:

```
      # __meta_kubernetes_pod_label_linkerd_io_foo=bar =>
      # foo=bar
      - action: labelmap
        regex: __meta_kubernetes_pod_label_linkerd_io_(.+)
```

This change also strips the "linkerd_io_" prefix from those labels, which is more consistent with how we're rewriting all of the linkerd.io/proxy* labels. Have verified that the Linkerd Health dashboard loads successfully with this change.