### PR TITLE
Add additional validation for stat command-line arguments

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -99,8 +99,15 @@ If no resource name is specified, displays stats about all resources of the spec
   # Get all pods in all namespaces that call the hello1 service in the test namesapce.
   linkerd stat pods --to svc/hello1 --to-namespace test --all-namespaces
 
-  # Get all services in all namespaces that receive calls from hello1 deployment in the test namesapce.
-  linkerd stat services --from deploy/hello1 --from-namespace test --all-namespaces`,
+  # Get all services in all namespaces that receive calls from hello1 deployment in the test namespace.
+  linkerd stat services --from deploy/hello1 --from-namespace test --all-namespaces
+
+  # Get all namespaces that receive traffic from the default namespace.
+  linkerd stat namespaces --from ns/default
+
+  # Get all inbound stats to the test namespace.
+  linkerd stat ns/test
+  `,
 		Args:      cobra.RangeArgs(1, 2),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -53,4 +53,54 @@ emoji      1/2   100.00%   2.0rps         123ms         123ms         123ms   10
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
 	})
+
+	t.Run("Rejects commands with both --to and --from flags", func(t *testing.T) {
+		options := newStatOptions()
+		options.toResource = "deploy/foo"
+		options.fromResource = "deploy/bar"
+		args := []string{"ns", "test"}
+		expectedError := "--to and --from flags are mutually exclusive"
+
+		_, err := buildStatSummaryRequest(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
+
+	t.Run("Rejects commands with both --to-namespace and --from-namespace flags", func(t *testing.T) {
+		options := newStatOptions()
+		options.toNamespace = "foo"
+		options.fromNamespace = "bar"
+		args := []string{"po"}
+		expectedError := "--to-namespace and --from-namespace flags are mutually exclusive"
+
+		_, err := buildStatSummaryRequest(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
+
+	t.Run("Rejects --to-namespace flag when the target is a namespace", func(t *testing.T) {
+		options := newStatOptions()
+		options.toNamespace = "bar"
+		args := []string{"ns", "foo"}
+		expectedError := "--to-namespace flag is incompatible with namespace resource type"
+
+		_, err := buildStatSummaryRequest(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
+
+	t.Run("Rejects --from-namespace flag when the target is a namespace", func(t *testing.T) {
+		options := newStatOptions()
+		options.fromNamespace = "foo"
+		args := []string{"ns/bar"}
+		expectedError := "--from-namespace flag is incompatible with namespace resource type"
+
+		_, err := buildStatSummaryRequest(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
 }


### PR DESCRIPTION
Closes #776.

This branch adds the following validation to the `linkerd stat` command:

* The `--to` and `--from` flags are now mutually exclusive
* The `--to-namespace` and `--from-namespace` commands are also mutually
  exclusive.
* The `namespace` resource type conflicts with the `--namespace`, 
  `--to-namespace`, and `--from-namespace` flags.

Examples:

```
$ bin/go-run cli/main.go stat deploy --to deploy/foo --from deploy/bar
Error: --to and --from flags are mutually exclusive
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

```
$ bin/go-run cli/main.go stat deploy --to-namespace foo --from-namespace bar
Error: --to-namespace and --from-namespace flags are mutually exclusive
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

```
$ bin/go-run cli/main.go stat namespace foo --namespace bar
Error: --namespace flag is incompatible with namespace resource type
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

```
$ bin/go-run cli/main.go stat ns --to-namespace bar
Error: --to-namespace flag is incompatible with namespace resource type
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

```
$ bin/go-run cli/main.go stat namespace --from-namespace bar
Error: --from-namespace flag is incompatible with namespace resource type
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

```
$ bin/go-run cli/main.go stat ns/foo --from-namespace bar
Error: --from-namespace flag is incompatible with namespace resource type
Usage:
  linkerd stat [flags] (RESOURCE)
  ...
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>