### PR TITLE
Use Tap data on Resource Detail page to display unmeshed resources

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -49,9 +49,11 @@ export default class Octopus extends React.Component {
     return (
       <div key={resource.name} className={`octopus-body ${type}`}>
         <div className={`octopus-title ${type}`}>
+          { _.isNil(resource.namespace) ? displayName(resource) :
           <this.props.api.ResourceLink
             resource={resource}
             linkText={displayName(resource)} />
+          }
         </div>
         {
           unmeshed ? <div>Unmeshed</div> :

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -4,6 +4,7 @@ import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import Octopus from './Octopus.jsx';
 import PageHeader from './PageHeader.jsx';
+import { processNeighborData } from './util/TapUtils.jsx';
 import { processSingleResourceRollup } from './util/MetricUtils.js';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -60,6 +61,7 @@ export class ResourceDetailBase extends React.Component {
         upstream: {},
         downstream: {}
       },
+      unmeshedSources: {},
       resourceIsMeshed: true,
       pendingRequests: false,
       loaded: false,
@@ -165,6 +167,13 @@ export class ResourceDetailBase extends React.Component {
     });
   }
 
+  updateNeighborsFromTapData = d => {
+    let n = processNeighborData(d, this.state.unmeshedSources, this.state.resource.type);
+    this.setState({
+      unmeshedSources: n
+    });
+  }
+
   banner = () => {
     if (!this.state.error) {
       return;
@@ -198,6 +207,7 @@ export class ResourceDetailBase extends React.Component {
           <Octopus
             resource={this.state.resourceMetrics[0]}
             neighbors={this.state.neighborMetrics}
+            unmeshedSources={_.values(this.state.unmeshedSources)}
             api={this.api} />
         </div>
 
@@ -208,6 +218,7 @@ export class ResourceDetailBase extends React.Component {
               pathPrefix={this.props.pathPrefix}
               query={topQuery}
               startTap={true}
+              updateNeighbors={this.updateNeighborsFromTapData}
               maxRowsToDisplay={10} />
           </div>
         }

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -169,6 +169,7 @@ export class ResourceDetailBase extends React.Component {
 
   updateNeighborsFromTapData = d => {
     let n = processNeighborData(d, this.state.unmeshedSources, this.state.resource.type);
+
     this.setState({
       unmeshedSources: n
     });

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -167,8 +167,8 @@ export class ResourceDetailBase extends React.Component {
     });
   }
 
-  updateNeighborsFromTapData = d => {
-    let n = processNeighborData(d, this.state.unmeshedSources, this.state.resource.type);
+  updateNeighborsFromTapData = (source, sourceLabels) => {
+    let n = processNeighborData(source, sourceLabels, this.state.unmeshedSources, this.state.resource.type);
 
     this.setState({
       unmeshedSources: n

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -1,6 +1,7 @@
-import BaseTable from './BaseTable.jsx';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
+import { Table } from 'antd';
 import { withContext } from './util/AppContext.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
@@ -58,10 +59,21 @@ const topColumns = ResourceLink => [
   }
 ];
 
-class TopEventTable extends BaseTable {
+class TopEventTable extends React.Component {
+  static propTypes = {
+    api: PropTypes.shape({
+      ResourceLink: PropTypes.func.isRequired,
+    }).isRequired,
+    tableRows: PropTypes.shape([]),
+  }
+
+  static defaultProps = {
+    tableRows: []
+  }
+
   render() {
     return (
-      <BaseTable
+      <Table
         dataSource={this.props.tableRows}
         columns={topColumns(this.props.api.ResourceLink)}
         rowKey="key"

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -64,7 +64,7 @@ class TopEventTable extends React.Component {
     api: PropTypes.shape({
       ResourceLink: PropTypes.func.isRequired,
     }).isRequired,
-    tableRows: PropTypes.shape([]),
+    tableRows: PropTypes.arrayOf(PropTypes.shape({})),
   }
 
   static defaultProps = {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -12,11 +12,13 @@ class TopModule extends React.Component {
     maxRowsToDisplay: PropTypes.number,
     pathPrefix: PropTypes.string.isRequired,
     query: PropTypes.shape({}).isRequired,
-    startTap: PropTypes.bool.isRequired
+    startTap: PropTypes.bool.isRequired,
+    updateNeighbors: PropTypes.func
   }
 
   static defaultProps = {
-    maxRowsToDisplay: 40 // max aggregated top rows to index and display in table
+    maxRowsToDisplay: 40, // max aggregated top rows to index and display in table
+    updateNeighbors: _.noop
   }
 
   constructor(props) {
@@ -67,6 +69,7 @@ class TopModule extends React.Component {
 
   onWebsocketRecv = e => {
     this.indexTapResult(e.data);
+    this.props.updateNeighbors(e.data);
     this.debouncedWebsocketRecvHandler();
   }
 

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -210,7 +210,7 @@ class TopModule extends React.Component {
   addSuccessCount = d => {
     // cope with the fact that gRPC failures are returned with HTTP status 200
     // and correctly classify gRPC failures as failures
-    let success = parseInt(d.responseInit.http.responseInit.httpStatus, 10) < 500;
+    let success = parseInt(_.get(d, "responseInit.http.responseInit.httpStatus"), 10) < 500;
     if (success) {
       let grpcStatusCode = _.get(d, "responseEnd.http.responseEnd.eos.grpcStatusCode");
       if (!_.isNil(grpcStatusCode)) {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -162,7 +162,7 @@ class TopModule extends React.Component {
     }
 
     if (d.base.proxyDirection === "INBOUND") {
-      this.props.updateNeighbors(_.get(d, "requestInit.sourceMeta.labels", null));
+      this.props.updateNeighbors(d.requestInit.source, _.get(d, "requestInit.sourceMeta.labels"), null);
     }
 
     return topResults;

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -161,6 +161,10 @@ class TopModule extends React.Component {
       this.deleteOldestIndexedResult(topResults);
     }
 
+    if (d.base.proxyDirection === "INBOUND") {
+      this.props.updateNeighbors(_.get(d, "requestInit.sourceMeta.labels", null));
+    }
+
     return topResults;
   }
 

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -41,7 +41,7 @@ export const processNeighborData = (jsonString, resourceAgg, resourceType) => {
       return resourceAgg;
     }
 
-    let neighb = getNeighbData(d, "source", "sourceMeta", resourceType);
+    let neighb = getNeighborData(d, "source", "sourceMeta", resourceType);
     resourceAgg[neighb.type + "/" + neighb.name] = neighb;
   }
 
@@ -51,7 +51,7 @@ export const processNeighborData = (jsonString, resourceAgg, resourceType) => {
 /*
   Extract the neighbor's data for display
 */
-const getNeighbData = (d, label, metaLabel, resourceType) => {
+const getNeighborData = (d, label, metaLabel, resourceType) => {
   let neighb = {
     type: "ip",
     name: publicAddressToString(_.get(d, [label, "ip.ipv4"]))

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -36,13 +36,17 @@ export const processNeighborData = (jsonString, resourceAgg, resourceType) => {
   let d = JSON.parse(jsonString);
 
   if (d.proxyDirection === "INBOUND") {
-    if (_.isEmpty(d.sourceMeta) || _.isEmpty(d.sourceMeta.labels) ||
-      _.has(d.sourceMeta.labels, "control_plane_ns")) {
+    if (_.isEmpty(d.sourceMeta) || _.isEmpty(d.sourceMeta.labels)) {
       return resourceAgg;
     }
 
     let neighb = getNeighborData(d, "source", "sourceMeta", resourceType);
-    resourceAgg[neighb.type + "/" + neighb.name] = neighb;
+    let key = neighb.type + "/" + neighb.name;
+    if (_.has(d.sourceMeta.labels, "control_plane_ns")) {
+      delete resourceAgg[key];
+    } else {
+      resourceAgg[key] = neighb;
+    }
   }
 
   return resourceAgg;

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -32,7 +32,7 @@ export const tapQueryPropType = PropTypes.shape(tapQueryProps);
 /*
   Use tap data to figure out a resource's unmeshed upstreams/downstreams
 */
-export const processNeighborData = (labels, resourceAgg, resourceType) => {
+export const processNeighborData = (source, labels, resourceAgg, resourceType) => {
   if (_.isEmpty(labels)) {
     return resourceAgg;
   }
@@ -49,6 +49,11 @@ export const processNeighborData = (labels, resourceAgg, resourceType) => {
       type: "pod",
       name: labels.pod,
       namespace: labels.namespace
+    };
+  } else {
+    neighb = {
+      type: "ip",
+      name: source.str
     };
   }
 


### PR DESCRIPTION
This branch uses the src data from tap to discern which unmeshed resources are sending traffic to the specified resource. We then show this resource in the octopus graph.

Note that tap is sampled data, so it's possible for an unmeshed resource to not show up.
Also, because we won't know about the resource until it appears in the Tap results, results could pop into the chart at any time. We should figure out how to deal with this.

I think the next thing we'd want to do is figure out some sort of modal on the card that displays the "Add resources to mesh" CTA.

![screen shot 2018-09-06 at 10 11 07 am](https://user-images.githubusercontent.com/549258/45173872-45568200-b1be-11e8-99ec-74dfddf8f757.png)

Fixes #1573
