### PR TITLE
Increase default max-rps for tap and top

### DIFF
--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -31,7 +31,7 @@ func newTapOptions() *tapOptions {
 		namespace:   "default",
 		toResource:  "",
 		toNamespace: "",
-		maxRps:      1.0,
+		maxRps:      100.0,
 		scheme:      "",
 		method:      "",
 		authority:   "",

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -72,7 +72,7 @@ func newTopOptions() *tapOptions {
 		namespace:   "default",
 		toResource:  "",
 		toNamespace: "",
-		maxRps:      1.0,
+		maxRps:      100.0,
 		scheme:      "",
 		method:      "",
 		authority:   "",

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -35,7 +35,7 @@ type (
 )
 
 var (
-	tapInterval = 10 * time.Second
+	tapInterval = 1 * time.Second
 )
 
 func (s *server) Tap(req *public.TapRequest, stream pb.Tap_TapServer) error {
@@ -240,8 +240,8 @@ func destinationLabels(resource *public.Resource) map[string]string {
 // request is cancelled via the context.  Thus it should be called as a
 // go-routine.
 // To limit the rps to maxRps, this method calls Observe on the pod with a limit
-// of maxRps * 10s at most once per 10s window.  If this limit is reached in
-// less than 10s, we sleep until the end of the window before calling Observe
+// of maxRps * 1s at most once per 10s window.  If this limit is reached in
+// less than 1s, we sleep until the end of the window before calling Observe
 // again.
 func (s *server) tapProxy(ctx context.Context, maxRps float32, match *proxy.ObserveRequest_Match, addr string, events chan *public.TapEvent) {
 	tapAddr := fmt.Sprintf("%s:%d", addr, s.tapPort)

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -240,7 +240,7 @@ func destinationLabels(resource *public.Resource) map[string]string {
 // request is cancelled via the context.  Thus it should be called as a
 // go-routine.
 // To limit the rps to maxRps, this method calls Observe on the pod with a limit
-// of maxRps * 1s at most once per 10s window.  If this limit is reached in
+// of maxRps * 1s at most once per 1s window.  If this limit is reached in
 // less than 1s, we sleep until the end of the window before calling Observe
 // again.
 func (s *server) tapProxy(ctx context.Context, maxRps float32, match *proxy.ObserveRequest_Match, addr string, events chan *public.TapEvent) {


### PR DESCRIPTION
The default value for the max-rps argument to the tap and top commands is an overly conservative 1rps.  This causes the data to come in very slowly and much data to be discarded.  Furthermore, because tap requests are windowed to 10 seconds, this causes long pauses between updates.

We fix this in two ways.  Firstly we reduce the window size to 1s so that updates will come in at least once per second, even when the actual RPS of the data path is extremely high.  Secondly, we increase the default max-rps parameter from 1 to 100.  This allows tap to paint an accurate picture of the data much more quickly and sidesteps some sampling bias that happens when the max-rps is low.

In general, tap events tend to happen in bursts.  For example, one request in may trigger one or more requests out.  Likewise, a single upstream event may trigger several requests to the tapped pod in quick succession.  Sampling bias will occur when the max-rps is less than the actual rps and when the tap event limit subdivides these event bursts (biasing towards the first few events in the burst).  The greater the max-rps, the less the effects of this bias.

Fixes #1525 

Signed-off-by: Alex Leong <alex@buoyant.io>