### PR TITLE
Fix sidebar resource names not appearing

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import {friendlyTitle} from './util/Utils.js';
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -258,6 +259,7 @@ class Sidebar extends React.Component {
                   <Menu.SubMenu
                     className="sidebar-menu-item"
                     key={resourceName}
+                    title={friendlyTitle(resourceName).plural}
                     disabled={_.isEmpty(sidebarComponents[resourceName])}>
                     {
                       _.map(_.sortBy(sidebarComponents[resourceName], r => `${r.namespace}/${r.name}`), r => {


### PR DESCRIPTION
In #1536 I removed the entire title attribute instead of removing the spans in the title, causing the titles to not appear.

Re-add the title text.

Fixes #1552