### PR TITLE
linkerd top GUI

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -7,7 +7,7 @@ import TapEventTable from './TapEventTable.jsx';
 import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
-import { defaultMaxRps, httpMethods, processTapEvent } from './util/TapUtils.js';
+import { defaultMaxRps, httpMethods, processTapEvent } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const maxNumFilterOptions = 12;

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -146,6 +146,13 @@ class Tap extends React.Component {
     let addFilter = this.genFilterAdder(filters, Date.now());
     addFilter("source", d.source.str);
     addFilter("destination", d.destination.str);
+    if (d.source.pod) {
+      addFilter("source", d.source.pod);
+    }
+    if (d.destination.pod) {
+      addFilter("destination", d.destination.pod);
+    }
+
     if (d.tls) {
       addFilter("tls", d.tls);
     }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -150,12 +150,12 @@ class Tap extends React.Component {
       addFilter("tls", d.tls);
     }
     switch (d.eventType) {
-      case "req":
+      case "requestInit":
         addFilter("authority", d.http.requestInit.authority);
         addFilter("path", d.http.requestInit.path);
         addFilter("scheme", _.get(d, "http.requestInit.scheme.registered"));
         break;
-      case "rsp":
+      case "responseInit":
         addFilter("httpStatus", _.get(d, "http.responseInit.httpStatus"));
         break;
     }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -337,7 +337,7 @@ class Tap extends React.Component {
           updateQuery={this.updateQuery}
           query={this.state.query} />
 
-        <TapQueryCliCmd query={this.state.query} />
+        <TapQueryCliCmd cmdName="tap" query={this.state.query} />
 
         <TapEventTable
           tableRows={tableRows}

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -53,16 +53,16 @@ let tapColumns = filterOptions => [
     key: "source",
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.source),
-    onFilter: (value, row) => row.base.source.str === value,
-    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "sourceMeta.labels", {}))
+    onFilter: (value, row) => row.base.source.pod === value || row.base.source.str === value,
+    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "sourceMeta.labels", {}))
   },
   {
     title: "Destination",
     key: "destination",
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.destination),
-    onFilter: (value, row) => row.base.destination.str === value,
-    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "destinationMeta.labels", {}))
+    onFilter: (value, row) => row.base.destination.pod === value || row.base.destination.str === value,
+    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "destinationMeta.labels", {}))
   },
   {
     title: "TLS",

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -36,7 +36,7 @@ const genFilterOptionList = options => _.map(options,  (_v, k) => {
 let tapColumns = filterOptions => [
   {
     title: "ID",
-    dataIndex: "base.id"
+    dataIndex: "requestInit.http.requestInit.id.stream"
   },
   {
     title: "Direction",
@@ -75,39 +75,39 @@ let tapColumns = filterOptions => [
       {
         title: "Authority",
         key: "authority",
-        dataIndex: "req.http.requestInit",
+        dataIndex: "requestInit.http.requestInit",
         filters: genFilterOptionList(filterOptions.authority),
         onFilter: (value, row) =>
-          _.get(row, "req.http.requestInit.authority") === value,
+          _.get(row, "requestInit.http.requestInit.authority") === value,
         render: d => !d ? <Icon type="loading" /> : d.authority
       },
       {
         title: "Path",
         key: "path",
-        dataIndex: "req.http.requestInit",
+        dataIndex: "requestInit.http.requestInit",
         filters: genFilterOptionList(filterOptions.path),
         onFilter: (value, row) =>
-          _.get(row, "req.http.requestInit.path") === value,
+          _.get(row, "requestInit.http.requestInit.path") === value,
         render: d => !d ? <Icon type="loading" /> : d.path
       },
       {
         title: "Scheme",
         key: "scheme",
-        dataIndex: "req.http.requestInit",
+        dataIndex: "requestInit.http.requestInit",
         filters: genFilterOptionList(filterOptions.scheme),
         onFilter: (value, row) =>
-          _.get(row, "req.http.requestInit.scheme.registered") === value,
+          _.get(row, "requestInit.http.requestInit.scheme.registered") === value,
         render: d => !d ? <Icon type="loading" /> : _.get(d, "scheme.registered")
       },
       {
         title: "Method",
         key: "method",
-        dataIndex: "req.http.requestInit",
+        dataIndex: "requestInit.http.requestInit",
         filters: _.map(filterOptions.httpMethod, d => {
           return { text: d, value: d};
         }),
         onFilter: (value, row) =>
-          _.get(row, "req.http.requestInit.method.registered") === value,
+          _.get(row, "requestInit.http.requestInit.method.registered") === value,
         render: d => !d ? <Icon type="loading" /> : _.get(d, "method.registered")
       }
     ]
@@ -118,16 +118,16 @@ let tapColumns = filterOptions => [
       {
         title: "HTTP status",
         key: "http-status",
-        dataIndex: "rsp.http.responseInit",
+        dataIndex: "responseInit.http.responseInit",
         filters: genFilterOptionList(filterOptions.httpStatus),
         onFilter: (value, row) =>
-          _.get(row, "rsp.http.responseInit.httpStatus") + "" === value,
+          _.get(row, "responseInit.http.responseInit.httpStatus") + "" === value,
         render: d => !d ? <Icon type="loading" /> : d.httpStatus
       },
       {
         title: "Latency",
         key: "rsp-latency",
-        dataIndex: "rsp.http.responseInit",
+        dataIndex: "responseInit.http.responseInit",
         render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceRequestInit)
       },
     ]
@@ -138,22 +138,22 @@ let tapColumns = filterOptions => [
       {
         title: "GRPC status",
         key: "grpc-status",
-        dataIndex: "end.http.responseEnd",
+        dataIndex: "responseEnd.http.responseEnd",
         filters: grpcStatusCodeFilters,
         onFilter: (value, row) =>
-          (_.get(row, "end.http.responseEnd.eos.grpcStatusCode") + "") === value,
+          (_.get(row, "responseEnd.http.responseEnd.eos.grpcStatusCode") + "") === value,
         render: d => !d ? <Icon type="loading" /> : _.get(d, "eos.grpcStatusCode")
       },
       {
         title: "Latency",
         key: "end-latency",
-        dataIndex: "end.http.responseEnd",
+        dataIndex: "responseEnd.http.responseEnd",
         render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceResponseInit)
       },
       {
         title: "Response Length (B)",
         key: "rsp-length",
-        dataIndex: "end.http.responseEnd",
+        dataIndex: "responseEnd.http.responseEnd",
         render: d => !d ? <Icon type="loading" /> : d.responseBytes
       },
     ]

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
 import { formatLatencySec } from './util/Utils.js';
 import React from 'react';
-import { Col, Icon, Popover, Row, Table } from 'antd';
+import { srcDstColumn } from './util/TapUtils.jsx';
+import { Col, Icon, Row, Table } from 'antd';
 
 // https://godoc.org/google.golang.org/grpc/codes#Code
 const grpcStatusCodes = {
@@ -163,19 +164,6 @@ let tapColumns = filterOptions => [
 
 const formatTapLatency = str => {
   return formatLatencySec(str.replace("s", ""));
-};
-
-const srcDstColumn = (display, labels) => {
-  let content = (
-    <React.Fragment>
-      <div>{ !labels.deployment ? null : "deploy/" + labels.deployment }</div>
-      <div>{ !labels.pod ? null : "po/" + labels.pod }</div>
-    </React.Fragment>
-  );
-
-  return (
-    <Popover content={content} title={display.str}>{ display.pod || display.str }</Popover>
-  );
 };
 
 const srcDstMetaColumns = [

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -53,7 +53,7 @@ let tapColumns = filterOptions => [
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.source),
     onFilter: (value, row) => row.base.source.str === value,
-    render: d => srcDstColumn(_.get(d, "destination.str"), _.get(d, "sourceMeta.labels", {}))
+    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "sourceMeta.labels", {}))
   },
   {
     title: "Destination",
@@ -61,7 +61,7 @@ let tapColumns = filterOptions => [
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.destination),
     onFilter: (value, row) => row.base.destination.str === value,
-    render: d => srcDstColumn(_.get(d, "source.str"), _.get(d, "destinationMeta.labels", {}))
+    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "destinationMeta.labels", {}))
   },
   {
     title: "TLS",
@@ -165,15 +165,16 @@ const formatTapLatency = str => {
   return formatLatencySec(str.replace("s", ""));
 };
 
-const srcDstColumn = (ipStr, labels) => {
+const srcDstColumn = (display, labels) => {
   let content = (
     <React.Fragment>
       <div>{ !labels.deployment ? null : "deploy/" + labels.deployment }</div>
       <div>{ !labels.pod ? null : "po/" + labels.pod }</div>
     </React.Fragment>
   );
+
   return (
-    <Popover content={content} title={ipStr}>{ !labels.pod ? ipStr : "po/" + labels.pod }</Popover>
+    <Popover content={content} title={display.str}>{ display.pod || display.str }</Popover>
   );
 };
 

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { tapQueryPropType } from './util/TapUtils.js';
 
@@ -8,6 +9,7 @@ import { tapQueryPropType } from './util/TapUtils.js';
 */
 export default class TapQueryCliCmd extends React.Component {
   static propTypes = {
+    cmdName: PropTypes.string.isRequired,
     query: tapQueryPropType
   }
 
@@ -47,9 +49,9 @@ export default class TapQueryCliCmd extends React.Component {
         {
           _.isEmpty(resource) ? null :
           <React.Fragment>
-            <div>Current Tap query:</div>
+            <div>Current {_.startCase(this.props.cmdName)} query:</div>
             <code>
-              linkerd tap {resource}
+              linkerd {this.props.cmdName} {resource}
               { this.renderCliItem("--namespace", namespace) }
               { this.renderCliItem("--to", toResource) }
               { this.renderCliItem("--to-namespace", toNamespace) }

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { tapQueryPropType } from './util/TapUtils.js';
+import { tapQueryPropType } from './util/TapUtils.jsx';
 
 /*
  prints a given tap query in an equivalent CLI format, such that it

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -11,7 +11,7 @@ import {
   Row,
   Select
 } from 'antd';
-import { defaultMaxRps, httpMethods, tapQueryPropType } from './util/TapUtils.js';
+import { defaultMaxRps, httpMethods, tapQueryPropType } from './util/TapUtils.jsx';
 
 const colSpan = 5;
 const rowGutter = 16;

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -22,11 +22,16 @@ const getResourceList = (resourcesByNs, ns) => {
 export default class TapQueryForm extends React.Component {
   static propTypes = {
     awaitingWebSocketConnection: PropTypes.bool.isRequired,
+    enableAdvancedForm: PropTypes.bool,
     handleTapStart: PropTypes.func.isRequired,
     handleTapStop: PropTypes.func.isRequired,
     query: tapQueryPropType.isRequired,
     tapRequestInProgress: PropTypes.bool.isRequired,
     updateQuery: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    enableAdvancedForm: true
   }
 
   constructor(props) {
@@ -256,14 +261,19 @@ export default class TapQueryForm extends React.Component {
           </Col>
         </Row>
 
-        <Button
-          className="tap-form-toggle"
-          onClick={() => this.toggleAdvancedForm(!this.state.showAdvancedForm)}>
-          { this.state.showAdvancedForm ?
+        {
+          !this.props.enableAdvancedForm ? null :
+          <React.Fragment>
+            <Button
+              className="tap-form-toggle"
+              onClick={() => this.toggleAdvancedForm(!this.state.showAdvancedForm)}>
+              { this.state.showAdvancedForm ?
           "Hide filters" : "Show more request filters" } <Icon type={this.state.showAdvancedForm ? 'up' : 'down'} />
-        </Button>
+            </Button>
 
-        { !this.state.showAdvancedForm ? null : this.renderAdvancedTapForm() }
+            { !this.state.showAdvancedForm ? null : this.renderAdvancedTapForm() }
+          </React.Fragment>
+        }
       </Form>
     );
   }

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -130,9 +130,9 @@ class Top extends React.Component {
   parseTapResult = data => {
     let d = processTapEvent(data);
 
-    if (d.eventType === "rsp") {
+    if (d.eventType === "responseInit") {
       d.success = parseInt(d.http.responseInit.httpStatus, 10) < 500;
-    } else if (d.eventType === "end") {
+    } else if (d.eventType === "responseEnd") {
       d.latency = parseFloat(d.http.responseEnd.sinceRequestInit.replace("s", ""));
       d.completed = true;
     }
@@ -147,15 +147,15 @@ class Top extends React.Component {
   initialTopResult(d, eventKey) {
     return {
       count: 1,
-      best: d.end.latency,
-      worst: d.end.latency,
-      last: d.end.latency,
-      success: !d.rsp.success ? 0 : 1,
-      failure: !d.rsp.success ? 1 : 0,
-      successRate: !d.rsp.success ? new Percentage(0, 1) : new Percentage(1, 1),
-      source: d.req.source.str,
-      destination: d.req.destination.str,
-      path: d.req.http.requestInit.path,
+      best: d.responseEnd.latency,
+      worst: d.responseEnd.latency,
+      last: d.responseEnd.latency,
+      success: !d.responseInit.success ? 0 : 1,
+      failure: !d.responseInit.success ? 1 : 0,
+      successRate: !d.responseInit.success ? new Percentage(0, 1) : new Percentage(1, 1),
+      source: d.requestInit.source.str,
+      destination: d.requestInit.destination.str,
+      path: d.requestInit.http.requestInit.path,
       key: eventKey,
       lastUpdated: Date.now()
     };
@@ -163,26 +163,26 @@ class Top extends React.Component {
 
   incrementTopResult(d, result) {
     result.count++;
-    if (!d.rsp.success) {
+    if (!d.responseInit.success) {
       result.failure++;
     } else {
       result.success++;
     }
     result.successRate = new Percentage(result.success, result.success + result.failure);
 
-    result.last = d.end.latency;
-    if (d.end.latency < result.best) {
-      result.best = d.end.latency;
+    result.last = d.responseEnd.latency;
+    if (d.responseEnd.latency < result.best) {
+      result.best = d.responseEnd.latency;
     }
-    if (d.end.latency > result.worst) {
-      result.worst = d.end.latency;
+    if (d.responseEnd.latency > result.worst) {
+      result.worst = d.responseEnd.latency;
     }
 
     result.lastUpdated = Date.now();
   }
 
   indexTopResult = (d, topResults) => {
-    let eventKey = this.topEventKey(d.req);
+    let eventKey = this.topEventKey(d.requestInit);
 
     if (!topResults[eventKey]) {
       topResults[eventKey] = this.initialTopResult(d, eventKey);

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -8,7 +8,7 @@ import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import TopEventTable from './TopEventTable.jsx';
 import { withContext } from './util/AppContext.jsx';
-import { defaultMaxRps, processTapEvent } from './util/TapUtils.js';
+import { defaultMaxRps, processTapEvent } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 class Top extends React.Component {
@@ -153,8 +153,10 @@ class Top extends React.Component {
       success: !d.responseInit.success ? 0 : 1,
       failure: !d.responseInit.success ? 1 : 0,
       successRate: !d.responseInit.success ? new Percentage(0, 1) : new Percentage(1, 1),
-      source: d.requestInit.source.pod || d.requestInit.source.str,
-      destination: d.requestInit.destination.pod || d.requestInit.destination.str,
+      source: d.requestInit.source,
+      sourceLabels: d.requestInit.sourceMeta.labels,
+      destination: d.requestInit.destination,
+      destinationLabels: d.requestInit.destinationMeta.labels,
       path: d.requestInit.http.requestInit.path,
       key: eventKey,
       lastUpdated: Date.now()

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -183,7 +183,7 @@ class Top extends React.Component {
 
   indexTopResult = (d, topResults) => {
     let eventKey = this.topEventKey(d.requestInit);
-    this.addSuccessRate(d);
+    this.addSuccessCount(d);
 
     if (!topResults[eventKey]) {
       topResults[eventKey] = this.initialTopResult(d, eventKey);
@@ -233,7 +233,7 @@ class Top extends React.Component {
     });
   }
 
-  addSuccessRate = d => {
+  addSuccessCount = d => {
     // cope with the fact that gRPC failures are returned with HTTP status 200
     // and correctly classify gRPC failures as failures
     let success = parseInt(d.responseInit.http.responseInit.httpStatus, 10) < 500;

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -1,0 +1,385 @@
+import _ from 'lodash';
+import { defaultMaxRps } from './util/TapUtils.js';
+import ErrorBanner from './ErrorBanner.jsx';
+import PageHeader from './PageHeader.jsx';
+import Percentage from './util/Percentage.js';
+import PropTypes from 'prop-types';
+import { publicAddressToString } from './util/Utils.js';
+import React from 'react';
+import TapQueryCliCmd from './TapQueryCliCmd.jsx';
+import TapQueryForm from './TapQueryForm.jsx';
+import TopEventTable from './TopEventTable.jsx';
+import { withContext } from './util/AppContext.jsx';
+import './../../css/tap.css';
+
+class Top extends React.Component {
+  static propTypes = {
+    api: PropTypes.shape({
+      PrefixedLink: PropTypes.func.isRequired,
+    }).isRequired,
+    pathPrefix: PropTypes.string.isRequired
+  }
+
+  constructor(props) {
+    super(props);
+    this.api = this.props.api;
+    this.loadFromServer = this.loadFromServer.bind(this);
+
+    this.state = {
+      tapResultsById: {},
+      topEventIndex: {},
+      error: null,
+      resourcesByNs: {},
+      authoritiesByNs: {},
+      query: {
+        resource: "",
+        namespace: "",
+        toResource: "",
+        toNamespace: "",
+        method: "",
+        path: "",
+        scheme: "",
+        authority: "",
+        maxRps: defaultMaxRps
+      },
+      maxRowsToStore: 40,
+      awaitingWebSocketConnection: false,
+      tapRequestInProgress: false,
+      pollingInterval: 10000,
+      pendingRequests: false
+    };
+  }
+
+  componentDidMount() {
+    this.startServerPolling();
+  }
+
+  componentWillUnmount() {
+    if (this.ws) {
+      this.ws.close(1000);
+    }
+    this.stopTapStreaming();
+    this.stopServerPolling();
+  }
+
+  onWebsocketOpen = () => {
+    let query = _.cloneDeep(this.state.query);
+    query.maxRps = parseFloat(query.maxRps);
+
+    this.ws.send(JSON.stringify({
+      id: "tap-web",
+      ...query
+    }));
+    this.setState({
+      awaitingWebSocketConnection: false,
+      error: null
+    });
+  }
+
+  onWebsocketRecv = e => {
+    this.indexTapResult(e.data);
+  }
+
+  onWebsocketClose = e => {
+    this.stopTapStreaming();
+
+    if (!e.wasClean) {
+      this.setState({
+        error: {
+          error: `Websocket [${e.code}] ${e.reason}`
+        }
+      });
+    }
+  }
+
+  onWebsocketError = e => {
+    this.setState({
+      error: { error: e.message }
+    });
+
+    this.stopTapStreaming();
+  }
+
+  getResourcesByNs(rsp) {
+    let statTables = _.get(rsp, [0, "ok", "statTables"]);
+    let authoritiesByNs = {};
+    let resourcesByNs = _.reduce(statTables, (mem, table) => {
+      _.map(table.podGroup.rows, row => {
+        if (!mem[row.resource.namespace]) {
+          mem[row.resource.namespace] = [];
+          authoritiesByNs[row.resource.namespace] = [];
+        }
+
+        switch (row.resource.type.toLowerCase()) {
+          case "service":
+            break;
+          case "authority":
+            authoritiesByNs[row.resource.namespace].push(row.resource.name);
+            break;
+          default:
+            mem[row.resource.namespace].push(`${row.resource.type}/${row.resource.name}`);
+        }
+      });
+      return mem;
+    }, {});
+    return {
+      authoritiesByNs,
+      resourcesByNs
+    };
+  }
+
+  parseTapResult = data => {
+    let d = JSON.parse(data);
+    d.source.str = publicAddressToString(_.get(d, "source.ip.ipv4"), d.source.port);
+    d.destination.str = publicAddressToString(_.get(d, "destination.ip.ipv4"), d.destination.port);
+
+    switch (d.proxyDirection) {
+      case "INBOUND":
+        d.tls = _.get(d, "sourceMeta.labels.tls", "");
+        break;
+      case "OUTBOUND":
+        d.tls = _.get(d, "destinationMeta.labels.tls", "");
+        break;
+      default:
+        // too old for TLS
+    }
+
+    if (_.isNil(d.http)) {
+      this.setState({ error: "Undefined request type"});
+    } else {
+      if (!_.isNil(d.http.requestInit)) {
+        d.eventType = "req";
+        d.id = `${_.get(d, "http.requestInit.id.base")}:${_.get(d, "http.requestInit.id.stream")} `;
+      } else if (!_.isNil(d.http.responseInit)) {
+        d.eventType = "rsp";
+        d.id = `${_.get(d, "http.responseInit.id.base")}:${_.get(d, "http.responseInit.id.stream")} `;
+        d.success = parseInt(d.http.responseInit.httpStatus, 10) < 500;
+      } else if (!_.isNil(d.http.responseEnd)) {
+        d.eventType = "end";
+        d.id = `${_.get(d, "http.responseEnd.id.base")}:${_.get(d, "http.responseEnd.id.stream")} `;
+        d.latency = parseFloat(d.http.responseEnd.sinceRequestInit.replace("s", ""));
+        d.completed = true;
+      }
+    }
+
+    return d;
+  }
+
+  topEventKey = event => {
+    return [event.source.str, event.destination.str, event.http.requestInit.path].join("_");
+  }
+
+  initialTopResult(d, eventKey) {
+    return {
+      count: 1,
+      best: d.end.latency,
+      worst: d.end.latency,
+      last: d.end.latency,
+      success: !d.rsp.success ? 0 : 1,
+      failure: !d.rsp.success ? 1 : 0,
+      successRate: !d.rsp.success ? new Percentage(0, 1) : new Percentage(1, 1),
+      source: d.req.source.str,
+      destination: d.req.destination.str,
+      path: d.req.http.requestInit.path,
+      key: eventKey,
+      lastUpdated: Date.now()
+    };
+  }
+
+  incrementTopResult(d, result) {
+    result.count++;
+    if (!d.rsp.success) {
+      result.failure++;
+    } else {
+      result.success++;
+    }
+    result.successRate = new Percentage(result.success, result.success + result.failure);
+
+    result.last = d.end.latency;
+    if (d.end.latency < result.best) {
+      result.best = d.end.latency;
+    }
+    if (d.end.latency > result.worst) {
+      result.worst = d.end.latency;
+    }
+
+    result.lastUpdated = Date.now();
+  }
+
+  indexTopResult = (d, topResults) => {
+    let eventKey = this.topEventKey(d.req);
+
+    if (!topResults[eventKey]) {
+      topResults[eventKey] = this.initialTopResult(d, eventKey);
+    } else {
+      this.incrementTopResult(d, topResults[eventKey]);
+    }
+
+    if (_.size(topResults) > this.state.maxRowsToStore) {
+      this.deleteOldestIndexedResult(topResults);
+    }
+
+    return topResults;
+  }
+
+  indexTapResult = data => {
+    // keep an index of tap results by id until the request is complete.
+    // when the request has completed, add it to the aggregated Top counts and
+    // discard the individual tap result
+    let resultIndex = this.state.tapResultsById;
+    let d = this.parseTapResult(data);
+
+    if (_.isNil(resultIndex[d.id])) {
+      // don't let tapResultsById grow unbounded
+      if (_.size(resultIndex) > this.state.maxRowsToStore) {
+        this.deleteOldestIndexedResult(resultIndex);
+      }
+
+      resultIndex[d.id] = {};
+    }
+    resultIndex[d.id][d.eventType] = d;
+
+    // assumption: requests of a given id all share the same high level metadata
+    resultIndex[d.id]["base"] = d;
+    resultIndex[d.id].lastUpdated = Date.now();
+
+    let topIndex = this.state.topEventIndex;
+    if (d.completed) {
+      // only add results into top if the request has completed
+      // we can also now delete this result from the Tap result index
+      topIndex = this.indexTopResult(resultIndex[d.id], topIndex);
+      delete resultIndex[d.id];
+    }
+
+    this.setState({
+      tapResultsById: resultIndex,
+      topEventIndex: topIndex
+    });
+  }
+
+  deleteOldestIndexedResult = resultIndex => {
+    let oldest = Date.now();
+    let oldestId = "";
+
+    _.each(resultIndex, (res, id) => {
+      if (res.lastUpdated < oldest) {
+        oldest = res.lastUpdated;
+        oldestId = id;
+      }
+    });
+
+    delete resultIndex[oldestId];
+  }
+
+  startServerPolling() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  stopServerPolling() {
+    window.clearInterval(this.timerId);
+    this.api.cancelCurrentRequests();
+  }
+
+  startTapSteaming() {
+    this.setState({
+      awaitingWebSocketConnection: true,
+      tapRequestInProgress: true,
+      tapResultsById: {},
+      topEventIndex: {}
+    });
+
+    let protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    let tapWebSocket = `${protocol}://${window.location.host}${this.props.pathPrefix}/api/tap`;
+
+    this.ws = new WebSocket(tapWebSocket);
+    this.ws.onmessage = this.onWebsocketRecv;
+    this.ws.onclose = this.onWebsocketClose;
+    this.ws.onopen = this.onWebsocketOpen;
+    this.ws.onerror = this.onWebsocketError;
+  }
+
+  stopTapStreaming() {
+    this.setState({
+      tapRequestInProgress: false,
+      awaitingWebSocketConnection: false
+    });
+  }
+
+  handleTapStart = e => {
+    e.preventDefault();
+    this.startTapSteaming();
+  }
+
+  handleTapStop = () => {
+    this.ws.close(1000);
+  }
+
+  loadFromServer() {
+    if (this.state.pendingRequests) {
+      return; // don't make more requests if the ones we sent haven't completed
+    }
+    this.setState({
+      pendingRequests: true
+    });
+
+    let url = "/api/tps-reports?resource_type=all&all_namespaces=true";
+    this.api.setCurrentRequests([this.api.fetchMetrics(url)]);
+    this.serverPromise = Promise.all(this.api.getCurrentPromises())
+      .then(rsp => {
+        let { resourcesByNs, authoritiesByNs } = this.getResourcesByNs(rsp);
+
+        this.setState({
+          resourcesByNs,
+          authoritiesByNs,
+          pendingRequests: false
+        });
+      })
+      .catch(this.handleApiError);
+  }
+
+  handleApiError = e => {
+    if (e.isCanceled) {
+      return;
+    }
+
+    this.setState({
+      pendingRequests: false,
+      error: e
+    });
+  }
+
+  updateQuery = query => {
+    this.setState({
+      query
+    });
+  }
+
+  render() {
+    let tableRows = _.values(this.state.topEventIndex);
+
+    return (
+      <div>
+        {!this.state.error ? null :
+        <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: null })} />}
+
+        <PageHeader header="Top" />
+        <TapQueryForm
+          tapRequestInProgress={this.state.tapRequestInProgress}
+          awaitingWebSocketConnection={this.state.awaitingWebSocketConnection}
+          handleTapStart={this.handleTapStart}
+          handleTapStop={this.handleTapStop}
+          resourcesByNs={this.state.resourcesByNs}
+          authoritiesByNs={this.state.authoritiesByNs}
+          updateQuery={this.updateQuery}
+          query={this.state.query} />
+
+        <TapQueryCliCmd query={this.state.query} />
+
+        <TopEventTable tableRows={tableRows} />
+      </div>
+    );
+  }
+}
+
+export default withContext(Top);

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -66,7 +66,7 @@ class Top extends React.Component {
     query.maxRps = parseFloat(query.maxRps);
 
     this.ws.send(JSON.stringify({
-      id: "tap-web",
+      id: "top-web",
       ...query
     }));
     this.setState({

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -340,6 +340,7 @@ class Top extends React.Component {
 
         <PageHeader header="Top" />
         <TapQueryForm
+          enableAdvancedForm={false}
           tapRequestInProgress={this.state.tapRequestInProgress}
           awaitingWebSocketConnection={this.state.awaitingWebSocketConnection}
           handleTapStart={this.handleTapStart}
@@ -349,7 +350,7 @@ class Top extends React.Component {
           updateQuery={this.updateQuery}
           query={this.state.query} />
 
-        <TapQueryCliCmd query={this.state.query} />
+        <TapQueryCliCmd cmdName="top" query={this.state.query} />
 
         <TopEventTable tableRows={tableRows} />
       </div>

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -153,8 +153,8 @@ class Top extends React.Component {
       success: !d.responseInit.success ? 0 : 1,
       failure: !d.responseInit.success ? 1 : 0,
       successRate: !d.responseInit.success ? new Percentage(0, 1) : new Percentage(1, 1),
-      source: d.requestInit.source.str,
-      destination: d.requestInit.destination.str,
+      source: d.requestInit.source.pod || d.requestInit.source.str,
+      destination: d.requestInit.destination.pod || d.requestInit.destination.str,
       path: d.requestInit.http.requestInit.path,
       key: eventKey,
       lastUpdated: Date.now()

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -6,12 +6,12 @@ const topColumns = [
   {
     title: "Source",
     dataIndex: "source",
-    sorter: (a, b) => a.source.localeCompare(b.source),
+    sorter: (a, b) => a.source.localeCompare(b.source)
   },
   {
     title: "Destination",
     dataIndex: "destination",
-    sorter: (a, b) => a.destination.localeCompare(b.destination),
+    sorter: (a, b) => a.destination.localeCompare(b.destination)
   },
   {
     title: "Path",

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -1,17 +1,24 @@
 import BaseTable from './BaseTable.jsx';
 import React from 'react';
+import { srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
+
+const srcDstSorter = key => {
+  return (a, b) => (a[key].pod || a[key].str).localeCompare(b[key].pod || b[key].str);
+};
 
 const topColumns = [
   {
     title: "Source",
-    dataIndex: "source",
-    sorter: (a, b) => a.source.localeCompare(b.source)
+    key: "source",
+    sorter: srcDstSorter("source"),
+    render: d => srcDstColumn(d.source, d.sourceLabels)
   },
   {
     title: "Destination",
-    dataIndex: "destination",
-    sorter: (a, b) => a.destination.localeCompare(b.destination)
+    key: "destination",
+    sorter: srcDstSorter("destination"),
+    render: d => srcDstColumn(d.destination, d.destinationLabels)
   },
   {
     title: "Path",

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -1,0 +1,65 @@
+import BaseTable from './BaseTable.jsx';
+import React from 'react';
+import { formatLatencySec, numericSort } from './util/Utils.js';
+
+const topColumns = [
+  {
+    title: "Source",
+    dataIndex: "source",
+    sorter: (a, b) => a.source.localeCompare(b.source),
+  },
+  {
+    title: "Destination",
+    dataIndex: "destination",
+    sorter: (a, b) => a.destination.localeCompare(b.destination),
+  },
+  {
+    title: "Path",
+    dataIndex: "path",
+    sorter: (a, b) => a.path.localeCompare(b.path),
+  },
+  {
+    title: "Count",
+    dataIndex: "count",
+    defaultSortOrder: "descend",
+    sorter: (a, b) => numericSort(a.count, b.count),
+  },
+  {
+    title: "Best",
+    dataIndex: "best",
+    sorter: (a, b) => numericSort(a.best, b.best),
+    render: formatLatencySec
+  },
+  {
+    title: "Worst",
+    dataIndex: "worst",
+    sorter: (a, b) => numericSort(a.worst, b.worst),
+    render: formatLatencySec
+  },
+  {
+    title: "Last",
+    dataIndex: "last",
+    sorter: (a, b) => numericSort(a.last, b.last),
+    render: formatLatencySec
+  },
+  {
+    title: "Success Rate",
+    dataIndex: "successRate",
+    sorter: (a, b) => numericSort(a.successRate.get(), b.successRate.get()),
+    render: d => !d ? "---" : d.prettyRate()
+  }
+];
+
+export default class TopEventTable extends BaseTable {
+  render() {
+    return (
+      <BaseTable
+        dataSource={this.props.tableRows}
+        columns={topColumns}
+        rowKey="key"
+        pagination={false}
+        className="top-event-table"
+        size="middle" />
+    );
+  }
+}

--- a/web/app/js/components/util/TapUtils.js
+++ b/web/app/js/components/util/TapUtils.js
@@ -21,8 +21,9 @@ export const processTapEvent = jsonString => {
   let d = JSON.parse(jsonString);
   d.source.str = publicAddressToString(_.get(d, "source.ip.ipv4"), d.source.port);
   d.destination.str = publicAddressToString(_.get(d, "destination.ip.ipv4"), d.destination.port);
-  d.source.pod = _.has(d, "sourceMeta.pod") ? "po/" + d.sourceMeta.pod : null;
-  d.destination.pod = _.has(d, "destinationMeta.pod") ? "po/" + d.destinationMeta.pod : null;
+
+  d.source.pod = _.has(d, "sourceMeta.labels.pod") ? "po/" + d.sourceMeta.labels.pod : null;
+  d.destination.pod = _.has(d, "destinationMeta.labels.pod") ? "po/" + d.destinationMeta.labels.pod : null;
 
   switch (d.proxyDirection) {
     case "INBOUND":

--- a/web/app/js/components/util/TapUtils.js
+++ b/web/app/js/components/util/TapUtils.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
@@ -15,3 +16,58 @@ export const tapQueryPropType = PropTypes.shape({
   authority: PropTypes.string,
   maxRps: PropTypes.string
 });
+
+export const processTapEvent = jsonString => {
+  let d = JSON.parse(jsonString);
+  d.source.str = publicAddressToString(_.get(d, "source.ip.ipv4"), d.source.port);
+  d.destination.str = publicAddressToString(_.get(d, "destination.ip.ipv4"), d.destination.port);
+
+  switch (d.proxyDirection) {
+    case "INBOUND":
+      d.tls = _.get(d, "sourceMeta.labels.tls", "");
+      break;
+    case "OUTBOUND":
+      d.tls = _.get(d, "destinationMeta.labels.tls", "");
+      break;
+    default:
+      // too old for TLS
+  }
+
+  if (_.isNil(d.http)) {
+    this.setState({ error: "Undefined request type"});
+  } else {
+    if (!_.isNil(d.http.requestInit)) {
+      d.eventType = "req";
+      d.id = `${_.get(d, "http.requestInit.id.base")}:${_.get(d, "http.requestInit.id.stream")} `;
+    } else if (!_.isNil(d.http.responseInit)) {
+      d.eventType = "rsp";
+      d.id = `${_.get(d, "http.responseInit.id.base")}:${_.get(d, "http.responseInit.id.stream")} `;
+    } else if (!_.isNil(d.http.responseEnd)) {
+      d.eventType = "end";
+      d.id = `${_.get(d, "http.responseEnd.id.base")}:${_.get(d, "http.responseEnd.id.stream")} `;
+    }
+  }
+
+  return d;
+};
+
+/*
+  produce octets given an ip address
+*/
+const decodeIPToOctets = ip => {
+  ip = parseInt(ip, 10);
+  return [
+    ip >> 24 & 255,
+    ip >> 16 & 255,
+    ip >> 8 & 255,
+    ip & 255
+  ];
+};
+
+/*
+  converts an address to an ipv4 formatted host:port pair
+*/
+const publicAddressToString = (ipv4, port) => {
+  let octets = decodeIPToOctets(ipv4);
+  return octets.join(".") + ":" + port;
+};

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -1,5 +1,7 @@
 import _ from 'lodash';
+import { Popover } from 'antd';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
 
@@ -80,4 +82,20 @@ const decodeIPToOctets = ip => {
 const publicAddressToString = (ipv4, port) => {
   let octets = decodeIPToOctets(ipv4);
   return octets.join(".") + ":" + port;
+};
+
+/*
+  display more human-readable information about source/destination
+*/
+export const srcDstColumn = (display, labels) => {
+  let content = (
+    <React.Fragment>
+      <div>{ !labels.deployment ? null : "deploy/" + labels.deployment }</div>
+      <div>{ !labels.pod ? null : "po/" + labels.pod }</div>
+    </React.Fragment>
+  );
+
+  return (
+    <Popover content={content} title={display.str}>{ display.pod || display.str }</Popover>
+  );
 };

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -21,8 +21,8 @@ export const tapQueryPropType = PropTypes.shape({
 
 export const processTapEvent = jsonString => {
   let d = JSON.parse(jsonString);
-  d.source.str = publicAddressToString(_.get(d, "source.ip.ipv4"), d.source.port);
-  d.destination.str = publicAddressToString(_.get(d, "destination.ip.ipv4"), d.destination.port);
+  d.source.str = publicAddressToString(_.get(d, "source.ip.ipv4"));
+  d.destination.str = publicAddressToString(_.get(d, "destination.ip.ipv4"));
 
   d.source.pod = _.has(d, "sourceMeta.labels.pod") ? "po/" + d.sourceMeta.labels.pod : null;
   d.destination.pod = _.has(d, "destinationMeta.labels.pod") ? "po/" + d.destinationMeta.labels.pod : null;
@@ -77,11 +77,11 @@ const decodeIPToOctets = ip => {
 };
 
 /*
-  converts an address to an ipv4 formatted host:port pair
+  converts an address to an ipv4 formatted host
 */
-const publicAddressToString = (ipv4, port) => {
+const publicAddressToString = ipv4 => {
   let octets = decodeIPToOctets(ipv4);
-  return octets.join(".") + ":" + port;
+  return octets.join(".");
 };
 
 /*

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -122,24 +122,3 @@ export const friendlyTitle = resource => {
   }
   return titles;
 };
-
-/*
-  produce octets given an ip address
-*/
-const decodeIPToOctets = ip => {
-  ip = parseInt(ip, 10);
-  return [
-    ip >> 24 & 255,
-    ip >> 16 & 255,
-    ip >> 8 & 255,
-    ip & 255
-  ];
-};
-
-/*
-  converts an address to an ipv4 formatted host:port pair
-*/
-export const publicAddressToString = (ipv4, port) => {
-  let octets = decodeIPToOctets(ipv4);
-  return octets.join(".") + ":" + port;
-};

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -9,6 +9,7 @@ import ResourceList from './components/ResourceList.jsx';
 import ServiceMesh from './components/ServiceMesh.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import Tap from './components/Tap.jsx';
+import Top from './components/Top.jsx';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import './../css/styles.css';
 import './../img/favicon.png'; // needs to be referenced somewhere so webpack bundles it
@@ -42,6 +43,7 @@ let applicationHtml = (
                 <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
                 <Route path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
                 <Route path={`${pathPrefix}/tap`} component={Tap} />
+                <Route path={`${pathPrefix}/top`} component={Top} />
                 <Route
                   path={`${pathPrefix}/namespaces`}
                   render={() => <ResourceList resource="namespace" />} />

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -91,6 +91,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 	server.router.GET("/pods", handler.handleIndex)
 	server.router.GET("/authorities", handler.handleIndex)
 	server.router.GET("/tap", handler.handleIndex)
+	server.router.GET("/top", handler.handleIndex)
 	server.router.ServeFiles(
 		"/dist/*filepath", // add catch-all parameter to match all files in dir
 		filesonly.FileSystem(server.staticDir))


### PR DESCRIPTION
Add a `Top` page to the linkerd web UI. This is the web equivalent of #1435.

I've used the same fields as in the current implementation.

This branch also includes some slight refactors to the Tap code to enable code reuse.

The request processing logic is pretty similar to that in Tap, except that we can immediately discard the result once we receive the response end and aggregate that result into the top results. So the index of tap results will tend to be smaller (unless they're long running requests like streaming). But we also add a similar index of aggregated Top results, and discard oldest results if top has been running for a long time.

![screen shot 2018-08-14 at 3 09 44 pm](https://user-images.githubusercontent.com/549258/44121338-6ac8d1d8-9fd4-11e8-9487-70fd8ebf981d.png)

Fixes #1448 