### PR TITLE
Move more info from the tap table into the expanded row

### DIFF
--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -18,3 +18,20 @@
     color: rgba(52, 137, 206, 0.906);
   }
 }
+
+.tap-more-info {
+  padding-right: 50px;
+
+  & .tap-info-section {
+    padding: 24px 0;
+
+    & hr {
+      color: red;
+
+    }
+
+    & .expand-section-header {
+      font-weight: var(--font-weight-bold);
+    }
+  }
+}

--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -23,12 +23,7 @@
   padding-right: 50px;
 
   & .tap-info-section {
-    padding: 24px 0;
-
-    & hr {
-      color: red;
-
-    }
+    padding: 4px 0;
 
     & .expand-section-header {
       font-weight: var(--font-weight-bold);

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -113,13 +113,13 @@ const requestInitSection = d => (
   <React.Fragment>
     <h3>Request Init</h3>
     <Row gutter={8} className="expand-section-header">
-      <Col span={6}>Authority</Col>
+      <Col span={8}>Authority</Col>
       <Col span={10}>Path</Col>
       <Col span={2}>Scheme</Col>
       <Col span={2}>Method</Col>
     </Row>
     <Row gutter={8}>
-      <Col span={6}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
+      <Col span={8}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
       <Col span={10}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
       <Col span={2}>{_.get(d, "requestInit.http.requestInit.scheme.registered")}</Col>
       <Col span={2}>{_.get(d, "requestInit.http.requestInit.method.registered")}</Col>

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -29,10 +29,6 @@ const grpcStatusCodes = {
 
 const smallMetricColWidth = "120px";
 
-const genFilterOptionList = options => _.map(options,  (_v, k) => {
-  return { text: k, value: k };
-});
-
 const httpStatusCol =   {
   title: "HTTP status",
   key: "http-status",

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -89,12 +89,6 @@ const topLevelColumns = (resourceType, filterOptions, ResourceLink) => [
       };
       return srcDstColumn(datum, resourceType, ResourceLink);
     }
-  },
-  {
-    title: "TLS",
-    dataIndex: "base.tls",
-    filters: genFilterOptionList(filterOptions.tls),
-    onFilter: (value, row) => row.tls === value
   }
 ];
 
@@ -114,15 +108,17 @@ const requestInitSection = d => (
     <h3>Request Init</h3>
     <Row gutter={8} className="expand-section-header">
       <Col span={8}>Authority</Col>
-      <Col span={10}>Path</Col>
+      <Col span={9}>Path</Col>
       <Col span={2}>Scheme</Col>
       <Col span={2}>Method</Col>
+      <Col span={3}>TLS</Col>
     </Row>
     <Row gutter={8}>
       <Col span={8}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
-      <Col span={10}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
+      <Col span={9}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
       <Col span={2}>{_.get(d, "requestInit.http.requestInit.scheme.registered")}</Col>
       <Col span={2}>{_.get(d, "requestInit.http.requestInit.method.registered")}</Col>
+      <Col span={3}>{_.get(d, "base.tls")}</Col>
     </Row>
   </React.Fragment>
 );

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -29,12 +29,20 @@ const grpcStatusCodes = {
 
 const smallMetricColWidth = "120px";
 
-const httpStatusCol =   {
+const httpStatusCol = {
   title: "HTTP status",
   key: "http-status",
   width: smallMetricColWidth,
   dataIndex: "responseInit.http.responseInit",
   render: d => !d ? <Icon type="loading" /> : d.httpStatus
+};
+
+const responseInitLatencyCol = {
+  title: "Latency",
+  key: "rsp-latency",
+  width: smallMetricColWidth,
+  dataIndex: "responseInit.http.responseInit",
+  render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceRequestInit)
 };
 
 const grpcStatusCol = {
@@ -91,7 +99,7 @@ const topLevelColumns = (resourceType, filterOptions, ResourceLink) => [
 const tapColumns = (resourceType, filterOptions, ResourceLink) => {
   return _.concat(
     topLevelColumns(resourceType, filterOptions, ResourceLink),
-    [ methodCol, pathCol, httpStatusCol, grpcStatusCol ]
+    [ methodCol, pathCol, responseInitLatencyCol, httpStatusCol, grpcStatusCol ]
   );
 };
 

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -27,15 +27,43 @@ const grpcStatusCodes = {
   16: "Unauthenticated"
 };
 
-const grpcStatusCodeFilters = _.map(grpcStatusCodes, (description, code) => {
-  return { text: `${code}: ${description}`, value: code };
-});
+const smallMetricColWidth = "120px";
 
 const genFilterOptionList = options => _.map(options,  (_v, k) => {
   return { text: k, value: k };
 });
 
-let tapColumns = (resourceType, filterOptions, ResourceLink) => [
+const httpStatusCol =   {
+  title: "HTTP status",
+  key: "http-status",
+  width: smallMetricColWidth,
+  dataIndex: "responseInit.http.responseInit",
+  render: d => !d ? <Icon type="loading" /> : d.httpStatus
+};
+
+const grpcStatusCol = {
+  title: "GRPC status",
+  key: "grpc-status",
+  width: smallMetricColWidth,
+  dataIndex: "responseEnd.http.responseEnd",
+  render: d => !d ? <Icon type="loading" /> : grpcStatusCodes[_.get(d, "eos.grpcStatusCode")]
+};
+
+const pathCol = {
+  title: "Path",
+  key: "path",
+  dataIndex: "requestInit.http.requestInit",
+  render: d => !d ? <Icon type="loading" /> : d.path
+};
+
+const methodCol = {
+  title: "Method",
+  key: "method",
+  dataIndex: "requestInit.http.requestInit",
+  render: d => !d ? <Icon type="loading" /> : _.get(d, "method.registered")
+};
+
+const topLevelColumns = (resourceType, filterOptions, ResourceLink) => [
   {
     title: "Direction",
     key: "direction",
@@ -67,143 +95,84 @@ let tapColumns = (resourceType, filterOptions, ResourceLink) => [
     dataIndex: "base.tls",
     filters: genFilterOptionList(filterOptions.tls),
     onFilter: (value, row) => row.tls === value
-  },
-  {
-    title: "Request Init",
-    children: [
-      {
-        title: "Authority",
-        key: "authority",
-        dataIndex: "requestInit.http.requestInit",
-        filters: genFilterOptionList(filterOptions.authority),
-        onFilter: (value, row) =>
-          _.get(row, "requestInit.http.requestInit.authority") === value,
-        render: d => !d ? <Icon type="loading" /> : d.authority
-      },
-      {
-        title: "Path",
-        key: "path",
-        dataIndex: "requestInit.http.requestInit",
-        filters: genFilterOptionList(filterOptions.path),
-        onFilter: (value, row) =>
-          _.get(row, "requestInit.http.requestInit.path") === value,
-        render: d => !d ? <Icon type="loading" /> : d.path
-      },
-      {
-        title: "Scheme",
-        key: "scheme",
-        dataIndex: "requestInit.http.requestInit",
-        filters: genFilterOptionList(filterOptions.scheme),
-        onFilter: (value, row) =>
-          _.get(row, "requestInit.http.requestInit.scheme.registered") === value,
-        render: d => !d ? <Icon type="loading" /> : _.get(d, "scheme.registered")
-      },
-      {
-        title: "Method",
-        key: "method",
-        dataIndex: "requestInit.http.requestInit",
-        filters: _.map(filterOptions.httpMethod, d => {
-          return { text: d, value: d};
-        }),
-        onFilter: (value, row) =>
-          _.get(row, "requestInit.http.requestInit.method.registered") === value,
-        render: d => !d ? <Icon type="loading" /> : _.get(d, "method.registered")
-      }
-    ]
-  },
-  {
-    title: "Response Init",
-    children: [
-      {
-        title: "HTTP status",
-        key: "http-status",
-        dataIndex: "responseInit.http.responseInit",
-        filters: genFilterOptionList(filterOptions.httpStatus),
-        onFilter: (value, row) =>
-          _.get(row, "responseInit.http.responseInit.httpStatus") + "" === value,
-        render: d => !d ? <Icon type="loading" /> : d.httpStatus
-      },
-      {
-        title: "Latency",
-        key: "rsp-latency",
-        dataIndex: "responseInit.http.responseInit",
-        render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceRequestInit)
-      },
-    ]
-  },
-  {
-    title: "Response End",
-    children: [
-      {
-        title: "GRPC status",
-        key: "grpc-status",
-        dataIndex: "responseEnd.http.responseEnd",
-        filters: grpcStatusCodeFilters,
-        onFilter: (value, row) =>
-          (_.get(row, "responseEnd.http.responseEnd.eos.grpcStatusCode") + "") === value,
-        render: d => !d ? <Icon type="loading" /> : _.get(d, "eos.grpcStatusCode")
-      },
-      {
-        title: "Latency",
-        key: "end-latency",
-        dataIndex: "responseEnd.http.responseEnd",
-        render: d => !d ? <Icon type="loading" /> : formatTapLatency(d.sinceResponseInit)
-      },
-      {
-        title: "Response Length (B)",
-        key: "rsp-length",
-        dataIndex: "responseEnd.http.responseEnd",
-        render: d => !d ? <Icon type="loading" /> : formatWithComma(d.responseBytes)
-      },
-    ]
-
   }
 ];
+
+const tapColumns = (resourceType, filterOptions, ResourceLink) => {
+  return _.concat(
+    topLevelColumns(resourceType, filterOptions, ResourceLink),
+    [ methodCol, pathCol, httpStatusCol, grpcStatusCol ]
+  );
+};
 
 const formatTapLatency = str => {
   return formatLatencySec(str.replace("s", ""));
 };
 
-const srcDstMetaColumns = [
-  {
-    title: "",
-    dataIndex: "labelName"
-  },
-  {
-    title: "",
-    dataIndex: "labelVal"
-  }
-];
-const renderMetaLabels = (title, labels) => {
-  let data = _.map(labels, (v, k) => {
-    return {
-      labelName: k,
-      labelVal: v
-    };
-  });
-  return (
-    <React.Fragment>
-      <div>{title}</div>
-      <Table
-        className="meta-table-nested"
-        columns={srcDstMetaColumns}
-        dataSource={data}
-        size="small"
-        rowKey={row => title.replace(" ", "_") + row.labelName + row.labelVal}
-        bordered={false}
-        showHeader={false}
-        pagination={false} />
-    </React.Fragment>
-  );
-};
+const requestInitSection = d => (
+  <React.Fragment>
+    <h3>Request Init</h3>
+    <Row gutter={8} className="expand-section-header">
+      <Col span={6}>Authority</Col>
+      <Col span={10}>Path</Col>
+      <Col span={2}>Scheme</Col>
+      <Col span={2}>Method</Col>
+    </Row>
+    <Row gutter={8}>
+      <Col span={6}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
+      <Col span={10}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
+      <Col span={2}>{_.get(d, "requestInit.http.requestInit.scheme.registered")}</Col>
+      <Col span={2}>{_.get(d, "requestInit.http.requestInit.method.registered")}</Col>
+    </Row>
+  </React.Fragment>
+);
+
+const responseInitSection = d => (
+  <React.Fragment>
+    <h3>Response Init</h3>
+    <Row gutter={8} className="expand-section-header">
+      <Col span={4}>HTTP Status</Col>
+      <Col span={4}>Latency</Col>
+    </Row>
+    <Row gutter={8}>
+      <Col span={4}>{_.get(d, "responseInit.http.responseInit.httpStatus")}</Col>
+      <Col span={4}>{formatTapLatency(_.get(d, "responseInit.http.responseInit.sinceRequestInit"))}</Col>
+    </Row>
+  </React.Fragment>
+);
+
+const responseEndSection = d => (
+  <React.Fragment>
+    <h3>Response End</h3>
+    <Row gutter={8} className="expand-section-header">
+      <Col span={4}>GRPC Status</Col>
+      <Col span={4}>Latency</Col>
+      <Col span={4}>Response Length (B)</Col>
+    </Row>
+    <Row gutter={8}>
+      <Col span={4}>{grpcStatusCodes[_.get(d, "responseEnd.http.responseEnd.eos.grpcStatusCode")]}</Col>
+      <Col span={4}>{formatTapLatency(_.get(d, "responseEnd.http.responseEnd.sinceResponseInit"))}</Col>
+      <Col span={4}>{formatWithComma(_.get(d, "responseEnd.http.responseEnd.responseBytes"))}</Col>
+    </Row>
+  </React.Fragment>
+);
 
 // hide verbose information
 const expandedRowRender = d => {
   return (
-    <Row gutter={8}>
-      <Col span={12}>{ renderMetaLabels("Source Metadata", _.get(d, "base.sourceMeta.labels", {})) }</Col>
-      <Col span={12}>{ renderMetaLabels("Destination Metadata", _.get(d, "base.destinationMeta.labels", {})) }</Col>
-    </Row>
+    <div className="tap-more-info">
+      <Row gutter={8} className="tap-info-section">
+        {requestInitSection(d)}
+      </Row>
+      <hr />
+      <Row gutter={8} className="tap-info-section">
+        {responseInitSection(d)}
+      </Row>
+      <hr />
+      <Row gutter={8} className="tap-info-section">
+        {responseEndSection(d)}
+      </Row>
+    </div>
   );
 };
 
@@ -228,7 +197,8 @@ class TapEventTable extends React.Component {
       <Table
         dataSource={this.props.tableRows}
         columns={tapColumns(resourceType, this.props.filterOptions, this.props.api.ResourceLink)}
-        expandedRowRender={expandedRowRender}
+        expandedRowRender={expandedRowRender} // hide extra info in expandable row
+        expandRowByClick={true} // click anywhere on row to expand
         rowKey={r => r.base.id}
         pagination={false}
         className="tap-event-table"

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -101,50 +101,58 @@ const formatTapLatency = str => {
 
 const requestInitSection = d => (
   <React.Fragment>
-    <h3>Request Init</h3>
-    <Row gutter={8} className="expand-section-header">
-      <Col span={8}>Authority</Col>
-      <Col span={9}>Path</Col>
-      <Col span={2}>Scheme</Col>
-      <Col span={2}>Method</Col>
-      <Col span={3}>TLS</Col>
-    </Row>
-    <Row gutter={8}>
-      <Col span={8}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
-      <Col span={9}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
-      <Col span={2}>{_.get(d, "requestInit.http.requestInit.scheme.registered")}</Col>
-      <Col span={2}>{_.get(d, "requestInit.http.requestInit.method.registered")}</Col>
-      <Col span={3}>{_.get(d, "base.tls")}</Col>
-    </Row>
-  </React.Fragment>
-);
-
-const responseInitSection = d => (
-  <React.Fragment>
-    <h3>Response Init</h3>
-    <Row gutter={8} className="expand-section-header">
-      <Col span={4}>HTTP Status</Col>
-      <Col span={4}>Latency</Col>
-    </Row>
-    <Row gutter={8}>
-      <Col span={4}>{_.get(d, "responseInit.http.responseInit.httpStatus")}</Col>
-      <Col span={4}>{formatTapLatency(_.get(d, "responseInit.http.responseInit.sinceRequestInit"))}</Col>
+    <Row gutter={8} className="tap-info-section">
+      <h3>Request Init</h3>
+      <Row gutter={8} className="expand-section-header">
+        <Col span={8}>Authority</Col>
+        <Col span={9}>Path</Col>
+        <Col span={2}>Scheme</Col>
+        <Col span={2}>Method</Col>
+        <Col span={3}>TLS</Col>
+      </Row>
+      <Row gutter={8}>
+        <Col span={8}>{_.get(d, "requestInit.http.requestInit.authority")}</Col>
+        <Col span={9}>{_.get(d, "requestInit.http.requestInit.path")}</Col>
+        <Col span={2}>{_.get(d, "requestInit.http.requestInit.scheme.registered")}</Col>
+        <Col span={2}>{_.get(d, "requestInit.http.requestInit.method.registered")}</Col>
+        <Col span={3}>{_.get(d, "base.tls")}</Col>
+      </Row>
     </Row>
   </React.Fragment>
 );
 
-const responseEndSection = d => (
+const responseInitSection = d => _.isEmpty(d.responseInit) ? null : (
   <React.Fragment>
-    <h3>Response End</h3>
-    <Row gutter={8} className="expand-section-header">
-      <Col span={4}>GRPC Status</Col>
-      <Col span={4}>Latency</Col>
-      <Col span={4}>Response Length (B)</Col>
+    <hr />
+    <Row gutter={8} className="tap-info-section">
+      <h3>Response Init</h3>
+      <Row gutter={8} className="expand-section-header">
+        <Col span={4}>HTTP Status</Col>
+        <Col span={4}>Latency</Col>
+      </Row>
+      <Row gutter={8}>
+        <Col span={4}>{_.get(d, "responseInit.http.responseInit.httpStatus")}</Col>
+        <Col span={4}>{formatTapLatency(_.get(d, "responseInit.http.responseInit.sinceRequestInit"))}</Col>
+      </Row>
     </Row>
-    <Row gutter={8}>
-      <Col span={4}>{grpcStatusCodes[_.get(d, "responseEnd.http.responseEnd.eos.grpcStatusCode")]}</Col>
-      <Col span={4}>{formatTapLatency(_.get(d, "responseEnd.http.responseEnd.sinceResponseInit"))}</Col>
-      <Col span={4}>{formatWithComma(_.get(d, "responseEnd.http.responseEnd.responseBytes"))}</Col>
+  </React.Fragment>
+);
+
+const responseEndSection = d => _.isEmpty(d.responseEnd) ? null : (
+  <React.Fragment>
+    <hr />
+    <Row gutter={8} className="tap-info-section">
+      <h3>Response End</h3>
+      <Row gutter={8} className="expand-section-header">
+        <Col span={4}>GRPC Status</Col>
+        <Col span={4}>Latency</Col>
+        <Col span={4}>Response Length (B)</Col>
+      </Row>
+      <Row gutter={8}>
+        <Col span={4}>{grpcStatusCodes[_.get(d, "responseEnd.http.responseEnd.eos.grpcStatusCode")]}</Col>
+        <Col span={4}>{formatTapLatency(_.get(d, "responseEnd.http.responseEnd.sinceResponseInit"))}</Col>
+        <Col span={4}>{formatWithComma(_.get(d, "responseEnd.http.responseEnd.responseBytes"))}</Col>
+      </Row>
     </Row>
   </React.Fragment>
 );
@@ -153,17 +161,9 @@ const responseEndSection = d => (
 const expandedRowRender = d => {
   return (
     <div className="tap-more-info">
-      <Row gutter={8} className="tap-info-section">
-        {requestInitSection(d)}
-      </Row>
-      <hr />
-      <Row gutter={8} className="tap-info-section">
-        {responseInitSection(d)}
-      </Row>
-      <hr />
-      <Row gutter={8} className="tap-info-section">
-        {responseEndSection(d)}
-      </Row>
+      {requestInitSection(d)}
+      {responseInitSection(d)}
+      {responseEndSection(d)}
     </div>
   );
 };


### PR DESCRIPTION
Try to make the tap table easier to parse by moving some info into the expanded row.
You can also now click anywhere on the row to expand.

The mocks in #1629 have Authority and Path buried, but I figured they might be useful to see in the top level, so I added them there. I also added http and grpc status so the user can still get a sense of responseInit and responseEnd. Comments on column choice welcome.

![screen shot 2018-09-13 at 3 50 52 pm](https://user-images.githubusercontent.com/549258/45520204-22ebd800-b76d-11e8-90e4-f38a5ea94368.png)
![screen shot 2018-09-13 at 3 50 44 pm](https://user-images.githubusercontent.com/549258/45520206-24b59b80-b76d-11e8-8e91-a31888dccb17.png)

Fixes #1629