### PR TITLE
Add --pre flag for linkerd check command

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -17,11 +17,13 @@ const (
 
 type checkOptions struct {
 	versionOverride string
+	preInstallOnly  bool
 }
 
 func newCheckOptions() *checkOptions {
 	return &checkOptions{
 		versionOverride: "",
+		preInstallOnly:  false,
 	}
 }
 
@@ -30,10 +32,13 @@ func newCmdCheck() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "check",
-		Short: "Check your Linkerd installation for potential problems.",
-		Long: `Check your Linkerd installation for potential problems. The check command will perform various checks of your
-local system, the Linkerd control plane, and connectivity between those. The process will exit with non-zero check if
-problems were found.`,
+		Short: "Check your Linkerd installation for potential problems",
+		Long: `Check your Linkerd installation for potential problems.
+
+The check command will perform various checks of your local system, the Linkerd
+control plane, and connectivity between them. If the command encounters a
+failure it will print additional information about the failure and exit with a
+non-zero exit code.`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			configureAndRunChecks(options)
@@ -42,15 +47,20 @@ problems were found.`,
 
 	cmd.Args = cobra.NoArgs
 	cmd.PersistentFlags().StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
+	cmd.PersistentFlags().BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
 
 	return cmd
 }
 
 func configureAndRunChecks(options *checkOptions) {
 	hc := healthcheck.NewHealthChecker()
-	hc.AddKubernetesAPIChecks(kubeconfigPath)
-	hc.AddLinkerdAPIChecks(apiAddr, controlPlaneNamespace)
-	hc.AddLinkerdVersionChecks(options.versionOverride)
+	hc.AddKubernetesAPIChecks(kubeconfigPath, false)
+	if options.preInstallOnly {
+		hc.AddLinkerdPreInstallChecks(controlPlaneNamespace)
+	} else {
+		hc.AddLinkerdAPIChecks(apiAddr, controlPlaneNamespace)
+	}
+	hc.AddLinkerdVersionChecks(options.versionOverride, options.preInstallOnly)
 
 	success := runChecks(os.Stdout, hc)
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 // checks fail, then CLI will print an error and exit.
 func validatedPublicAPIClient() pb.ApiClient {
 	hc := healthcheck.NewHealthChecker()
-	hc.AddKubernetesAPIChecks(kubeconfigPath)
+	hc.AddKubernetesAPIChecks(kubeconfigPath, false)
 	hc.AddLinkerdAPIChecks(apiAddr, controlPlaneNamespace)
 
 	exitOnError := func(category, description string, err error) {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -47,8 +47,8 @@ func NewHealthChecker() *HealthChecker {
 
 // AddKubernetesAPIChecks adds a series of checks to validate that the caller is
 // configured to interact with a working Kubernetes cluster and that the cluster
-// meets the minimum version requirement.
-func (hc *HealthChecker) AddKubernetesAPIChecks(kubeconfigPath string) {
+// meets the minimum version requirement, unless skipVersionCheck is specified.
+func (hc *HealthChecker) AddKubernetesAPIChecks(kubeconfigPath string, skipVersionCheck bool) {
 	hc.checkers = append(hc.checkers, &checker{
 		category:    KubernetesAPICategory,
 		description: "can initialize the client",
@@ -73,12 +73,36 @@ func (hc *HealthChecker) AddKubernetesAPIChecks(kubeconfigPath string) {
 		},
 	})
 
+	if !skipVersionCheck {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    KubernetesAPICategory,
+			description: "is running the minimum Kubernetes API version",
+			fatal:       false,
+			check: func() error {
+				return hc.kubeAPI.CheckVersion(hc.kubeVersion)
+			},
+		})
+	}
+}
+
+// AddLinkerdPreInstallChecks adds a check to validate that the control plane
+// namespace does not already exist. This check only runs as part of the set of
+// pre-install checks. This check is dependent on the output of
+// AddKubernetesAPIChecks, so those checks must be added first.
+func (hc *HealthChecker) AddLinkerdPreInstallChecks(controlPlaneNamespace string) {
 	hc.checkers = append(hc.checkers, &checker{
-		category:    KubernetesAPICategory,
-		description: "is running the minimum Kubernetes API version",
+		category:    LinkerdAPICategory,
+		description: "control plane namespace does not already exist",
 		fatal:       false,
 		check: func() error {
-			return hc.kubeAPI.CheckVersion(hc.kubeVersion)
+			exists, err := hc.kubeAPI.NamespaceExists(hc.httpClient, controlPlaneNamespace)
+			if err != nil {
+				return err
+			}
+			if exists {
+				return fmt.Errorf("The \"%s\" namespace already exists", controlPlaneNamespace)
+			}
+			return nil
 		},
 	})
 }
@@ -93,7 +117,14 @@ func (hc *HealthChecker) AddLinkerdAPIChecks(apiAddr, controlPlaneNamespace stri
 		description: "control plane namespace exists",
 		fatal:       true,
 		check: func() error {
-			return hc.kubeAPI.CheckNamespaceExists(hc.httpClient, controlPlaneNamespace)
+			exists, err := hc.kubeAPI.NamespaceExists(hc.httpClient, controlPlaneNamespace)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return fmt.Errorf("The \"%s\" namespace does not exist", controlPlaneNamespace)
+			}
+			return nil
 		},
 	})
 
@@ -126,8 +157,8 @@ func (hc *HealthChecker) AddLinkerdAPIChecks(apiAddr, controlPlaneNamespace stri
 // AddLinkerdVersionChecks adds a series of checks to validate that the CLI and
 // control plane are running the latest available version. These checks are
 // dependent on the output of AddLinkerdAPIChecks, so those checks must be added
-// first.
-func (hc *HealthChecker) AddLinkerdVersionChecks(versionOverride string) {
+// first, unless clientOnly is specified.
+func (hc *HealthChecker) AddLinkerdVersionChecks(versionOverride string, clientOnly bool) {
 	hc.checkers = append(hc.checkers, &checker{
 		category:    LinkerdVersionCategory,
 		description: "can get the latest version",
@@ -151,14 +182,16 @@ func (hc *HealthChecker) AddLinkerdVersionChecks(versionOverride string) {
 		},
 	})
 
-	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdVersionCategory,
-		description: "control plane is up-to-date",
-		fatal:       false,
-		check: func() error {
-			return version.CheckServerVersion(hc.apiClient, hc.latestVersion)
-		},
-	})
+	if !clientOnly {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdVersionCategory,
+			description: "control plane is up-to-date",
+			fatal:       false,
+			check: func() error {
+				return version.CheckServerVersion(hc.apiClient, hc.latestVersion)
+			},
+		})
+	}
 }
 
 // Add adds an arbitrary checker. This should only be used for testing. For


### PR DESCRIPTION
This branch updates `linkerd check` to accept a `--pre` flag, which will cause the command to run a subset of checks to validate that linkerd can be installed (fixes #1470). It will also validate that the linkerd namespace does not already exist (fixes #1473).

I made one additional change as part of this branch, which is to bypass the kubernetes server version check when running other linkerd subcommands. As it was previously written, those subcommands would preemptively fail if the kubernetes cluster did not meet the minimum required version. It seems better to let those commands run, and only warn in the check output if the minimum server version is not met.

Fixes #1470.
Fixes #1473.