### PR TITLE
Introduce inject check for known sidecars

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -35,6 +35,7 @@ const (
 
 	// for inject reports
 	hostNetworkDesc = "hostNetwork: pods do not use host networking"
+	sidecarDesc     = "sidecar: pods do not have a proxy or initContainer already injected"
 	unsupportedDesc = "supported: at least one resource injected"
 	udpDesc         = "udp: pod specs do not include UDP ports"
 )
@@ -50,6 +51,7 @@ type injectOptions struct {
 type injectReport struct {
 	name                string
 	hostNetwork         bool
+	sidecar             bool
 	udp                 bool // true if any port in any container has `protocol: UDP`
 	unsupportedResource bool
 }
@@ -179,13 +181,16 @@ func injectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string, options
  * injected, return false.
  */
 func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameOverride string, options *injectOptions, report *injectReport) bool {
+	report.hostNetwork = t.HostNetwork
+	report.sidecar = checkSidecars(t)
 	report.udp = checkUDPPorts(t)
 
-	// Pods with `hostNetwork: true` share a network namespace with the host. The
-	// init-container would destroy the iptables configuration on the host, so
-	// skip the injection in this case.
-	if t.HostNetwork {
-		report.hostNetwork = true
+	// Skip injection if:
+	// 1) Pods with `hostNetwork: true` share a network namespace with the host.
+	//    The init-container would destroy the iptables configuration on the host.
+	// OR
+	// 2) Known sidecars already present.
+	if report.hostNetwork || report.sidecar {
 		return false
 	}
 
@@ -637,15 +642,20 @@ func generateReport(injectReports []injectReport, output io.Writer) {
 
 	injected := []string{}
 	hostNetwork := []string{}
+	sidecar := []string{}
 	udp := []string{}
 
 	for _, r := range injectReports {
-		if !r.hostNetwork && !r.unsupportedResource {
+		if !r.hostNetwork && !r.sidecar && !r.unsupportedResource {
 			injected = append(injected, r.name)
 		}
 
 		if r.hostNetwork {
 			hostNetwork = append(hostNetwork, r.name)
+		}
+
+		if r.sidecar {
+			sidecar = append(sidecar, r.name)
 		}
 
 		if r.udp {
@@ -664,11 +674,14 @@ func generateReport(injectReports []injectReport, output io.Writer) {
 	if len(hostNetwork) == 0 {
 		output.Write([]byte(fmt.Sprintf("%s%s\n", hostNetworkPrefix, okStatus)))
 	} else {
-		verb := "uses"
-		if len(hostNetwork) > 1 {
-			verb = "use"
-		}
-		output.Write([]byte(fmt.Sprintf("%s%s -- %s %s \"hostNetwork: true\"\n", hostNetworkPrefix, warnStatus, strings.Join(hostNetwork, ", "), verb)))
+		output.Write([]byte(fmt.Sprintf("%s%s -- \"hostNetwork: true\" detected in %s\n", hostNetworkPrefix, warnStatus, strings.Join(hostNetwork, ", "))))
+	}
+
+	sidecarPrefix := fmt.Sprintf("%s%s", sidecarDesc, getFiller(sidecarDesc))
+	if len(sidecar) == 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", sidecarPrefix, okStatus)))
+	} else {
+		output.Write([]byte(fmt.Sprintf("%s%s -- known sidecar detected in %s\n", sidecarPrefix, warnStatus, strings.Join(sidecar, ", "))))
 	}
 
 	unsupportedPrefix := fmt.Sprintf("%s%s", unsupportedDesc, getFiller(unsupportedDesc))
@@ -722,5 +735,33 @@ func checkUDPPorts(t *v1.PodSpec) bool {
 			}
 		}
 	}
+	return false
+}
+
+func checkSidecars(t *v1.PodSpec) bool {
+	// check for known proxies and initContainers
+	for _, container := range t.Containers {
+		if strings.HasPrefix(container.Image, "gcr.io/linkerd-io/proxy:") ||
+			strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
+			strings.HasPrefix(container.Image, "gcr.io/heptio-images/contour:") ||
+			strings.HasPrefix(container.Image, "docker.io/envoyproxy/envoy-alpine:") ||
+			container.Name == "linkerd-proxy" ||
+			container.Name == "istio-proxy" ||
+			container.Name == "contour" ||
+			container.Name == "envoy" {
+			return true
+		}
+	}
+	for _, ic := range t.InitContainers {
+		if strings.HasPrefix(ic.Image, "gcr.io/linkerd-io/proxy-init:") ||
+			strings.HasPrefix(ic.Image, "gcr.io/istio-release/proxy_init:") ||
+			strings.HasPrefix(ic.Image, "gcr.io/heptio-images/contour:") ||
+			ic.Name == "linkerd-init" ||
+			ic.Name == "istio-init" ||
+			ic.Name == "envoy-initconfig" {
+			return true
+		}
+	}
+
 	return false
 }

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -85,6 +85,24 @@ func TestInjectYAML(t *testing.T) {
 			reportFileName:    "inject_emojivoto_deployment_udp.report",
 			testInjectOptions: defaultOptions,
 		},
+		{
+			inputFileName:     "inject_emojivoto_already_injected.input.yml",
+			goldenFileName:    "inject_emojivoto_already_injected.input.yml",
+			reportFileName:    "inject_emojivoto_already_injected.report",
+			testInjectOptions: defaultOptions,
+		},
+		{
+			inputFileName:     "inject_emojivoto_istio.input.yml",
+			goldenFileName:    "inject_emojivoto_istio.input.yml",
+			reportFileName:    "inject_emojivoto_istio.report",
+			testInjectOptions: defaultOptions,
+		},
+		{
+			inputFileName:     "inject_contour.input.yml",
+			goldenFileName:    "inject_contour.input.yml",
+			reportFileName:    "inject_contour.report",
+			testInjectOptions: defaultOptions,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 
@@ -8,6 +9,7 @@ Summary: 1 of 1 YAML document(s) injected
 
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_contour.input.yml
+++ b/cli/cmd/testdata/inject_contour.input.yml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: contour
+  name: contour
+  namespace: heptio-contour
+spec:
+  selector:
+    matchLabels:
+      app: contour
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: contour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/stats"
+        prometheus.io/format: "prometheus"
+    spec:
+      containers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+        command: ["contour"]
+        args: ["serve", "--incluster"]
+      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+        name: envoy
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        command: ["envoy"]
+        args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
+      initContainers:
+      - image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: envoy-initconfig
+        command: ["contour"]
+        args: ["bootstrap", "/config/contour.yaml"]
+        volumeMounts:
+        - name: contour-config
+          mountPath: /config
+---

--- a/cli/cmd/testdata/inject_contour.report
+++ b/cli/cmd/testdata/inject_contour.report
@@ -1,6 +1,6 @@
 
-hostNetwork: pods do not use host networking...............................[warn] -- "hostNetwork: true" detected in deployment/web
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
+hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[warn] -- known sidecar detected in deployment/contour
 supported: at least one resource injected..................................[warn] -- no supported objects found
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
@@ -1,0 +1,151 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web1
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - image: gcr.io/linkerd-io/proxy:foo
+status: {}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web2
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - name: linkerd-proxy
+status: {}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web3
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      initContainers:
+      - image: gcr.io/linkerd-io/proxy-init:foo
+status: {}
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web4
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      initContainers:
+      - name: linkerd-init
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report
@@ -1,0 +1,8 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[warn] -- known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
+supported: at least one resource injected..................................[warn] -- no supported objects found
+udp: pod specs do not include UDP ports....................................[ok]
+
+Summary: 0 of 4 YAML document(s) injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[warn] -- deployment/web uses "protocol: UDP"
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_istio.input.yml
@@ -1,0 +1,42 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - image: gcr.io/istio-release/proxyv2:1.0.2
+        name: istio-proxy
+      initContainers:
+      - image: gcr.io/istio-release/proxy_init:1.0.2
+        name: istio-init
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_istio.report
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report
@@ -1,6 +1,6 @@
 
-hostNetwork: pods do not use host networking...............................[warn] -- "hostNetwork: true" detected in deployment/web
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
+hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[warn] -- known sidecar detected in deployment/web
 supported: at least one resource injected..................................[warn] -- no supported objects found
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report
+++ b/cli/cmd/testdata/inject_emojivoto_list.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 

--- a/test/testdata/inject.report.golden
+++ b/test/testdata/inject.report.golden
@@ -1,5 +1,6 @@
 
 hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 


### PR DESCRIPTION
`linkerd inject` was not checking its input for known sidecars and
initContainers.

Modify `linkerd inject` to check for existing sidecars and
initContainers, specifically, Linkerd, Istio, and Contour.

Part of #1516

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Depends on #1617