### PR TITLE
Add inbound destination label hydration to Tap server

### DIFF
--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -460,6 +460,24 @@ func (s *server) translateEvent(orig *proxy.TapEvent) *public.TapEvent {
 		}
 	}
 
+	if ev.ProxyDirection == public.TapEvent_INBOUND {
+		// Events emitted by an inbound proxies don't have destination labels,
+		// since the inbound proxy _is_ the destination, and proxies don't know
+		// their own labels.
+		destIPMeta, err := s.hydrateIPMeta(ev.Destination.Ip)
+		if err != nil {
+			log.Errorf(
+				"error hydrating destination metadata for %s: %s",
+				ev.Destination,
+				err,
+			)
+		} else {
+			for k, v := range destIPMeta {
+				ev.DestinationMeta.Labels[k] = v
+			}
+		}
+	}
+
 	return ev
 }
 

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -487,8 +487,8 @@ func indexPodByIP(obj interface{}) ([]string, error) {
 }
 
 // hydrateEventLabels attempts to hydrate the metadata labels for an event's
-// source and (if the event was reported by an inbound proxxy) destination,
-// and adds thhem to the event's `SourceMeta` and `DestinationMeta` fields.
+// source and (if the event was reported by an inbound proxy) destination,
+// and adds them to the event's `SourceMeta` and `DestinationMeta` fields.
 //
 // Since errors encountered while hydrating metadata are non-fatal and result
 // only in missing labels, any errors are logged at the WARN level.


### PR DESCRIPTION
Based on @adleong's suggestion in
https://github.com/linkerd/linkerd2/pull/1434#pullrequestreview-145428857,
this branch adds label hydration from destination IPs to the Tap server.
This works the same as the label hydration for destination IPs added in
#1434. However, it is only applied to the destination fields of events
recorded by proxies in the inbound direction, since outbound
destinations are already labeled with metadata provided by the
Destination service.

This means that when a user taps inbound traffic, the CLI will show k8s
metadata labels for the destination peer (if it's available). This can
be useful especially when tapping several pods at once, as it makes it
easier to distinguish what pod received a request.

This branch also refactors how the label hydration is performed,
primarily to make adding it to the destination field less repetitive.
Also, the `hydrateIPLabels` function now mutates the label map in the
`TapEvent`, rather than returning a new map of labels, so that the case
where no pod was found doesn't require an additional allocation of an
empty map.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>