### PR TITLE
Add --wait flag for CLI check and dashboard commands

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -24,12 +24,14 @@ const (
 type dashboardOptions struct {
 	dashboardProxyPort int
 	dashboardShow      string
+	wait               bool
 }
 
 func newDashboardOptions() *dashboardOptions {
 	return &dashboardOptions{
 		dashboardProxyPort: 0,
 		dashboardShow:      showLinkerd,
+		wait:               false,
 	}
 }
 
@@ -68,7 +70,7 @@ func newCmdDashboard() *cobra.Command {
 			}
 
 			// ensure we can connect to the public API before starting the proxy
-			validatedPublicAPIClient()
+			validatedPublicAPIClient(options.wait)
 
 			fmt.Printf("Linkerd dashboard available at:\n%s\n", url.String())
 			fmt.Printf("Grafana dashboard available at:\n%s\n", grafanaUrl.String())
@@ -109,6 +111,7 @@ func newCmdDashboard() *cobra.Command {
 	// This is identical to what `kubectl proxy --help` reports, `--port 0` indicates a random port.
 	cmd.PersistentFlags().IntVarP(&options.dashboardProxyPort, "port", "p", options.dashboardProxyPort, "The port on which to run the proxy (when set to 0, a random port will be used)")
 	cmd.PersistentFlags().StringVar(&options.dashboardShow, "show", options.dashboardShow, "Open a dashboard in a browser or show URLs in the CLI (one of: linkerd, grafana, url)")
+	cmd.PersistentFlags().BoolVar(&options.wait, "wait", false, "Wait for dashboard to become available if it's not available when the command is run")
 
 	return cmd
 }

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -55,7 +55,7 @@ Only pod resources (aka pods, po) are supported.`,
 				return fmt.Errorf("invalid resource type %s, valid types: %s", friendlyName, k8s.Pod)
 			}
 
-			podNames, err := getPods(validatedPublicAPIClient(), options)
+			podNames, err := getPods(validatedPublicAPIClient(false), options)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -69,20 +69,27 @@ func init() {
 
 // validatedPublicAPIClient builds a new public API client and executes status
 // checks to determine if the client can successfully connect to the API. If the
-// checks fail, then CLI will print an error and exit.
-func validatedPublicAPIClient() pb.ApiClient {
+// checks fail, then CLI will print an error and exit. If the shouldRetry param
+// is specified, then the CLI will print a message to stderr and retry.
+func validatedPublicAPIClient(shouldRetry bool) pb.ApiClient {
 	checks := []healthcheck.Checks{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.LinkerdAPIChecks,
 	}
 
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.HealthCheckOptions{
-		Namespace:  controlPlaneNamespace,
-		KubeConfig: kubeconfigPath,
-		APIAddr:    apiAddr,
+		Namespace:   controlPlaneNamespace,
+		KubeConfig:  kubeconfigPath,
+		APIAddr:     apiAddr,
+		ShouldRetry: shouldRetry,
 	})
 
 	exitOnError := func(result *healthcheck.CheckResult) {
+		if result.Retry {
+			fmt.Fprintln(os.Stderr, "Waiting for control plane to become available")
+			return
+		}
+
 		if result.Err != nil {
 			var msg string
 			switch result.Category {

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -106,7 +106,7 @@ If no resource name is specified, displays stats about all resources of the spec
 				return fmt.Errorf("error creating metrics request while making stats request: %v", err)
 			}
 
-			output, err := requestStatsFromAPI(validatedPublicAPIClient(), req, options)
+			output, err := requestStatsFromAPI(validatedPublicAPIClient(false), req, options)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -103,7 +103,7 @@ func newCmdTap() *cobra.Command {
 				return fmt.Errorf("output format \"%s\" not recognized", options.output)
 			}
 
-			return requestTapByResourceFromAPI(os.Stdout, validatedPublicAPIClient(), req, wide)
+			return requestTapByResourceFromAPI(os.Stdout, validatedPublicAPIClient(false), req, wide)
 		},
 	}
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -129,7 +129,7 @@ func newCmdTop() *cobra.Command {
 				return err
 			}
 
-			return getTrafficByResourceFromAPI(os.Stdout, validatedPublicAPIClient(), req)
+			return getTrafficByResourceFromAPI(os.Stdout, validatedPublicAPIClient(false), req)
 		},
 	}
 


### PR DESCRIPTION
This branch updates the check and dashboard commands to support a `--wait` flag. This flag can be used to control the behavior of the pod ready check that was added in #1498.

When `--wait` is specified, check will retry on failed pod ready check up to 10 times / 50 seconds, which looks like this:

```
$ bin/linkerd check --wait --expected-version=$(bin/root-tag)
kubernetes-api: can initialize the client..................................[ok]
kubernetes-api: can query the Kubernetes API...............................[ok]
kubernetes-api: is running the minimum Kubernetes API version..............[ok]
linkerd-api: control plane namespace exists................................[ok]
linkerd-api: control plane pods are ready..................................[retry] -- No running pods for controller
linkerd-api: control plane pods are ready..................................[retry] -- The grafana pod's grafana container is not ready
linkerd-api: control plane pods are ready..................................[retry] -- The grafana pod's grafana container is not ready
linkerd-api: control plane pods are ready..................................[retry] -- The grafana pod's grafana container is not ready
linkerd-api: control plane pods are ready..................................[retry] -- The prometheus pod's prometheus container is not ready
linkerd-api: control plane pods are ready..................................[retry] -- The prometheus pod's prometheus container is not ready
linkerd-api: control plane pods are ready..................................[ok]
linkerd-api: can initialize the client.....................................[ok]
linkerd-api: can query the control plane API...............................[ok]
linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
linkerd-version: can determine the latest version..........................[ok]
linkerd-version: cli is up-to-date.........................................[ok]
linkerd-version: control plane is up-to-date...............................[ok]

Status check results are [ok]
```

The dashboard command will also block for up to 50 seconds, which looks like this:

```
$ bin/go-run cli dashboard --wait
Waiting for control plane to become available
Waiting for control plane to become available
Waiting for control plane to become available
Linkerd dashboard available at:
http://127.0.0.1:59707/api/v1/namespaces/linkerd/services/web:http/proxy/
Grafana dashboard available at:
http://127.0.0.1:59707/api/v1/namespaces/linkerd/services/grafana:http/proxy/
Opening Linkerd dashboard in the default browser
```

Based on #1502.
Fixes #1477.