### PR TITLE
Add with-source flag to top

### DIFF
--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -286,11 +286,7 @@ func tableInsert(table *[]tableRow, req topRequest, withSource bool) {
 
 	found := false
 	for i, row := range *table {
-		match := row.by == by && row.destination == destination
-		if withSource {
-			match = row.by == by && row.source == source && row.destination == destination
-		}
-		if match {
+		if row.by == by && row.destination == destination && (row.source == source || !withSource) {
 			(*table)[i].count++
 			if latency.Nanoseconds() < row.best.Nanoseconds() {
 				(*table)[i].best = latency

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -29,7 +29,7 @@ type topOptions struct {
 	method      string
 	authority   string
 	path        string
-	withSource  bool
+	hideSources bool
 }
 
 type topRequest struct {
@@ -78,7 +78,7 @@ func newTopOptions() *topOptions {
 		method:      "",
 		authority:   "",
 		path:        "",
-		withSource:  true,
+		hideSources: false,
 	}
 }
 
@@ -151,7 +151,7 @@ func newCmdTop() *cobra.Command {
 		"Display requests with this :authority")
 	cmd.PersistentFlags().StringVar(&options.path, "path", options.path,
 		"Display requests with paths that start with this prefix")
-	cmd.PersistentFlags().BoolVar(&options.withSource, "with-source", options.withSource, "Include the source column")
+	cmd.PersistentFlags().BoolVar(&options.hideSources, "hide-sources", options.hideSources, "Hide the source column")
 
 	return cmd
 }
@@ -174,7 +174,7 @@ func getTrafficByResourceFromAPI(w io.Writer, client pb.ApiClient, req *pb.TapBy
 	go recvEvents(rsp, requestCh, done)
 	go pollInput(done)
 
-	renderTable(requestCh, done, options.withSource)
+	renderTable(requestCh, done, !options.hideSources)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #1593 

Add a `--with-source` flag to `linkerd top` which defaults to true.  Setting this to false remove the source column from the output.

Here is an example of the difference when the emojivoto demo is used with the vote-bot deployment scaled up to 3 pods:

```
linkerd top -n emojivoto deploy/web
(press q to quit)

Source                  Destination             Path                                                    Count  Best   Worst  Last   Success Rate
web-c6775f4c8-z6pvh     emoji-b59755f8d-7bwsb   /emojivoto.v1.EmojiService/ListAll                      33     1ms    11ms   5ms    100.00%
web-c6775f4c8-z6pvh     emoji-b59755f8d-7bwsb   /emojivoto.v1.EmojiService/FindByShortcode              33     1ms    20ms   4ms    100.00%
vote-bot-5976d69bc6-h66wweb-c6775f4c8-z6pvh     /api/list                                               11     4ms    16ms   8ms    100.00%
vote-bot-5976d69bc6-h66wweb-c6775f4c8-z6pvh     /api/vote                                               11     6ms    26ms   14ms   81.82%
vote-bot-5976d69bc6-rwtkweb-c6775f4c8-z6pvh     /api/list                                               11     5ms    15ms   15ms   100.00%
vote-bot-5976d69bc6-rwtkweb-c6775f4c8-z6pvh     /api/vote                                               11     6ms    35ms   35ms   72.73%
vote-bot-5976d69bc6-wkj2web-c6775f4c8-z6pvh     /api/list                                               11     4ms    15ms   14ms   100.00%
vote-bot-5976d69bc6-wkj2web-c6775f4c8-z6pvh     /api/vote                                               11     6ms    63ms   28ms   100.00%
web-c6775f4c8-z6pvh     voting-597f647876-n2p89 /emojivoto.v1.VotingService/VoteDoughnut                6      2ms    11ms   4ms    100.00%
web-c6775f4c8-z6pvh     voting-597f647876-n2p89 /emojivoto.v1.VotingService/VotePoop                    5      2ms    7ms    3ms    0.00%
web-c6775f4c8-z6pvh     voting-597f647876-n2p89 /emojivoto.v1.VotingService/VoteThumbsup                2      4ms    7ms    7ms    100.00%
```

```
linkerd top -n emojivoto deploy/web --with-source=false
(press q to quit)

Destination             Path                                                    Count  Best   Worst  Last   Success Rate
emoji-b59755f8d-7bwsb   /emojivoto.v1.EmojiService/ListAll                      83     869µs  27ms   2ms    100.00%
web-c6775f4c8-z6pvh     /api/list                                               83     2ms    53ms   5ms    100.00%
emoji-b59755f8d-7bwsb   /emojivoto.v1.EmojiService/FindByShortcode              83     640µs  10ms   1ms    100.00%
web-c6775f4c8-z6pvh     /api/vote                                               83     5ms    54ms   13ms   75.90%
voting-597f647876-n2p89 /emojivoto.v1.VotingService/VotePoop                    20     1ms    10ms   5ms    0.00%
voting-597f647876-n2p89 /emojivoto.v1.VotingService/VoteDoughnut                14     2ms    5ms    3ms    100.00%
voting-597f647876-n2p89 /emojivoto.v1.VotingService/VoteClap                    3      2ms    5ms    2ms    100.00%
voting-597f647876-n2p89 /emojivoto.v1.VotingService/VoteBulb                    2      5ms    6ms    5ms    100.00%
```

Signed-off-by: Alex Leong <alex@buoyant.io>