### PR TITLE
Fix missing ns/svc labels in metadata hydrated by Tap server

### DIFF
--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -390,7 +390,7 @@ func (p *peer) formatResource(resourceKind string) string {
 	}
 	if resourceKind != k8s.Namespace {
 		if ns, hasNs := p.labels[k8s.Namespace]; hasNs {
-			s += fmt.Sprintf("%s_ns=%s", p.direction, ns)
+			s += fmt.Sprintf(" %s_ns=%s", p.direction, ns)
 		}
 	}
 	return s

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -526,6 +526,10 @@ func (s *server) hydrateIPLabels(ip *public.IPAddress, labels map[string]string)
 		for key, value := range podLabels {
 			labels[key] = value
 		}
+		labels[pkgK8s.Namespace] = pod.Namespace
+		if ownerKind == pkgK8s.Service {
+			labels[pkgK8s.Service] = ownerName
+		}
 		return nil
 	}
 }

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -527,9 +527,6 @@ func (s *server) hydrateIPLabels(ip *public.IPAddress, labels map[string]string)
 			labels[key] = value
 		}
 		labels[pkgK8s.Namespace] = pod.Namespace
-		if ownerKind == pkgK8s.Service {
-			labels[pkgK8s.Service] = ownerName
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
Fixes #1493.

When the tap server hydrates metadata for the source or destination peer
of a Tap event from the peer's IP address, it doesn't currently add a
namespace label. However, destinations labeled by the proxy do have such
a label.

This is because the tap server currently gets the hydrated labels from
the `GetPodLabels` function, which is also used by the Destination
service for labeling the individual endpoints in a `WeightedAddrSet`
response. However, the Destination service also adds some labels to all
the endpoints in the set, including the namespace and service, so
`GetPodLabels` doesn't return these labels. However, when the tap server
uses that function, it does not add the service or namespace labels.

This branch fixes this issue by adding those labels to the Tap event 
after calling `GetPodLabels`. In addition, it fixes a missing space 
between the `src/dst_res` and `src/dst_ns` labels in Tap CLI output
with the `-o wide` flag set. This issue was introduced during the 
review of #1437, but was missed at the time because the namespace label
wasn't being set correctly.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>