### PR TITLE
Consolidate the source and destination columns in the Tap and Top tables

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -359,6 +359,7 @@ class Tap extends React.Component {
         <TapQueryCliCmd cmdName="tap" query={this.state.query} />
 
         <TapEventTable
+          resource={this.state.query.resource}
           tableRows={tableRows}
           filterOptions={this.state.tapResultFilterOptions} />
       </div>

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -53,7 +53,7 @@ let tapColumns = (filterOptions, ResourceLink) => [
     onFilter: (value, row) => _.get(row, "base.proxyDirection").includes(value)
   },
   {
-    title: "Source/Destination",
+    title: "Name",
     key: "src-dst",
     render: d => {
       let datum = {

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -37,10 +37,6 @@ const genFilterOptionList = options => _.map(options,  (_v, k) => {
 
 let tapColumns = (filterOptions, ResourceLink) => [
   {
-    title: "ID",
-    dataIndex: "requestInit.http.requestInit.id.stream"
-  },
-  {
     title: "Direction",
     key: "direction",
     dataIndex: "base.proxyDirection",

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -40,10 +40,10 @@ let tapColumns = (resourceType, filterOptions, ResourceLink) => [
     title: "Direction",
     key: "direction",
     dataIndex: "base.proxyDirection",
-    width: "60px",
+    width: "80px",
     filters: [
-      { text: "Inbound", value: "INBOUND" },
-      { text: "Outbound", value: "OUTBOUND" }
+      { text: "FROM", value: "INBOUND" },
+      { text: "TO", value: "OUTBOUND" }
     ],
     render: directionColumn,
     onFilter: (value, row) => _.get(row, "base.proxyDirection").includes(value)

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -35,7 +35,7 @@ const genFilterOptionList = options => _.map(options,  (_v, k) => {
   return { text: k, value: k };
 });
 
-let tapColumns = (filterOptions, ResourceLink) => [
+let tapColumns = (resourceType, filterOptions, ResourceLink) => [
   {
     title: "Direction",
     key: "direction",
@@ -59,7 +59,7 @@ let tapColumns = (filterOptions, ResourceLink) => [
         sourceLabels: _.get(d, "base.sourceMeta.labels", {}),
         destinationLabels: _.get(d, "base.destinationMeta.labels", {})
       };
-      return srcDstColumn(datum, ResourceLink);
+      return srcDstColumn(datum, resourceType, ResourceLink);
     }
   },
   {
@@ -222,10 +222,11 @@ class TapEventTable extends React.Component {
   }
 
   render() {
+    let resourceType = this.props.resource.split("/")[0];
     return (
       <Table
         dataSource={this.props.tableRows}
-        columns={tapColumns(this.props.filterOptions, this.props.api.ResourceLink)}
+        columns={tapColumns(resourceType, this.props.filterOptions, this.props.api.ResourceLink)}
         expandedRowRender={expandedRowRender}
         rowKey={r => r.base.id}
         pagination={false}

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -40,7 +40,7 @@ let tapColumns = (resourceType, filterOptions, ResourceLink) => [
     title: "Direction",
     key: "direction",
     dataIndex: "base.proxyDirection",
-    width: "80px",
+    width: "98px",
     filters: [
       { text: "FROM", value: "INBOUND" },
       { text: "TO", value: "OUTBOUND" }

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { srcDstColumn } from './util/TapUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
 import { Col, Icon, Row, Table } from 'antd';
+import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, formatWithComma } from './util/Utils.js';
 
 // https://godoc.org/google.golang.org/grpc/codes#Code
@@ -42,28 +42,29 @@ let tapColumns = (filterOptions, ResourceLink) => [
   },
   {
     title: "Direction",
+    key: "direction",
     dataIndex: "base.proxyDirection",
+    width: "60px",
     filters: [
       { text: "Inbound", value: "INBOUND" },
       { text: "Outbound", value: "OUTBOUND" }
     ],
+    render: directionColumn,
     onFilter: (value, row) => _.get(row, "base.proxyDirection").includes(value)
   },
   {
-    title: "Source",
-    key: "source",
-    dataIndex: "base",
-    filters: genFilterOptionList(filterOptions.source),
-    onFilter: (value, row) => row.base.source.pod === value || row.base.source.str === value,
-    render: d => srcDstColumn(_.get(d, "source"), _.get(d, "sourceMeta.labels", {}), ResourceLink)
-  },
-  {
-    title: "Destination",
-    key: "destination",
-    dataIndex: "base",
-    filters: genFilterOptionList(filterOptions.destination),
-    onFilter: (value, row) => row.base.destination.pod === value || row.base.destination.str === value,
-    render: d => srcDstColumn(_.get(d, "destination"), _.get(d, "destinationMeta.labels", {}), ResourceLink)
+    title: "Source/Destination",
+    key: "src-dst",
+    render: d => {
+      let datum = {
+        direction: _.get(d, "base.proxyDirection"),
+        source: _.get(d, "base.source"),
+        destination: _.get(d, "base.destination"),
+        sourceLabels: _.get(d, "base.sourceMeta.labels", {}),
+        destinationLabels: _.get(d, "base.destinationMeta.labels", {})
+      };
+      return srcDstColumn(datum, ResourceLink);
+    }
   },
   {
     title: "TLS",

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -213,6 +213,7 @@ class TapEventTable extends React.Component {
       ResourceLink: PropTypes.func.isRequired,
     }).isRequired,
     filterOptions: PropTypes.shape({}),
+    resource: PropTypes.string.isRequired,
     tableRows: PropTypes.arrayOf(PropTypes.shape({})),
   }
 

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -14,7 +14,7 @@ const topColumns = ResourceLink => [
     render: directionColumn
   },
   {
-    title: "Source/Destination",
+    title: "Name",
     key: "src-dst",
     render: d => srcDstColumn(d, ResourceLink)
   },

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -1,26 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { srcDstColumn } from './util/TapUtils.jsx';
 import { Table } from 'antd';
 import { withContext } from './util/AppContext.jsx';
+import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
-
-const srcDstSorter = key => {
-  return (a, b) => (a[key].pod || a[key].str).localeCompare(b[key].pod || b[key].str);
-};
 
 const topColumns = ResourceLink => [
   {
-    title: "Source",
-    key: "source",
-    sorter: srcDstSorter("source"),
-    render: d => srcDstColumn(d.source, d.sourceLabels, ResourceLink)
+    title: " ",
+    key: "direction",
+    dataIndex: "direction",
+    width: "60px",
+    render: directionColumn
   },
   {
-    title: "Destination",
-    key: "destination",
-    sorter: srcDstSorter("destination"),
-    render: d => srcDstColumn(d.destination, d.destinationLabels, ResourceLink)
+    title: "Source/Destination",
+    key: "src-dst",
+    render: d => srcDstColumn(d, ResourceLink)
   },
   {
     title: "Path",

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -5,7 +5,7 @@ import { withContext } from './util/AppContext.jsx';
 import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
-const topColumns = ResourceLink => [
+const topColumns = (resourceType, ResourceLink) => [
   {
     title: " ",
     key: "direction",
@@ -16,7 +16,7 @@ const topColumns = ResourceLink => [
   {
     title: "Name",
     key: "src-dst",
-    render: d => srcDstColumn(d, ResourceLink)
+    render: d => srcDstColumn(d, resourceType, ResourceLink)
   },
   {
     title: "Path",
@@ -60,6 +60,7 @@ class TopEventTable extends React.Component {
     api: PropTypes.shape({
       ResourceLink: PropTypes.func.isRequired,
     }).isRequired,
+    resourceType: PropTypes.string.isRequired,
     tableRows: PropTypes.arrayOf(PropTypes.shape({})),
   }
 
@@ -71,7 +72,7 @@ class TopEventTable extends React.Component {
     return (
       <Table
         dataSource={this.props.tableRows}
-        columns={topColumns(this.props.api.ResourceLink)}
+        columns={topColumns(this.props.resourceType, this.props.api.ResourceLink)}
         rowKey="key"
         pagination={false}
         className="top-event-table"

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -117,6 +117,7 @@ class TopModule extends React.Component {
       success: !d.success ? 0 : 1,
       failure: !d.success ? 1 : 0,
       successRate: !d.success ? new Percentage(0, 1) : new Percentage(1, 1),
+      direction: d.base.proxyDirection,
       source: d.requestInit.source,
       sourceLabels: d.requestInit.sourceMeta.labels,
       destination: d.requestInit.destination,

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -11,7 +11,9 @@ class TopModule extends React.Component {
   static propTypes = {
     maxRowsToDisplay: PropTypes.number,
     pathPrefix: PropTypes.string.isRequired,
-    query: PropTypes.shape({}).isRequired,
+    query: PropTypes.shape({
+      resource: PropTypes.string.isRequired
+    }).isRequired,
     startTap: PropTypes.bool.isRequired,
     updateNeighbors: PropTypes.func
   }
@@ -263,11 +265,12 @@ class TopModule extends React.Component {
 
   render() {
     let tableRows = _.values(this.state.topEventIndex);
+    let resourceType = this.props.query.resource.split("/")[0];
 
     return (
       <React.Fragment>
         {this.banner()}
-        <TopEventTable tableRows={tableRows} />
+        <TopEventTable resourceType={resourceType} tableRows={tableRows} />
       </React.Fragment>
     );
   }

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -147,7 +147,7 @@ const resourceSection = (ip, labels, ResourceLink) => {
     <React.Fragment>
       {
         _.map(labels, (labelVal, labelName) => {
-          if (_.has(shortNameLookup, labelName) && labelName !== "namespace") {
+          if (_.has(shortNameLookup, labelName) && labelName !== "namespace" && labelName !== "service") {
             return <div key={labelName + "-" + labelVal}>{ resourceShortLink(labelName, labels, ResourceLink) }</div>;
           }
         })

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { toShortResourceName } from './Utils.js';
 import { Popover, Tooltip } from 'antd';
 
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
@@ -135,23 +136,17 @@ const publicAddressToString = ipv4 => {
 /*
   display more human-readable information about source/destination
 */
-const podLink = (labels, ResourceLink) => (
+const resourceShortLink = (labels, resourceType, ResourceLink) => (
   <ResourceLink
-    resource={{ type: "pod", name: labels.pod, namespace: labels.namespace }}
-    linkText={"po/" + labels.pod} />
-);
-
-const deployLink = (labels, ResourceLink) => (
-  <ResourceLink
-    resource={{ type: "deployment", name: labels.deployment, namespace: labels.namespace}}
-    linkText={"deploy/" + labels.deployment} />
+    resource={{ type: resourceType, name: labels[resourceType], namespace: labels.namespace}}
+    linkText={toShortResourceName(resourceType) + "/" + labels[resourceType]} />
 );
 
 const resourceSection = (ip, labels, ResourceLink) => {
   return (
     <React.Fragment>
-      <div>{ !labels.deployment ? null : deployLink(labels, ResourceLink) }</div>
-      <div>{ !labels.pod ? null : podLink(labels, ResourceLink) }</div>
+      <div>{ !labels.deployment ? null : resourceShortLink(labels, "deployment", ResourceLink) }</div>
+      <div>{ !labels.pod ? null : resourceShortLink(labels, "pod", ResourceLink) }</div>
       <div>{ip}</div>
     </React.Fragment>
   );
@@ -165,7 +160,7 @@ export const directionColumn = d => (
   </Tooltip>
 );
 
-export const srcDstColumn = (d, ResourceLink) => {
+export const srcDstColumn = (d, resourceType, ResourceLink) => {
   let display = {};
   let labels = {};
 
@@ -192,9 +187,7 @@ export const srcDstColumn = (d, ResourceLink) => {
       content={content}
       trigger="hover">
       <div className="src-dst-name">
-        { !_.isEmpty(labels.deployment) ? deployLink(labels, ResourceLink) :
-            !_.isEmpty(display.pod) ? podLink(labels, ResourceLink) : display.str
-        }
+        { !_.isEmpty(labels[resourceType]) ? resourceShortLink(labels, resourceType, ResourceLink) : display.str }
       </div>
     </Popover>
   );

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { toShortResourceName } from './Utils.js';
 import { Popover, Tooltip } from 'antd';
+import { shortNameLookup, toShortResourceName } from './Utils.js';
 
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
 
@@ -136,7 +136,7 @@ const publicAddressToString = ipv4 => {
 /*
   display more human-readable information about source/destination
 */
-const resourceShortLink = (labels, resourceType, ResourceLink) => (
+const resourceShortLink = (resourceType, labels, ResourceLink) => (
   <ResourceLink
     resource={{ type: resourceType, name: labels[resourceType], namespace: labels.namespace}}
     linkText={toShortResourceName(resourceType) + "/" + labels[resourceType]} />
@@ -145,8 +145,13 @@ const resourceShortLink = (labels, resourceType, ResourceLink) => (
 const resourceSection = (ip, labels, ResourceLink) => {
   return (
     <React.Fragment>
-      <div>{ !labels.deployment ? null : resourceShortLink(labels, "deployment", ResourceLink) }</div>
-      <div>{ !labels.pod ? null : resourceShortLink(labels, "pod", ResourceLink) }</div>
+      {
+        _.map(labels, (labelVal, labelName) => {
+          if (_.has(shortNameLookup, labelName) && labelName !== "namespace") {
+            return <div key={labelName + "-" + labelVal}>{ resourceShortLink(labelName, labels, ResourceLink) }</div>;
+          }
+        })
+      }
       <div>{ip}</div>
     </React.Fragment>
   );
@@ -187,7 +192,7 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
       content={content}
       trigger="hover">
       <div className="src-dst-name">
-        { !_.isEmpty(labels[resourceType]) ? resourceShortLink(labels, resourceType, ResourceLink) : display.str }
+        { !_.isEmpty(labels[resourceType]) ? resourceShortLink(resourceType, labels, ResourceLink) : display.str }
       </div>
     </Popover>
   );

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -156,7 +156,7 @@ export const resourceTypeToCamelCase = resource => camelCaseLookUp[resource] || 
 /*
   A simplified version of ShortNameFromCanonicalResourceName
 */
-const shortNameLookup = {
+export const shortNameLookup = {
   "deployment": "deploy",
   "daemonset": "ds",
   "namespace": "ns",


### PR DESCRIPTION
Consolidate the source and destination columns into one column, and add a direction column (To/From) so the user knows if the displayed resource is src/dst.

![screen shot 2018-09-10 at 4 18 03 pm](https://user-images.githubusercontent.com/549258/45329460-6e0bae00-b515-11e8-84bd-3fce2815889b.png)

![deploys](https://user-images.githubusercontent.com/549258/45329509-aa3f0e80-b515-11e8-95eb-144dce475861.png)

Fixes #1588 (and alleviates #1554)