### PR TITLE
Perform linkerd version check once upon page load

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -139,7 +139,9 @@ class Sidebar extends React.Component {
   }
 
   handleNamespaceSelector(value) {
-    this.setState({namespaceFilter: value});
+    this.setState({
+      namespaceFilter: value
+    });
   }
 
   filterResourcesByNamespace(resources, namespace) {
@@ -158,6 +160,7 @@ class Sidebar extends React.Component {
       return {value: ns, name: ns};
     }));
     let sidebarComponents = this.filterResourcesByNamespace(this.state.finalResourceGroups, this.state.namespaceFilter);
+
     return (
       <Layout.Sider
         width="260px"
@@ -223,28 +226,31 @@ class Sidebar extends React.Component {
             theme="dark"
             mode="inline"
             selectedKeys={[normalizedPath]}>
-            { this.state.collapsed ? null : (
-              <Menu.Item className="sidebar-menu-item" key="/namespace-selector">
-                <Form layout="inline">
-                  <Form.Item>
-                    <Select
-                      defaultValue="All Namespaces"
-                      dropdownMatchSelectWidth={true}
-                      onChange={this.handleNamespaceSelector}>
-                      {
+            {
+              this.state.collapsed ? null : (
+                <Menu.Item className="sidebar-menu-item" key="/namespace-selector">
+                  <Form layout="inline">
+                    <Form.Item>
+                      <Select
+                        defaultValue="All Namespaces"
+                        dropdownMatchSelectWidth={true}
+                        onChange={this.handleNamespaceSelector}>
+                        {
                       _.map(namespaces, label => {
                         return (
                           <Select.Option key={label.value} value={label.value}>{label.name}</Select.Option>
                         );
                       })
                     }
-                    </Select>
-                  </Form.Item>
-                </Form>
-              </Menu.Item>
-            )}
+                      </Select>
+                    </Form.Item>
+                  </Form>
+                </Menu.Item>
+              )
+            }
 
-            {this.state.collapsed ? null :
+            {
+              this.state.collapsed ? null :
               _.map(_.keys(sidebarComponents).sort(), resourceName => {
                 return (
                   <Menu.SubMenu
@@ -275,6 +281,7 @@ class Sidebar extends React.Component {
                 );
               })
             }
+
             <Menu.Item className="sidebar-menu-item" key="/docs">
               <Link to="https://linkerd.io/2/overview/" target="_blank">
                 <Icon type="file-text" />
@@ -282,27 +289,31 @@ class Sidebar extends React.Component {
               </Link>
             </Menu.Item>
 
-            { this.state.isLatest ? null : (
-              <Menu.Item className="sidebar-menu-item" key="/update">
-                <Link to="https://versioncheck.linkerd.io/update" target="_blank">
-                  <Icon type="exclamation-circle-o" className="update" />
-                  <span>Update {this.props.productName}</span>
-                </Link>
-              </Menu.Item>
-            )}
+            {
+              this.state.isLatest ? null : (
+                <Menu.Item className="sidebar-menu-item" key="/update">
+                  <Link to="https://versioncheck.linkerd.io/update" target="_blank">
+                    <Icon type="exclamation-circle-o" className="update" />
+                    <span>Update {this.props.productName}</span>
+                  </Link>
+                </Menu.Item>
+              )
+            }
           </Menu>
 
-          { this.state.collapsed ? null : (
-            <div className="sidebar-menu-footer">
-              <SocialLinks />
-              <Version
-                isLatest={this.state.isLatest}
-                latestVersion={this.state.latestVersion}
-                releaseVersion={this.props.releaseVersion}
-                error={this.state.error}
-                uuid={this.props.uuid} />
-            </div>
-          )}
+          {
+            this.state.collapsed ? null : (
+              <div className="sidebar-menu-footer">
+                <SocialLinks />
+                <Version
+                  isLatest={this.state.isLatest}
+                  latestVersion={this.state.latestVersion}
+                  releaseVersion={this.props.releaseVersion}
+                  error={this.state.error}
+                  uuid={this.props.uuid} />
+              </div>
+            )
+          }
         </div>
       </Layout.Sider>
     );

--- a/web/app/test/SidebarTest.jsx
+++ b/web/app/test/SidebarTest.jsx
@@ -2,7 +2,7 @@ import Adapter from "enzyme-adapter-react-16";
 import ApiHelpers from "../js/components/util/ApiHelpers.jsx";
 import { BrowserRouter } from 'react-router-dom';
 import { expect } from 'chai';
-import multiResourceRollupFixtures from './fixtures/allRollup.json';
+import namespaceFixtures from './fixtures/namespaces.json';
 import React from "react";
 import { Select } from 'antd';
 import Sidebar from "../js/components/Sidebar.jsx";
@@ -46,7 +46,7 @@ describe('Sidebar', () => {
   it("namespace selector has options", () => {
     fetchStub.returnsPromise().resolves({
       ok: true,
-      json: () => Promise.resolve(multiResourceRollupFixtures)
+      json: () => Promise.resolve(namespaceFixtures)
     });
 
     component = mount(
@@ -62,9 +62,7 @@ describe('Sidebar', () => {
 
     return withPromise(() => {
       openNamespaceSelector(component);
-      expect(component.find(".ant-select-dropdown-menu-item")).to.have.length(2);
+      expect(component.find(".ant-select-dropdown-menu-item")).to.have.length(6);
     });
   });
 });
-
-

--- a/web/app/test/SidebarTest.jsx
+++ b/web/app/test/SidebarTest.jsx
@@ -62,6 +62,11 @@ describe('Sidebar', () => {
 
     return withPromise(() => {
       openNamespaceSelector(component);
+
+      // number of namespaces in api result
+      expect(namespaceFixtures.ok.statTables[0].podGroup.rows).to.have.length(5);
+
+      // plus "All namespaces" option
       expect(component.find(".ant-select-dropdown-menu-item")).to.have.length(6);
     });
   });

--- a/web/app/test/fixtures/namespaces.json
+++ b/web/app/test/fixtures/namespaces.json
@@ -25,6 +25,23 @@
               "resource": {
                 "namespace": "",
                 "type": "namespace",
+                "name": "shiny-product-other"
+              },
+              "timeWindow": "1m",
+              "meshedPodCount": "4",
+              "runningPodCount": "4",
+              "stats": {
+                "successCount": "30",
+                "failureCount": "0",
+                "latencyMsP50": "5",
+                "latencyMsP95": "10",
+                "latencyMsP99": "10"
+              }
+            },
+            {
+              "resource": {
+                "namespace": "",
+                "type": "namespace",
                 "name": "kube-system"
               },
               "timeWindow": "1m",


### PR DESCRIPTION
Previously, we included a version check in the server polling loop, which meant we were hitting the version check endpoint once very 10 seconds from the sidebar. This PR moves that check out of the loop so that we only hit it once, upon pageload.

This PR also includes
- some whitespace fixes
- a fix for a console error we were triggering with our tests

Fixes #1522 

Before:
![screen shot 2018-08-28 at 11 49 58 am](https://user-images.githubusercontent.com/549258/44743965-bd36f500-aab8-11e8-804a-887b365d359a.png)

After:
![screen shot 2018-08-28 at 11 46 31 am](https://user-images.githubusercontent.com/549258/44743964-bd36f500-aab8-11e8-9f65-43fcdf98d117.png)