### PR TITLE
Add success rate visuals to the octopus graph

### DIFF
--- a/web/app/css/octopus.css
+++ b/web/app/css/octopus.css
@@ -1,21 +1,19 @@
 @import 'styles.css';
 
-.octopus-container {
-  padding: calc(var(--base-width) * 4);
-}
-
 .octopus-graph {
+  padding: calc(var(--base-width) * 4);
+  background-color: #FAFAFA;
+
   & .octopus-body {
     background-color: white;
     margin-bottom: calc(var(--base-width) * 3);
-    box-shadow: 2px 2px 2px var(--neutralgrey);
+    border: 1px solid #F2F2F2;
   }
 
   & .octopus-col {
     text-align: center;
   }
   & .resource-col {
-    background-color: #FAFAFA;
     padding: 32px;
   }
 
@@ -32,6 +30,23 @@
     }
   }
 
+  & .octopus-sr-gauge {
+    padding-top: calc(var(--base-width) * 2);
+
+    & .ant-progress-text {
+      color: black;
+    }
+    & .status-good .ant-progress-circle-path {
+      stroke: var(--green);
+    }
+    & .status-ok .ant-progress-circle-path {
+      stroke: var(--orange)
+    }
+    & .status-poor .ant-progress-circle-path {
+      stroke: var(--siennared);
+    }
+  }
+
   & .octopus-metric {
     line-height: 32px;
 
@@ -45,7 +60,7 @@
       color: #E0E0E0;
     }
     &.status-ok {
-      color: #FF8C00;
+      color: var(--orange);
     }
   }
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -14,6 +14,7 @@
   --silver: #BDBDBD;
   --green: #27AE60;
   --siennared: #EB5757;
+  --orange: #FF8C00;
   --latency-p99: var(--royalblue);
   --latency-p95: var(--curiousblue);
   --latency-p50: var(--pictonblue);


### PR DESCRIPTION
Add gauge chart to octopus cards

![screen shot 2018-08-23 at 2 28 05 pm](https://user-images.githubusercontent.com/549258/44553150-73799380-a6e1-11e8-98d5-c94e94f85937.png)

Part of #1468
