### PR TITLE
Modify inject to warn when file is un-injectable

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -10,8 +10,6 @@ import (
 )
 
 const (
-	lineWidth   = 80
-	okStatus    = "[ok]"
 	retryStatus = "[retry]"
 	failStatus  = "[FAIL]"
 )

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -32,6 +32,10 @@ const (
 	ControlPlanePodName = "controller"
 	// The name of the variable used to pass the pod's namespace.
 	PodNamespaceEnvVarName = "LINKERD2_PROXY_POD_NAMESPACE"
+
+	// for inject reports
+	hostNetworkDesc = "hostNetwork: pods do not use host networking"
+	unsupportedDesc = "supported: at least one resource injected"
 )
 
 type injectOptions struct {
@@ -40,6 +44,17 @@ type injectOptions struct {
 	ignoreInboundPorts  []uint
 	ignoreOutboundPorts []uint
 	*proxyConfigOptions
+}
+
+type injectReport struct {
+	name                string
+	hostNetwork         bool
+	unsupportedResource bool
+}
+
+// objMeta provides a generic struct to parse the names of Kubernetes objects
+type objMeta struct {
+	metaV1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 }
 
 func newInjectOptions() *injectOptions {
@@ -117,14 +132,19 @@ func read(path string) ([]io.Reader, error) {
 // Returns the integer representation of os.Exit code; 0 on success and 1 on failure.
 func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, options *injectOptions) int {
 	postInjectBuf := &bytes.Buffer{}
+	reportBuf := &bytes.Buffer{}
 
 	for _, input := range inputs {
-		err := InjectYAML(input, postInjectBuf, options)
+		err := InjectYAML(input, postInjectBuf, reportBuf, options)
 		if err != nil {
 			fmt.Fprintf(errWriter, "Error injecting linkerd proxy: %v\n", err)
 			return 1
 		}
 		_, err = io.Copy(outWriter, postInjectBuf)
+
+		// print error report after yaml output, for better visibility
+		io.Copy(errWriter, reportBuf)
+
 		if err != nil {
 			fmt.Fprintf(errWriter, "Error printing YAML: %v\n", err)
 			return 1
@@ -156,11 +176,12 @@ func injectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string, options
  * and init-container injected. If the pod is unsuitable for having them
  * injected, return false.
  */
-func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameOverride string, options *injectOptions) bool {
+func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameOverride string, options *injectOptions, report *injectReport) bool {
 	// Pods with `hostNetwork=true` share a network namespace with the host. The
 	// init-container would destroy the iptables configuration on the host, so
 	// skip the injection in this case.
 	if t.HostNetwork {
+		report.hostNetwork = true
 		return false
 	}
 
@@ -332,8 +353,10 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 }
 
 // InjectYAML takes an input stream of YAML, outputting injected YAML to out.
-func InjectYAML(in io.Reader, out io.Writer, options *injectOptions) error {
+func InjectYAML(in io.Reader, out io.Writer, report io.Writer, options *injectOptions) error {
 	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
+
+	injectReports := []injectReport{}
 
 	// Iterate over all YAML objects in the input
 	for {
@@ -346,19 +369,24 @@ func InjectYAML(in io.Reader, out io.Writer, options *injectOptions) error {
 			return err
 		}
 
-		result, err := injectResource(bytes, options)
+		ir := injectReport{}
+		result, err := injectResource(bytes, options, &ir)
 		if err != nil {
 			return err
 		}
 
 		out.Write(result)
 		out.Write([]byte("---\n"))
+
+		injectReports = append(injectReports, ir)
 	}
+
+	generateReport(injectReports, report)
 
 	return nil
 }
 
-func injectList(b []byte, options *injectOptions) ([]byte, error) {
+func injectList(b []byte, options *injectOptions, report *injectReport) ([]byte, error) {
 	var sourceList v1.List
 	if err := yaml.Unmarshal(b, &sourceList); err != nil {
 		return nil, err
@@ -367,7 +395,7 @@ func injectList(b []byte, options *injectOptions) ([]byte, error) {
 	items := []runtime.RawExtension{}
 
 	for _, item := range sourceList.Items {
-		result, err := injectResource(item.Raw, options)
+		result, err := injectResource(item.Raw, options, report)
 		if err != nil {
 			return nil, err
 		}
@@ -387,8 +415,8 @@ func injectList(b []byte, options *injectOptions) ([]byte, error) {
 	return yaml.Marshal(sourceList)
 }
 
-func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
-	// The Kuberentes API is versioned and each version has an API modeled
+func injectResource(bytes []byte, options *injectOptions, report *injectReport) ([]byte, error) {
+	// The Kubernetes API is versioned and each version has an API modeled
 	// with its own distinct Go types. If we tell `yaml.Unmarshal()` which
 	// version we support then it will provide a representation of that
 	// object using the given type if possible. However, it only allows us
@@ -404,6 +432,13 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 	if err := yaml.Unmarshal(bytes, &meta); err != nil {
 		return nil, err
 	}
+
+	// retrieve the `metadata/name` field for reporting later
+	var om objMeta
+	if err := yaml.Unmarshal(bytes, &om); err != nil {
+		return nil, err
+	}
+	report.name = fmt.Sprintf("%s/%s", strings.ToLower(meta.Kind), om.Name)
 
 	// obj and podTemplateSpec will reference zero or one the following
 	// objects, depending on the type.
@@ -510,7 +545,9 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 		// Lists are a little different than the other types. There's no immediate
 		// pod template. Because of this, we do a recursive call for each element
 		// in the list (instead of just marshaling the injected pod template).
-		return injectList(bytes, options)
+
+		// TODO: generate an injectReport per list item
+		return injectList(bytes, options, report)
 
 	}
 
@@ -534,7 +571,7 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 			ControllerNamespace: controlPlaneNamespace,
 		}
 
-		if injectPodSpec(podSpec, identity, DNSNameOverride, options) {
+		if injectPodSpec(podSpec, identity, DNSNameOverride, options, report) {
 			injectObjectMeta(objectMeta, k8sLabels, options)
 			var err error
 			output, err = yaml.Marshal(obj)
@@ -542,6 +579,8 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, error) {
 				return nil, err
 			}
 		}
+	} else {
+		report.unsupportedResource = true
 	}
 
 	return output, nil
@@ -588,4 +627,58 @@ func walk(path string) ([]io.Reader, error) {
 	}
 
 	return in, nil
+}
+
+func generateReport(injectReports []injectReport, output io.Writer) {
+
+	injected := []string{}
+	hostNetwork := []string{}
+
+	for _, r := range injectReports {
+		if !r.hostNetwork && !r.unsupportedResource {
+			injected = append(injected, r.name)
+		} else if r.hostNetwork {
+			hostNetwork = append(hostNetwork, r.name)
+		}
+	}
+
+	// leading newline to separate from yaml output on stdout
+	output.Write([]byte("\n"))
+
+	hostNetworkPrefix := fmt.Sprintf("%s%s", hostNetworkDesc, getFiller(hostNetworkDesc))
+	if len(hostNetwork) == 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", hostNetworkPrefix, okStatus)))
+	} else {
+		verb := "uses"
+		if len(hostNetwork) > 1 {
+			verb = "use"
+		}
+		output.Write([]byte(fmt.Sprintf("%s%s -- %s %s \"hostNetwork: true\"\n", hostNetworkPrefix, warnStatus, strings.Join(hostNetwork, ", "), verb)))
+	}
+
+	unsupportedPrefix := fmt.Sprintf("%s%s", unsupportedDesc, getFiller(unsupportedDesc))
+	if len(injected) > 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", unsupportedPrefix, okStatus)))
+	} else {
+		output.Write([]byte(fmt.Sprintf("%s%s -- no supported objects found\n", unsupportedPrefix, warnStatus)))
+	}
+
+	summary := fmt.Sprintf("Summary: %d of %d YAML document(s) injected", len(injected), len(injectReports))
+	output.Write([]byte(fmt.Sprintf("\n%s\n", summary)))
+
+	for _, i := range injected {
+		output.Write([]byte(fmt.Sprintf("  %s\n", i)))
+	}
+
+	// trailing newline to separate from kubectl output if piping
+	output.Write([]byte("\n"))
+}
+
+func getFiller(text string) string {
+	filler := ""
+	for i := 0; i < lineWidth-len(text)-len(okStatus)-len("\n"); i++ {
+		filler = filler + "."
+	}
+
+	return filler
 }

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"text/template"
 
@@ -133,7 +134,7 @@ func render(config installConfig, w io.Writer, options *installOptions) error {
 	// Special case for linkerd-proxy running in the Prometheus pod.
 	injectOptions.proxyOutboundCapacity[config.PrometheusImage] = prometheusProxyOutboundCapacity
 
-	return InjectYAML(buf, w, injectOptions)
+	return InjectYAML(buf, w, ioutil.Discard, injectOptions)
 }
 
 func validate(options *installOptions) error {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -14,7 +14,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultNamespace = "linkerd"
+const (
+	defaultNamespace = "linkerd"
+
+	lineWidth  = 80
+	okStatus   = "[ok]"
+	warnStatus = "[warn]"
+)
 
 var controlPlaneNamespace string
 var apiAddr string // An empty value means "use the Kubernetes configuration"

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
@@ -1,0 +1,7 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 1 of 1 YAML document(s) injected
+  deployment/nginx
+

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
@@ -1,0 +1,14 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 1 of 1 YAML document(s) injected
+  deployment/redis
+
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 1 of 1 YAML document(s) injected
+  deployment/nginx
+

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
@@ -1,0 +1,7 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 1 of 1 YAML document(s) injected
+  deployment/redis
+

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
@@ -1,0 +1,8 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 2 of 2 YAML document(s) injected
+  deployment/get-test-deploy-injected-1
+  deployment/get-test-deploy-injected-2
+

--- a/controller/api/proxy/server.go
+++ b/controller/api/proxy/server.go
@@ -39,7 +39,7 @@ func (s *server) Get(dest *destination.GetDestination, stream destination.Destin
 			return err
 		}
 
-		log.Debug("Get update: %v", update)
+		log.Debugf("Get update: %v", update)
 		stream.Send(update)
 	}
 

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 //////////////////////
 
 func TestEgressHttp(t *testing.T) {
-	out, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
+	out, _, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -46,7 +46,7 @@ var (
 //////////////////////
 
 func TestCliGet(t *testing.T) {
-	out, err := TestHelper.LinkerdRun("inject", "testdata/to_be_injected_application.yaml")
+	out, _, err := TestHelper.LinkerdRun("inject", "testdata/to_be_injected_application.yaml")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestCliGet(t *testing.T) {
 	}
 
 	t.Run("get pods from --all-namespaces", func(t *testing.T) {
-		out, err = TestHelper.LinkerdRun("get", "pods", "--all-namespaces")
+		out, _, err = TestHelper.LinkerdRun("get", "pods", "--all-namespaces")
 
 		if err != nil {
 			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
@@ -94,7 +94,7 @@ func TestCliGet(t *testing.T) {
 	})
 
 	t.Run("get pods from the linkerd namespace", func(t *testing.T) {
-		out, err = TestHelper.LinkerdRun("get", "pods", "-n", TestHelper.GetLinkerdNamespace())
+		out, _, err = TestHelper.LinkerdRun("get", "pods", "-n", TestHelper.GetLinkerdNamespace())
 
 		if err != nil {
 			t.Fatalf("Unexpected error: %v output:\n%s", err, out)

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -54,7 +54,7 @@ func TestVersionPreInstall(t *testing.T) {
 }
 
 func TestCheckPreInstall(t *testing.T) {
-	out, err := TestHelper.LinkerdRun("check", "--pre", "--expected-version", TestHelper.GetVersion())
+	out, _, err := TestHelper.LinkerdRun("check", "--pre", "--expected-version", TestHelper.GetVersion())
 	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)
 	}
@@ -72,7 +72,7 @@ func TestInstall(t *testing.T) {
 		linkerdDeployReplicas["ca"] = 1
 	}
 
-	out, err := TestHelper.LinkerdRun(cmd...)
+	out, _, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		t.Fatalf("linkerd install command failed\n%s", out)
 	}
@@ -131,7 +131,7 @@ func TestCheckPostInstall(t *testing.T) {
 	var out string
 	var err error
 	overallErr := TestHelper.RetryFor(30*time.Second, func() error {
-		out, err = TestHelper.LinkerdRun("check", "--expected-version", TestHelper.GetVersion())
+		out, _, err = TestHelper.LinkerdRun("check", "--expected-version", TestHelper.GetVersion())
 		return err
 	})
 	if overallErr != nil {
@@ -185,9 +185,14 @@ func TestInject(t *testing.T) {
 		cmd = append(cmd, []string{"--tls", "optional"}...)
 	}
 
-	out, err := TestHelper.LinkerdRun(cmd...)
+	out, injectReport, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s", out)
+	}
+
+	err = TestHelper.ValidateOutput(injectReport, "inject.report.golden")
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err.Error())
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
@@ -215,7 +220,7 @@ func TestInject(t *testing.T) {
 
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	out, err := TestHelper.LinkerdRun(
+	out, _, err := TestHelper.LinkerdRun(
 		"check",
 		"--proxy",
 		"--expected-version",

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -122,7 +122,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	} {
 		t.Run("linkerd "+strings.Join(tt.args, " "), func(t *testing.T) {
 			err := TestHelper.RetryFor(20*time.Second, func() error {
-				out, err := TestHelper.LinkerdRun(tt.args...)
+				out, _, err := TestHelper.LinkerdRun(tt.args...)
 				if err != nil {
 					t.Fatalf("Unexpected stat error: %s\n%s", err, out)
 				}

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -73,7 +73,7 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, err := TestHelper.LinkerdRun("inject", "testdata/tap_application.yaml")
+	out, _, err := TestHelper.LinkerdRun("inject", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s", out)
 	}

--- a/test/testdata/inject.report.golden
+++ b/test/testdata/inject.report.golden
@@ -1,0 +1,8 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+supported: at least one resource injected..................................[ok]
+
+Summary: 2 of 4 YAML document(s) injected
+  deployment/smoke-test-terminus
+  deployment/smoke-test-gateway
+


### PR DESCRIPTION
If an input file is un-injectable, existing inject behavior is to simply
output a copy of the input.

Introduce a report, printed to stderr, that communicates the end state
of the inject command. Currently this includes checking for hostNetwork
and unsupported resources.

Malformed YAML documents will continue to cause no YAML output, and return
error code 1.

example outputs...

some pods injected, none with host networking:

```
hostNetwork: pods do not use host networking...............................[ok]
supported: at least one resource injected..................................[ok]

Summary: 4 of 8 YAML document(s) injected
  deploy/emoji
  deploy/voting
  deploy/web
  deploy/vote-bot
```

some pods injected, one host networking:

```
hostNetwork: pods do not use host networking...............................[warn] -- deploy/vote-bot uses "hostNetwork: true"
supported: at least one resource injected..................................[ok]

Summary: 3 of 8 YAML document(s) injected
  deploy/emoji
  deploy/voting
  deploy/web
```

no pods injected:

```
hostNetwork: pods do not use host networking...............................[warn] -- deploy/emoji, deploy/voting, deploy/web, deploy/vote-bot use "hostNetwork: true"
supported: at least one resource injected..................................[warn] -- no supported objects found

Summary: 0 of 8 YAML document(s) injected
```

TODO: check for UDP and other init containers

Part of #1516

Signed-off-by: Andrew Seigner <siggy@buoyant.io>