### PR TITLE
Don't start a Top in the resource detail page if the resource is unmeshed

### DIFF
--- a/web/app/js/components/AddResources.jsx
+++ b/web/app/js/components/AddResources.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { friendlyTitle } from './util/Utils.js';
 import { incompleteMeshMessage } from './util/CopyUtils.jsx';
 import PropTypes from 'prop-types';

--- a/web/app/js/components/AddResources.jsx
+++ b/web/app/js/components/AddResources.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { friendlyTitle } from './util/Utils.js';
 import { incompleteMeshMessage } from './util/CopyUtils.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -14,7 +15,7 @@ export default class AddResources extends React.Component {
 
     return (
       <div className="mesh-completion-message">
-        {_.startCase(resourceType)} {resourceName} is not in the mesh.
+        {friendlyTitle(resourceType).singular} {resourceName} is not in the mesh.
         {incompleteMeshMessage()}
       </div>
     );

--- a/web/app/js/components/AddResources.jsx
+++ b/web/app/js/components/AddResources.jsx
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+import { incompleteMeshMessage } from './util/CopyUtils.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class AddResources extends React.Component {
+  static propTypes = {
+    resourceName: PropTypes.string.isRequired,
+    resourceType: PropTypes.string.isRequired
+  }
+
+  render() {
+    const {resourceName, resourceType} = this.props;
+
+    return (
+      <div className="mesh-completion-message">
+        {_.startCase(resourceType)} {resourceName} is not in the mesh.
+        {incompleteMeshMessage()}
+      </div>
+    );
+  }
+}

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import AddResources from './AddResources.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import Octopus from './Octopus.jsx';
@@ -130,9 +131,11 @@ export class ResourceDetailBase extends React.Component {
         }, {});
 
         let podMetricsForResource = _.filter(podMetrics, pod => podBelongsToResource[pod.namespace + "/" + pod.name]);
+        let resourceIsMeshed = _.get(this.state.resourceMetrics, '[0].pods.meshedPods') > 0;
 
         this.setState({
           resourceMetrics,
+          resourceIsMeshed,
           podMetrics: podMetricsForResource,
           neighborMetrics: {
             upstream: upstreamMetrics,
@@ -178,6 +181,15 @@ export class ResourceDetailBase extends React.Component {
 
     return (
       <div>
+        {
+          this.state.resourceIsMeshed ? null :
+          <div className="page-section">
+            <AddResources
+              resourceName={this.state.resourceName}
+              resourceType={this.state.resourceType} />
+          </div>
+        }
+
         <div className="page-section">
           <Octopus
             resource={this.state.resourceMetrics[0]}
@@ -185,13 +197,16 @@ export class ResourceDetailBase extends React.Component {
             api={this.api} />
         </div>
 
-        <div className="page-section">
-          <TopModule
-            pathPrefix={this.props.pathPrefix}
-            query={topQuery}
-            startTap={true}
-            maxRowsToDisplay={10} />
-        </div>
+        {
+          !this.state.resourceIsMeshed ? null :
+          <div className="page-section">
+            <TopModule
+              pathPrefix={this.props.pathPrefix}
+              query={topQuery}
+              startTap={true}
+              maxRowsToDisplay={10} />
+          </div>
+        }
 
         { _.isEmpty(this.state.neighborMetrics.upstream) ? null : (
           <div className="page-section">

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -60,6 +60,7 @@ export class ResourceDetailBase extends React.Component {
         upstream: {},
         downstream: {}
       },
+      resourceIsMeshed: true,
       pendingRequests: false,
       loaded: false,
       error: null
@@ -131,7 +132,10 @@ export class ResourceDetailBase extends React.Component {
         }, {});
 
         let podMetricsForResource = _.filter(podMetrics, pod => podBelongsToResource[pod.namespace + "/" + pod.name]);
-        let resourceIsMeshed = _.get(this.state.resourceMetrics, '[0].pods.meshedPods') > 0;
+        let resourceIsMeshed = true;
+        if (!_.isEmpty(this.state.resourceMetrics)) {
+          resourceIsMeshed = _.get(this.state.resourceMetrics, '[0].pods.meshedPods') > 0;
+        }
 
         this.setState({
           resourceMetrics,


### PR DESCRIPTION
Instead show a CTA.

Before:
![screen shot 2018-08-30 at 2 41 28 pm](https://user-images.githubusercontent.com/549258/44881500-b8af3f80-ac64-11e8-97ea-2c2c33d1ebcc.png)

After:
![screen shot 2018-08-30 at 2 39 44 pm](https://user-images.githubusercontent.com/549258/44881499-b8af3f80-ac64-11e8-8936-9a644c52414d.png)



Fixes #1544 