### PR TITLE
Fix sidebar dot colours for resources not receiving traffic

### DIFF
--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -264,20 +264,20 @@ class Sidebar extends React.Component {
                     {
                       _.map(_.sortBy(sidebarComponents[resourceName], r => `${r.namespace}/${r.name}`), r => {
                         // only display resources that have been meshed
-                          return (
-                            <Menu.Item
-                              className="sidebar-submenu-item"
-                              title={`${r.namespace}/${r.name}`}
-                              key={this.api.generateResourceURL(r)}>
-                              <div>
-                                <PrefixedLink
-                                  to={this.api.generateResourceURL(r)}>
-                                  {`${r.namespace}/${r.name}`}
-                                </PrefixedLink>
-                                <Badge status={getSuccessRateClassification(r.successRate, classificationLabels)} />
-                              </div>
-                            </Menu.Item>
-                          );
+                        return (
+                          <Menu.Item
+                            className="sidebar-submenu-item"
+                            title={`${r.namespace}/${r.name}`}
+                            key={this.api.generateResourceURL(r)}>
+                            <div>
+                              <PrefixedLink
+                                to={this.api.generateResourceURL(r)}>
+                                {`${r.namespace}/${r.name}`}
+                              </PrefixedLink>
+                              <Badge status={getSuccessRateClassification(r.successRate, classificationLabels)} />
+                            </div>
+                          </Menu.Item>
+                        );
                       })
                     }
                   </Menu.SubMenu>

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -20,7 +20,8 @@ import 'whatwg-fetch';
 const classificationLabels = {
   good: "success",
   neutral: "warning",
-  bad: "error"
+  bad: "error",
+  default: "default"
 };
 
 class Sidebar extends React.Component {

--- a/web/app/js/components/util/MetricUtils.js
+++ b/web/app/js/components/util/MetricUtils.js
@@ -14,6 +14,10 @@ const getPodCategorization = pod => {
 };
 
 export const getSuccessRateClassification = (rate, successRateLabels) => {
+  if (_.isNull(rate)) {
+    return successRateLabels.default;
+  }
+
   if (rate < 0.9) {
     return successRateLabels.bad;
   } else if (rate < 0.95) {


### PR DESCRIPTION
Colour the dot gray in the sidebar if the resource isn't receiving traffic (i.e. success rate is null).

![screen shot 2018-09-07 at 2 15 50 pm](https://user-images.githubusercontent.com/549258/45243473-d0ac4200-b2a8-11e8-9b02-5cf7a3ddc3d3.png)

![screen shot 2018-09-07 at 2 19 09 pm](https://user-images.githubusercontent.com/549258/45243516-03eed100-b2a9-11e8-8e87-b9f3b27af588.png)

Fixes #1602 
