### PR TITLE
Increase MaxRps in Tap server, remove default setting from Web

### DIFF
--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -26,6 +26,7 @@ import (
 )
 
 const podIPIndex = "ip"
+const defaultMaxRps = 100.0
 
 type (
 	server struct {
@@ -49,6 +50,9 @@ func (s *server) TapByResource(req *public.TapByResourceRequest, stream pb.Tap_T
 	}
 	if req.Target == nil {
 		return status.Errorf(codes.InvalidArgument, "TapByResource received nil target ResourceSelection: %+v", *req)
+	}
+	if req.MaxRps == 0.0 {
+		req.MaxRps = defaultMaxRps
 	}
 
 	objects, err := s.k8sAPI.GetObjects(req.Target.Resource.Namespace, req.Target.Resource.Type, req.Target.Resource.Name)

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -173,8 +173,7 @@ export class ResourceDetailBase extends React.Component {
 
     let topQuery = {
       resource: this.state.resourceType + "/" + this.state.resourceName,
-      namespace: this.state.namespace,
-      maxRps: "1.0"
+      namespace: this.state.namespace
     };
 
     return (

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -7,7 +7,7 @@ import TapEventTable from './TapEventTable.jsx';
 import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
-import { defaultMaxRps, httpMethods, processTapEvent } from './util/TapUtils.jsx';
+import { httpMethods, processTapEvent, setMaxRps } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const maxNumFilterOptions = 12;
@@ -39,7 +39,7 @@ class Tap extends React.Component {
         path: "",
         scheme: "",
         authority: "",
-        maxRps: defaultMaxRps
+        maxRps: ""
       },
       maxLinesToDisplay: 40,
       tapRequestInProgress: false,
@@ -62,7 +62,7 @@ class Tap extends React.Component {
 
   onWebsocketOpen = () => {
     let query = _.cloneDeep(this.state.query);
-    query.maxRps = parseFloat(query.maxRps);
+    setMaxRps(query);
 
     this.ws.send(JSON.stringify({
       id: "tap-web",

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -186,9 +186,8 @@ export default class TapQueryForm extends React.Component {
 
           <Col span={colSpan}>
             <Form.Item
-              extra="Maximum requests per second to tap">
+              extra={`Maximum requests per second to tap (default ${defaultMaxRps})`}>
               <Input
-                defaultValue={defaultMaxRps}
                 placeholder="Max RPS"
                 onChange={this.handleFormEvent("maxRps")} />
             </Form.Item>

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { defaultMaxRps } from './util/TapUtils.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import PageHeader from './PageHeader.jsx';
 import PropTypes from 'prop-types';
@@ -36,7 +35,7 @@ class Top extends React.Component {
         path: "",
         scheme: "",
         authority: "",
-        maxRps: defaultMaxRps
+        maxRps: ""
       },
       pollingInterval: 10000,
       tapRequestInProgress: false,

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import ErrorBanner from './ErrorBanner.jsx';
 import Percentage from './util/Percentage.js';
-import { processTapEvent } from './util/TapUtils.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import TopEventTable from './TopEventTable.jsx';
 import { withContext } from './util/AppContext.jsx';
+import { processTapEvent, setMaxRps } from './util/TapUtils.jsx';
 
 class TopModule extends React.Component {
   static propTypes = {
@@ -51,7 +51,7 @@ class TopModule extends React.Component {
 
   onWebsocketOpen = () => {
     let query = _.cloneDeep(this.props.query);
-    query.maxRps = parseFloat(query.maxRps);
+    setMaxRps(query);
 
     this.ws.send(JSON.stringify({
       id: "top-web",

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -5,7 +5,14 @@ import React from 'react';
 
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
 
-export const defaultMaxRps = "1.0";
+export const defaultMaxRps = "100.0";
+export const setMaxRps = query => {
+  if (!_.isEmpty(query.maxRps)) {
+    query.maxRps = parseFloat(query.maxRps);
+  } else {
+    query.maxRps = 0; // golang unset value for maxRps
+  }
+};
 
 export const tapQueryPropType = PropTypes.shape({
   resource: PropTypes.string,

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -145,10 +145,6 @@ func (h *handler) handleApiTap(w http.ResponseWriter, req *http.Request, p httpr
 		return
 	}
 
-	if requestParams.MaxRps == 0.0 {
-		requestParams.MaxRps = 1.0
-	}
-
 	tapReq, err := util.BuildTapByResourceRequest(requestParams)
 	if err != nil {
 		ws.WriteMessage(websocket.CloseMessage, []byte(err.Error()))


### PR DESCRIPTION
Increase the `MaxRps` on the tap server to 100 RPS.

The max RPS for tap/top was increased in for the CLI #1531, but we still manually set this to 1 RPS in the Web UI.
Remove the pervasive setting of MaxRps to 1 in the web frontend and server

Fixes #1557 