### PR TITLE
Use url query params for tap/top form filters

### DIFF
--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -123,6 +123,9 @@ class TapQueryForm extends React.Component {
     };
   }
 
+  // Each time state.query is updated, this method calls the equivalent
+  // onChange method to reflect the update in url query params. These onChange
+  // methods are automatically added to props by react-url-query.
   handleUrlUpdate = (name, formVal) => {
     this.props[`onChange${_.upperFirst(name)}`](formVal);
   }

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 import {
   AutoComplete,
   Button,
@@ -11,7 +12,7 @@ import {
   Row,
   Select
 } from 'antd';
-import { defaultMaxRps, httpMethods, tapQueryPropType } from './util/TapUtils.jsx';
+import { defaultMaxRps, httpMethods, tapQueryProps, tapQueryPropType } from './util/TapUtils.jsx';
 
 const colSpan = 5;
 const rowGutter = 16;
@@ -19,7 +20,12 @@ const rowGutter = 16;
 const getResourceList = (resourcesByNs, ns) => {
   return resourcesByNs[ns] || _.uniq(_.flatten(_.values(resourcesByNs)));
 };
-export default class TapQueryForm extends React.Component {
+
+const urlPropsQueryConfig = _.mapValues(tapQueryProps, () => {
+  return { type: UrlQueryParamTypes.string };
+});
+
+class TapQueryForm extends React.Component {
   static propTypes = {
     enableAdvancedForm: PropTypes.bool,
     handleTapStart: PropTypes.func.isRequired,
@@ -36,11 +42,18 @@ export default class TapQueryForm extends React.Component {
   constructor(props) {
     super(props);
 
+    let query = _.merge({}, props.query, _.pick(this.props, _.keys(tapQueryProps)));
+    props.updateQuery(query);
+
+    let showAdvancedForm = _.some(
+      _.omit(query, ['namespace', 'resource']),
+      v => !_.isEmpty(v));
+
     this.state = {
+      query,
+      showAdvancedForm,
       authoritiesByNs: {},
       resourcesByNs: {},
-      showAdvancedForm: false,
-      query: props.query,
       autocomplete: {
         namespace: [],
         resource: [],
@@ -90,13 +103,17 @@ export default class TapQueryForm extends React.Component {
 
     return formVal => {
       state.query[name] = formVal;
+      this.handleUrlUpdate(name, formVal);
+
       if (!_.isNil(scopeResource)) {
         // scope the available typeahead resources to the selected namespace
         state.autocomplete[scopeResource] = this.state.resourcesByNs[formVal];
         if (_.isEmpty(state.query[scopeResource]) || state.query[scopeResource].indexOf("namespace") !== -1) {
           state.query[scopeResource] = `namespace/${formVal}`;
+          this.handleUrlUpdate(scopeResource, `namespace/${formVal}`);
         }
       }
+
       if (shouldScopeAuthority) {
         state.autocomplete.authority = this.state.authoritiesByNs[formVal];
       }
@@ -106,6 +123,10 @@ export default class TapQueryForm extends React.Component {
     };
   }
 
+  handleUrlUpdate = (name, formVal) => {
+    this.props[`onChange${_.upperFirst(name)}`](formVal);
+  }
+
   handleFormEvent = name => {
     let state = {
       query: this.state.query
@@ -113,6 +134,7 @@ export default class TapQueryForm extends React.Component {
 
     return event => {
       state.query[name] = event.target.value;
+      this.handleUrlUpdate(name, event.target.value);
       this.setState(state);
       this.props.updateQuery(state.query);
     };
@@ -136,7 +158,8 @@ export default class TapQueryForm extends React.Component {
                 allowClear
                 placeholder="To Namespace"
                 optionFilterProp="children"
-                onChange={this.handleFormChange("toNamespace", "toResource")}>
+                onChange={this.handleFormChange("toNamespace", "toResource")}
+                value={this.state.query.toNamespace}>
                 {
                   _.map(this.state.autocomplete.toNamespace, (n, i) => (
                     <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
@@ -162,14 +185,18 @@ export default class TapQueryForm extends React.Component {
                 dataSource={this.autoCompleteData("authority")}
                 onSelect={this.handleFormChange("authority")}
                 onSearch={this.handleFormChange("authority")}
-                placeholder="Authority" />
+                placeholder="Authority"
+                value={this.state.query.authority} />
             </Form.Item>
           </Col>
 
           <Col span={2 * colSpan}>
             <Form.Item
               extra="Display requests with paths that start with this prefix">
-              <Input placeholder="Path" onChange={this.handleFormEvent("path")} />
+              <Input
+                placeholder="Path"
+                onChange={this.handleFormEvent("path")}
+                value={this.state.query.path} />
             </Form.Item>
           </Col>
 
@@ -179,7 +206,10 @@ export default class TapQueryForm extends React.Component {
           <Col span={colSpan}>
             <Form.Item
               extra="Display requests with this scheme">
-              <Input placeholder="Scheme" onChange={this.handleFormEvent("scheme")} />
+              <Input
+                placeholder="Scheme"
+                onChange={this.handleFormEvent("scheme")}
+                value={this.state.query.scheme} />
             </Form.Item>
           </Col>
 
@@ -188,7 +218,8 @@ export default class TapQueryForm extends React.Component {
               extra={`Maximum requests per second to tap (default ${defaultMaxRps})`}>
               <Input
                 placeholder="Max RPS"
-                onChange={this.handleFormEvent("maxRps")} />
+                onChange={this.handleFormEvent("maxRps")}
+                value={this.state.query.maxRps} />
             </Form.Item>
           </Col>
 
@@ -198,7 +229,8 @@ export default class TapQueryForm extends React.Component {
               <Select
                 allowClear
                 placeholder="HTTP method"
-                onChange={this.handleFormChange("method")}>
+                onChange={this.handleFormChange("method")}
+                value={this.state.query.method}>
                 {
                   _.map(httpMethods, m =>
                     <Select.Option key={`method-select-${m}`} value={m}>{m}</Select.Option>
@@ -254,7 +286,8 @@ export default class TapQueryForm extends React.Component {
                 allowClear
                 placeholder="Namespace"
                 optionFilterProp="children"
-                onChange={this.handleFormChange("namespace", "resource", true)}>
+                onChange={this.handleFormChange("namespace", "resource", true)}
+                value={this.state.query.namespace}>
                 {
                 _.map(this.state.autocomplete.namespace, (n, i) => (
                   <Select.Option key={`ns-dr-${i}`} value={n}>{n}</Select.Option>
@@ -299,3 +332,5 @@ export default class TapQueryForm extends React.Component {
     );
   }
 }
+
+export default addUrlProps({ urlPropsQueryConfig })(TapQueryForm);

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -14,7 +14,7 @@ export const setMaxRps = query => {
   }
 };
 
-export const tapQueryPropType = PropTypes.shape({
+export const tapQueryProps = {
   resource: PropTypes.string,
   namespace: PropTypes.string,
   toResource: PropTypes.string,
@@ -24,7 +24,9 @@ export const tapQueryPropType = PropTypes.shape({
   scheme: PropTypes.string,
   authority: PropTypes.string,
   maxRps: PropTypes.string
-});
+};
+
+export const tapQueryPropType = PropTypes.shape(tapQueryProps);
 
 export const processTapEvent = jsonString => {
   let d = JSON.parse(jsonString);

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -7,6 +7,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ResourceDetail from './components/ResourceDetail.jsx';
 import ResourceList from './components/ResourceList.jsx';
+import { RouterToUrlQuery } from 'react-url-query';
 import ServiceMesh from './components/ServiceMesh.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import Tap from './components/Tap.jsx';
@@ -34,41 +35,43 @@ const context = {
 let applicationHtml = (
   <AppContext.Provider value={context}>
     <BrowserRouter>
-      <Layout>
-        <Route component={Sidebar} />
+      <RouterToUrlQuery>
         <Layout>
-          <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
-            <div className="main-content">
-              <Switch>
-                <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
-                <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
-                <Route exact path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
-                <Route path={`${pathPrefix}/namespaces/:namespace/pods/:pod`} component={ResourceDetail} />
-                <Route path={`${pathPrefix}/namespaces/:namespace/deployments/:deployment`} component={ResourceDetail} />
-                <Route path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers/:replicationcontroller`} component={ResourceDetail} />
-                <Route path={`${pathPrefix}/tap`} component={Tap} />
-                <Route path={`${pathPrefix}/top`} component={Top} />
-                <Route
-                  path={`${pathPrefix}/namespaces`}
-                  render={() => <ResourceList resource="namespace" />} />
-                <Route
-                  path={`${pathPrefix}/deployments`}
-                  render={() => <ResourceList resource="deployment" />} />
-                <Route
-                  path={`${pathPrefix}/replicationcontrollers`}
-                  render={() => <ResourceList resource="replicationcontroller" />} />
-                <Route
-                  path={`${pathPrefix}/pods`}
-                  render={() => <ResourceList resource="pod" />} />
-                <Route
-                  path={`${pathPrefix}/authorities`}
-                  render={() => <ResourceList resource="authority" />} />
-                <Route component={NoMatch} />
-              </Switch>
-            </div>
-          </Layout.Content>
+          <Route component={Sidebar} />
+          <Layout>
+            <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
+              <div className="main-content">
+                <Switch>
+                  <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
+                  <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
+                  <Route exact path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
+                  <Route path={`${pathPrefix}/namespaces/:namespace/pods/:pod`} component={ResourceDetail} />
+                  <Route path={`${pathPrefix}/namespaces/:namespace/deployments/:deployment`} component={ResourceDetail} />
+                  <Route path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers/:replicationcontroller`} component={ResourceDetail} />
+                  <Route path={`${pathPrefix}/tap`} component={Tap} />
+                  <Route path={`${pathPrefix}/top`} component={Top} />
+                  <Route
+                    path={`${pathPrefix}/namespaces`}
+                    render={() => <ResourceList resource="namespace" />} />
+                  <Route
+                    path={`${pathPrefix}/deployments`}
+                    render={() => <ResourceList resource="deployment" />} />
+                  <Route
+                    path={`${pathPrefix}/replicationcontrollers`}
+                    render={() => <ResourceList resource="replicationcontroller" />} />
+                  <Route
+                    path={`${pathPrefix}/pods`}
+                    render={() => <ResourceList resource="pod" />} />
+                  <Route
+                    path={`${pathPrefix}/authorities`}
+                    render={() => <ResourceList resource="authority" />} />
+                  <Route component={NoMatch} />
+                </Switch>
+              </div>
+            </Layout.Content>
+          </Layout>
         </Layout>
-      </Layout>
+      </RouterToUrlQuery>
     </BrowserRouter>
   </AppContext.Provider>
 );

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -27,6 +27,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-prop-types": "^1.0.3",
     "react-test-renderer": "15.6.1",
+    "react-url-query": "^1.4.0",
     "sinon": "^4.1.2",
     "sinon-chai": "^2.14.0",
     "sinon-stub-promise": "^4.0.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -6570,7 +6570,7 @@ qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.2.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
@@ -7140,6 +7140,14 @@ react-test-renderer@^16.0.0-0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-url-query@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-url-query/-/react-url-query-1.4.0.tgz#e0e639e25ec63e28c548140f4b12fba4c10cfcb2"
+  dependencies:
+    loose-envify "^1.2.0"
+    prop-types "^15.5.9"
+    query-string "^4.2.3"
 
 react@^16.2.0:
   version "16.3.2"


### PR DESCRIPTION
This branch updates the tap and top pages to set their form filters based on values from URL query params, and it updates those values on form field change. To do this I'm using [react-url-query](https://github.com/pbeshai/react-url-query).

Fixes #1459.

