### PR TITLE
Refactor Tap Form into its own component

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import { publicAddressToString } from './util/Utils.js';
 import React from 'react';
 import TapEventTable from './TapEventTable.jsx';
+import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
+import { defaultMaxRps, httpMethods } from './util/TapUtils.js';
 import './../../css/tap.css';
 
-const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
-const defaultMaxRps = 1.0;
 const maxNumFilterOptions = 12;
 class Tap extends React.Component {
   static propTypes = {
@@ -63,8 +63,8 @@ class Tap extends React.Component {
   }
 
   onWebsocketOpen = () => {
-    let query = this.state.query;
-    query.maxRps = parseFloat(query.maxRps) || defaultMaxRps;
+    let query = _.cloneDeep(this.state.query);
+    query.maxRps = parseFloat(query.maxRps);
 
     this.ws.send(JSON.stringify({
       id: "tap-web",
@@ -331,30 +331,6 @@ class Tap extends React.Component {
     });
   }
 
-  renderCurrentQuery = () => {
-    let emptyVals =  _.countBy(_.values(this.state.query), v => _.isEmpty(v));
-
-    return (
-      <div className="tap-query">
-        <code>
-          { !emptyVals.false || emptyVals.false === 1 ? null :
-          <div>
-            Current query:
-            {
-              _.map(this.state.query, (query, queryName) => {
-                if (query === "") {
-                  return null;
-                }
-                return <div key={queryName}>{queryName}: {query}</div>;
-              })
-            }
-          </div>
-          }
-        </code>
-      </div>
-    );
-  }
-
   render() {
     let tableRows = _(this.state.tapResultsById)
       .values().sortBy('lastUpdated').reverse().value();
@@ -373,7 +349,8 @@ class Tap extends React.Component {
           resourcesByNs={this.state.resourcesByNs}
           authoritiesByNs={this.state.authoritiesByNs}
           query={this.state.query} />
-        {this.renderCurrentQuery()}
+
+        <TapQueryCliCmd query={this.state.query} />
 
         <TapEventTable
           tableRows={tableRows}

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -331,6 +331,12 @@ class Tap extends React.Component {
     });
   }
 
+  updateQuery = query => {
+    this.setState({
+      query
+    });
+  }
+
   render() {
     let tableRows = _(this.state.tapResultsById)
       .values().sortBy('lastUpdated').reverse().value();
@@ -348,6 +354,7 @@ class Tap extends React.Component {
           handleTapStop={this.handleTapStop}
           resourcesByNs={this.state.resourcesByNs}
           authoritiesByNs={this.state.authoritiesByNs}
+          updateQuery={this.updateQuery}
           query={this.state.query} />
 
         <TapQueryCliCmd query={this.state.query} />

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -5,21 +5,10 @@ import PropTypes from 'prop-types';
 import { publicAddressToString } from './util/Utils.js';
 import React from 'react';
 import TapEventTable from './TapEventTable.jsx';
+import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
-import {
-  AutoComplete,
-  Button,
-  Col,
-  Form,
-  Icon,
-  Input,
-  Row,
-  Select
-} from 'antd';
 import './../../css/tap.css';
 
-const colSpan = 5;
-const rowGutter = 16;
 const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
 const defaultMaxRps = 1.0;
 const maxNumFilterOptions = 12;
@@ -53,17 +42,9 @@ class Tap extends React.Component {
         authority: "",
         maxRps: defaultMaxRps
       },
-      autocomplete: {
-        namespace: [],
-        resource: [],
-        toNamespace: [],
-        toResource: [],
-        authority: []
-      },
       maxLinesToDisplay: 40,
       awaitingWebSocketConnection: false,
       tapRequestInProgress: false,
-      showAdvancedForm: false,
       pollingInterval: 10000,
       pendingRequests: false
     };
@@ -158,10 +139,6 @@ class Tap extends React.Component {
       authoritiesByNs,
       resourcesByNs
     };
-  }
-
-  getResourceList(resourcesByNs, ns) {
-    return resourcesByNs[ns] || _.uniq(_.flatten(_.values(resourcesByNs)));
   }
 
   parseTapResult = data => {
@@ -311,12 +288,6 @@ class Tap extends React.Component {
     });
   }
 
-  toggleAdvancedForm = show => {
-    this.setState({
-      showAdvancedForm: show
-    });
-  }
-
   handleTapStart = e => {
     e.preventDefault();
     this.startTapSteaming();
@@ -324,44 +295,6 @@ class Tap extends React.Component {
 
   handleTapStop = () => {
     this.ws.close(1000);
-  }
-
-  handleFormChange = (name, scopeResource, shouldScopeAuthority) => {
-    let state = {
-      query: this.state.query,
-      autocomplete: this.state.autocomplete
-    };
-
-    return formVal => {
-      state.query[name] = formVal;
-      if (!_.isNil(scopeResource)) {
-        // scope the available typeahead resources to the selected namespace
-        state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
-      }
-      if (shouldScopeAuthority) {
-        state.autocomplete.authority = this.state.authoritiesByNs[formVal];
-      }
-
-      this.setState(state);
-    };
-  }
-
-  handleFormEvent = name => {
-    let state = {
-      query: this.state.query
-    };
-
-    return event => {
-      state.query[name] = event.target.value;
-      this.setState(state);
-    };
-  }
-
-  autoCompleteData = name => {
-    return _(this.state.autocomplete[name])
-      .filter(d => d.indexOf(this.state.query[name]) !== -1)
-      .sortBy()
-      .value();
   }
 
   loadFromServer() {
@@ -377,21 +310,10 @@ class Tap extends React.Component {
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
       .then(rsp => {
         let { resourcesByNs, authoritiesByNs } = this.getResourcesByNs(rsp);
-        let namespaces = _.sortBy(_.keys(resourcesByNs));
-        let resourceNames  = this.getResourceList(resourcesByNs, this.state.query.namespace);
-        let toResourceNames = this.getResourceList(resourcesByNs, this.state.query.toNamespace);
-        let authorities = this.getResourceList(authoritiesByNs, this.state.query.namespace);
 
         this.setState({
           resourcesByNs,
           authoritiesByNs,
-          autocomplete: {
-            namespace: namespaces,
-            resource: resourceNames,
-            toNamespace: namespaces,
-            toResource: toResourceNames,
-            authority: authorities
-          },
           pendingRequests: false
         });
       })
@@ -407,156 +329,6 @@ class Tap extends React.Component {
       pendingRequests: false,
       error: e
     });
-  }
-
-  renderTapForm = () => {
-    return (
-      <Form className="tap-form">
-        <Row gutter={rowGutter}>
-          <Col span={colSpan}>
-            <Form.Item>
-              <Select
-                showSearch
-                allowClear
-                placeholder="Namespace"
-                optionFilterProp="children"
-                onChange={this.handleFormChange("namespace", "resource", true)}>
-                {
-                  _.map(this.state.autocomplete.namespace, (n, i) => (
-                    <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
-                  ))
-                }
-              </Select>
-            </Form.Item>
-          </Col>
-
-          <Col span={colSpan}>
-            <Form.Item>
-              <AutoComplete
-                dataSource={this.autoCompleteData("resource")}
-                onSelect={this.handleFormChange("resource")}
-                onSearch={this.handleFormChange("resource")}
-                placeholder="Resource" />
-            </Form.Item>
-          </Col>
-
-          <Col span={colSpan}>
-            <Form.Item>
-              {
-                this.state.tapRequestInProgress ?
-                  <Button type="primary" className="tap-stop" onClick={this.handleTapStop}>Stop</Button> :
-                  <Button type="primary" className="tap-start" onClick={this.handleTapStart}>Start</Button>
-              }
-              {
-                this.state.awaitingWebSocketConnection ?
-                  <Icon type="loading" style={{ paddingLeft: rowGutter, fontSize: 20, color: '#08c' }} /> : null
-              }
-            </Form.Item>
-          </Col>
-        </Row>
-
-        <Button
-          className="tap-form-toggle"
-          onClick={() => this.toggleAdvancedForm(!this.state.showAdvancedForm)}>
-          { this.state.showAdvancedForm ?
-            "Hide filters" : "Show more request filters" } <Icon type={this.state.showAdvancedForm ? 'up' : 'down'} />
-        </Button>
-
-        { !this.state.showAdvancedForm ? null : this.renderAdvancedTapForm() }
-      </Form>
-    );
-  }
-
-  renderAdvancedTapForm = () => {
-    return (
-      <React.Fragment>
-        <Row gutter={rowGutter}>
-          <Col span={colSpan}>
-            <Form.Item>
-              <Select
-                showSearch
-                allowClear
-                placeholder="To Namespace"
-                optionFilterProp="children"
-                onChange={this.handleFormChange("toNamespace", "toResource")}>
-                {
-                  _.map(this.state.autocomplete.toNamespace, (n, i) => (
-                    <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
-                  ))
-                }
-              </Select>
-            </Form.Item>
-          </Col>
-
-          <Col span={colSpan}>
-            <Form.Item>
-              <AutoComplete
-                dataSource={this.autoCompleteData("toResource")}
-                onSelect={this.handleFormChange("toResource")}
-                onSearch={this.handleFormChange("toResource")}
-                placeholder="To Resource" />
-            </Form.Item>
-          </Col>
-        </Row>
-
-        <Row gutter={rowGutter}>
-          <Col span={2 * colSpan}>
-            <Form.Item
-              extra="Display requests with this :authority">
-
-              <AutoComplete
-                dataSource={this.autoCompleteData("authority")}
-                onSelect={this.handleFormChange("authority")}
-                onSearch={this.handleFormChange("authority")}
-                placeholder="Authority" />
-            </Form.Item>
-          </Col>
-
-          <Col span={2 * colSpan}>
-            <Form.Item
-              extra="Display requests with paths that start with this prefix">
-              <Input placeholder="Path" onChange={this.handleFormEvent("path")} />
-            </Form.Item>
-          </Col>
-
-        </Row>
-
-        <Row gutter={rowGutter}>
-          <Col span={colSpan}>
-            <Form.Item
-              extra="Display requests with this scheme">
-              <Input placeholder="Scheme" onChange={this.handleFormEvent("scheme")} />
-            </Form.Item>
-          </Col>
-
-          <Col span={colSpan}>
-            <Form.Item
-              extra="Maximum requests per second to tap">
-              <Input
-                defaultValue={defaultMaxRps}
-                placeholder="Max RPS"
-                onChange={this.handleFormEvent("maxRps")} />
-            </Form.Item>
-          </Col>
-
-          <Col span={colSpan}>
-            <Form.Item
-              extra="Display requests with this HTTP method">
-              <Select
-                allowClear
-                placeholder="HTTP method"
-                onChange={this.handleFormChange("method")}>
-                {
-                  _.map(httpMethods, m =>
-                    <Select.Option key={`method-select-${m}`} value={m}>{m}</Select.Option>
-                  )
-                }
-              </Select>
-            </Form.Item>
-          </Col>
-        </Row>
-      </React.Fragment>
-    );
   }
 
   renderCurrentQuery = () => {
@@ -593,7 +365,14 @@ class Tap extends React.Component {
         <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: null })} />}
 
         <PageHeader header="Tap" />
-        {this.renderTapForm()}
+        <TapQueryForm
+          tapRequestInProgress={this.state.tapRequestInProgress}
+          awaitingWebSocketConnection={this.state.awaitingWebSocketConnection}
+          handleTapStart={this.handleTapStart}
+          handleTapStop={this.handleTapStop}
+          resourcesByNs={this.state.resourcesByNs}
+          authoritiesByNs={this.state.authoritiesByNs}
+          query={this.state.query} />
         {this.renderCurrentQuery()}
 
         <TapEventTable

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -1,0 +1,67 @@
+import _ from 'lodash';
+import React from 'react';
+import { tapQueryPropType } from './util/TapUtils.js';
+
+/*
+ prints a given tap query in an equivalent CLI format, such that it
+ could be pasted into a terminal
+*/
+export default class TapQueryCliCmd extends React.Component {
+  static propTypes = {
+    query: tapQueryPropType
+  }
+
+  static defaultProps = {
+    query: {
+      resource: "",
+      namespace: "",
+      toResource: "",
+      toNamespace: "",
+      method: "",
+      path: "",
+      scheme: "",
+      authority: "",
+      maxRps: ""
+    }
+  }
+
+  renderCliItem = (queryLabel, queryVal) => {
+    return _.isEmpty(queryVal) ? null : ` ${queryLabel} ${queryVal}`;
+  }
+
+  render = () => {
+    let {
+      resource,
+      namespace,
+      toResource,
+      toNamespace,
+      method,
+      path,
+      scheme,
+      authority,
+      maxRps
+    } = this.props.query;
+
+    return (
+      <div className="tap-query">
+        {
+          _.isEmpty(resource) ? null :
+          <React.Fragment>
+            <div>Current Tap query:</div>
+            <code>
+                  linkerd tap {resource}
+              { this.renderCliItem("--namespace", namespace) }
+              { this.renderCliItem("--to", toResource) }
+              { this.renderCliItem("--to-namespace", toNamespace) }
+              { this.renderCliItem("--method", method) }
+              { this.renderCliItem("--scheme", scheme) }
+              { this.renderCliItem("--authority", authority) }
+              { this.renderCliItem("--path", path) }
+              { this.renderCliItem("--max-rps", maxRps) }
+            </code>
+          </React.Fragment>
+        }
+      </div>
+    );
+  }
+}

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -49,7 +49,7 @@ export default class TapQueryCliCmd extends React.Component {
           <React.Fragment>
             <div>Current Tap query:</div>
             <code>
-                  linkerd tap {resource}
+              linkerd tap {resource}
               { this.renderCliItem("--namespace", namespace) }
               { this.renderCliItem("--to", toResource) }
               { this.renderCliItem("--to-namespace", toNamespace) }

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -1,0 +1,281 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+  AutoComplete,
+  Button,
+  Col,
+  Form,
+  Icon,
+  Input,
+  Row,
+  Select
+} from 'antd';
+
+const colSpan = 5;
+const rowGutter = 16;
+
+const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
+const defaultMaxRps = 1.0;
+
+const getResourceList = (resourcesByNs, ns) => {
+  return resourcesByNs[ns] || _.uniq(_.flatten(_.values(resourcesByNs)));
+};
+export default class TapQueryForm extends React.Component {
+  static propTypes = {
+    awaitingWebSocketConnection: PropTypes.bool.isRequired,
+    handleTapStart: PropTypes.func.isRequired,
+    handleTapStop: PropTypes.func.isRequired,
+    query: PropTypes.shape({
+      resource: PropTypes.string,
+      namespace: PropTypes.string,
+      toResource: PropTypes.string,
+      toNamespace: PropTypes.string,
+      method: PropTypes.string,
+      path: PropTypes.string,
+      scheme: PropTypes.string,
+      authority: PropTypes.string,
+      maxRps: PropTypes.number
+    }).isRequired,
+    tapRequestInProgress: PropTypes.bool.isRequired
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      authoritiesByNs: {},
+      resourcesByNs: {},
+      showAdvancedForm: false,
+      query: props.query,
+      autocomplete: {
+        namespace: [],
+        resource: [],
+        toNamespace: [],
+        toResource: [],
+        authority: []
+      },
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (!_.isEqual(props.resourcesByNs, state.resourcesByNs)) {
+      let resourcesByNs = props.resourcesByNs;
+      let authoritiesByNs = props.authoritiesByNs;
+      let namespaces = _.sortBy(_.keys(resourcesByNs));
+      let resourceNames  = getResourceList(resourcesByNs, state.query.namespace);
+      let toResourceNames = getResourceList(resourcesByNs, state.query.toNamespace);
+      let authorities = getResourceList(authoritiesByNs, state.query.namespace);
+
+      return _.merge(state, {
+        resourcesByNs,
+        authoritiesByNs,
+        autocomplete: {
+          namespace: namespaces,
+          resource: resourceNames,
+          toNamespace: namespaces,
+          toResource: toResourceNames,
+          authority: authorities
+        }
+      });
+    } else {
+      return null;
+    }
+  }
+
+
+
+  toggleAdvancedForm = show => {
+    this.setState({
+      showAdvancedForm: show
+    });
+  }
+
+  handleFormChange = (name, scopeResource, shouldScopeAuthority) => {
+    let state = {
+      query: this.state.query,
+      autocomplete: this.state.autocomplete
+    };
+
+    return formVal => {
+      state.query[name] = formVal;
+      if (!_.isNil(scopeResource)) {
+        // scope the available typeahead resources to the selected namespace
+        state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
+      }
+      if (shouldScopeAuthority) {
+        state.autocomplete.authority = this.state.authoritiesByNs[formVal];
+      }
+
+      this.setState(state);
+    };
+  }
+
+  handleFormEvent = name => {
+    let state = {
+      query: this.state.query
+    };
+
+    return event => {
+      state.query[name] = event.target.value;
+      this.setState(state);
+    };
+  }
+
+  autoCompleteData = name => {
+    return _(this.state.autocomplete[name])
+      .filter(d => d.indexOf(this.state.query[name]) !== -1)
+      .sortBy()
+      .value();
+  }
+
+  renderAdvancedTapForm = () => {
+    return (
+      <React.Fragment>
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item>
+              <Select
+                showSearch
+                allowClear
+                placeholder="To Namespace"
+                optionFilterProp="children"
+                onChange={this.handleFormChange("toNamespace", "toResource")}>
+                {
+                  _.map(this.state.autocomplete.toNamespace, (n, i) => (
+                    <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
+                  ))
+                }
+              </Select>
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item>
+              <AutoComplete
+                dataSource={this.autoCompleteData("toResource")}
+                onSelect={this.handleFormChange("toResource")}
+                onSearch={this.handleFormChange("toResource")}
+                placeholder="To Resource" />
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Row gutter={rowGutter}>
+          <Col span={2 * colSpan}>
+            <Form.Item
+              extra="Display requests with this :authority">
+
+              <AutoComplete
+                dataSource={this.autoCompleteData("authority")}
+                onSelect={this.handleFormChange("authority")}
+                onSearch={this.handleFormChange("authority")}
+                placeholder="Authority" />
+            </Form.Item>
+          </Col>
+
+          <Col span={2 * colSpan}>
+            <Form.Item
+              extra="Display requests with paths that start with this prefix">
+              <Input placeholder="Path" onChange={this.handleFormEvent("path")} />
+            </Form.Item>
+          </Col>
+
+        </Row>
+
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Display requests with this scheme">
+              <Input placeholder="Scheme" onChange={this.handleFormEvent("scheme")} />
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Maximum requests per second to tap">
+              <Input
+                defaultValue={defaultMaxRps}
+                placeholder="Max RPS"
+                onChange={this.handleFormEvent("maxRps")} />
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item
+              extra="Display requests with this HTTP method">
+              <Select
+                allowClear
+                placeholder="HTTP method"
+                onChange={this.handleFormChange("method")}>
+                {
+                  _.map(httpMethods, m =>
+                    <Select.Option key={`method-select-${m}`} value={m}>{m}</Select.Option>
+                  )
+                }
+              </Select>
+            </Form.Item>
+          </Col>
+        </Row>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    return (
+      <Form className="tap-form">
+        <Row gutter={rowGutter}>
+          <Col span={colSpan}>
+            <Form.Item>
+              <Select
+                showSearch
+                allowClear
+                placeholder="Namespace"
+                optionFilterProp="children"
+                onChange={this.handleFormChange("namespace", "resource", true)}>
+                {
+                _.map(this.state.autocomplete.namespace, (n, i) => (
+                  <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
+                ))
+              }
+              </Select>
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item>
+              <AutoComplete
+                dataSource={this.autoCompleteData("resource")}
+                onSelect={this.handleFormChange("resource")}
+                onSearch={this.handleFormChange("resource")}
+                placeholder="Resource" />
+            </Form.Item>
+          </Col>
+
+          <Col span={colSpan}>
+            <Form.Item>
+              {
+              this.props.tapRequestInProgress ?
+                <Button type="primary" className="tap-stop" onClick={this.props.handleTapStop}>Stop</Button> :
+                <Button type="primary" className="tap-start" onClick={this.props.handleTapStart}>Start</Button>
+            }
+              {
+              this.props.awaitingWebSocketConnection ?
+                <Icon type="loading" style={{ paddingLeft: rowGutter, fontSize: 20, color: '#08c' }} /> : null
+            }
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Button
+          className="tap-form-toggle"
+          onClick={() => this.toggleAdvancedForm(!this.state.showAdvancedForm)}>
+          { this.state.showAdvancedForm ?
+          "Hide filters" : "Show more request filters" } <Icon type={this.state.showAdvancedForm ? 'up' : 'down'} />
+        </Button>
+
+        { !this.state.showAdvancedForm ? null : this.renderAdvancedTapForm() }
+      </Form>
+    );
+  }
+}

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -25,7 +25,8 @@ export default class TapQueryForm extends React.Component {
     handleTapStart: PropTypes.func.isRequired,
     handleTapStop: PropTypes.func.isRequired,
     query: tapQueryPropType.isRequired,
-    tapRequestInProgress: PropTypes.bool.isRequired
+    tapRequestInProgress: PropTypes.bool.isRequired,
+    updateQuery: PropTypes.func.isRequired
   }
 
   constructor(props) {
@@ -94,6 +95,7 @@ export default class TapQueryForm extends React.Component {
       }
 
       this.setState(state);
+      this.props.updateQuery(state.query);
     };
   }
 
@@ -105,6 +107,7 @@ export default class TapQueryForm extends React.Component {
     return event => {
       state.query[name] = event.target.value;
       this.setState(state);
+      this.props.updateQuery(state.query);
     };
   }
 

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -11,12 +11,10 @@ import {
   Row,
   Select
 } from 'antd';
+import { defaultMaxRps, httpMethods, tapQueryPropType } from './util/TapUtils.js';
 
 const colSpan = 5;
 const rowGutter = 16;
-
-const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
-const defaultMaxRps = 1.0;
 
 const getResourceList = (resourcesByNs, ns) => {
   return resourcesByNs[ns] || _.uniq(_.flatten(_.values(resourcesByNs)));
@@ -26,17 +24,7 @@ export default class TapQueryForm extends React.Component {
     awaitingWebSocketConnection: PropTypes.bool.isRequired,
     handleTapStart: PropTypes.func.isRequired,
     handleTapStop: PropTypes.func.isRequired,
-    query: PropTypes.shape({
-      resource: PropTypes.string,
-      namespace: PropTypes.string,
-      toResource: PropTypes.string,
-      toNamespace: PropTypes.string,
-      method: PropTypes.string,
-      path: PropTypes.string,
-      scheme: PropTypes.string,
-      authority: PropTypes.string,
-      maxRps: PropTypes.number
-    }).isRequired,
+    query: tapQueryPropType.isRequired,
     tapRequestInProgress: PropTypes.bool.isRequired
   }
 
@@ -82,8 +70,6 @@ export default class TapQueryForm extends React.Component {
       return null;
     }
   }
-
-
 
   toggleAdvancedForm = show => {
     this.setState({

--- a/web/app/js/components/util/TapUtils.js
+++ b/web/app/js/components/util/TapUtils.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+
+export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
+
+export const defaultMaxRps = "1.0";
+
+export const tapQueryPropType = PropTypes.shape({
+  resource: PropTypes.string,
+  namespace: PropTypes.string,
+  toResource: PropTypes.string,
+  toNamespace: PropTypes.string,
+  method: PropTypes.string,
+  path: PropTypes.string,
+  scheme: PropTypes.string,
+  authority: PropTypes.string,
+  maxRps: PropTypes.string
+});


### PR DESCRIPTION
Tap.jsx is really large and contains a lot of logic that pertains only to the Tap Query Form.
This PR tries to separate the concerns of the form and the query display from the main Tap querying and rendering logic. This will also allow us to easily reuse this form for the Top page.

Changes in this PR:
- moves all the code for the form into its own component
- moves the code that displays the current query into its own component
- formats the current tap query as the equivalent command line format, that you can paste into a terminal

![screen shot 2018-08-13 at 4 38 35 pm](https://user-images.githubusercontent.com/549258/44063962-af4a7ed2-9f17-11e8-9943-5cfae169f61c.png)
