### PR TITLE
Add link to top in sidebar, fix js errors

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -162,6 +162,13 @@ class Sidebar extends React.Component {
               </PrefixedLink>
             </Menu.Item>
 
+            <Menu.Item className="sidebar-menu-item" key="/top">
+              <PrefixedLink to="/top">
+                <Icon type="caret-up" />
+                <span>Top</span>
+              </PrefixedLink>
+            </Menu.Item>
+
             {
               _.map(_.take(this.state.namespaces, this.state.maxNsItemsToShow), ns => {
                 return (

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -191,7 +191,7 @@ const renderMetaLabels = (title, labels) => {
         columns={srcDstMetaColumns}
         dataSource={data}
         size="small"
-        rowKey="labelVal"
+        rowKey={row => title.replace(" ", "_") + row.labelName + row.labelVal}
         bordered={false}
         showHeader={false}
         pagination={false} />


### PR DESCRIPTION
- Add a link to Top in the sidebar
- Fix a console error caused by having duplicate react keys.

![screen shot 2018-08-22 at 5 05 20 pm](https://user-images.githubusercontent.com/549258/44497389-da3d7500-a62d-11e8-9626-6af3f8b90c5a.png)
