### PR TITLE
WIP: Introduce mutating webhook for sidecar injection.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,6 +36,14 @@
   version = "v3.1.0"
 
 [[projects]]
+  name = "github.com/docker/distribution"
+  packages = [
+    "digestset",
+    "reference"
+  ]
+  revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
@@ -196,6 +204,12 @@
   name = "github.com/mxk/go-flowrate"
   packages = ["flowrate"]
   revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
+
+[[projects]]
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
 
 [[projects]]
   branch = "master"
@@ -419,6 +433,7 @@
   branch = "release-1.11"
   name = "k8s.io/api"
   packages = [
+    "admission/v1beta1",
     "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -450,6 +465,12 @@
     "storage/v1beta1"
   ]
   revision = "2d6f90ab1293a1fb871cf149423ebb72aa7423aa"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = ["pkg/features"]
+  revision = "4d05e43ad98c1edcf2f52291685bd9bbc12fd2cd"
 
 [[projects]]
   branch = "release-1.11"
@@ -501,6 +522,15 @@
     "third_party/forked/golang/reflect"
   ]
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/apiserver"
+  packages = [
+    "pkg/features",
+    "pkg/util/feature"
+  ]
+  revision = "f26e5b1f0e9c0ddd9bbff06bf6facf000baffe8f"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -680,9 +710,17 @@
 [[projects]]
   name = "k8s.io/kubernetes"
   packages = [
+    "pkg/apis/autoscaling",
     "pkg/apis/core",
+    "pkg/apis/core/v1",
+    "pkg/apis/extensions",
+    "pkg/apis/networking",
+    "pkg/apis/policy",
+    "pkg/features",
     "pkg/kubectl/proxy",
-    "pkg/kubectl/util"
+    "pkg/kubectl/util",
+    "pkg/util/parsers",
+    "pkg/util/pointer"
   ]
   revision = "b1b29978270dc22fecc592ac55d903350454310a"
   version = "v1.11.1"
@@ -690,6 +728,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "771d4a9ac32fe84b400577444ceb014a105cc6ce0b5adbf85952a596026b5158"
+  inputs-digest = "d4c9e126f922a9fe0fcfbfe7e51333d838065944054eb88439d84428b00a41a2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -17,3 +17,4 @@ if [ -z "${LINKERD_SKIP_CLI_CONTAINER:-}" ]; then
 fi
 $bindir/docker-build-grafana
 $bindir/docker-build-proxy
+$bindir/docker-build-sidecar-injection

--- a/bin/docker-build-sidecar-injection
+++ b/bin/docker-build-sidecar-injection
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    exit 64
+fi
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/sidecar-injection/Dockerfile
+
+validate_go_deps_tag $dockerfile
+
+(
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
+) >/dev/null
+
+tag="$(head_root_tag)"
+docker_build sidecar-injection $tag $dockerfile --build-arg LINKERD_VERSION=$tag

--- a/bin/webhook-create-signed-cert.sh
+++ b/bin/webhook-create-signed-cert.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat <<EOF
+Generate certificate suitable for use with an sidecar-injector webhook service.
+
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with sidecar-injector webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+
+The server key/cert k8s CA cert are stored in a k8s secret.
+
+usage: ${0} [OPTIONS]
+
+The following flags are required.
+
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --service)
+            service="$2"
+            shift
+            ;;
+        --secret)
+            secret="$2"
+            shift
+            ;;
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=sidecar-injector-webhook-svc
+[ -z ${secret} ] && secret=sidecar-injector-webhook-certs
+[ -z ${namespace} ] && namespace=default
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+FROM gcr.io/linkerd-io/go-deps:3bac64dd as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -18,6 +18,7 @@ type installConfig struct {
 	Namespace                   string
 	ControllerImage             string
 	WebImage                    string
+	SidecarInjectionImage		string
 	PrometheusImage             string
 	GrafanaImage                string
 	ControllerReplicas          uint
@@ -88,6 +89,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		Namespace:                   controlPlaneNamespace,
 		ControllerImage:             fmt.Sprintf("%s/controller:%s", options.dockerRegistry, options.linkerdVersion),
 		WebImage:                    fmt.Sprintf("%s/web:%s", options.dockerRegistry, options.linkerdVersion),
+		SidecarInjectionImage:       fmt.Sprintf("%s/sidecar-injection:%s", options.dockerRegistry, options.linkerdVersion),
 		PrometheusImage:             "prom/prometheus:v2.3.1",
 		GrafanaImage:                fmt.Sprintf("%s/grafana:%s", options.dockerRegistry, options.linkerdVersion),
 		ControllerReplicas:          options.controllerReplicas,

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -61,7 +61,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
-
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -74,6 +73,42 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
+  namespace: {{.Namespace}}
+
+### Sidecar Service Account ####
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkerd-sidecar-injector
+  namespace: {{.Namespace}}
+
+### Sidecar RBAC ###
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: linkerd-{{.Namespace}}-sidecar-injector
+rules:
+- apiGroups: ["*"]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd-{{.Namespace}}-sidecar-injector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-{{.Namespace}}--sidecar-injector
+subjects:
+- kind: ServiceAccount
+  name: linkerd-sidecar-injector
   namespace: {{.Namespace}}
 
 ### Controller ###
@@ -578,6 +613,86 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: linkerd-top-line
+
+
+### Sidecar injection ###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: linkerd-sidecar-injector
+  namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: sidecar-injection
+  annotations:
+    {{.CreatedByAnnotation}}: {{.CliVersion}}
+spec:
+  type: ClusterIP
+  selector:
+    {{.ControllerComponentLabel}}: sidecar-injection
+  ports:
+  - name: http
+    port: 8084
+    targetPort: 8084
+
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: sidecar-injection
+  namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: sidecar-injection
+  annotations:
+    {{.CreatedByAnnotation}}: {{.CliVersion}}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        {{.ControllerComponentLabel}}: sidecar-injection
+      annotations:
+        {{.CreatedByAnnotation}}: {{.CliVersion}}
+    spec:
+      serviceAccountName: linkerd-sidecar-injector
+      containers: 
+        - name: sidecar-injection
+          ports:
+          - name: http
+            containerPort: 8084
+          image: {{.SidecarInjectionImage}}
+          imagePullPolicy: {{.ImagePullPolicy}}
+      volumes:
+        - name: linkerd-secret
+          secretName: linkerd.linkerd-sidecar-injector
+
+---
+kind: MutatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1beta1
+metadata:
+  name: linkerd-sidecar-injector
+  namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: sidecar-injection
+  annotations:
+    {{.CreatedByAnnotation}}: {{.CliVersion}}
+webhooks:
+  - name: sidecar-injector.linkerd.io
+    clientConfig:
+      service:
+        name: linkerd-sidecar-injector
+        namespace: {{.Namespace}}
+        path: "/inject"
+      caBundle: ""
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        linkerd-inject: enabled
 `
 
 const TlsTemplate = `

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+FROM gcr.io/linkerd-io/go-deps:3bac64dd as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/doc/sidecar-injection.md
+++ b/doc/sidecar-injection.md
@@ -1,0 +1,64 @@
++++
+title = "Experimental: Automatic sidecar injection"
+docpage = true
+[menu.docs]
+    parent = "sidecar-injection"
++++
+
+Linkerd can be configured to automatically inject the sidecar proxy in all pod
+that are contained in a specific namespace with the correct label.
+
+This feature is currently **experimental**. As the feature matures,
+more automation to this task is introduced.
+
+## Prerequisites
+
+This feature need Kubernetes 1.9.0 or above with the
+`admissionregistration.k8s.io/v1beta1` API enabled.
+Verify that by the following command:
+```
+kubectl api-versions | grep admissionregistration.k8s.io/v1beta1
+```
+The result should be:
+```
+admissionregistration.k8s.io/v1beta1
+```
+
+In addition, the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook`
+admission controllers should be added and listed in the correct order in the
+admission-control flag of kube-apiserver.
+
+## Creating the secret
+
+In order to work the webhook must use TLS, with a certificate signed from the
+cluster, for creating the secret run `webhook-create-signed-cert.sh` script with
+ the following parameters:
+
+```bash
+./bin/webhook-create-signed-cert.sh \
+    --service linkerd-sidecar-injector \
+    --secret linkerd-webhook-certs \
+    --namespace linkerd
+```
+
+## Setup
+
+Once you have create the secret you can run `linkerd install`, for automatic
+sidecar injection you have to label the namespace, only namespace with label
+`inkerd-inject=enabled` are injected:
+
+```bash
+kubectl label namespace default inkerd-inject=enabled
+```
+
+**Note**: only new pod are injected so you have to redeploy the whole namespace
+after you have labelled it.
+
+## Known issues
+
+As this feature is _experimental_, we know that there's still a lot of [work
+to do][tls-issues]. We **LOVE** bug reports though, so please don't hesitate
+to [file an issue][new-issue] if you run into any problems while testing
+automatic sidecar injection.
+
+[new-issue]: https://github.com/linkerd/linkerd2/issues/new

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+FROM gcr.io/linkerd-io/go-deps:3bac64dd as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/sidecar-injection/Dockerfile
+++ b/sidecar-injection/Dockerfile
@@ -1,5 +1,5 @@
 ## compile sidecar-injection utility
-FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+FROM gcr.io/linkerd-io/go-deps:3bac64dd as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./sidecar-injection ./sidecar-injection
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./sidecar-injection/

--- a/sidecar-injection/Dockerfile
+++ b/sidecar-injection/Dockerfile
@@ -1,0 +1,10 @@
+## compile sidecar-injection utility
+FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+WORKDIR /go/src/github.com/linkerd/linkerd2
+COPY ./sidecar-injection ./sidecar-injection
+RUN CGO_ENABLED=0 GOOS=linux go install -v ./sidecar-injection/
+
+## package runtime
+FROM ubuntu:16.04
+COPY --from=golang /go/bin/sidecar-injection /usr/local/bin/sidecar-injection
+ENTRYPOINT ["/usr/local/bin/sidecar-injection"]

--- a/sidecar-injection/main.go
+++ b/sidecar-injection/main.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Note: the example only works with the code within the same release/branch.
+package main
+
+import (
+		"fmt"
+						// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sync"
+	"time"
+	"net/http"
+	"crypto/tls"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"syscall"
+	)
+
+// WaitSignal awaits for SIGINT or SIGTERM and closes the channel
+func WaitSignal(stop chan struct{}) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+	close(stop)
+}
+
+func main() {
+	wh, _ := NewWebhook(WebhookParameters{Port: 8084})
+	stop := make(chan struct{})
+	go wh.Run(stop)
+	WaitSignal(stop)
+}
+
+// Webhook implements a mutating webhook for automatic proxy injection.
+type Webhook struct {
+	mu                     sync.RWMutex
+	sidecarTemplateVersion string
+
+	healthCheckInterval time.Duration
+	healthCheckFile     string
+
+	server     *http.Server
+	meshFile   string
+	configFile string
+	certFile   string
+	keyFile    string
+	cert       *tls.Certificate
+}
+
+
+// WebhookParameters configures parameters for the sidecar injection
+type WebhookParameters struct {
+	// ConfigFile is the path to the sidecar injection configuration file.
+	ConfigFile string
+
+	// MeshFile is the path to the mesh configuration file.
+	MeshFile string
+
+	// CertFile is the path to the x509 certificate for https.
+	CertFile string
+
+	// KeyFile is the path to the x509 private key matching `CertFile`.
+	KeyFile string
+
+	// Port is the webhook port, e.g. typically 443 for https.
+	Port int
+
+	// HealthCheckInterval configures how frequently the health check
+	// file is updated. Value of zero disables the health check
+	// update.
+	HealthCheckInterval time.Duration
+
+	// HealthCheckFile specifies the path to the health check file
+	// that is periodically updated.
+	HealthCheckFile string
+}
+
+// NewWebhook creates a new instance of a mutating webhook for automatic sidecar injection.
+func NewWebhook(p WebhookParameters) (*Webhook, error) {
+	duration, _ := time.ParseDuration("5s")
+	wh := &Webhook{
+		sidecarTemplateVersion: "",
+		healthCheckInterval:    duration,
+		healthCheckFile:        "",
+		server: &http.Server{
+			Addr: fmt.Sprintf(":%v", p.Port),
+		},
+		meshFile:   "",
+		configFile: "",
+		certFile:   "",
+		keyFile:    "",
+		cert:       nil,
+	}
+	// mtls disabled because apiserver webhook cert usage is still TBD.
+	h := http.NewServeMux()
+	h.HandleFunc("/inject", wh.serveInject)
+	wh.server.Handler = h
+
+	return wh, nil
+}
+
+// Run implements the webhook server
+func (wh *Webhook) Run(stop <-chan struct{}) {
+	go func() {
+		if err := wh.server.ListenAndServe(); err != nil {
+			fmt.Println("ListenAndServe for admission webhook returned error: %v", err)
+		}
+	}()
+
+	defer wh.server.Close()  // nolint: errcheck
+
+	for {
+		select {
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (wh *Webhook) serveInject(w http.ResponseWriter, r *http.Request) {
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		fmt.Println("no body found")
+		http.Error(w, "no body found", http.StatusBadRequest)
+		return
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		fmt.Println("contentType=%s, expect application/json", contentType)
+		http.Error(w, "invalid Content-Type, want `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	fmt.Println("Webhook triggered!")
+}
+

--- a/sidecar-injection/webhook.go
+++ b/sidecar-injection/webhook.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"k8s.io/api/admission/v1beta1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+var (
+	runtimeScheme = runtime.NewScheme()
+	codecs        = serializer.NewCodecFactory(runtimeScheme)
+	deserializer  = codecs.UniversalDeserializer()
+
+	// (https://github.com/kubernetes/kubernetes/issues/57982)
+	defaulter = runtime.ObjectDefaulter(runtimeScheme)
+)
+
+var ignoredNamespaces = []string{
+	metav1.NamespaceSystem,
+	metav1.NamespacePublic,
+}
+
+const (
+	admissionWebhookAnnotationInjectKey = "sidecar-injector-webhook.linkerd.io/inject"
+	admissionWebhookAnnotationStatusKey = "sidecar-injector-webhook.linkerd.io/status"
+)
+
+type WebhookServer struct {
+	sidecarConfig *Config
+	server        *http.Server
+}
+
+// Webhook Server parameters
+type WhSvrParameters struct {
+	port           int    // webhook server port
+	certFile       string // path to the x509 certificate for https
+	keyFile        string // path to the x509 private key matching `CertFile`
+	sidecarCfgFile string // path to sidecar injector configuration file
+}
+
+type Config struct {
+	Containers []corev1.Container `yaml:"containers"`
+	Volumes    []corev1.Volume    `yaml:"volumes"`
+}
+
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func init() {
+	_ = corev1.AddToScheme(runtimeScheme)
+	_ = admissionregistrationv1beta1.AddToScheme(runtimeScheme)
+	// defaulting with webhooks:
+	// https://github.com/kubernetes/kubernetes/issues/57982
+	_ = v1.AddToScheme(runtimeScheme)
+}
+
+// (https://github.com/kubernetes/kubernetes/issues/57982)
+func applyDefaultsWorkaround(containers []corev1.Container, volumes []corev1.Volume) {
+	defaulter.Default(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: containers,
+			Volumes:    volumes,
+		},
+	})
+}
+
+func loadConfig(configFile string) (*Config, error) {
+	data, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+	glog.Infof("New configuration: sha256sum %x", sha256.Sum256(data))
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// Check whether the target resoured need to be mutated
+func mutationRequired(ignoredList []string, metadata *metav1.ObjectMeta) bool {
+	// skip special kubernete system namespaces
+	for _, namespace := range ignoredList {
+		if metadata.Namespace == namespace {
+			glog.Infof("Skip mutation for %v for it' in special namespace:%v", metadata.Name, metadata.Namespace)
+			return false
+		}
+	}
+
+	annotations := metadata.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	status := annotations[admissionWebhookAnnotationStatusKey]
+
+	// determine whether to perform mutation based on annotation for the target resource
+	var required bool
+	if strings.ToLower(status) == "injected" {
+		required = false
+	} else {
+		switch strings.ToLower(annotations[admissionWebhookAnnotationInjectKey]) {
+		default:
+			required = false
+		case "y", "yes", "true", "on":
+			required = true
+		}
+	}
+
+	glog.Infof("Mutation policy for %v/%v: status: %q required:%v", metadata.Namespace, metadata.Name, status, required)
+	return required
+}
+
+func addContainer(target, added []corev1.Container, basePath string) (patch []patchOperation) {
+	first := len(target) == 0
+	var value interface{}
+	for _, add := range added {
+		value = add
+		path := basePath
+		if first {
+			first = false
+			value = []corev1.Container{add}
+		} else {
+			path = path + "/-"
+		}
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  path,
+			Value: value,
+		})
+	}
+	return patch
+}
+
+func addVolume(target, added []corev1.Volume, basePath string) (patch []patchOperation) {
+	first := len(target) == 0
+	var value interface{}
+	for _, add := range added {
+		value = add
+		path := basePath
+		if first {
+			first = false
+			value = []corev1.Volume{add}
+		} else {
+			path = path + "/-"
+		}
+		patch = append(patch, patchOperation{
+			Op:    "add",
+			Path:  path,
+			Value: value,
+		})
+	}
+	return patch
+}
+
+func updateAnnotation(target map[string]string, added map[string]string) (patch []patchOperation) {
+	for key, value := range added {
+		if target == nil || target[key] == "" {
+			target = map[string]string{}
+			patch = append(patch, patchOperation{
+				Op:   "add",
+				Path: "/metadata/annotations",
+				Value: map[string]string{
+					key: value,
+				},
+			})
+		} else {
+			patch = append(patch, patchOperation{
+				Op:    "replace",
+				Path:  "/metadata/annotations/" + key,
+				Value: value,
+			})
+		}
+	}
+	return patch
+}
+
+// create mutation patch for resoures
+func createPatch(pod *corev1.Pod, sidecarConfig *Config, annotations map[string]string) ([]byte, error) {
+	var patch []patchOperation
+
+	patch = append(patch, addContainer(pod.Spec.Containers, sidecarConfig.Containers, "/spec/containers")...)
+	patch = append(patch, addVolume(pod.Spec.Volumes, sidecarConfig.Volumes, "/spec/volumes")...)
+	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
+
+	return json.Marshal(patch)
+}
+
+// main mutation process
+func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		glog.Errorf("Could not unmarshal raw object: %v", err)
+		return &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	}
+
+	glog.Infof("AdmissionReview for Kind=%v, Namespace=%v Name=%v (%v) UID=%v patchOperation=%v UserInfo=%v",
+		req.Kind, req.Namespace, req.Name, pod.Name, req.UID, req.Operation, req.UserInfo)
+
+	// determine whether to perform mutation
+	if !mutationRequired(ignoredNamespaces, &pod.ObjectMeta) {
+		glog.Infof("Skipping mutation for %s/%s due to policy check", pod.Namespace, pod.Name)
+		return &v1beta1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	// Workaround: https://github.com/kubernetes/kubernetes/issues/57982
+	applyDefaultsWorkaround(whsvr.sidecarConfig.Containers, whsvr.sidecarConfig.Volumes)
+	annotations := map[string]string{admissionWebhookAnnotationStatusKey: "injected"}
+	patchBytes, err := createPatch(&pod, whsvr.sidecarConfig, annotations)
+	if err != nil {
+		return &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	}
+
+	glog.Infof("AdmissionResponse: patch=%v\n", string(patchBytes))
+	return &v1beta1.AdmissionResponse{
+		Allowed: true,
+		Patch:   patchBytes,
+		PatchType: func() *v1beta1.PatchType {
+			pt := v1beta1.PatchTypeJSONPatch
+			return &pt
+		}(),
+	}
+}
+
+// Serve method for webhook server
+func (whsvr *WebhookServer) serve(w http.ResponseWriter, r *http.Request) {
+	glog.Info("Webhook incoming!!")
+
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+	if len(body) == 0 {
+		glog.Error("empty body")
+		http.Error(w, "empty body", http.StatusBadRequest)
+		return
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		glog.Errorf("Content-Type=%s, expect application/json", contentType)
+		http.Error(w, "invalid Content-Type, expect `application/json`", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var admissionResponse *v1beta1.AdmissionResponse
+	ar := v1beta1.AdmissionReview{}
+	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+		glog.Errorf("Can't decode body: %v", err)
+		admissionResponse = &v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: err.Error(),
+			},
+		}
+	} else {
+		admissionResponse = whsvr.mutate(&ar)
+	}
+
+	admissionReview := v1beta1.AdmissionReview{}
+	if admissionResponse != nil {
+		admissionReview.Response = admissionResponse
+		if ar.Request != nil {
+			admissionReview.Response.UID = ar.Request.UID
+		}
+	}
+
+	resp, err := json.Marshal(admissionReview)
+	if err != nil {
+		glog.Errorf("Can't encode response: %v", err)
+		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)
+	}
+	glog.Infof("Ready to write reponse ...")
+	if _, err := w.Write(resp); err != nil {
+		glog.Errorf("Can't write response: %v", err)
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:5aeb9bf4 as golang
+FROM gcr.io/linkerd-io/go-deps:3bac64dd as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY web web
 COPY controller controller


### PR DESCRIPTION
For manage deployment with linkerd2 with other tools like helm is really
important to make the pod injection at the lower level we can.

#561 Using MutatingWebhook (new k8s 1.9) we can modify a pod before the pod
is created.

So far i have created:
* new container called 'sidecar-injection'
* update install profile for add 'sidecar-injection'
* create for now fake webhook for test integration

This PR is really WIP, before we have to solve:
* Ho we issue certificate for webhook in k8s
* Link the webhook inject handler with existing api for sidecar
injection.
* code review.

Signed-off-by: Mattia Rossi <mattia.rossi@criptalia.it>