### PR TITLE
Tap the entire namespace if no resource is specified

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -116,7 +116,7 @@ class Tap extends React.Component {
     let resourcesByNs = _.reduce(statTables, (mem, table) => {
       _.each(table.podGroup.rows, row => {
         // filter out resources that aren't meshed. note that authorities don't
-        // have pod counds and therefore can't be filtered out here
+        // have pod counts and therefore can't be filtered out here
         if (row.meshedPodCount === "0" && row.resource.type !== "authority") {
           return;
         }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -115,7 +115,9 @@ class Tap extends React.Component {
     let authoritiesByNs = {};
     let resourcesByNs = _.reduce(statTables, (mem, table) => {
       _.each(table.podGroup.rows, row => {
-        if (row.meshedPodCount === "0") {
+        // filter out resources that aren't meshed. note that authorities don't
+        // have pod counds and therefore can't be filtered out here
+        if (row.meshedPodCount === "0" && row.resource.type !== "authority") {
           return;
         }
 

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -52,9 +52,9 @@ export default class TapQueryCliCmd extends React.Component {
             <div>Current {_.startCase(this.props.cmdName)} query:</div>
             <code>
               linkerd {this.props.cmdName} {resource}
-              { this.renderCliItem("--namespace", namespace) }
+              { resource.indexOf("namespace") === 0 ? null : this.renderCliItem("--namespace", namespace) }
               { this.renderCliItem("--to", toResource) }
-              { this.renderCliItem("--to-namespace", toNamespace) }
+              { toResource.indexOf("namespace") === 0 ? null : this.renderCliItem("--to-namespace", toNamespace) }
               { this.renderCliItem("--method", method) }
               { this.renderCliItem("--scheme", scheme) }
               { this.renderCliItem("--authority", authority) }

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -214,17 +214,20 @@ export default class TapQueryForm extends React.Component {
   }
 
   renderResourceSelect = (resourceKey, namespaceKey) => {
+    let selectedNs = this.state.query[namespaceKey];
+    let nsEmpty = _.isNil(selectedNs) || _.isEmpty(selectedNs);
+
     let resourceOptions = _.concat(
       this.state.autocomplete[resourceKey] || [],
-      _.isEmpty(this.state.query[namespaceKey]) ? [] : [`namespace/${this.state.query[namespaceKey]}`]
+      nsEmpty ? [] : [`namespace/${selectedNs}`]
     );
 
     return (
       <Select
         showSearch
         allowClear
-        disabled={_.isNil(this.state.query[namespaceKey])}
-        value={_.isNil(this.state.query[namespaceKey]) ? _.startCase(resourceKey) : this.state.query[resourceKey]}
+        disabled={nsEmpty}
+        value={nsEmpty ? _.startCase(resourceKey) : this.state.query[resourceKey]}
         placeholder={_.startCase(resourceKey)}
         optionFilterProp="children"
         onChange={this.handleFormChange(resourceKey)}>

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -223,6 +223,7 @@ export default class TapQueryForm extends React.Component {
       <Select
         showSearch
         allowClear
+        disabled={this.state.query[namespaceKey] === ""}
         placeholder={_.startCase(resourceKey)}
         optionFilterProp="children"
         onChange={this.handleFormChange(resourceKey)}>

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -93,7 +93,7 @@ export default class TapQueryForm extends React.Component {
       if (!_.isNil(scopeResource)) {
         // scope the available typeahead resources to the selected namespace
         state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
-        if (_.isEmpty(state.query[scopeResource])) {
+        if (_.isEmpty(state.query[scopeResource]) || state.query[scopeResource].indexOf("namespace") !== -1) {
           state.query[scopeResource] = `namespace/${formVal}`;
         }
       }
@@ -224,6 +224,7 @@ export default class TapQueryForm extends React.Component {
         showSearch
         allowClear
         disabled={_.isNil(this.state.query[namespaceKey])}
+        value={_.isNil(this.state.query[namespaceKey]) ? _.startCase(resourceKey) : this.state.query[resourceKey]}
         placeholder={_.startCase(resourceKey)}
         optionFilterProp="children"
         onChange={this.handleFormChange(resourceKey)}>

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -93,6 +93,9 @@ export default class TapQueryForm extends React.Component {
       if (!_.isNil(scopeResource)) {
         // scope the available typeahead resources to the selected namespace
         state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
+        if (_.isEmpty(state.query[scopeResource])) {
+          state.query[scopeResource] = `namespace/${formVal}`;
+        }
       }
       if (shouldScopeAuthority) {
         state.autocomplete.authority = this.state.authoritiesByNs[formVal];
@@ -145,11 +148,7 @@ export default class TapQueryForm extends React.Component {
 
           <Col span={colSpan}>
             <Form.Item>
-              <AutoComplete
-                dataSource={this.autoCompleteData("toResource")}
-                onSelect={this.handleFormChange("toResource")}
-                onSearch={this.handleFormChange("toResource")}
-                placeholder="To Resource" />
+              {this.renderResourceSelect("toResource", "toNamespace")}
             </Form.Item>
           </Col>
         </Row>
@@ -214,6 +213,32 @@ export default class TapQueryForm extends React.Component {
     );
   }
 
+  renderResourceSelect(resourceKey, namespaceKey) {
+    let resourceOptions = _.concat(
+      this.state.autocomplete[resourceKey],
+      _.isEmpty(this.state.query[namespaceKey]) ? [] : [`namespace/${this.state.query[namespaceKey]}`]
+    );
+
+    return (
+      <Select
+        showSearch
+        allowClear
+        placeholder={_.startCase(resourceKey)}
+        optionFilterProp="children"
+        onChange={this.handleFormChange(resourceKey)}>
+        {
+        _.map(_.sortBy(resourceOptions), resource => (
+          <Select.Option
+            key={`${resourceKey}-${resource}`}
+            value={resource}>{resource}
+          </Select.Option>
+          )
+        )
+      }
+      </Select>
+    );
+  }
+
   render() {
     return (
       <Form className="tap-form">
@@ -237,11 +262,7 @@ export default class TapQueryForm extends React.Component {
 
           <Col span={colSpan}>
             <Form.Item>
-              <AutoComplete
-                dataSource={this.autoCompleteData("resource")}
-                onSelect={this.handleFormChange("resource")}
-                onSearch={this.handleFormChange("resource")}
-                placeholder="Resource" />
+              {this.renderResourceSelect("resource", "namespace")}
             </Form.Item>
           </Col>
 

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -213,9 +213,9 @@ export default class TapQueryForm extends React.Component {
     );
   }
 
-  renderResourceSelect(resourceKey, namespaceKey) {
+  renderResourceSelect = (resourceKey, namespaceKey) => {
     let resourceOptions = _.concat(
-      this.state.autocomplete[resourceKey],
+      this.state.autocomplete[resourceKey] || [],
       _.isEmpty(this.state.query[namespaceKey]) ? [] : [`namespace/${this.state.query[namespaceKey]}`]
     );
 
@@ -223,7 +223,7 @@ export default class TapQueryForm extends React.Component {
       <Select
         showSearch
         allowClear
-        disabled={this.state.query[namespaceKey] === ""}
+        disabled={_.isNil(this.state.query[namespaceKey])}
         placeholder={_.startCase(resourceKey)}
         optionFilterProp="children"
         onChange={this.handleFormChange(resourceKey)}>


### PR DESCRIPTION
- Use an ant Select instead of Autocomplete for resource list, so that the user can see all available tappable resources
- Fix bug where the authority autocomplete wasn't showing any options
- Refactor the resource dropdown to share code
- Adds "namespace/<name>" as an option in the resource selection dropdown

This required some weird handling because we allow requests of the form 
`linkerd tap namespace/linkerd` (taps namespace linkerd) 
but not 
`linkerd tap namespace --namespace linkerd` (does not work as intended, taps every namespace)

![screen shot 2018-08-29 at 4 52 20 pm](https://user-images.githubusercontent.com/549258/44821776-34998100-abac-11e8-8fe9-16e05d5cc064.png)


Fixes #1521