### PR TITLE
Link the resources in the Tap and Top tables to their detail pages

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -47,9 +47,9 @@ export default class Octopus extends React.Component {
     return (
       <div key={resource.name} className={`octopus-body ${type}`}>
         <div className={`octopus-title ${type}`}>
-          <this.props.api.PrefixedLink to={`/namespaces/${resource.namespace}/${resource.type}s/${resource.name}`}>
-            {displayName(resource)}
-          </this.props.api.PrefixedLink>
+          <this.props.api.ResourceLink
+            resource={resource}
+            linkText={displayName(resource)} />
         </div>
         <div className="octopus-sr-gauge">
           <Progress

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import BaseTable from './BaseTable.jsx';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
+import { withContext } from './util/AppContext.jsx';
 import { Col, Icon, Row, Table } from 'antd';
 import { formatLatencySec, formatWithComma } from './util/Utils.js';
 
@@ -34,7 +35,7 @@ const genFilterOptionList = options => _.map(options,  (_v, k) => {
   return { text: k, value: k };
 });
 
-let tapColumns = filterOptions => [
+let tapColumns = (filterOptions, ResourceLink) => [
   {
     title: "ID",
     dataIndex: "requestInit.http.requestInit.id.stream"
@@ -54,7 +55,7 @@ let tapColumns = filterOptions => [
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.source),
     onFilter: (value, row) => row.base.source.pod === value || row.base.source.str === value,
-    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "sourceMeta.labels", {}))
+    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "sourceMeta.labels", {}), ResourceLink)
   },
   {
     title: "Destination",
@@ -62,7 +63,7 @@ let tapColumns = filterOptions => [
     dataIndex: "base",
     filters: genFilterOptionList(filterOptions.destination),
     onFilter: (value, row) => row.base.destination.pod === value || row.base.destination.str === value,
-    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "destinationMeta.labels", {}))
+    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "destinationMeta.labels", {}), ResourceLink)
   },
   {
     title: "TLS",
@@ -209,12 +210,12 @@ const expandedRowRender = d => {
   );
 };
 
-export default class TapEventTable extends BaseTable {
+class TapEventTable extends BaseTable {
   render() {
     return (
       <BaseTable
         dataSource={this.props.tableRows}
-        columns={tapColumns(this.props.filterOptions)}
+        columns={tapColumns(this.props.filterOptions, this.props.api.ResourceLink)}
         expandedRowRender={expandedRowRender}
         rowKey={r => r.base.id}
         pagination={false}
@@ -223,3 +224,5 @@ export default class TapEventTable extends BaseTable {
     );
   }
 }
+
+export default withContext(TapEventTable);

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -1,24 +1,25 @@
 import BaseTable from './BaseTable.jsx';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
+import { withContext } from './util/AppContext.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
 const srcDstSorter = key => {
   return (a, b) => (a[key].pod || a[key].str).localeCompare(b[key].pod || b[key].str);
 };
 
-const topColumns = [
+const topColumns = ResourceLink => [
   {
     title: "Source",
     key: "source",
     sorter: srcDstSorter("source"),
-    render: d => srcDstColumn(d.source, d.sourceLabels)
+    render: d => srcDstColumn(d.source, d.sourceLabels, ResourceLink)
   },
   {
     title: "Destination",
     key: "destination",
     sorter: srcDstSorter("destination"),
-    render: d => srcDstColumn(d.destination, d.destinationLabels)
+    render: d => srcDstColumn(d.destination, d.destinationLabels, ResourceLink)
   },
   {
     title: "Path",
@@ -57,12 +58,12 @@ const topColumns = [
   }
 ];
 
-export default class TopEventTable extends BaseTable {
+class TopEventTable extends BaseTable {
   render() {
     return (
       <BaseTable
         dataSource={this.props.tableRows}
-        columns={topColumns}
+        columns={topColumns(this.props.api.ResourceLink)}
         rowKey="key"
         pagination={false}
         className="top-event-table"
@@ -70,3 +71,5 @@ export default class TopEventTable extends BaseTable {
     );
   }
 }
+
+export default withContext(TopEventTable);

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -117,10 +117,6 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     });
   };
 
-  const generateResourceURL = r => {
-    return "/namespaces/" + r.namespace + "/" + r.type + "s/" + r.name;
-  };
-
   // prefix all links in the app with `pathPrefix`
   class PrefixedLink extends React.Component {
     static defaultProps = {
@@ -152,6 +148,31 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     }
   }
 
+  const generateResourceURL = r => {
+    return "/namespaces/" + r.namespace + "/" + r.type + "s/" + r.name;
+  };
+
+  // a prefixed link to a Resource Detail page
+  const ResourceLink = ({resource, linkText}) => {
+    return (
+      <PrefixedLink to={generateResourceURL(resource)}>
+        { linkText || resource.type + "/" + resource.name}
+      </PrefixedLink>
+    );
+  };
+  ResourceLink.propTypes = {
+    linkText: PropTypes.string,
+    resource: PropTypes.shape({
+      name: PropTypes.string,
+      namespace: PropTypes.string,
+      type: PropTypes.string,
+    })
+  };
+  ResourceLink.defaultProps = {
+    resource: {},
+    linkText: ""
+  };
+
   return {
     fetch: apiFetch,
     fetchMetrics,
@@ -162,6 +183,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     getMetricsWindowDisplayText,
     urlsForResource,
     PrefixedLink,
+    ResourceLink,
     setCurrentRequests,
     getCurrentPromises,
     generateResourceURL,

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -94,15 +94,35 @@ const publicAddressToString = ipv4 => {
 /*
   display more human-readable information about source/destination
 */
-export const srcDstColumn = (display, labels) => {
+export const srcDstColumn = (display, labels, ResourceLink) => {
+  let podLink = (
+    <ResourceLink
+      resource={{ type: "pod", name: labels.pod, namespace: labels.namespace }}
+      linkText={"po/" + labels.pod} />
+  );
+
   let content = (
     <React.Fragment>
-      <div>{ !labels.deployment ? null : "deploy/" + labels.deployment }</div>
-      <div>{ !labels.pod ? null : "po/" + labels.pod }</div>
+      <div>
+        {
+          !labels.deployment ? null :
+          <ResourceLink
+            resource={{ type: "deployment", name: labels.deployment, namespace: labels.namespace}}
+            linkText={"deploy/" + labels.deployment} />
+        }
+      </div>
+      <div>{ !labels.pod ? null : podLink }</div>
     </React.Fragment>
   );
 
   return (
-    <Popover content={content} title={display.str}>{ display.pod || display.str }</Popover>
+    <Popover
+      content={content}
+      trigger="hover"
+      title={display.str}>
+      <div className="src-dst-name">
+        { !_.isEmpty(display.pod) ? podLink : display.str }
+      </div>
+    </Popover>
   );
 };


### PR DESCRIPTION
Introduces a new helper, ResourceLink, that makes a prefixed link to the Resource Detail pages.

![screen shot 2018-08-31 at 2 31 50 pm](https://user-images.githubusercontent.com/549258/44937955-c9c58280-ad30-11e8-83f1-17f9789a6903.png)
![screen shot 2018-08-31 at 3 16 13 pm](https://user-images.githubusercontent.com/549258/44937961-d21dbd80-ad30-11e8-8838-e9b0ac26dcc9.png)

Fixes #1553