### PR TITLE
Improve performance of tap table by throttling updates

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -22,11 +22,14 @@ class Tap extends React.Component {
   constructor(props) {
     super(props);
     this.api = this.props.api;
+    this.tapResultsById = {};
+    this.tapResultFilterOptions = this.getInitialTapFilterOptions();
+    this.debouncedWebsocketRecvHandler = _.throttle(this.updateTapResults, 500);
     this.loadFromServer = this.loadFromServer.bind(this);
 
     this.state = {
-      tapResultsById: {},
-      tapResultFilterOptions: this.getInitialTapFilterOptions(),
+      tapResultsById: this.tapResultsById,
+      tapResultFilterOptions: this.tapResultFilterOptions,
       error: null,
       resourcesByNs: {},
       authoritiesByNs: {},
@@ -56,6 +59,7 @@ class Tap extends React.Component {
     if (this.ws) {
       this.ws.close(1000);
     }
+    this.debouncedWebsocketRecvHandler.cancel();
     this.stopTapStreaming();
     this.stopServerPolling();
   }
@@ -75,6 +79,7 @@ class Tap extends React.Component {
 
   onWebsocketRecv = e => {
     this.indexTapResult(e.data);
+    this.debouncedWebsocketRecvHandler();
   }
 
   onWebsocketClose = e => {
@@ -145,7 +150,7 @@ class Tap extends React.Component {
   }
 
   getFilterOptions(d) {
-    let filters = this.state.tapResultFilterOptions;
+    let filters = this.tapResultFilterOptions;
     // keep track of unique values we encounter, to populate the table filters
     let addFilter = this.genFilterAdder(filters, Date.now());
     addFilter("source", d.source.str);
@@ -207,8 +212,9 @@ class Tap extends React.Component {
     // keep an index of tap request rows by id. this allows us to collate
     // requestInit/responseInit/responseEnd into one single table row,
     // as opposed to three separate rows as in the CLI
-    let resultIndex = this.state.tapResultsById;
+    let resultIndex = this.tapResultsById;
     let parsedResults = this.parseTapResult(data);
+    this.tapResultFilterOptions = parsedResults.updatedFilters;
     let d = parsedResults.tapResult;
 
     if (_.isNil(resultIndex[d.id])) {
@@ -223,10 +229,12 @@ class Tap extends React.Component {
     // assumption: requests of a given id all share the same high level metadata
     resultIndex[d.id]["base"] = d;
     resultIndex[d.id].lastUpdated = Date.now();
+  }
 
+  updateTapResults = () => {
     this.setState({
-      tapResultsById: resultIndex,
-      tapResultFilterOptions: parsedResults.updatedFilters
+      tapResultsById: this.tapResultsById,
+      tapResultFilterOptions: this.tapResultFilterOptions
     });
   }
 
@@ -255,10 +263,13 @@ class Tap extends React.Component {
   }
 
   startTapStreaming() {
+    this.tapResultsById = {};
+    this.tapResultFilterOptions = this.getInitialTapFilterOptions();
+
     this.setState({
       tapRequestInProgress: true,
-      tapResultsById: {},
-      tapResultFilterOptions: this.getInitialTapFilterOptions()
+      tapResultsById: this.tapResultsById,
+      tapResultFilterOptions: this.tapResultFilterOptions
     });
 
     let protocol = window.location.protocol === "https:" ? "wss" : "ws";

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -24,7 +24,7 @@ class Tap extends React.Component {
     this.api = this.props.api;
     this.tapResultsById = {};
     this.tapResultFilterOptions = this.getInitialTapFilterOptions();
-    this.debouncedWebsocketRecvHandler = _.throttle(this.updateTapResults, 500);
+    this.throttledWebsocketRecvHandler = _.throttle(this.updateTapResults, 500);
     this.loadFromServer = this.loadFromServer.bind(this);
 
     this.state = {
@@ -59,7 +59,7 @@ class Tap extends React.Component {
     if (this.ws) {
       this.ws.close(1000);
     }
-    this.debouncedWebsocketRecvHandler.cancel();
+    this.throttledWebsocketRecvHandler.cancel();
     this.stopTapStreaming();
     this.stopServerPolling();
   }
@@ -79,7 +79,7 @@ class Tap extends React.Component {
 
   onWebsocketRecv = e => {
     this.indexTapResult(e.data);
-    this.debouncedWebsocketRecvHandler();
+    this.throttledWebsocketRecvHandler();
   }
 
   onWebsocketClose = e => {

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import BaseTable from './BaseTable.jsx';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { srcDstColumn } from './util/TapUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
@@ -210,10 +210,23 @@ const expandedRowRender = d => {
   );
 };
 
-class TapEventTable extends BaseTable {
+class TapEventTable extends React.Component {
+  static propTypes = {
+    api: PropTypes.shape({
+      ResourceLink: PropTypes.func.isRequired,
+    }).isRequired,
+    filterOptions: PropTypes.shape({}),
+    tableRows: PropTypes.arrayOf(PropTypes.shape({})),
+  }
+
+  static defaultProps = {
+    filterOptions: {},
+    tableRows: []
+  }
+
   render() {
     return (
-      <BaseTable
+      <Table
         dataSource={this.props.tableRows}
         columns={tapColumns(this.props.filterOptions, this.props.api.ResourceLink)}
         expandedRowRender={expandedRowRender}

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -25,7 +25,7 @@ class TopModule extends React.Component {
     super(props);
     this.tapResultsById = {};
     this.topEventIndex = {};
-    this.debouncedWebsocketRecvHandler = _.throttle(this.updateTapEventIndexState, 500);
+    this.throttledWebsocketRecvHandler = _.throttle(this.updateTapEventIndexState, 500);
 
     this.state = {
       error: null,
@@ -50,7 +50,7 @@ class TopModule extends React.Component {
   }
 
   componentWillUnmount() {
-    this.debouncedWebsocketRecvHandler.cancel();
+    this.throttledWebsocketRecvHandler.cancel();
     this.stopTapStreaming();
   }
 
@@ -70,7 +70,7 @@ class TopModule extends React.Component {
   onWebsocketRecv = e => {
     this.indexTapResult(e.data);
     this.props.updateNeighbors(e.data);
-    this.debouncedWebsocketRecvHandler();
+    this.throttledWebsocketRecvHandler();
   }
 
   onWebsocketClose = e => {


### PR DESCRIPTION
This branch updates the tap table to limit re-rendering to once every 500ms, similar to the approach taken for the top table in #1616. With this change in place I'm able to tap an entire namespace without the page freezing. It's still the case that this table renders pretty slowly (~250ms), but given the 500ms throttling it's not a problem. In the long run, however, I'd like to reduce the amount of data in this table to speed up rendering.

Fixes #1597.