### PR TITLE
Miscellaneous small web UI fixes

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -75,13 +75,14 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       title: formatTitle("Dash", "Grafana Dashboard"),
       key: "grafanaDashboard",
       className: "numeric",
-      render: row => !row.added ? null : (
+      render: row => !row.added || _.get(row, "pods.totalPods") === "0" ? null : (
         <GrafanaLink
           name={row.name}
           namespace={row.namespace}
           resource={resource}
           PrefixedLink={PrefixedLink} />
-      )}
+      )
+    }
   ];
 
   let columns = [

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import ApiHelpers from './util/ApiHelpers.jsx';
-import {friendlyTitle} from './util/Utils.js';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -247,8 +246,7 @@ class Sidebar extends React.Component {
                   <Menu.SubMenu
                     className="sidebar-menu-item"
                     key={resourceName}
-                    disabled={_.isEmpty(sidebarComponents[resourceName])}
-                    title={<span>{friendlyTitle(resourceName).plural}</span>}>
+                    disabled={_.isEmpty(sidebarComponents[resourceName])}>
                     {
                       _.map(_.sortBy(sidebarComponents[resourceName], r => `${r.namespace}/${r.name}`), r => {
                         // only display resources that have been meshed

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -114,7 +114,11 @@ class Tap extends React.Component {
     let statTables = _.get(rsp, [0, "ok", "statTables"]);
     let authoritiesByNs = {};
     let resourcesByNs = _.reduce(statTables, (mem, table) => {
-      _.map(table.podGroup.rows, row => {
+      _.each(table.podGroup.rows, row => {
+        if (row.meshedPodCount === "0") {
+          return;
+        }
+
         if (!mem[row.resource.namespace]) {
           mem[row.resource.namespace] = [];
           authoritiesByNs[row.resource.namespace] = [];

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
-import { formatLatencySec, formatWithComma } from './util/Utils.js';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
 import { Col, Icon, Row, Table } from 'antd';
+import { formatLatencySec, formatWithComma } from './util/Utils.js';
 
 // https://godoc.org/google.golang.org/grpc/codes#Code
 const grpcStatusCodes = {

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
-import { formatLatencySec } from './util/Utils.js';
+import { formatLatencySec, formatWithComma } from './util/Utils.js';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
 import { Col, Icon, Row, Table } from 'antd';
@@ -155,7 +155,7 @@ let tapColumns = filterOptions => [
         title: "Response Length (B)",
         key: "rsp-length",
         dataIndex: "responseEnd.http.responseEnd",
-        render: d => !d ? <Icon type="loading" /> : d.responseBytes
+        render: d => !d ? <Icon type="loading" /> : formatWithComma(d.responseBytes)
       },
     ]
 

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -56,7 +56,11 @@ class Top extends React.Component {
     let statTables = _.get(rsp, [0, "ok", "statTables"]);
     let authoritiesByNs = {};
     let resourcesByNs = _.reduce(statTables, (mem, table) => {
-      _.map(table.podGroup.rows, row => {
+      _.each(table.podGroup.rows, row => {
+        if (row.meshedPodCount === "0") {
+          return;
+        }
+
         if (!mem[row.resource.namespace]) {
           mem[row.resource.namespace] = [];
           authoritiesByNs[row.resource.namespace] = [];

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -11,7 +11,15 @@ export const rowGutter = 3 * baseWidth;
 * Number formatters
 */
 const successRateFormatter = d3.format(".2%");
-const latencyFormatter = d3.format(",");
+const commaFormatter = d3.format(",");
+
+export const formatWithComma = m => {
+  if (_.isNil(m)) {
+    return "---";
+  } else {
+    return commaFormatter(m);
+  }
+};
 
 export const formatLatencyMs = m => {
   if (_.isNil(m)) {
@@ -21,7 +29,7 @@ export const formatLatencyMs = m => {
   }
 };
 
-const niceLatency = l => latencyFormatter(Math.round(l));
+const niceLatency = l => commaFormatter(Math.round(l));
 
 export const formatLatencySec = latency => {
   let s = parseFloat(latency);


### PR DESCRIPTION
A bunch of small items. This PR
- filters out un-meshed resources from the Tap and Top autocompletes
- removes an un-rendered `title` attribute from the sidebar menu items
- formats latency in Tap with a comma
- prevents the grafana link from showing if there are 0 pods in a deployment

Fixes #1524
Fixes #1527 
Fixes #1510