### PR TITLE
Refactor healthcheck init and observe setup

### DIFF
--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestCheckStatus(t *testing.T) {
 	t.Run("Prints expected output", func(t *testing.T) {
-		hc := healthcheck.NewHealthChecker()
+		hc := healthcheck.NewHealthChecker(
+			[]healthcheck.Checks{},
+			&healthcheck.HealthCheckOptions{},
+		)
 		hc.Add("category", "check1", func() error {
 			return nil
 		})

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHealthChecker(t *testing.T) {
-	nullObserver := func(_, _ string, _ error) {}
+	nullObserver := func(_ *CheckResult) {}
 
 	passingCheck1 := &checker{
 		category:    "cat1",
@@ -104,10 +104,10 @@ func TestHealthChecker(t *testing.T) {
 		}
 
 		observedResults := make([]string, 0)
-		observer := func(category, description string, err error) {
-			res := fmt.Sprintf("%s %s", category, description)
-			if err != nil {
-				res += fmt.Sprintf(": %s", err)
+		observer := func(result *CheckResult) {
+			res := fmt.Sprintf("%s %s", result.Category, result.Description)
+			if result.Err != nil {
+				res += fmt.Sprintf(": %s", result.Err)
 			}
 			observedResults = append(observedResults, res)
 		}
@@ -187,10 +187,10 @@ func TestHealthChecker(t *testing.T) {
 		}
 
 		observedResults := make([]string, 0)
-		observer := func(category, description string, err error) {
-			res := fmt.Sprintf("%s %s", category, description)
-			if err != nil {
-				res += fmt.Sprintf(": %s", err)
+		observer := func(result *CheckResult) {
+			res := fmt.Sprintf("%s %s", result.Category, result.Description)
+			if result.Err != nil {
+				res += fmt.Sprintf(": %s", result.Err)
 			}
 			observedResults = append(observedResults, res)
 		}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -53,6 +53,18 @@ func TestVersionPreInstall(t *testing.T) {
 	}
 }
 
+func TestCheckPreInstall(t *testing.T) {
+	out, err := TestHelper.LinkerdRun("check", "--pre", "--expected-version", TestHelper.GetVersion())
+	if err != nil {
+		t.Fatalf("Check command failed\n%s", out)
+	}
+
+	err = TestHelper.ValidateOutput(out, "check.pre.golden")
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err.Error())
+	}
+}
+
 func TestInstall(t *testing.T) {
 	cmd := []string{"install", "--linkerd-version", TestHelper.GetVersion()}
 	if TestHelper.TLS() {
@@ -115,7 +127,7 @@ func TestVersionPostInstall(t *testing.T) {
 	}
 }
 
-func TestCheck(t *testing.T) {
+func TestCheckPostInstall(t *testing.T) {
 	var out string
 	var err error
 	overallErr := TestHelper.RetryFor(30*time.Second, func() error {

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -1,0 +1,8 @@
+kubernetes-api: can initialize the client..................................[ok]
+kubernetes-api: can query the Kubernetes API...............................[ok]
+kubernetes-api: is running the minimum Kubernetes API version..............[ok]
+linkerd-ns: control plane namespace does not already exist.................[ok]
+linkerd-version: can determine the latest version..........................[ok]
+linkerd-version: cli is up-to-date.........................................[ok]
+
+Status check results are [ok]


### PR DESCRIPTION
In the process of working on #1477, I decided to streamline the way in which the `HealthChecker` is configured as follows:

* `NewHealthChecks` now takes a list of checks to execute and a struct with check options
* Check results are now stored in a `CheckResult` struct, and the method signature for the observer is now `func(*CheckResult)`
* The `RunChecks` function has been refactor to call separate methods for local checks and RPC checks

I've also updated our install integration test to validate the output of running `linkerd check --pre`.