### PR TITLE
Add a meshed column to metrics tables in the web UI

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -59,6 +59,15 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
     }
   ];
 
+  let meshedColumn = {
+    title: formatTitle("M", "Meshed"),
+    dataIndex: "pods",
+    key: "pods",
+    className: "numeric",
+    sorter: (a, b) => numericSort(a.pods.running, b.pods.running),
+    render: p => p.meshed + "/" + p.running
+  };
+
   let columns = [
     {
       title: formatTitle(friendlyTitle(resource).singular),
@@ -141,6 +150,11 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       render: d => _.isNil(d) || d.get() === -1 ? "---" : d.prettyRate()
     }
   ];
+
+  // don't add the meshed column on a Authority MetricsTable
+  if (resource !== "authority") {
+    columns.splice(1, 0, meshedColumn);
+  }
 
   if (!showNamespaceColumn) {
     return columns;

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -43,6 +43,15 @@ const formatTitle = (title, tooltipText) => {
 
 };
 
+const meshedColumn = {
+  title: formatTitle("Meshed"),
+  dataIndex: "pods",
+  key: "pods",
+  className: "numeric",
+  sorter: (a, b) => numericSort(a.pods.totalPods, b.pods.totalPods),
+  render: p => p.meshedPods + "/" + p.totalPods
+};
+
 const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceColumn, PrefixedLink, showGrafanaLink) => {
   let nsColumn = [
     {
@@ -58,15 +67,6 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       }
     }
   ];
-
-  let meshedColumn = {
-    title: formatTitle("M", "Meshed"),
-    dataIndex: "pods",
-    key: "pods",
-    className: "numeric",
-    sorter: (a, b) => numericSort(a.pods.running, b.pods.running),
-    render: p => p.meshed + "/" + p.running
-  };
 
   let columns = [
     {

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -119,9 +119,9 @@ const processStatTable = table => {
       tlsRequestPercent: getTlsRequestPercentage(row),
       added: row.meshedPodCount === row.runningPodCount,
       pods: {
-        running: row.runningPodCount,
-        meshed: row.meshedPodCount,
-        percentage: new Percentage(parseInt(row.meshedPodCount, 10), parseInt(row.runningPodCount, 10))
+        totalPods: row.runningPodCount,
+        meshedPods: row.meshedPodCount,
+        meshedPercentage: new Percentage(parseInt(row.meshedPodCount, 10), parseInt(row.runningPodCount, 10))
       },
       errors: row.errorsByPod
     };

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import Percentage from './Percentage';
+import Percentage from './Percentage.js';
 import PropTypes from 'prop-types';
 
 const getPodCategorization = pod => {
@@ -118,6 +118,11 @@ const processStatTable = table => {
       latency: getLatency(row),
       tlsRequestPercent: getTlsRequestPercentage(row),
       added: row.meshedPodCount === row.runningPodCount,
+      pods: {
+        running: row.runningPodCount,
+        meshed: row.meshedPodCount,
+        percentage: new Percentage(parseInt(row.meshedPodCount, 10), parseInt(row.runningPodCount, 10))
+      },
       errors: row.errorsByPod
     };
   })

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -26,7 +26,7 @@ describe('MetricUtils', () => {
             P95: 2,
             P99: 7
           },
-          pods: {running: "1", meshed: "1", percentage: new Percentage(1,1)},
+          pods: {totalPods: "1", meshedPods: "1", meshedPercentage: new Percentage(1,1)},
           added: true,
           errors: {}
         }

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -26,6 +26,7 @@ describe('MetricUtils', () => {
             P95: 2,
             P99: 7
           },
+          pods: {running: "1", meshed: "1", percentage: new Percentage(1,1)},
           added: true,
           errors: {}
         }

--- a/web/app/test/MetricsTableTest.js
+++ b/web/app/test/MetricsTableTest.js
@@ -29,7 +29,7 @@ describe('Tests for <MetricsTableBase>', () => {
 
     expect(table).to.have.length(1);
     expect(table.props().dataSource).to.have.length(1);
-    expect(table.props().columns).to.have.length(8);
+    expect(table.props().columns).to.have.length(9);
   });
 
   it('omits the namespace column for the namespace resource', () => {
@@ -43,7 +43,7 @@ describe('Tests for <MetricsTableBase>', () => {
     const table = component.find(BaseTable);
 
     expect(table).to.have.length(1);
-    expect(table.props().columns).to.have.length(7);
+    expect(table.props().columns).to.have.length(8);
   });
 
   it('omits the namespace column when showNamespaceColumn is false', () => {
@@ -58,7 +58,21 @@ describe('Tests for <MetricsTableBase>', () => {
     const table = component.find(BaseTable);
 
     expect(table).to.have.length(1);
-    expect(table.props().columns).to.have.length(7);
+    expect(table.props().columns).to.have.length(8);
+  });
+
+  it('omits meshed column for authority resource', () => {
+    const component = shallow(
+      <MetricsTableBase
+        {...defaultProps}
+        metrics={[]}
+        resource="authority" />
+    );
+
+    const table = component.find(BaseTable);
+
+    expect(table).to.have.length(1);
+    expect(table.props().columns).to.have.length(8);
   });
 
 });


### PR DESCRIPTION
Currently `conduit stat` outputs a column that shows the number of meshed pods in the resource being 
queried. The web UI does not have this information about meshed pod state. 

This PR adds a meshed column for better UI parity with the `stat` command.

<img width="1440" alt="screen shot 2018-08-15 at 12 02 35 pm" src="https://user-images.githubusercontent.com/2197104/44167525-3d099c00-a083-11e8-9649-7c538a0d5708.png">

fixes #1266