### PR TITLE
Hide scrollbars in sidebar

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -1,8 +1,7 @@
 @import 'styles.css';
 
-.ant-layout-sider-children {
- overflow-y: scroll;
-}
+/*.ant-layout-sider-children {*/
+/*}*/
 
 ul.ant-menu.ant-menu-sub {
   background: var(--sider-black);
@@ -11,6 +10,12 @@ ul.ant-menu.ant-menu-sub {
 .sidebar {
   background: var(--header-black);
   color: white;
+  /* position: absolute; */
+  overflow-x: hidden;
+  overflow-y: scroll;
+  right: -16px;
+  height: 100%;
+  position: relative;
 
   & .ant-menu-submenu {
     & .ant-menu-submenu-title, & .anticon{
@@ -105,6 +110,7 @@ ul.ant-menu.ant-menu-sub {
 .ant-layout-sider {
   /* override ant color */
   background: var(--header-black);
+  overflow: hidden;
 }
 
 .ant-layout .ant-layout-sider .ant-layout-sider-trigger {

--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -1,8 +1,5 @@
 @import 'styles.css';
 
-/*.ant-layout-sider-children {*/
-/*}*/
-
 ul.ant-menu.ant-menu-sub {
   background: var(--sider-black);
 }
@@ -10,15 +7,17 @@ ul.ant-menu.ant-menu-sub {
 .sidebar {
   background: var(--header-black);
   color: white;
-  /* position: absolute; */
   overflow-x: hidden;
   overflow-y: scroll;
-  right: -16px;
   height: 100%;
   position: relative;
 
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   & .ant-menu-submenu {
-    & .ant-menu-submenu-title, & .anticon{
+    & .ant-menu-submenu-title, & .anticon {
       /* override ant transition animation */
       transition: none;
       font-size: 16px;
@@ -116,4 +115,11 @@ ul.ant-menu.ant-menu-sub {
 .ant-layout .ant-layout-sider .ant-layout-sider-trigger {
   /* override ant color */
   background: var(--sider-black);
+}
+
+/* Hack to hide the scrollbar for firefox browsers */
+@-moz-document url-prefix() {
+  .ant-layout-sider-children {
+    margin-right: -15px;
+  }
 }

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -166,7 +166,7 @@ class Sidebar extends React.Component {
 
     return (
       <Layout.Sider
-        width="275px"
+        width="260px"
         breakpoint="lg"
         collapsed={this.state.collapsed}
         collapsible={true}

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -166,7 +166,7 @@ class Sidebar extends React.Component {
 
     return (
       <Layout.Sider
-        width="260px"
+        width="275px"
         breakpoint="lg"
         collapsed={this.state.collapsed}
         collapsible={true}


### PR DESCRIPTION
When scrollbars are set to always be visible in a browser, we see them appear in the sidebar component of the dashboard. 

This PR adds CSS that hides the scrollbar for WebKit browsers, i.e., Chrome and Safari and uses an `overflow: hidden` technique inspired by [this solution](https://blogs.msdn.microsoft.com/kurlak/2013/11/03/hiding-vertical-scrollbars-with-pure-css-in-chrome-ie-6-firefox-opera-and-safari/) to hide the scrollbar in Firefox.

fixes #1611 
