### PR TITLE
Display more helpful websocket errors

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -7,10 +7,11 @@ import TapEventTable from './TapEventTable.jsx';
 import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
-import { httpMethods, processTapEvent, setMaxRps } from './util/TapUtils.jsx';
+import { httpMethods, processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const maxNumFilterOptions = 12;
+
 class Tap extends React.Component {
   static propTypes = {
     api: PropTypes.shape({
@@ -88,7 +89,7 @@ class Tap extends React.Component {
     if (!e.wasClean) {
       this.setState({
         error: {
-          error: `Websocket [${e.code}] ${e.reason}`
+          error: `Websocket close error [${e.code}: ${wsCloseCodes[e.code]}] ${e.reason ? ":" : ""} ${e.reason}`
         }
       });
     }
@@ -96,7 +97,7 @@ class Tap extends React.Component {
 
   onWebsocketError = e => {
     this.setState({
-      error: { error: e.message }
+      error: { error: `Websocket error: ${e.message}` }
     });
 
     this.stopTapStreaming();

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import TopEventTable from './TopEventTable.jsx';
 import { withContext } from './util/AppContext.jsx';
-import { processTapEvent, setMaxRps } from './util/TapUtils.jsx';
+import { processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 
 class TopModule extends React.Component {
   static propTypes = {
@@ -76,14 +76,16 @@ class TopModule extends React.Component {
   onWebsocketClose = e => {
     if (!e.wasClean) {
       this.setState({
-        error: { error: `Websocket [${e.code}] ${e.reason}` }
+        error: {
+          error: `Websocket close error [${e.code}: ${wsCloseCodes[e.code]}] ${e.reason ? ":" : ""} ${e.reason}`
+        }
       });
     }
   }
 
   onWebsocketError = e => {
     this.setState({
-      error: { error: e.message }
+      error: { error: `Websocket error: ${e.message}` }
     });
   }
 

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -28,6 +28,25 @@ export const tapQueryProps = {
 
 export const tapQueryPropType = PropTypes.shape(tapQueryProps);
 
+// from https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+export const wsCloseCodes = {
+  1000: "Normal Closure",
+  1001: "Going Away",
+  1002: "Protocol Error",
+  1003: "Unsupported Data",
+  1004: "Reserved",
+  1005: "No Status Recvd",
+  1006: "Abnormal Closure",
+  1007: "Invalid frame payload data",
+  1008: "Policy Violation",
+  1009: "Message too big",
+  1010: "Missing Extension",
+  1011: "Internal Error",
+  1012: "Service Restart",
+  1013: "Try Again Later",
+  1014: "Bad Gateway",
+  1015: "TLS Handshake"
+};
 
 /*
   Use tap data to figure out a resource's unmeshed upstreams/downstreams


### PR DESCRIPTION
The web client displays `Websocket [code]` on websocket close errors.

Modify the web client to render a more helpful error message to the
user. If a reason is present, render that, otherwise translate the
websocket error code into a message.

Fixes #1599

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2018-09-11 at 2 08 11 pm](https://user-images.githubusercontent.com/236915/45388689-8ab7ec80-b5ce-11e8-8c69-14bde82f582c.png)
