### PR TITLE
Add source metadata to Tap server tap events

### DIFF
--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -335,10 +335,16 @@ func contains(list []string, s string) bool {
 
 func RenderTapEvent(event *pb.TapEvent) string {
 	dstLabels := event.GetDestinationMeta().GetLabels()
+	srcLabels := event.GetSourceMeta().GetLabels()
 
 	dst := addr.PublicAddressToString(event.GetDestination())
 	if pod := dstLabels["pod"]; pod != "" {
 		dst = fmt.Sprintf("%s:%d", pod, event.GetDestination().GetPort())
+	}
+
+	src := addr.PublicAddressToString(event.GetSource())
+	if pod := srcLabels["pod"]; pod != "" {
+		src = fmt.Sprintf("%s:%d", pod, event.GetSource().GetPort())
 	}
 
 	proxy := "???"
@@ -346,7 +352,6 @@ func RenderTapEvent(event *pb.TapEvent) string {
 	switch event.GetProxyDirection() {
 	case pb.TapEvent_INBOUND:
 		proxy = "in " // A space is added so it aligns with `out`.
-		srcLabels := event.GetSourceMeta().GetLabels()
 		tls = srcLabels["tls"]
 	case pb.TapEvent_OUTBOUND:
 		proxy = "out"
@@ -357,7 +362,7 @@ func RenderTapEvent(event *pb.TapEvent) string {
 
 	flow := fmt.Sprintf("proxy=%s src=%s dst=%s tls=%s",
 		proxy,
-		addr.PublicAddressToString(event.GetSource()),
+		src,
 		dst,
 		tls,
 	)

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -333,19 +333,20 @@ func contains(list []string, s string) bool {
 	return false
 }
 
+func formatPeer(peerAddr *pb.TcpAddress, labels map[string]string) string {
+	if pod := labels["pod"]; pod != "" {
+		return fmt.Sprintf("%s:%d", pod, peerAddr.GetPort())
+	} else {
+		return addr.PublicAddressToString(peerAddr)
+	}
+}
+
 func RenderTapEvent(event *pb.TapEvent) string {
-	dstLabels := event.GetDestinationMeta().GetLabels()
 	srcLabels := event.GetSourceMeta().GetLabels()
+	dstLabels := event.GetDestinationMeta().GetLabels()
 
-	dst := addr.PublicAddressToString(event.GetDestination())
-	if pod := dstLabels["pod"]; pod != "" {
-		dst = fmt.Sprintf("%s:%d", pod, event.GetDestination().GetPort())
-	}
-
-	src := addr.PublicAddressToString(event.GetSource())
-	if pod := srcLabels["pod"]; pod != "" {
-		src = fmt.Sprintf("%s:%d", pod, event.GetSource().GetPort())
-	}
+	dst := formatPeer(event.GetDestination(), dstLabels)
+	src := formatPeer(event.GetSource(), srcLabels)
 
 	proxy := "???"
 	tls := ""

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -34,6 +34,7 @@ func main() {
 		k8s.Pod,
 		k8s.RC,
 		k8s.Svc,
+		k8s.RS,
 	)
 
 	server, lis, err := tap.NewServer(*addr, *tapPort, k8sAPI)

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -503,7 +503,8 @@ func (s *server) hydrateIPMeta(ip *public.IPAddress) (map[string]string, error) 
 	pod, err := s.podForIP(ip)
 	if err != nil {
 		return nil, err
-	} else if pod == nil {
+	}
+	if pod == nil {
 		log.WithFields(log.Fields{"ip": addr.PublicIPToString(ip)}).Debugln("no pod for IP")
 		return make(map[string]string), nil
 	}
@@ -516,7 +517,7 @@ func (s *server) hydrateIPMeta(ip *public.IPAddress) (map[string]string, error) 
 //
 // If multiple pods exist with the same IP address, this may be because some
 // are terminating and the IP has been assigned to a new pod. In this case, this
-// function preferrentially selects the currently running pod, if there is one;
+// function preferentially selects the currently running pod, if there is one;
 // otherwise, it chooses the pod that terminated the most recently (based on the
 // assumption that it's most likely to have sent a request).
 //
@@ -536,11 +537,9 @@ func (s *server) podForIP(ip *public.IPAddress) (*apiv1.Pod, error) {
 	var mostRecentlyStopped *apiv1.Pod
 	stopTime := int64(0)
 	for _, obj := range objs {
-		pod, ok := obj.(*apiv1.Pod)
-		if !ok {
-			logc.Errorf("found something that wasn't a pod when indexing pods by IP")
-			continue
-		}
+		// It's safe to cast the object to a pod here, as otherwise, it would
+		// not have been indexed by the indexing func in the first place.
+		pod := obj.(*apiv1.Pod)
 		switch pod.Status.Phase {
 		case apiv1.PodRunning:
 			// Found a running pod with this IP --- it's that!

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 const podIPIndex = "ip"
@@ -471,6 +472,7 @@ func NewServer(
 	tapPort uint,
 	k8sAPI *k8s.API,
 ) (*grpc.Server, net.Listener, error) {
+	k8sAPI.Pod().Informer().AddIndexers(cache.Indexers{podIPIndex: indexPodByIP})
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -494,14 +494,14 @@ func indexPodByIP(obj interface{}) ([]string, error) {
 }
 
 // hydrateIPMeta returns a map of expanded metadata labels for a given IP.
-// If no pod cound be found for that IP, it returns an empty map.
+// If no pod could be found for that IP, it returns an empty map.
 func (s *server) hydrateIPMeta(ip *public.IPAddress) (map[string]string, error) {
 	pod, err := s.podForIP(ip)
 	if err != nil {
 		return nil, err
 	}
 	if pod == nil {
-		log.Debugln("no pod for IP %s", addr.PublicIPToString(ip))
+		log.Debugf("no pod for IP %s", addr.PublicIPToString(ip))
 		return make(map[string]string), nil
 	}
 
@@ -529,12 +529,13 @@ func (s *server) podForIP(ip *public.IPAddress) (*apiv1.Pod, error) {
 
 	if len(objs) == 1 {
 		log.Debugf("found one pod at IP %s", ipStr)
+		// It's safe to cast elements of `objs` to a `Pod`s here (and in the
+		// loop below). If the object wasn't a pod, it should never have been
+		// indexed by the indexing func in the first place.
 		return objs[0].(*apiv1.Pod), nil
 	}
 
 	for _, obj := range objs {
-		// It's safe to cast the object to a pod here, as otherwise, it would
-		// not have been indexed by the indexing func in the first place.
 		pod := obj.(*apiv1.Pod)
 		if pod.Status.Phase == apiv1.PodRunning {
 			// Found a running pod with this IP --- it's that!

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -501,7 +501,7 @@ func (s *server) hydrateIPMeta(ip *public.IPAddress) (map[string]string, error) 
 		return nil, err
 	}
 	if pod == nil {
-		log.Debugln("no pod for IP %s", addr.PublicAddressToString(ip))
+		log.Debugln("no pod for IP %s", addr.PublicIPToString(ip))
 		return make(map[string]string), nil
 	}
 

--- a/pkg/addr/addr.go
+++ b/pkg/addr/addr.go
@@ -14,6 +14,11 @@ func PublicAddressToString(addr *public.TcpAddress) string {
 	return fmt.Sprintf("%d.%d.%d.%d:%d", octects[0], octects[1], octects[2], octects[3], addr.GetPort())
 }
 
+func PublicIPToString(ip *public.IPAddress) string {
+	octets := decodeIPToOctets(ip.GetIpv4())
+	return fmt.Sprintf("%d.%d.%d.%d", octets[0], octets[1], octets[2], octets[3])
+}
+
 func ProxyAddressToString(addr *pb.TcpAddress) string {
 	octects := decodeIPToOctets(addr.GetIp().GetIpv4())
 	return fmt.Sprintf("%d.%d.%d.%d:%d", octects[0], octects[1], octects[2], octects[3], addr.GetPort())


### PR DESCRIPTION
The `TapEvent` protobuf contains two maps, `DestinationMeta` and
`SourceMeta`. The `DestinationMeta` contains all the metadata provided
by the proxy that originated the event (ultimately originating from the
Destination service), while the `SourceMeta` currently only contains the
source connection's TLS status.

This branch modifies the Tap server to hydrate the same set of metadata
from the source IP address, when the source was within the cluster. It
does this by adding an indexer of pod IPs to pods to its k8s API client,
and looking up IPs against this index. If a pod was found, the extra
metadata is added to the tap event sent to the client.

This branch also changes the client so that if a source pod name was
provided in the metadata, it prints the pod name rather than the IP
address for the `src` field in its output. This mimics what is currently
done for the `dst` field in tap output. Furthermore, the added source
metadata will be necessary for adding src resource types to tap output
(see issue #1170).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>