### PR TITLE
Add a new namespace overview page with expandable sections

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -262,6 +262,10 @@ div.status-dot {
   }
 }
 
+.anticon-check-circle.status-ok {
+  color: var(--green);
+}
+
 div.ant-layout-has-sider {
   height: 100vh;
   overflow: hidden;

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -83,6 +83,10 @@ h2, h3, h4, h5, h6 {
   align-items: center;
   justify-content: center;
   height: 75vh;
+
+  &.short-spin-section {
+    height: 100px;
+  }
 }
 
 .page-section {

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -132,8 +132,10 @@ class Namespaces extends React.Component {
           <div>
             <PageHeader header={`Namespace: ${this.state.ns}`} />
             { noMetrics ? <div>No resources detected.</div> : null}
-            { _.isEmpty(deploymentsWithMetrics) ? null :
-            <NetworkGraph namespace={this.state.ns} deployments={metrics.deployment} />}
+            {
+              _.isEmpty(deploymentsWithMetrics) ? null :
+              <NetworkGraph namespace={this.state.ns} deployments={metrics.deployment} />
+            }
             {this.renderResourceSection("deployment", metrics.deployment)}
             {this.renderResourceSection("replicationcontroller", metrics.replicationcontroller)}
             {this.renderResourceSection("pod", metrics.pod)}

--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -123,6 +123,10 @@ class NamespaceLanding extends React.Component {
   }
 
   renderNamespaceSection(namespace) {
+    if (!_.has(this.state.metricsByNs, namespace)) {
+      return <Spin size="large" className="short-spin-section" />;
+    }
+
     let metrics = this.state.metricsByNs[namespace] || {};
     let noMetrics = _.isEmpty(metrics.pod);
 

--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -1,0 +1,182 @@
+import _ from 'lodash';
+import ErrorBanner from './ErrorBanner.jsx';
+import { friendlyTitle } from './util/Utils.js';
+import MetricsTable from './MetricsTable.jsx';
+import PageHeader from './PageHeader.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withContext } from './util/AppContext.jsx';
+import { Collapse, Icon, Spin } from 'antd';
+import { processMultiResourceRollup, processSingleResourceRollup } from './util/MetricUtils.js';
+import 'whatwg-fetch';
+
+class NamespaceLanding extends React.Component {
+  static propTypes = {
+    api: PropTypes.shape({
+      cancelCurrentRequests: PropTypes.func.isRequired,
+      fetchMetrics: PropTypes.func.isRequired,
+      getCurrentPromises: PropTypes.func.isRequired,
+      setCurrentRequests: PropTypes.func.isRequired,
+      urlsForResource: PropTypes.func.isRequired,
+    }).isRequired,
+    controllerNamespace: PropTypes.string.isRequired
+  }
+
+  constructor(props) {
+    super(props);
+    this.api = this.props.api;
+    this.handleApiError = this.handleApiError.bind(this);
+    this.loadFromServer = this.loadFromServer.bind(this);
+    this.state = this.getInitialState();
+  }
+
+  getInitialState() {
+    return {
+      selectedNs: null,
+      metricsByNs: {},
+      namespaces: [],
+      pollingInterval: 2000,
+      pendingRequests: false,
+      loaded: false,
+      error: null
+    };
+  }
+
+  componentDidMount() {
+    this.loadFromServer();
+    this.timerId = window.setInterval(this.loadFromServer, this.state.pollingInterval);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.timerId);
+    this.api.cancelCurrentRequests();
+  }
+
+  onNsSelect = ns => {
+    this.setState({
+      selectedNs: ns
+    });
+  }
+
+  loadFromServer() {
+    if (this.state.pendingRequests) {
+      return; // don't make more requests if the ones we sent haven't completed
+    }
+    this.setState({ pendingRequests: true });
+
+    let apiRequests = [
+      this.api.fetchMetrics(this.api.urlsForResource("namespace"))
+    ];
+    if (!_.isEmpty(this.state.selectedNs)) {
+      apiRequests = _.concat(apiRequests, [this.api.fetchMetrics(this.api.urlsForResource("all", this.state.selectedNs))]);
+    }
+    this.api.setCurrentRequests(apiRequests);
+
+    Promise.all(this.api.getCurrentPromises())
+      .then(([allNs, metricsForNs]) => {
+        let namespaces = processSingleResourceRollup(allNs);
+        let metricsByNs = this.state.metricsByNs;
+        if (!_.isNil(this.state.selectedNs) && !_.isNil(metricsForNs)) {
+          metricsByNs[this.state.selectedNs] = processMultiResourceRollup(metricsForNs);
+        }
+
+        // by default, show the first non-linkerd meshed resource
+        let defaultOpenNs = _.find(namespaces, ns => ns.added && ns.name !== this.props.controllerNamespace);
+
+        this.setState({
+          namespaces,
+          metricsByNs,
+          defaultOpenNs,
+          selectedNs: this.state.selectedNs || defaultOpenNs.name,
+          pendingRequests: false,
+          loaded: true,
+          error: null
+        });
+      })
+      .catch(this.handleApiError);
+  }
+
+  handleApiError = e => {
+    if (e.isCanceled) {
+      return;
+    }
+
+    this.setState({
+      pendingRequests: false,
+      error: e
+    });
+  }
+
+  renderResourceSection(resource, metrics) {
+    if (_.isEmpty(metrics)) {
+      return null;
+    }
+    return (
+      <div className="page-section">
+        <h3>{friendlyTitle(resource).plural}</h3>
+        <MetricsTable
+          resource={resource}
+          metrics={metrics}
+          showNamespaceColumn={false} />
+      </div>
+    );
+  }
+
+  renderNamespaceSection(namespace) {
+    let metrics = this.state.metricsByNs[namespace] || {};
+    let noMetrics = _.isEmpty(metrics.pod);
+
+    return (
+      <div>
+        <h2>Namespace: {namespace}</h2>
+        { noMetrics ? <div>No resources detected.</div> : null}
+        {this.renderResourceSection("deployment", metrics.deployment)}
+        {this.renderResourceSection("replicationcontroller", metrics.replicationcontroller)}
+        {this.renderResourceSection("pod", metrics.pod)}
+        {this.renderResourceSection("authority", metrics.authority)}
+      </div>
+    );
+  }
+
+  renderAccordion() {
+    return (
+      <React.Fragment>
+        <PageHeader header="Namespaces" />
+        <Collapse
+          accordion={true}
+          defaultActiveKey={_.get(this.state.defaultOpenNs, 'name', null)}
+          onChange={this.onNsSelect}>
+          {
+            _.map(this.state.namespaces, ns => {
+              let header = (
+                <React.Fragment>
+                  {ns.name} {!ns.added ? null : <Icon className="status-ok" type="check-circle" />}
+                </React.Fragment>
+              );
+
+              return (
+                <Collapse.Panel
+                  showArrow={false}
+                  header={header}
+                  key={ns.name}>
+                  {ns.name === this.state.selectedNs || ns.name === this.state.defaultOpenNs.name ?
+                  this.renderNamespaceSection(ns.name) : null}
+                </Collapse.Panel>
+              );
+            })
+          }
+        </Collapse>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    return (
+      <div className="page-content">
+        { !this.state.error ? null : <ErrorBanner message={this.state.error} /> }
+        { !this.state.loaded ? <Spin size="large" /> : this.renderAccordion() }
+      </div>);
+  }
+}
+
+export default withContext(NamespaceLanding);

--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -6,10 +6,15 @@ import PageHeader from './PageHeader.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withContext } from './util/AppContext.jsx';
-import { Collapse, Icon, Spin } from 'antd';
+import { Collapse, Icon, Spin, Tooltip } from 'antd';
 import { processMultiResourceRollup, processSingleResourceRollup } from './util/MetricUtils.js';
 import 'whatwg-fetch';
 
+const isMeshedTooltip = (
+  <Tooltip placement="right" title="Namespace is meshed" overlayStyle={{ fontSize: "12px" }}>
+    <Icon className="status-ok" type="check-circle" />
+  </Tooltip>
+);
 class NamespaceLanding extends React.Component {
   static propTypes = {
     api: PropTypes.shape({
@@ -153,9 +158,7 @@ class NamespaceLanding extends React.Component {
           {
             _.map(this.state.namespaces, ns => {
               let header = (
-                <React.Fragment>
-                  {ns.name} {!ns.added ? null : <Icon className="status-ok" type="check-circle" />}
-                </React.Fragment>
+                <React.Fragment>{ns.name} {!ns.added ? null : isMeshedTooltip}</React.Fragment>
               );
 
               return (

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -173,7 +173,7 @@ class Sidebar extends React.Component {
         <div className="sidebar">
 
           <div className={`sidebar-menu-header ${this.state.collapsed ? "collapsed" : ""}`}>
-            <PrefixedLink to="/servicemesh">
+            <PrefixedLink to="/overview">
               {this.state.collapsed ? linkerdLogoOnly : linkerdWordLogo}
             </PrefixedLink>
           </div>
@@ -182,17 +182,11 @@ class Sidebar extends React.Component {
             className="sidebar-menu"
             theme="dark"
             selectedKeys={[normalizedPath]}>
-            <Menu.Item className="sidebar-menu-item" key="/servicemesh">
-              <PrefixedLink to="/servicemesh">
-                <Icon type="home" />
-                <span>Service mesh</span>
-              </PrefixedLink>
-            </Menu.Item>
 
-            <Menu.Item className="sidebar-menu-item" key="/namespaces">
-              <PrefixedLink to="/namespaces">
-                <Icon type="dashboard" />
-                <span>Namespaces</span>
+            <Menu.Item className="sidebar-menu-item" key="/overview">
+              <PrefixedLink to="/overview">
+                <Icon type="home" />
+                <span>Overview</span>
               </PrefixedLink>
             </Menu.Item>
 
@@ -210,12 +204,20 @@ class Sidebar extends React.Component {
               </PrefixedLink>
             </Menu.Item>
 
+            <Menu.Item className="sidebar-menu-item" key="/servicemesh">
+              <PrefixedLink to="/servicemesh">
+                <Icon type="cloud" />
+                <span>Service mesh</span>
+              </PrefixedLink>
+            </Menu.Item>
+
             <Menu.SubMenu
               className="sidebar-menu-item"
               key="byresource"
               title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "Resources"}</span>}>
               <Menu.Item><PrefixedLink to="/authorities">Authorities</PrefixedLink></Menu.Item>
               <Menu.Item><PrefixedLink to="/deployments">Deployments</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to="/namespaces">Namespaces</PrefixedLink></Menu.Item>
               <Menu.Item><PrefixedLink to="/pods">Pods</PrefixedLink></Menu.Item>
               <Menu.Item><PrefixedLink to="/replicationcontrollers">Replication Controllers</PrefixedLink></Menu.Item>
             </Menu.SubMenu>

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -119,6 +119,8 @@ export const getComponentPods = componentPods => {
 
 const processStatTable = table => {
   return _(table.podGroup.rows).map(row => {
+    let runningPodCount = parseInt(row.runningPodCount, 10);
+    let meshedPodCount = parseInt(row.meshedPodCount, 10);
     return {
       name: row.resource.name,
       namespace: row.resource.namespace,
@@ -128,11 +130,11 @@ const processStatTable = table => {
       successRate: getSuccessRate(row),
       latency: getLatency(row),
       tlsRequestPercent: getTlsRequestPercentage(row),
-      added: row.meshedPodCount === row.runningPodCount,
+      added: runningPodCount > 0 && meshedPodCount > 0,
       pods: {
         totalPods: row.runningPodCount,
         meshedPods: row.meshedPodCount,
-        meshedPercentage: new Percentage(parseInt(row.meshedPodCount, 10), parseInt(row.runningPodCount, 10))
+        meshedPercentage: new Percentage(meshedPodCount, runningPodCount)
       },
       errors: row.errorsByPod
     };

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -2,6 +2,7 @@ import ApiHelpers from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
 import { Layout } from 'antd';
 import Namespace from './components/Namespace.jsx';
+import NamespaceLanding from './components/NamespaceLanding.jsx';
 import NoMatch from './components/NoMatch.jsx';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -42,7 +43,8 @@ let applicationHtml = (
             <Layout.Content style={{ margin: '0 0', padding: 0, background: '#fff' }}>
               <div className="main-content">
                 <Switch>
-                  <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/servicemesh`} />
+                  <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/overview`} />
+                  <Route path={`${pathPrefix}/overview`} component={NamespaceLanding} />
                   <Route path={`${pathPrefix}/servicemesh`} component={ServiceMesh} />
                   <Route exact path={`${pathPrefix}/namespaces/:namespace`} component={Namespace} />
                   <Route path={`${pathPrefix}/namespaces/:namespace/pods/:pod`} component={ResourceDetail} />

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -83,6 +83,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 
 	// webapp routes
 	server.router.GET("/", handler.handleIndex)
+	server.router.GET("/overview", handler.handleIndex)
 	server.router.GET("/servicemesh", handler.handleIndex)
 	server.router.GET("/namespaces", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace", handler.handleIndex)


### PR DESCRIPTION
Adds a new page that shows all namespaces in an accordion. This will replace ServiceMesh as the default landing page.

The page will request stats for all namespaces, and then pick the first meshed namespace that's not the `linkerd` namespace to auto-expand in the accordion.

This code has a lot in common with `Namespace.jsx`, but I think it's likely this page will replace that one, so I'm not super worried about the repetition.

This branch also updates the definition of "added to the mesh" in the frontend to be `runningPodCount > 0 && meshedPodCount > 0` (previously, it was `runningPodCount === meshedPodCount`, which would count resources with no pods as "added").

I've also moved the link to `/namespaces` out of the top-level sidebar and into the `Resources` sub-menu.

![screen shot 2018-09-06 at 2 06 31 pm](https://user-images.githubusercontent.com/549258/45185179-24058e00-b1de-11e8-951d-c3aa35fb2a39.png)

![screen shot 2018-09-06 at 2 06 49 pm](https://user-images.githubusercontent.com/549258/45185180-249e2480-b1de-11e8-81b4-b5d48c0de5c9.png)


![screen shot 2018-09-06 at 2 03 21 pm](https://user-images.githubusercontent.com/549258/45185042-bb1e1600-b1dd-11e8-9eb2-73fed3fd29e4.png)

Fixes #1590
