### PR TITLE
Error display fixes in web for the tap query handling

### DIFF
--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -34,9 +34,9 @@ export class ResourceListBase extends React.Component {
   }
 
   content = () => {
-    const {data, loading} = this.props;
+    const {data, loading, error} = this.props;
 
-    if (loading) {
+    if (loading && !error) {
       return <Spin size="large" />;
     }
 

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -250,6 +250,7 @@ class ServiceMesh extends React.Component {
 
     this.setState({
       pendingRequests: false,
+      loaded: true,
       error: e
     });
   }


### PR DESCRIPTION
Previously, WebSocket error messages would appear with the first couple characters cut off.
I've fixed this by using `ws.WriteControl` instead of `ws.WriteMessage` to write errors, as gorilla does in their example app [here](https://github.com/gorilla/websocket/blob/master/examples/autobahn/server.go).

Before:
![screen shot 2018-09-04 at 5 55 09 pm](https://user-images.githubusercontent.com/549258/45065093-27790800-b06c-11e8-9ba2-b1335a977be1.png)
![screen shot 2018-09-04 at 5 29 20 pm](https://user-images.githubusercontent.com/549258/45065110-38c21480-b06c-11e8-84ef-3f9a504ba4f3.png)



After:
![screen shot 2018-09-04 at 5 54 24 pm](https://user-images.githubusercontent.com/549258/45065088-2516ae00-b06c-11e8-8c76-20e23df56e02.png)
![screen shot 2018-09-04 at 5 27 50 pm](https://user-images.githubusercontent.com/549258/45065103-2fd14300-b06c-11e8-8b94-a33955d2f772.png)

Fixes #1534
