### PR TITLE
Better visual distinction of inline code snippet in mesh completion message

### DIFF
--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -24,7 +24,12 @@
   font-size: 16;
   border-radius: calc(var(--base-width)/2);
   font-weight: var(--font-weight-extra-bold);
-  border-radius: var
+
+  & code {
+    color: #2f80ed;
+    background-color: white;
+    padding: 0.2em;
+  }
 }
 
 .service-mesh-table {


### PR DESCRIPTION
When the mesh completion message calls to action it prints a CLI command to copy&paste. It's visually hard to separate message from the command snippet which is what this commit fixes.

Flipped background and font color to create a better visual distinction

Successfully ran web app test suite