### PR TITLE
`linkerd check` sends params on version check

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -309,14 +309,13 @@ func (hc *HealthChecker) addLinkerdVersionChecks() {
 							if container.Name == "web" {
 								for _, arg := range container.Args {
 									if strings.HasPrefix(arg, "-uuid=") {
-										uuid = arg[len("-uuid="):]
+										uuid = strings.TrimPrefix(arg, "-uuid=")
 									}
 								}
 							}
 						}
 					}
 				}
-
 				hc.latestVersion, err = version.GetLatestVersion(uuid, "cli")
 			}
 			return

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ var Version = undefinedVersion
 
 const (
 	undefinedVersion = "undefined"
-	versionCheckURL  = "https://versioncheck.linkerd.io/version.json"
+	versionCheckURL  = "https://versioncheck.linkerd.io/version.json?version=%s&uuid=%s&source=%s"
 )
 
 func init() {
@@ -61,8 +61,9 @@ func CheckServerVersion(apiClient pb.ApiClient, latestVersion string) error {
 	return nil
 }
 
-func GetLatestVersion() (string, error) {
-	req, err := http.NewRequest("GET", versionCheckURL, nil)
+func GetLatestVersion(uuid string, source string) (string, error) {
+	url := fmt.Sprintf(versionCheckURL, Version, uuid, source)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
 	}

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -85,7 +85,7 @@ class Sidebar extends React.Component {
   }
 
   fetchVersion() {
-    let versionUrl = `https://versioncheck.linkerd.io/version.json?version=${this.props.releaseVersion}&uuid=${this.props.uuid}`;
+    let versionUrl = `https://versioncheck.linkerd.io/version.json?version=${this.props.releaseVersion}&uuid=${this.props.uuid}&source=web`;
     fetch(versionUrl, { credentials: 'include' })
       .then(rsp => rsp.json())
       .then(versionRsp =>


### PR DESCRIPTION
The `linkerd check` parameter hits
https://versioncheck.linkerd.io/version.json to check for the latest
Linkerd version. This loses information, as that endpoint is intended to
record current version, uuid, and source.

Modify `linkerd check` to set `version`, `uuid`, and `source`
parameters when performing a version check.

Part of #1604.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>