### PR TITLE
Only tap pods that are meshed

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -211,6 +211,7 @@ spec:
       - args:
         - tap
         - -log-level=info
+        - -controller-namespace=linkerd
         image: gcr.io/linkerd-io/controller:undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -212,6 +212,7 @@ spec:
       - args:
         - tap
         - -log-level=ControllerLogLevel
+        - -controller-namespace=Namespace
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         livenessProbe:

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -214,6 +214,7 @@ spec:
         args:
         - "tap"
         - "-log-level={{.ControllerLogLevel}}"
+        - "-controller-namespace={{.Namespace}}"
         livenessProbe:
           httpGet:
             path: /ping

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -17,6 +17,7 @@ func main() {
 	addr := flag.String("addr", "127.0.0.1:8088", "address to serve on")
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
+	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	tapPort := flag.Uint("tap-port", 4190, "proxy tap port to connect to")
 	flags.ConfigureAndParse()
 
@@ -37,7 +38,7 @@ func main() {
 		k8s.RS,
 	)
 
-	server, lis, err := tap.NewServer(*addr, *tapPort, k8sAPI)
+	server, lis, err := tap.NewServer(*addr, *tapPort, *controllerNamespace, k8sAPI)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -35,6 +35,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
+    linkerd.io/control-plane-ns: controller-ns
   annotations:
     linkerd.io/proxy-version: testinjectversion
 status:
@@ -52,6 +53,30 @@ status:
 					Match: &public.TapByResourceRequest_Match{
 						Match: &public.TapByResourceRequest_Match_Any{
 							Any: &public.TapByResourceRequest_Match_Seq{},
+						},
+					},
+				},
+			},
+			tapExpected{
+				msg: "rpc error: code = NotFound desc = no pods found for ResourceSelection: {Resource:namespace:\"emojivoto\" type:\"pod\" name:\"emojivoto-not-meshed\"  LabelSelector:}",
+				k8sRes: []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emojivoto-not-meshed
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+status:
+  phase: Running
+`,
+				},
+				req: public.TapByResourceRequest{
+					Target: &public.ResourceSelection{
+						Resource: &public.Resource{
+							Namespace: "emojivoto",
+							Type:      pkgK8s.Pod,
+							Name:      "emojivoto-not-meshed",
 						},
 					},
 				},
@@ -134,6 +159,7 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
+    linkerd.io/control-plane-ns: controller-ns
   annotations:
     linkerd.io/proxy-version: testinjectversion
 status:
@@ -163,7 +189,7 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			server, listener, err := NewServer("localhost:0", 0, k8sAPI)
+			server, listener, err := NewServer("localhost:0", 0, "controller-ns", k8sAPI)
 			if err != nil {
 				t.Fatalf("NewServer error: %s", err)
 			}


### PR DESCRIPTION
Previously, we would tap any resource's pods, regardless of whether the pods were meshed or not.
We can't actually tap non-meshed pods, so I'm adding a check that will filter out non-meshed pods from the pods that tap watches.

*Previous behaviour*
when attempting to hang a non meshed pod, it would establish a watch on the pods, but then never return any results. In the CLI you could just cancel it with Ctrl-C. In the web, clicking Stop would send a `WebSocket.close(1000)` but wouldn't actually close the connection... (I think that part is web not handling the close properly, but I discovered this while trying to address that).

*Behaviour after change*
If no pods under the specified resource are meshed, it'll go on to this line, which will return an error of no pods being found to tap:
```
	if len(pods) == 0 {
		return status.Errorf(codes.NotFound, "no pods found for ResourceSelection: %+v", *req.Target)
	}
```