### PR TITLE
Fix display of Tap errors into the ErrorBanner component

### DIFF
--- a/web/app/js/components/ErrorBanner.jsx
+++ b/web/app/js/components/ErrorBanner.jsx
@@ -47,9 +47,9 @@ class ErrorMessage extends React.Component {
       <Row gutter={0}>
         <div className="error-message-container">
           <Col span={20}>
-            <div><b>Error:</b> {status} {statusText}</div>
-            { !error ? null : <div><b>Message:</b> {error}</div> }
-            <div><b>URL:</b> {url}</div>
+            { !status && !statusText ? null : <div>{status} {statusText}</div> }
+            { !error ? null : <div>{error}</div> }
+            { !url ? null : <div>{url}</div> }
           </Col>
           <Col span={4}>
             <div className="dismiss" onClick={this.hideMessage} role="presentation">Dismiss X</div>

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Icon, Modal, Switch } from 'antd';
 
-// max characters we displaly for error messages before truncating them
+// max characters we display for error messages before truncating them
 const maxErrorLength = 500;
 
 export default class ErrorModal extends React.Component {

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -53,7 +53,7 @@ class Namespaces extends React.Component {
       metrics: {},
       pendingRequests: false,
       loaded: false,
-      error: ''
+      error: null
     };
   }
 

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -91,7 +91,7 @@ class Tap extends React.Component {
     }));
     this.setState({
       awaitingWebSocketConnection: false,
-      error: ""
+      error: null
     });
   }
 
@@ -104,14 +104,16 @@ class Tap extends React.Component {
 
     if (!e.wasClean) {
       this.setState({
-        error: `Websocket [${e.code}] ${e.reason}`
+        error: {
+          error: `Websocket [${e.code}] ${e.reason}`
+        }
       });
     }
   }
 
   onWebsocketError = e => {
     this.setState({
-      error: e.message
+      error: { error: e.message }
     });
 
     this.stopTapStreaming();
@@ -588,7 +590,7 @@ class Tap extends React.Component {
     return (
       <div>
         {!this.state.error ? null :
-        <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: "" })} />}
+        <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: null })} />}
 
         <PageHeader header="Tap" />
         {this.renderTapForm()}


### PR DESCRIPTION
We have a new format for displaying errors in ErrorBanner. When a websocket error occurred, we'd pass in text where ErrorBanner expects and object. This PR puts the websocket errors in an object
Also clean up the display of the error by removing redundant text.

Before:
![screen shot 2018-08-13 at 10 52 21 am](https://user-images.githubusercontent.com/549258/44049148-26e3e54e-9ee8-11e8-9dc8-826265f94b5a.png)

![screen shot 2018-08-13 at 10 43 44 am](https://user-images.githubusercontent.com/549258/44049169-367540c0-9ee8-11e8-83b8-9ee9bea8dbac.png)


After:

![screen shot 2018-08-13 at 10 51 38 am](https://user-images.githubusercontent.com/549258/44049155-2a2cb08c-9ee8-11e8-8510-e6bf5134d6ab.png)

![screen shot 2018-08-13 at 10 44 21 am](https://user-images.githubusercontent.com/549258/44049160-33044080-9ee8-11e8-8d8a-82e451997296.png)
