### PR TITLE
Add resource metadata to Tap CLI output

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -92,12 +92,11 @@ func newCmdTap() *cobra.Command {
 				return err
 			}
 
-			var wide bool
+			wide := false
 			switch options.output {
 			// TODO: support more output formats?
 			case "":
 				// default output format.
-				wide := false
 			case "wide":
 				wide = true
 			default:

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -36,6 +36,7 @@ func newTapOptions() *tapOptions {
 		method:      "",
 		authority:   "",
 		path:        "",
+		output:      "",
 	}
 }
 
@@ -94,10 +95,13 @@ func newCmdTap() *cobra.Command {
 			var wide bool
 			switch options.output {
 			// TODO: support more output formats?
+			case "":
+				// default output format.
+				wide := false
 			case "wide":
 				wide = true
 			default:
-				wide = false
+				return fmt.Errorf("output format \"%s\" not recognized", options.output)
 			}
 
 			return requestTapByResourceFromAPI(os.Stdout, validatedPublicAPIClient(), req, wide)

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -23,6 +23,7 @@ type tapOptions struct {
 	method      string
 	authority   string
 	path        string
+	output      string
 }
 
 func newTapOptions() *tapOptions {
@@ -90,7 +91,16 @@ func newCmdTap() *cobra.Command {
 				return err
 			}
 
-			return requestTapByResourceFromAPI(os.Stdout, validatedPublicAPIClient(), req)
+			var wide bool
+			switch options.output {
+			// TODO: support more output formats?
+			case "wide":
+				wide = true
+			default:
+				wide = false
+			}
+
+			return requestTapByResourceFromAPI(os.Stdout, validatedPublicAPIClient(), req, wide)
 		},
 	}
 
@@ -110,21 +120,28 @@ func newCmdTap() *cobra.Command {
 		"Display requests with this :authority")
 	cmd.PersistentFlags().StringVar(&options.path, "path", options.path,
 		"Display requests with paths that start with this prefix")
+	cmd.PersistentFlags().StringVarP(&options.output, "output", "o", options.output,
+		"Output format. One of: wide")
 
 	return cmd
 }
 
-func requestTapByResourceFromAPI(w io.Writer, client pb.ApiClient, req *pb.TapByResourceRequest) error {
+func requestTapByResourceFromAPI(w io.Writer, client pb.ApiClient, req *pb.TapByResourceRequest, wide bool) error {
+	var resource string
+	if wide {
+		resource = req.Target.Resource.GetType()
+	}
+
 	rsp, err := client.TapByResource(context.Background(), req)
 	if err != nil {
 		return err
 	}
-	return renderTap(w, rsp)
+	return renderTap(w, rsp, resource)
 }
 
-func renderTap(w io.Writer, tapClient pb.Api_TapByResourceClient) error {
+func renderTap(w io.Writer, tapClient pb.Api_TapByResourceClient, resource string) error {
 	tableWriter := tabwriter.NewWriter(w, 0, 0, 0, ' ', tabwriter.AlignRight)
-	err := writeTapEventsToBuffer(tapClient, tableWriter)
+	err := writeTapEventsToBuffer(tapClient, tableWriter, resource)
 	if err != nil {
 		return err
 	}
@@ -133,7 +150,7 @@ func renderTap(w io.Writer, tapClient pb.Api_TapByResourceClient) error {
 	return nil
 }
 
-func writeTapEventsToBuffer(tapClient pb.Api_TapByResourceClient, w *tabwriter.Writer) error {
+func writeTapEventsToBuffer(tapClient pb.Api_TapByResourceClient, w *tabwriter.Writer, resource string) error {
 	for {
 		log.Debug("Waiting for data...")
 		event, err := tapClient.Recv()
@@ -144,7 +161,7 @@ func writeTapEventsToBuffer(tapClient pb.Api_TapByResourceClient, w *tabwriter.W
 			fmt.Fprintln(os.Stderr, err)
 			break
 		}
-		_, err = fmt.Fprintln(w, util.RenderTapEvent(event))
+		_, err = fmt.Fprintln(w, util.RenderTapEvent(event, resource))
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -16,82 +16,97 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+func busyTest(t *testing.T, wide bool) {
+	resourceType := k8s.Pod
+	targetName := "pod-666"
+	params := util.TapRequestParams{
+		Resource:  resourceType + "/" + targetName,
+		Scheme:    "https",
+		Method:    "GET",
+		Authority: "localhost",
+		Path:      "/some/path",
+	}
+
+	req, err := util.BuildTapByResourceRequest(params)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	event1 := createEvent(
+		&pb.TapEvent_Http{
+			Event: &pb.TapEvent_Http_RequestInit_{
+				RequestInit: &pb.TapEvent_Http_RequestInit{
+					Id: &pb.TapEvent_Http_StreamId{
+						Base: 1,
+					},
+					Authority: params.Authority,
+					Path:      params.Path,
+				},
+			},
+		},
+		map[string]string{
+			"pod": "my-pod",
+			"tls": "true",
+		},
+	)
+	event2 := createEvent(
+		&pb.TapEvent_Http{
+			Event: &pb.TapEvent_Http_ResponseEnd_{
+				ResponseEnd: &pb.TapEvent_Http_ResponseEnd{
+					Id: &pb.TapEvent_Http_StreamId{
+						Base: 1,
+					},
+					Eos: &pb.Eos{
+						End: &pb.Eos_GrpcStatusCode{GrpcStatusCode: 666},
+					},
+					SinceRequestInit: &duration.Duration{
+						Seconds: 10,
+					},
+					SinceResponseInit: &duration.Duration{
+						Seconds: 100,
+					},
+					ResponseBytes: 1337,
+				},
+			},
+		},
+		map[string]string{},
+	)
+	mockApiClient := &public.MockApiClient{}
+	mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
+		TapEventsToReturn: []pb.TapEvent{event1, event2},
+	}
+
+	writer := bytes.NewBufferString("")
+	err = requestTapByResourceFromAPI(writer, mockApiClient, req, wide)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var goldenFilePath string
+	if wide {
+		goldenFilePath = "testdata/tap_busy_output_wide.golden"
+	} else {
+		goldenFilePath = "testdata/tap_busy_output.golden"
+	}
+
+	goldenFileBytes, err := ioutil.ReadFile(goldenFilePath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expectedContent := string(goldenFileBytes)
+	output := writer.String()
+	if expectedContent != output {
+		t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
+	}
+}
+
 func TestRequestTapByResourceFromAPI(t *testing.T) {
 	t.Run("Should render busy response if everything went well", func(t *testing.T) {
-		resourceType := k8s.Pod
-		targetName := "pod-666"
-		params := util.TapRequestParams{
-			Resource:  resourceType + "/" + targetName,
-			Scheme:    "https",
-			Method:    "GET",
-			Authority: "localhost",
-			Path:      "/some/path",
-		}
+		busyTest(t, false)
+	})
 
-		req, err := util.BuildTapByResourceRequest(params)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		event1 := createEvent(
-			&pb.TapEvent_Http{
-				Event: &pb.TapEvent_Http_RequestInit_{
-					RequestInit: &pb.TapEvent_Http_RequestInit{
-						Id: &pb.TapEvent_Http_StreamId{
-							Base: 1,
-						},
-						Authority: params.Authority,
-						Path:      params.Path,
-					},
-				},
-			},
-			map[string]string{
-				"pod": "my-pod",
-				"tls": "true",
-			},
-		)
-		event2 := createEvent(
-			&pb.TapEvent_Http{
-				Event: &pb.TapEvent_Http_ResponseEnd_{
-					ResponseEnd: &pb.TapEvent_Http_ResponseEnd{
-						Id: &pb.TapEvent_Http_StreamId{
-							Base: 1,
-						},
-						Eos: &pb.Eos{
-							End: &pb.Eos_GrpcStatusCode{GrpcStatusCode: 666},
-						},
-						SinceRequestInit: &duration.Duration{
-							Seconds: 10,
-						},
-						SinceResponseInit: &duration.Duration{
-							Seconds: 100,
-						},
-						ResponseBytes: 1337,
-					},
-				},
-			},
-			map[string]string{},
-		)
-		mockApiClient := &public.MockApiClient{}
-		mockApiClient.Api_TapByResourceClientToReturn = &public.MockApi_TapByResourceClient{
-			TapEventsToReturn: []pb.TapEvent{event1, event2},
-		}
-
-		writer := bytes.NewBufferString("")
-		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		goldenFileBytes, err := ioutil.ReadFile("testdata/tap_busy_output.golden")
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		expectedContent := string(goldenFileBytes)
-		output := writer.String()
-		if expectedContent != output {
-			t.Fatalf("Expected function to render:\n%s\bbut got:\n%s", expectedContent, output)
-		}
+	t.Run("Should render wide busy response if everything went well", func(t *testing.T) {
+		busyTest(t, true)
 	})
 
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {
@@ -116,7 +131,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 		}
 
 		writer := bytes.NewBufferString("")
-		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
+		err = requestTapByResourceFromAPI(writer, mockApiClient, req, false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -155,7 +170,7 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 		}
 
 		writer := bytes.NewBufferString("")
-		err = requestTapByResourceFromAPI(writer, mockApiClient, req)
+		err = requestTapByResourceFromAPI(writer, mockApiClient, req, false)
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing but output [%s]", writer.String())
 		}
@@ -212,8 +227,8 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "req id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello dst_resource=au/hello.default:7777"
-		output := util.RenderTapEvent(event)
+		expectedOutput := "req id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello"
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -230,7 +245,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "rsp id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :status=200 latency=999µs"
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -251,7 +266,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= grpc-status=OK duration=888µs response-length=111B"
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -272,7 +287,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= reset-error=123 duration=888µs response-length=111B"
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -291,7 +306,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= duration=888µs response-length=111B"
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -309,7 +324,7 @@ func TestEventToString(t *testing.T) {
 		})
 
 		expectedOutput := "end id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= duration=888µs response-length=111B"
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}
@@ -319,7 +334,7 @@ func TestEventToString(t *testing.T) {
 		event := toTapEvent(&pb.TapEvent_Http{})
 
 		expectedOutput := "unknown proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls="
-		output := util.RenderTapEvent(event)
+		output := util.RenderTapEvent(event, "")
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)
 		}

--- a/cli/cmd/tap_test.go
+++ b/cli/cmd/tap_test.go
@@ -212,7 +212,7 @@ func TestEventToString(t *testing.T) {
 			},
 		})
 
-		expectedOutput := "req id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello"
+		expectedOutput := "req id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :method=POST :authority=hello.default:7777 :path=/hello.v1.HelloService/Hello dst_resource=au/hello.default:7777"
 		output := util.RenderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)

--- a/cli/cmd/testdata/tap_busy_output.golden
+++ b/cli/cmd/testdata/tap_busy_output.golden
@@ -1,2 +1,2 @@
-req id=1:0 proxy=out src=0.0.0.1:0 dst=my-pod:0 tls=true :method=GET :authority=localhost :path=/some/path dst_resource=po/my-pod
+req id=1:0 proxy=out src=0.0.0.1:0 dst=0.0.0.9:0 tls=true :method=GET :authority=localhost :path=/some/path
 end id=1:0 proxy=out src=0.0.0.1:0 dst=0.0.0.9:0 tls= grpc-status=Code(666) duration=0µs response-length=1337B

--- a/cli/cmd/testdata/tap_busy_output.golden
+++ b/cli/cmd/testdata/tap_busy_output.golden
@@ -1,2 +1,2 @@
-req id=1:0 proxy=out src=0.0.0.1:0 dst=my-pod:0 tls=true :method=GET :authority=localhost :path=/some/path
+req id=1:0 proxy=out src=0.0.0.1:0 dst=my-pod:0 tls=true :method=GET :authority=localhost :path=/some/path dst_resource=po/my-pod
 end id=1:0 proxy=out src=0.0.0.1:0 dst=0.0.0.9:0 tls= grpc-status=Code(666) duration=0µs response-length=1337B

--- a/cli/cmd/testdata/tap_busy_output_wide.golden
+++ b/cli/cmd/testdata/tap_busy_output_wide.golden
@@ -1,0 +1,2 @@
+req id=1:0 proxy=out src=0.0.0.1:0 dst=0.0.0.9:0 tls=true :method=GET :authority=localhost :path=/some/path dst_res=po/my-pod
+end id=1:0 proxy=out src=0.0.0.1:0 dst=0.0.0.9:0 tls= grpc-status=Code(666) duration=0µs response-length=1337B

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -367,11 +367,11 @@ func (p *peer) formatAddr() string {
 	)
 }
 
-// formatResource a label describing what Kubernetes resources the peer belongs
-// to. If the peer belongs to a resource of kind `resourceKind`, it will return
-// a label for that resource; otherwise, it will fall back to the peer's pod
-// name. Additionally, if the resource is not of type `namespace`, it will also
-// add a label describing the peer's resource.
+// formatResource returns a label describing what Kubernetes resources the peer
+// belongs to. If the peer belongs to a resource of kind `resourceKind`, it will
+// return a label for that resource; otherwise, it will fall back to the peer's
+// pod name. Additionally, if the resource is not of type `namespace`, it will
+// also add a label describing the peer's resource.
 func (p *peer) formatResource(resourceKind string) string {
 	var s string
 	if resourceName, exists := p.labels[resourceKind]; exists {
@@ -390,7 +390,7 @@ func (p *peer) formatResource(resourceKind string) string {
 	}
 	if resourceKind != k8s.Namespace {
 		if ns, hasNs := p.labels[k8s.Namespace]; hasNs {
-			s = fmt.Sprintf("%s %s_ns=%s", s, p.direction, ns)
+			s += fmt.Sprintf("%s_ns=%s", p.direction, ns)
 		}
 	}
 	return s

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -11,12 +11,14 @@ import (
 const (
 	All                   = "all"
 	Authority             = "authority"
+	DaemonSet             = "daemonset"
 	Deployment            = "deployment"
 	Namespace             = "namespace"
 	Pod                   = "pod"
 	ReplicationController = "replicationcontroller"
 	ReplicaSet            = "replicaset"
 	Service               = "service"
+	StatefulSet           = "statefulset"
 )
 
 // resources to query in StatSummary when Resource.Type is "all"
@@ -74,6 +76,8 @@ func CanonicalResourceNameFromFriendlyName(friendlyName string) (string, error) 
 	switch friendlyName {
 	case "deploy", "deployment", "deployments":
 		return Deployment, nil
+	case "ds", "daemonset", "daemonsets":
+		return DaemonSet, nil
 	case "ns", "namespace", "namespaces":
 		return Namespace, nil
 	case "po", "pod", "pods":
@@ -82,6 +86,8 @@ func CanonicalResourceNameFromFriendlyName(friendlyName string) (string, error) 
 		return ReplicationController, nil
 	case "svc", "service", "services":
 		return Service, nil
+	case "sts", "statefulset", "statefulsets":
+		return StatefulSet, nil
 	case "au", "authority", "authorities":
 		return Authority, nil
 	case "all":
@@ -97,6 +103,8 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 	switch canonicalName {
 	case Deployment:
 		return "deploy"
+	case DaemonSet:
+		return "ds"
 	case Namespace:
 		return "ns"
 	case Pod:
@@ -107,6 +115,8 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 		return "rs"
 	case Service:
 		return "svc"
+	case StatefulSet:
+		return "au"
 	case Authority:
 		return "au"
 	default:

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -15,6 +15,7 @@ const (
 	Namespace             = "namespace"
 	Pod                   = "pod"
 	ReplicationController = "replicationcontroller"
+	ReplicaSet            = "replicaset"
 	Service               = "service"
 )
 
@@ -102,6 +103,8 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 		return "po"
 	case ReplicationController:
 		return "rc"
+	case ReplicaSet:
+		return "rs"
 	case Service:
 		return "svc"
 	case Authority:

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -116,7 +116,7 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 	case Service:
 		return "svc"
 	case StatefulSet:
-		return "au"
+		return "sts"
 	case Authority:
 		return "au"
 	default:


### PR DESCRIPTION
Closes #1170.

This branch adds a `-o wide` (or `--output wide`) flag to the Tap CLI.
Passing this flag adds `src_res` and `dst_res` elements to the Tap
output, as described in #1170. These use the metadata labels in the tap
event to describe what Kubernetes resource the source and destination
peers belong to, based on what resource type is being tapped, and fall
back to pods if either peer is not a member of the specified resource
type.

In addition, when the resource type is not `namespace`, `src_ns` and
`dst_ns` elements are added, which show what namespaces the the source
and destination peers are in. For peers which are not in the Kubernetes
cluster, none of these labels are displayed.

The source metadata added in #1434 is used to populate the `src_res` and
`src_ns` fields.

Also, this branch includes some refactoring to how tap output is
formatted.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>