### PR TITLE
Add ReadinessProbe and LivenessProbe to injected proxy containers

### DIFF
--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -16,7 +16,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error from validateAndBuildConfig(): %v", err)
 	}
-	defaultConfig.UUID = "deaab91a-f4ab-448a-b7d1-c832a2fa0a60"
+	defaultConfig.UUID = "3e5903bf-803b-4555-abc4-9de68d35c4e3"
 
 	// A configuration that shows that all config setting strings are honored
 	// by `render()`.

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -16,7 +16,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error from validateAndBuildConfig(): %v", err)
 	}
-	defaultConfig.UUID = "3e5903bf-803b-4555-abc4-9de68d35c4e3"
+	defaultConfig.UUID = "deaab91a-f4ab-448a-b7d1-c832a2fa0a60"
 
 	// A configuration that shows that all config setting strings are honored
 	// by `render()`.

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -47,12 +47,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -47,12 +47,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -128,12 +138,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -47,12 +47,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -58,12 +58,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -58,12 +58,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -150,12 +160,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -59,12 +59,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
@@ -70,12 +70,22 @@ spec:
           value: controller.deployment.linkerd.linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -60,12 +60,22 @@ items:
                 fieldPath: metadata.namespace
           image: gcr.io/linkerd-io/proxy:testinjectversion
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 4191
+            initialDelaySeconds: 10
           name: linkerd-proxy
           ports:
           - containerPort: 4143
             name: linkerd-proxy
           - containerPort: 4191
             name: linkerd-metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 4191
+            initialDelaySeconds: 10
           resources: {}
           securityContext:
             runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -41,12 +41,22 @@ spec:
           fieldPath: metadata.namespace
     image: gcr.io/linkerd-io/proxy:testinjectversion
     imagePullPolicy: IfNotPresent
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
     name: linkerd-proxy
     ports:
     - containerPort: 4143
       name: linkerd-proxy
     - containerPort: 4191
       name: linkerd-metrics
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
     resources: {}
     securityContext:
       runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
@@ -53,12 +53,22 @@ spec:
       value: controller.deployment.linkerd.linkerd-managed.linkerd.svc.cluster.local
     image: gcr.io/linkerd-io/proxy:testinjectversion
     imagePullPolicy: IfNotPresent
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
     name: linkerd-proxy
     ports:
     - containerPort: 4143
       name: linkerd-proxy
     - containerPort: 4191
       name: linkerd-metrics
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
     resources: {}
     securityContext:
       runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -58,12 +58,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -60,12 +60,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -154,12 +164,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -251,12 +251,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -335,7 +345,7 @@ spec:
         - -api-addr=api.linkerd.svc.cluster.local:8085
         - -static-dir=/dist
         - -template-dir=/templates
-        - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
+        - -uuid=3e5903bf-803b-4555-abc4-9de68d35c4e3
         - -controller-namespace=linkerd
         - -log-level=info
         image: gcr.io/linkerd-io/web:undefined
@@ -378,12 +388,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -503,12 +523,22 @@ spec:
           value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -712,12 +742,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -345,7 +345,7 @@ spec:
         - -api-addr=api.linkerd.svc.cluster.local:8085
         - -static-dir=/dist
         - -template-dir=/templates
-        - -uuid=3e5903bf-803b-4555-abc4-9de68d35c4e3
+        - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
         - -log-level=info
         image: gcr.io/linkerd-io/web:undefined

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -252,12 +252,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -380,12 +390,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -506,12 +526,22 @@ spec:
           value: "10000"
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -716,12 +746,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -931,12 +971,22 @@ spec:
               fieldPath: metadata.namespace
         image: gcr.io/linkerd-io/proxy:undefined
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         name: linkerd-proxy
         ports:
         - containerPort: 4143
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
         resources: {}
         securityContext:
           runAsUser: 2102


### PR DESCRIPTION
Adds basic probes to the `linkerd-proxy` containers injected by `linkerd inject`.

- Currently the Readiness and Liveness probes are configured to be the same. But we can change the parameters pretty easily. 
- I haven't supplied a `periodSeconds`, but the default is 10.
- I also set the initialDelaySeconds to 10, but that might be a bit high.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/

Fixes #1515