### PR TITLE
Make sidebar scrollbar independently

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -1,5 +1,9 @@
 @import 'styles.css';
 
+.ant-layout-sider-children{
+ overflow-y: scroll;
+}
+
 ul.ant-menu.ant-menu-sub {
   background: var(--sider-black);
 }
@@ -7,8 +11,6 @@ ul.ant-menu.ant-menu-sub {
 .sidebar {
   background: var(--header-black);
   color: white;
-  height: 100vh;
-  overflow-y: scroll;
 
   & .ant-menu-submenu {
     & .ant-menu-submenu-title, & .anticon{

--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -7,7 +7,8 @@ ul.ant-menu.ant-menu-sub {
 .sidebar {
   background: var(--header-black);
   color: white;
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: scroll;
 
   & .ant-menu-submenu {
     & .ant-menu-submenu-title, & .anticon{

--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -1,6 +1,6 @@
 @import 'styles.css';
 
-.ant-layout-sider-children{
+.ant-layout-sider-children {
  overflow-y: scroll;
 }
 

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -262,7 +262,7 @@ div.status-dot {
   }
 }
 
-div.ant-layout-has-sider{
+div.ant-layout-has-sider {
   height: 100vh;
   overflow: hidden;
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -261,3 +261,8 @@ div.status-dot {
     background-color: #ffd54f;
   }
 }
+
+div.ant-layout-has-sider{
+  height: 100vh;
+  overflow: hidden;
+}


### PR DESCRIPTION
For a better UI experience, the sidebar should be able to scroll independently from the detail view. This PR allows both the sidebar and the detail view to scroll independently.

fixes #1547

![sidebar-scroll](https://user-images.githubusercontent.com/2197104/45048199-232ef980-b030-11e8-8703-74384b074018.gif)

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>