### PR TITLE
Add data plane check to validate proxies are ready

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -78,10 +78,10 @@ func validatedPublicAPIClient(shouldRetry bool) pb.ApiClient {
 	}
 
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.HealthCheckOptions{
-		Namespace:   controlPlaneNamespace,
-		KubeConfig:  kubeconfigPath,
-		APIAddr:     apiAddr,
-		ShouldRetry: shouldRetry,
+		ControlPlaneNamespace: controlPlaneNamespace,
+		KubeConfig:            kubeconfigPath,
+		APIAddr:               apiAddr,
+		ShouldRetry:           shouldRetry,
 	})
 
 	exitOnError := func(result *healthcheck.CheckResult) {

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -96,8 +96,7 @@ If no resource name is specified, displays stats about all resources of the spec
   linkerd stat namespaces --from ns/default
 
   # Get all inbound stats to the test namespace.
-  linkerd stat ns/test
-  `,
+  linkerd stat ns/test`,
 		Args:      cobra.RangeArgs(1, 2),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -254,7 +254,7 @@ func TestHealthChecker(t *testing.T) {
 	})
 }
 
-func TestValidatePods(t *testing.T) {
+func TestValidateControlPlanePods(t *testing.T) {
 	pod := func(name string, phase v1.PodPhase, ready bool) v1.Pod {
 		return v1.Pod{
 			ObjectMeta: meta.ObjectMeta{Name: name},
@@ -278,11 +278,11 @@ func TestValidatePods(t *testing.T) {
 			pod("web-98c9ddbcd-7b5lh", v1.PodRunning, true),
 		}
 
-		err := validatePods(pods)
+		err := validateControlPlanePods(pods)
 		if err == nil {
 			t.Fatal("Expected error, got nothing")
 		}
-		if err.Error() != "No running pods for prometheus" {
+		if err.Error() != "No running pods for \"prometheus\"" {
 			t.Fatalf("Unexpected error message: %s", err.Error())
 		}
 	})
@@ -295,11 +295,11 @@ func TestValidatePods(t *testing.T) {
 			pod("web-98c9ddbcd-7b5lh", v1.PodRunning, true),
 		}
 
-		err := validatePods(pods)
+		err := validateControlPlanePods(pods)
 		if err == nil {
 			t.Fatal("Expected error, got nothing")
 		}
-		if err.Error() != "The grafana pod's grafana container is not ready" {
+		if err.Error() != "The \"grafana\" pod's \"grafana\" container is not ready" {
 			t.Fatalf("Unexpected error message: %s", err.Error())
 		}
 	})
@@ -312,7 +312,82 @@ func TestValidatePods(t *testing.T) {
 			pod("web-98c9ddbcd-7b5lh", v1.PodRunning, true),
 		}
 
-		err := validatePods(pods)
+		err := validateControlPlanePods(pods)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	})
+}
+
+func TestValidateDataPlanePods(t *testing.T) {
+	pod := func(name string, phase v1.PodPhase, ready bool) v1.Pod {
+		return v1.Pod{
+			ObjectMeta: meta.ObjectMeta{Name: name, Namespace: "emojivoto"},
+			Status: v1.PodStatus{
+				Phase: phase,
+				ContainerStatuses: []v1.ContainerStatus{
+					v1.ContainerStatus{
+						Name:  "linkerd-proxy",
+						Ready: ready,
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("Returns an error if no inject pods were found", func(t *testing.T) {
+		err := validateDataPlanePods([]v1.Pod{}, "emojivoto")
+		if err == nil {
+			t.Fatal("Expected error, got nothing")
+		}
+		if err.Error() != "No \"linkerd-proxy\" containers found in the \"emojivoto\" namespace" {
+			t.Fatalf("Unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("Returns an error if not all pods are running", func(t *testing.T) {
+		pods := []v1.Pod{
+			pod("emoji-d9c7866bb-7v74n", v1.PodRunning, true),
+			pod("vote-bot-644b8cb6b4-g8nlr", v1.PodRunning, true),
+			pod("voting-65b9fffd77-rlwsd", v1.PodFailed, false),
+			pod("web-6cfbccc48-5g8px", v1.PodRunning, true),
+		}
+
+		err := validateDataPlanePods(pods, "emojivoto")
+		if err == nil {
+			t.Fatal("Expected error, got nothing")
+		}
+		if err.Error() != "The \"voting-65b9fffd77-rlwsd\" pod in the \"emojivoto\" namespace is not running" {
+			t.Fatalf("Unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("Returns an error if the linkerd-proxy container is not ready", func(t *testing.T) {
+		pods := []v1.Pod{
+			pod("emoji-d9c7866bb-7v74n", v1.PodRunning, true),
+			pod("vote-bot-644b8cb6b4-g8nlr", v1.PodRunning, false),
+			pod("voting-65b9fffd77-rlwsd", v1.PodRunning, true),
+			pod("web-6cfbccc48-5g8px", v1.PodRunning, true),
+		}
+
+		err := validateDataPlanePods(pods, "emojivoto")
+		if err == nil {
+			t.Fatal("Expected error, got nothing")
+		}
+		if err.Error() != "The \"linkerd-proxy\" container in the \"vote-bot-644b8cb6b4-g8nlr\" pod in the \"emojivoto\" namespace is not ready" {
+			t.Fatalf("Unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("Returns nil if all pods are running and all linkerd-proxy containers are ready", func(t *testing.T) {
+		pods := []v1.Pod{
+			pod("emoji-d9c7866bb-7v74n", v1.PodRunning, true),
+			pod("vote-bot-644b8cb6b4-g8nlr", v1.PodRunning, true),
+			pod("voting-65b9fffd77-rlwsd", v1.PodRunning, true),
+			pod("web-6cfbccc48-5g8px", v1.PodRunning, true),
+		}
+
+		err := validateDataPlanePods(pods, "emojivoto")
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -212,3 +212,23 @@ func TestInject(t *testing.T) {
 			expectedStringInPayload, output)
 	}
 }
+
+func TestCheckProxy(t *testing.T) {
+	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
+	out, err := TestHelper.LinkerdRun(
+		"check",
+		"--proxy",
+		"--expected-version",
+		TestHelper.GetVersion(),
+		"--namespace",
+		prefixedNs,
+	)
+	if err != nil {
+		t.Fatalf("Check command failed\n%s", out)
+	}
+
+	err = TestHelper.ValidateOutput(out, "check.proxy.golden")
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err.Error())
+	}
+}

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -1,0 +1,13 @@
+kubernetes-api: can initialize the client..................................[ok]
+kubernetes-api: can query the Kubernetes API...............................[ok]
+kubernetes-api: is running the minimum Kubernetes API version..............[ok]
+linkerd-api: control plane namespace exists................................[ok]
+linkerd-api: control plane pods are ready..................................[ok]
+linkerd-api: can initialize the client.....................................[ok]
+linkerd-api: can query the control plane API...............................[ok]
+linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
+linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
+linkerd-data-plane: data plane namespace exists............................[ok]
+linkerd-data-plane: data plane proxies are ready...........................[ok]
+
+Status check results are [ok]


### PR DESCRIPTION
This branch adds a data plane check to validate that all linkerd-proxy containers are in the Ready state. As part of this change I'm also updating the check command to accept a `--namespace` flag. If provided, the data plane checks will only be run against proxies in that namespace. This flag will be useful when implementing #1513. I'm also adding an integration test that exercises the data plane check code.

Fixes #1514.