### PR TITLE
Follow up to fix extraneous css style in sidebar css.

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -90,7 +90,7 @@ ul.ant-menu.ant-menu-sub {
 
   & .sidebar-menu-header {
     height: 60px;
-    padding: calc(var(--base-width)) 14px;
+    padding: var(--base-width) 14px;
 
     &.collapsed {
       text-align: center;


### PR DESCRIPTION
This PR is a result of a change request that was missed in PR #1613.  This change removes an unnecessary  `calc()` function in the sidebar.css

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>