### PR TITLE
Bump Prometheus to v2.4.0, Grafana to 5.2.4

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -90,7 +90,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		Namespace:                   controlPlaneNamespace,
 		ControllerImage:             fmt.Sprintf("%s/controller:%s", options.dockerRegistry, options.linkerdVersion),
 		WebImage:                    fmt.Sprintf("%s/web:%s", options.dockerRegistry, options.linkerdVersion),
-		PrometheusImage:             "prom/prometheus:v2.3.1",
+		PrometheusImage:             "prom/prometheus:v2.4.0",
 		GrafanaImage:                fmt.Sprintf("%s/grafana:%s", options.dockerRegistry, options.linkerdVersion),
 		ControllerReplicas:          options.controllerReplicas,
 		WebReplicas:                 options.webReplicas,

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -478,7 +478,7 @@ spec:
       - args:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        image: prom/prometheus:v2.3.1
+        image: prom/prometheus:v2.4.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.1.3
+FROM grafana/grafana:5.2.4
 
 COPY grafana/dashboards               /var/lib/grafana/dashboards
 COPY grafana/dashboards/top-line.json /usr/share/grafana/public/dashboards/home.json


### PR DESCRIPTION
Prometheus v2.3.1 -> v2.4.0
Grafana 5.1.3 -> 5.2.4

Signed-off-by: Andrew Seigner <siggy@buoyant.io>