### PR TITLE
Add a link to the Tap page in the sidebar

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -162,12 +162,12 @@ class Sidebar extends React.Component {
               </PrefixedLink>
             </Menu.Item>
 
-            {/* <Menu.Item className="sidebar-menu-item" key="/tap">
+            <Menu.Item className="sidebar-menu-item" key="/tap">
               <PrefixedLink to="/tap">
-                <Icon type="coffee" />
+                <Icon type="filter" />
                 <span>Tap</span>
               </PrefixedLink>
-            </Menu.Item> */}
+            </Menu.Item>
 
             {
               _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {


### PR DESCRIPTION
Reenable tap from the sidebar. 
Other icon options at https://ant.design/components/icon/

![screen shot 2018-08-07 at 1 06 04 pm](https://user-images.githubusercontent.com/549258/43799596-dca1478c-9a42-11e8-8a51-cac4a80e6e6c.png)
