### PR TITLE
Fix landing page when there are no meshed namespaces

### DIFF
--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -85,8 +85,10 @@ class NamespaceLanding extends React.Component {
           metricsByNs[this.state.selectedNs] = processMultiResourceRollup(metricsForNs);
         }
 
-        // by default, show the first non-linkerd meshed resource
+        // by default, show the first non-linkerd meshed namesapce
+        // if no other meshed namespaces are found, show the linkerd namespace
         let defaultOpenNs = _.find(namespaces, ns => ns.added && ns.name !== this.props.controllerNamespace);
+        defaultOpenNs = defaultOpenNs || _.find(namespaces, ['name', this.props.controllerNamespace]);
 
         this.setState({
           namespaces,


### PR DESCRIPTION
If the only meshed namesace is the controller namespace itself, our dashboard landing page defaulted to showing both a spinner and an error banner. This branch fixes it so that we auto-expand the controller namespace. Previously it looked like this:

![image](https://user-images.githubusercontent.com/9226/45331755-52a6a000-b521-11e8-8def-1e050a57023d.png)
