### PR TITLE
Improve top table to better cope with high RPS traffic

### DIFF
--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -6,7 +6,7 @@ import { withContext } from './util/AppContext.jsx';
 import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
-const topMetricColWidth = "80px";
+const topMetricColWidth = "85px";
 const topColumns = (resourceType, ResourceLink) => [
   {
     title: " ",

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -6,6 +6,7 @@ import { withContext } from './util/AppContext.jsx';
 import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
+const topMetricColWidth = "80px";
 const topColumns = (resourceType, ResourceLink) => [
   {
     title: " ",
@@ -28,6 +29,7 @@ const topColumns = (resourceType, ResourceLink) => [
     title: "Count",
     dataIndex: "count",
     className: "numeric",
+    width: topMetricColWidth,
     defaultSortOrder: "descend",
     sorter: (a, b) => numericSort(a.count, b.count),
   },
@@ -35,6 +37,7 @@ const topColumns = (resourceType, ResourceLink) => [
     title: "Best",
     dataIndex: "best",
     className: "numeric",
+    width: topMetricColWidth,
     sorter: (a, b) => numericSort(a.best, b.best),
     render: formatLatencySec
   },
@@ -42,6 +45,7 @@ const topColumns = (resourceType, ResourceLink) => [
     title: "Worst",
     dataIndex: "worst",
     className: "numeric",
+    width: topMetricColWidth,
     sorter: (a, b) => numericSort(a.worst, b.worst),
     render: formatLatencySec
   },
@@ -49,6 +53,7 @@ const topColumns = (resourceType, ResourceLink) => [
     title: "Last",
     dataIndex: "last",
     className: "numeric",
+    width: topMetricColWidth,
     sorter: (a, b) => numericSort(a.last, b.last),
     render: formatLatencySec
   },

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -18,6 +18,7 @@ const topColumns = (resourceType, ResourceLink) => [
   {
     title: "Name",
     key: "src-dst",
+    width: "180px",
     render: d => srcDstColumn(d, resourceType, ResourceLink)
   },
   {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -25,7 +25,7 @@ class TopModule extends React.Component {
     // max rows to keep in index. there are two indexes we keep:
     // - un-ended tap results, pre-aggregation into the top counts
     // - aggregated top rows
-    maxRowsToStore: 40,
+    maxRowsToStore: 50,
     updateNeighbors: _.noop
   }
 

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -10,6 +10,7 @@ import { processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 class TopModule extends React.Component {
   static propTypes = {
     maxRowsToDisplay: PropTypes.number,
+    maxRowsToStore: PropTypes.number,
     pathPrefix: PropTypes.string.isRequired,
     query: PropTypes.shape({
       resource: PropTypes.string.isRequired
@@ -19,7 +20,12 @@ class TopModule extends React.Component {
   }
 
   static defaultProps = {
-    maxRowsToDisplay: 40, // max aggregated top rows to index and display in table
+    // max aggregated top rows to index and display in table
+    maxRowsToDisplay: 40,
+    // max rows to keep in index. there are two indexes we keep:
+    // - un-ended tap results, pre-aggregation into the top counts
+    // - aggregated top rows
+    maxRowsToStore: 40,
     updateNeighbors: _.noop
   }
 
@@ -31,8 +37,7 @@ class TopModule extends React.Component {
 
     this.state = {
       error: null,
-      topEventIndex: {},
-      maxRowsToStore: 40 // max un-ended tap results to keep in index (pre-aggregation into the top counts)
+      topEventIndex: {}
     };
   }
 
@@ -162,7 +167,7 @@ class TopModule extends React.Component {
       this.incrementTopResult(d, topResults[eventKey]);
     }
 
-    if (_.size(topResults) > this.props.maxRowsToDisplay) {
+    if (_.size(topResults) > this.props.maxRowsToStore) {
       this.deleteOldestIndexedResult(topResults);
     }
 
@@ -192,7 +197,7 @@ class TopModule extends React.Component {
 
     if (_.isNil(resultIndex[d.id])) {
       // don't let tapResultsById grow unbounded
-      if (_.size(resultIndex) > this.state.maxRowsToStore) {
+      if (_.size(resultIndex) > this.props.maxRowsToStore) {
         this.deleteOldestIndexedResult(resultIndex);
       }
 
@@ -266,7 +271,7 @@ class TopModule extends React.Component {
   }
 
   render() {
-    let tableRows = _.values(this.state.topEventIndex);
+    let tableRows = _.take(_.values(this.state.topEventIndex), this.props.maxRowsToDisplay);
     let resourceType = this.props.query.resource.split("/")[0];
 
     return (


### PR DESCRIPTION
There are two variables we use to control the volume of Top output, maxRowsToDisplay, which controls how many rows are in the table, and maxRowsToStore, which controls the size of the event index we keep in memory for aggregating results.

Previously, we were only keeping in index maxRowsToDisplay rows, which for the Resource Detail page was 10 (which is really small for high traffic rest-y resource traffic - it causes rows to be deleted from the index too soon, and then causes the data in the table to change a lot). Change this to store maxRowsToStore rows, and also bump this to 50. This allows us to store results for longer, and also ensures more consistent data over time.

Another fix for the appearance of the Top columns is to add fixed widths to the metrics. This will prevent the table from wobbling from side to side. Some widths were added in #1620 and #1628 though, so it'd be helpful to look at widths again once these three branches have merged.

Fixes #1601