### PR TITLE
Add data plane check to validate proxy version

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -75,24 +75,25 @@ func configureAndRunChecks(options *checkOptions) {
 
 	if options.preInstallOnly {
 		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
-		checks = append(checks, healthcheck.LinkerdVersionChecks)
 	} else if options.dataPlaneOnly {
 		checks = append(checks, healthcheck.LinkerdAPIChecks)
 		checks = append(checks, healthcheck.LinkerdDataPlaneChecks)
 	} else {
 		checks = append(checks, healthcheck.LinkerdAPIChecks)
-		checks = append(checks, healthcheck.LinkerdVersionChecks)
 	}
 
+	checks = append(checks, healthcheck.LinkerdVersionChecks)
+
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.HealthCheckOptions{
-		ControlPlaneNamespace:        controlPlaneNamespace,
-		DataPlaneNamespace:           options.namespace,
-		KubeConfig:                   kubeconfigPath,
-		APIAddr:                      apiAddr,
-		VersionOverride:              options.versionOverride,
-		ShouldRetry:                  options.wait,
-		ShouldCheckKubeVersion:       true,
-		ShouldCheckControllerVersion: !options.preInstallOnly,
+		ControlPlaneNamespace:          controlPlaneNamespace,
+		DataPlaneNamespace:             options.namespace,
+		KubeConfig:                     kubeconfigPath,
+		APIAddr:                        apiAddr,
+		VersionOverride:                options.versionOverride,
+		ShouldRetry:                    options.wait,
+		ShouldCheckKubeVersion:         true,
+		ShouldCheckControlPlaneVersion: !(options.preInstallOnly || options.dataPlaneOnly),
+		ShouldCheckDataPlaneVersion:    options.dataPlaneOnly,
 	})
 
 	success := runChecks(os.Stdout, hc)

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -193,7 +193,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	}
 
 	initContainer := v1.Container{
-		Name:                     "linkerd-init",
+		Name:                     k8s.InitContainerName,
 		Image:                    options.taggedProxyInitImage(),
 		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
@@ -224,7 +224,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	}
 
 	sidecar := v1.Container{
-		Name:                     "linkerd-proxy",
+		Name:                     k8s.ProxyContainerName,
 		Image:                    options.taggedProxyImage(),
 		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -32,6 +32,7 @@ type installConfig struct {
 	ProxyAPIPort                uint
 	EnableTLS                   bool
 	TLSTrustAnchorConfigMapName string
+	ProxyContainerName          string
 }
 
 type installOptions struct {
@@ -102,6 +103,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		ProxyAPIPort:                options.proxyAPIPort,
 		EnableTLS:                   options.enableTLS(),
 		TLSTrustAnchorConfigMapName: k8s.TLSTrustAnchorConfigMapName,
+		ProxyContainerName:          k8s.ProxyContainerName,
 	}, nil
 }
 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -38,6 +38,7 @@ func TestRender(t *testing.T) {
 		ProxyAPIPort:                123,
 		EnableTLS:                   true,
 		TLSTrustAnchorConfigMapName: "TLSTrustAnchorConfigMapName",
+		ProxyContainerName:          "ProxyContainerName",
 	}
 
 	testCases := []struct {

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -630,7 +630,7 @@ data:
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics;Namespace$
+        regex: ^ProxyContainerName;linkerd-metrics;Namespace$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -423,7 +423,7 @@ data:
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics;{{.Namespace}}$
+        regex: ^{{.ProxyContainerName}};linkerd-metrics;{{.Namespace}}$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -510,8 +510,8 @@ func (s *grpcServer) getPodStats(obj runtime.Object) (*podStats, error) {
 			}
 		}
 
-		errors := checkContainerErrors(pod.Status.ContainerStatuses, "linkerd-proxy")
-		errors = append(errors, checkContainerErrors(pod.Status.InitContainerStatuses, "linkerd-init")...)
+		errors := checkContainerErrors(pod.Status.ContainerStatuses, k8s.ProxyContainerName)
+		errors = append(errors, checkContainerErrors(pod.Status.InitContainerStatuses, k8s.InitContainerName)...)
 
 		if len(errors) > 0 {
 			podErrors[pod.Name] = &pb.PodErrors{Errors: errors}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/api/public"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -327,7 +328,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 				Phase: phase,
 				ContainerStatuses: []v1.ContainerStatus{
 					v1.ContainerStatus{
-						Name:  "linkerd-proxy",
+						Name:  k8s.ProxyContainerName,
 						Ready: ready,
 					},
 				},
@@ -362,7 +363,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns an error if the linkerd-proxy container is not ready", func(t *testing.T) {
+	t.Run("Returns an error if the proxy container is not ready", func(t *testing.T) {
 		pods := []v1.Pod{
 			pod("emoji-d9c7866bb-7v74n", v1.PodRunning, true),
 			pod("vote-bot-644b8cb6b4-g8nlr", v1.PodRunning, false),
@@ -379,7 +380,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns nil if all pods are running and all linkerd-proxy containers are ready", func(t *testing.T) {
+	t.Run("Returns nil if all pods are running and all proxy containers are ready", func(t *testing.T) {
 		pods := []v1.Pod{
 			pod("emoji-d9c7866bb-7v74n", v1.PodRunning, true),
 			pod("vote-bot-644b8cb6b4-g8nlr", v1.PodRunning, true),

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -68,6 +69,22 @@ func (kubeAPI *KubernetesAPI) CheckVersion(versionInfo *version.Info) error {
 		return fmt.Errorf("Kubernetes is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required",
 			apiVersion[0], apiVersion[1], apiVersion[2],
 			minApiVersion[0], minApiVersion[1], minApiVersion[2])
+	}
+
+	return nil
+}
+
+func (kubeAPI *KubernetesAPI) CheckProxyVersion(pods []v1.Pod, version string) error {
+	for _, pod := range pods {
+		for _, container := range pod.Spec.Containers {
+			if container.Name == ProxyContainerName {
+				parts := strings.Split(container.Image, ":")
+				if len(parts) == 2 && parts[1] != version {
+					return fmt.Errorf("%s is running version %s but the latest version is %s",
+						pod.Name, parts[1], version)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -66,6 +66,12 @@ const (
 	 * Component Names
 	 */
 
+	// InitContainerName is the name assigned to the injected init container.
+	InitContainerName = "linkerd-init"
+
+	// ProxyContainerName is the name assigned to the injected proxy container.
+	ProxyContainerName = "linkerd-proxy"
+
 	// TLSTrustAnchorConfigMapName is the name of the ConfigMap that holds the
 	// trust anchors (trusted root certificates).
 	TLSTrustAnchorConfigMapName = "linkerd-ca-bundle"

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -9,5 +9,8 @@ linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
 linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
 linkerd-data-plane: data plane namespace exists............................[ok]
 linkerd-data-plane: data plane proxies are ready...........................[ok]
+linkerd-version: can determine the latest version..........................[ok]
+linkerd-version: cli is up-to-date.........................................[ok]
+linkerd-version: data plane is up-to-date..................................[ok]
 
 Status check results are [ok]


### PR DESCRIPTION
This branch adds an additional data plane check to validate that all proxies are running the latest version. This is similar to the CLI and controller version checks that already exist.

As part of this change I've added new constants in `pkg/k8s/labels.go` for the "linkerd-init" and "linkerd-proxy" container names, so that we can stop hardcoding those strings in multiple places in the codebase.

Fixes #1566.