### PR TITLE
Add the basis for an octopus graph to resource detail page

### DIFF
--- a/web/app/css/octopus.css
+++ b/web/app/css/octopus.css
@@ -1,0 +1,40 @@
+@import 'styles.css';
+
+.octopus-container {
+  padding: 80px;
+}
+
+.octopus-graph {
+  background-color: #ffffff;
+  height: 100%;
+  width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 24px;
+  box-shadow: 2px 2px 2px var(--neutralgrey);
+
+  & .octopus-title, & .octopus-metric {
+    text-align: center;
+  }
+
+  & .octopus-upstreams .neighbor, & .octopus-downstreams .neighbor {
+    clear: both;
+
+    & .status-dot {
+      margin: 4px 4px 0 4px;
+    }
+  }
+
+  & .octopus-upstreams .neighbor > div div {
+    float: left;
+  }
+
+  & .octopus-downstreams .neighbor > div div {
+    float: right;
+  }
+}
+
+.octopus-metric-lg {
+  text-align: center;
+  line-height: 32px;
+}

--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -62,27 +62,13 @@
 }
 
 /* styles for the StatusTable */
-td .status-dot {
+td div.status-dot {
   float: left;
-  width: calc(2 * var(--base-width));
-  height: calc(2 * var(--base-width));
-  min-width: calc(2 * var(--base-width));
-  border-radius: 50%;
   margin-right: var(--base-width);
 
   &.dot-multiline {
     margin-top: calc(0.5 * var(--base-width));
     margin-bottom: calc(0.5 * var(--base-width));
-  }
-
-  &.status-dot-good {
-    background-color: var(--green);
-  }
-  &.status-dot-poor {
-    background-color: var(--siennared);
-  }
-  &.status-dot-neutral {
-    background-color: #E0E0E0;
   }
 }
 

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -239,3 +239,24 @@ a.button.primary:active {
     text-align: right;
   }
 }
+
+/* Colored dot for indicating statuses */
+div.status-dot {
+  width: calc(2 * var(--base-width));
+  height: calc(2 * var(--base-width));
+  min-width: calc(2 * var(--base-width));
+  border-radius: 50%;
+
+  &.status-dot-good {
+    background-color: var(--green);
+  }
+  &.status-dot-poor {
+    background-color: var(--siennared);
+  }
+  &.status-dot-neutral {
+    background-color: #E0E0E0;
+  }
+  &.status-dot-ok {
+    background-color: #ffd54f;
+  }
+}

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -65,9 +65,13 @@ MetricSummaryRow.propTypes = {
 };
 
 export default class Octopus extends React.Component {
+  static defaultProps = {
+    metrics: {},
+    neighbors: {}
+  }
   static propTypes = {
-    metrics: PropTypes.shape({}).isRequired,
-    neighbors: PropTypes.shape({}).isRequired,
+    metrics: PropTypes.shape({}),
+    neighbors: PropTypes.shape({}),
     resource: PropTypes.shape({}).isRequired
   }
 

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -25,7 +25,7 @@ const Neighbor = ({neighbor, direction}) => {
         <div className="neighbor-row">
           <div>{direction === "in" ? "<" : ">"}</div>
           <div className={`status-dot ${getDotClassification(neighbor.successRate)}`} />
-          <div>{neighbor.name}</div>
+          <div>{displayName(neighbor)}</div>
         </div>
       </Popover>
     </div>

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -1,0 +1,93 @@
+import _ from 'lodash';
+import { metricToFormatter } from './util/Utils.js';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Col, Popover, Row } from 'antd';
+import './../../css/octopus.css';
+
+const getDotClassification = sr => {
+  if (sr < 0.9) {
+    return "status-dot-poor";
+  } else if (sr < 0.95) {
+    return "status-dot-ok";
+  } else {return "status-dot-good";}
+};
+
+const Neighbor = ({neighbor, direction}) => {
+  return (
+    <div className="neighbor">
+      <Popover
+        title={neighbor.name}
+        content={<MetricSummaryRow resource={neighbor} metricClass="metric-sm" />}
+        placement={direction ==="in" ? "left" : "right"}>
+        <div className="neighbor-row">
+          <div>{direction === "in" ? "<" : ">"}</div>
+          <div className={`status-dot ${getDotClassification(neighbor.successRate)}`} />
+          <div>{neighbor.name}</div>
+        </div>
+      </Popover>
+    </div>
+  );
+};
+Neighbor.propTypes = {
+  direction: PropTypes.string.isRequired,
+  neighbor: PropTypes.shape({}).isRequired
+};
+
+const Metric = ({title, value, metricClass}) => {
+  return (
+    <Row type="flex" justify="center" className={`octopus-${metricClass}`}>
+      <Col span={12} className="octopus-metric-title"><div>{title}</div></Col>
+      <Col span={12} className="octopus-metric-value"><div>{value}</div></Col>
+    </Row>
+  );
+};
+Metric.propTypes = {
+  metricClass: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired
+};
+
+const MetricSummaryRow = ({resource, metricClass}) => {
+  return (
+    <React.Fragment>
+      <Metric title="Success Rate" value={metricToFormatter["SUCCESS_RATE"](resource.successRate)} metricClass={metricClass} />
+      <Metric title="Request Rate" value={metricToFormatter["REQUEST_RATE"](resource.requestRate)} metricClass={metricClass} />
+      <Metric title="P99 Latency" value={metricToFormatter["LATENCY"](_.get(resource, "latency.P99"))} metricClass={metricClass}  />
+    </React.Fragment>
+  );
+};
+MetricSummaryRow.propTypes = {
+  metricClass: PropTypes.string.isRequired,
+  resource: PropTypes.shape({}).isRequired
+};
+
+export default class Octopus extends React.Component {
+  static propTypes = {
+    metrics: PropTypes.shape({}).isRequired,
+    neighbors: PropTypes.shape({}).isRequired,
+    resource: PropTypes.string.isRequired
+  }
+
+  render() {
+    let { resource, metrics, neighbors } = this.props;
+
+    return (
+      <div className="octopus-container">
+        <div className="octopus-graph">
+          <h1 className="octopus-title">{resource}</h1>
+          <MetricSummaryRow resource={metrics} metricClass="metric-lg" />
+          <hr />
+          <Row type="flex" justify="center">
+            <Col span={12} className="octopus-upstreams">
+              {_.map(neighbors.upstream, n => <Neighbor neighbor={n} direction="in" key={n.name} />)}
+            </Col>
+            <Col span={12} className="octopus-downstreams">
+              {_.map(neighbors.downstream, n => <Neighbor neighbor={n} direction="out" key={n.name} />)}
+            </Col>
+          </Row>
+        </div>
+      </div>
+    );
+  }
+}

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -1,9 +1,11 @@
 import _ from 'lodash';
-import { metricToFormatter } from './util/Utils.js';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Popover, Row } from 'antd';
+import { metricToFormatter, toShortResourceName } from './util/Utils.js';
 import './../../css/octopus.css';
+
+const displayName = resource => `${toShortResourceName(resource.type)}/${resource.name}`;
 
 const getDotClassification = sr => {
   if (sr < 0.9) {
@@ -17,7 +19,7 @@ const Neighbor = ({neighbor, direction}) => {
   return (
     <div className="neighbor">
       <Popover
-        title={neighbor.name}
+        title={displayName(neighbor)}
         content={<MetricSummaryRow resource={neighbor} metricClass="metric-sm" />}
         placement={direction ==="in" ? "left" : "right"}>
         <div className="neighbor-row">
@@ -66,7 +68,7 @@ export default class Octopus extends React.Component {
   static propTypes = {
     metrics: PropTypes.shape({}).isRequired,
     neighbors: PropTypes.shape({}).isRequired,
-    resource: PropTypes.string.isRequired
+    resource: PropTypes.shape({}).isRequired
   }
 
   render() {
@@ -75,7 +77,7 @@ export default class Octopus extends React.Component {
     return (
       <div className="octopus-container">
         <div className="octopus-graph">
-          <h1 className="octopus-title">{resource}</h1>
+          <h1 className="octopus-title">{displayName(resource)}</h1>
           <MetricSummaryRow resource={metrics} metricClass="metric-lg" />
           <hr />
           <Row type="flex" justify="center">

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -82,10 +82,10 @@ export default class Octopus extends React.Component {
           <hr />
           <Row type="flex" justify="center">
             <Col span={12} className="octopus-upstreams">
-              {_.map(neighbors.upstream, n => <Neighbor neighbor={n} direction="in" key={n.name} />)}
+              {_.map(neighbors.upstream, n => <Neighbor neighbor={n} direction="in" key={n.namespace + "-" + n.name} />)}
             </Col>
             <Col span={12} className="octopus-downstreams">
-              {_.map(neighbors.downstream, n => <Neighbor neighbor={n} direction="out" key={n.name} />)}
+              {_.map(neighbors.downstream, n => <Neighbor neighbor={n} direction="out" key={n.namespace + "-" + n.name} />)}
             </Col>
           </Row>
         </div>

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -97,11 +97,11 @@ export class ResourceDetailBase extends React.Component {
       ),
       // upstream resources of this resource (meshed traffic only)
       this.api.fetchMetrics(
-        `${this.api.urlsForResource(resource.type, resource.namespace)}&to_name=${resource.name}`
+        `${this.api.urlsForResource(resource.type)}&to_name=${resource.name}&to_type=${resource.type}&to_namespace=${resource.namespace}`
       ),
       // downstream resources of this resource (meshed traffic only)
       this.api.fetchMetrics(
-        `${this.api.urlsForResource(resource.type, resource.namespace)}&from_name=${resource.name}`
+        `${this.api.urlsForResource(resource.type)}&from_name=${resource.name}&from_type=${resource.type}&from_namespace=${resource.namespace}`
       )
     ]);
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -170,7 +170,7 @@ export class ResourceDetailBase extends React.Component {
       <div>
         <div className="page-section">
           <Octopus
-            resource={this.state.resource.name}
+            resource={this.state.resource}
             metrics={this.state.resourceMetrics[0]}
             neighbors={this.state.neighborMetrics} />
         </div>

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -175,6 +175,26 @@ export class ResourceDetailBase extends React.Component {
             neighbors={this.state.neighborMetrics} />
         </div>
 
+        { _.isEmpty(this.state.neighborMetrics.upstream) ? null : (
+          <div className="page-section">
+            <h2 className="subsection-header">Upstreams</h2>
+            <MetricsTable
+              resource={this.state.resource.type}
+              metrics={this.state.neighborMetrics.upstream} />
+          </div>
+          )
+        }
+
+        { _.isEmpty(this.state.neighborMetrics.downstream) ? null : (
+          <div className="page-section">
+            <h2 className="subsection-header">Downstreams</h2>
+            <MetricsTable
+              resource={this.state.resource.type}
+              metrics={this.state.neighborMetrics.downstream} />
+          </div>
+          )
+        }
+
         {
           this.state.resource.type === "pod" ? null : (
             <div className="page-section">
@@ -183,7 +203,7 @@ export class ResourceDetailBase extends React.Component {
                 resource="pod"
                 metrics={this.state.podMetrics} />
             </div>
-        )
+          )
         }
       </div>
     );

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -112,6 +112,7 @@ const processStatTable = table => {
     return {
       name: row.resource.name,
       namespace: row.resource.namespace,
+      type: row.resource.type,
       totalRequests: getTotalRequests(row),
       requestRate: getRequestRate(row),
       successRate: getSuccessRate(row),

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -143,9 +143,7 @@ const camelCaseLookUp = {
   "daemonset": "daemonSet"
 };
 
-export const resourceTypeToCamelCase = resource => {
-  return camelCaseLookUp[resource] || resource;
-};
+export const resourceTypeToCamelCase = resource => camelCaseLookUp[resource] || resource;
 
 /*
   A simplified version of ShortNameFromCanonicalResourceName

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -148,6 +148,23 @@ export const resourceTypeToCamelCase = resource => {
 };
 
 /*
+  A simplified version of ShortNameFromCanonicalResourceName
+*/
+const shortNameLookup = {
+  "deployment": "deploy",
+  "daemonset": "ds",
+  "namespace": "ns",
+  "pod": "po",
+  "replicationcontroller": "rc",
+  "replicaset": "rs",
+  "service": "svc",
+  "statefulset": "sts",
+  "authority": "au"
+};
+
+export const toShortResourceName = name => shortNameLookup[name] || name;
+
+/*
   produce octets given an ip address
 */
 const decodeIPToOctets = ip => {

--- a/web/app/test/MetricUtilsTest.js
+++ b/web/app/test/MetricUtilsTest.js
@@ -17,6 +17,7 @@ describe('MetricUtils', () => {
         {
           name: 'voting',
           namespace: 'emojivoto',
+          type: 'deployment',
           requestRate: 2.5,
           successRate: 0.9,
           totalRequests: 150,


### PR DESCRIPTION
Add a basic top graph depicting the current resource's stats and it's upstreams and downstreams. This will be styled more later, but just getting the basic components and data onto the page.

![screen shot 2018-08-20 at 3 11 25 pm](https://user-images.githubusercontent.com/549258/44369485-67949400-a48b-11e8-9aca-4127c98e8fe7.png)


Part of #1468
Also fixes #1460 