### PR TITLE
Add link to tap each row in top table

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -1,4 +1,4 @@
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css');
+@import url('https://use.fontawesome.com/releases/v5.3.1/css/all.css');
 
 :root {
   --white: #fff;

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -6,17 +6,27 @@ import TapEventTable from './TapEventTable.jsx';
 import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
+import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 import { httpMethods, processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const maxNumFilterOptions = 12;
+
+const urlPropsQueryConfig = {
+  autostart: { type: UrlQueryParamTypes.string }
+};
 
 class Tap extends React.Component {
   static propTypes = {
     api: PropTypes.shape({
       PrefixedLink: PropTypes.func.isRequired,
     }).isRequired,
+    autostart: PropTypes.string,
     pathPrefix: PropTypes.string.isRequired
+  }
+
+  static defaultProps = {
+    autostart: ""
   }
 
   constructor(props) {
@@ -53,6 +63,9 @@ class Tap extends React.Component {
 
   componentDidMount() {
     this.startServerPolling();
+    if (this.props.autostart === "true") {
+      this.startTapStreaming();
+    }
   }
 
   componentWillUnmount() {
@@ -366,4 +379,4 @@ class Tap extends React.Component {
   }
 }
 
-export default withContext(Tap);
+export default addUrlProps({ urlPropsQueryConfig })(withContext(Tap));

--- a/web/app/js/components/TapLink.jsx
+++ b/web/app/js/components/TapLink.jsx
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, path}) => {
+  let params = {
+    autostart: "true",
+    namespace,
+    resource,
+    toNamespace,
+    toResource,
+    path
+  };
+  let queryStr = _.join(_.map(params, (v,k) => `${k}=${v}`), "&");
+
+  return (
+    <PrefixedLink to={`/tap?${queryStr}`}>
+      <i className="fas fa-microscope" />
+    </PrefixedLink>
+  );
+};
+
+TapLink.propTypes = {
+  namespace: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  PrefixedLink: PropTypes.func.isRequired,
+  resource: PropTypes.string.isRequired,
+  toNamespace: PropTypes.string.isRequired,
+  toResource: PropTypes.string.isRequired,
+};
+
+export default TapLink;

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { successRateWithMiniChart } from './util/MetricUtils.jsx';
 import { Table } from 'antd';
 import { withContext } from './util/AppContext.jsx';
-import { directionColumn, srcDstColumn } from './util/TapUtils.jsx';
+import { directionColumn, srcDstColumn, tapLink } from './util/TapUtils.jsx';
 import { formatLatencySec, numericSort } from './util/Utils.js';
 
 const topMetricColWidth = "85px";
-const topColumns = (resourceType, ResourceLink) => [
+const topColumns = (resourceType, ResourceLink, PrefixedLink) => [
   {
     title: " ",
     key: "direction",
@@ -65,12 +65,20 @@ const topColumns = (resourceType, ResourceLink) => [
     width: "128px",
     sorter: (a, b) => numericSort(a.successRate.get(), b.successRate.get()),
     render: d => successRateWithMiniChart(d.get())
+  },
+  {
+    title: "Tap",
+    key: "tap",
+    className: "numeric",
+    width: topMetricColWidth,
+    render: d => tapLink(d, resourceType, PrefixedLink)
   }
 ];
 
 class TopEventTable extends React.Component {
   static propTypes = {
     api: PropTypes.shape({
+      PrefixedLink: PropTypes.func.isRequired,
       ResourceLink: PropTypes.func.isRequired,
     }).isRequired,
     resourceType: PropTypes.string.isRequired,
@@ -85,7 +93,7 @@ class TopEventTable extends React.Component {
     return (
       <Table
         dataSource={this.props.tableRows}
-        columns={topColumns(this.props.resourceType, this.props.api.ResourceLink)}
+        columns={topColumns(this.props.resourceType, this.props.api.ResourceLink, this.props.api.PrefixedLink)}
         rowKey="key"
         pagination={false}
         className="top-event-table metric-table"

--- a/web/app/js/components/TopEventTable.jsx
+++ b/web/app/js/components/TopEventTable.jsx
@@ -70,7 +70,7 @@ const topColumns = (resourceType, ResourceLink, PrefixedLink) => [
     title: "Tap",
     key: "tap",
     className: "numeric",
-    width: topMetricColWidth,
+    width: "30px",
     render: d => tapLink(d, resourceType, PrefixedLink)
   }
 ];

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import TapLink from '../TapLink.jsx';
 import { Popover, Tooltip } from 'antd';
 import { shortNameLookup, toShortResourceName } from './Utils.js';
 
@@ -214,5 +215,36 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
         { !_.isEmpty(labels[resourceType]) ? resourceShortLink(resourceType, labels, ResourceLink) : display.str }
       </div>
     </Popover>
+  );
+};
+
+export const tapLink = (d, resourceType, PrefixedLink) => {
+  let namespace = d.sourceLabels.namespace;
+  let resource = "";
+
+  if (_.has(d.sourceLabels, resourceType)) {
+    resource = `${resourceType}/${d.sourceLabels[resourceType]}`;
+  } else if (_.has(d.sourceLabels, "pod")) {
+    resource = `pod/${d.sourceLabels.pod}`;
+  } else {
+    return null; // can't tap a resource by IP from the web UI
+  }
+
+  let toNamespace = "";
+  let toResource = "";
+
+  if (_.has(d.destinationLabels, resourceType)) {
+    toNamespace = d.destinationLabels.namespace,
+    toResource = `${resourceType}/${d.destinationLabels[resourceType]}`;
+  }
+
+  return (
+    <TapLink
+      namespace={namespace}
+      resource={resource}
+      toNamespace={toNamespace}
+      toResource={toResource}
+      path={d.path}
+      PrefixedLink={PrefixedLink} />
   );
 };

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -236,6 +236,9 @@ export const tapLink = (d, resourceType, PrefixedLink) => {
   if (_.has(d.destinationLabels, resourceType)) {
     toNamespace = d.destinationLabels.namespace,
     toResource = `${resourceType}/${d.destinationLabels[resourceType]}`;
+  } else if (_.has(d.destinationLabels, "pod")) {
+    toNamespace = d.destinationLabels.namespace,
+    toResource = `${resourceType}/${d.destinationLabels.pod}`;
   }
 
   return (


### PR DESCRIPTION
This branch updates the `TopEventTable` component with a column to tap each row in the table. It looks like this:

![image](https://user-images.githubusercontent.com/9226/45526458-fbf0ce80-b78b-11e8-8733-21cb6abfbf8d.png)

Clicking on the icon takes you to the tap page with the form fields pre-populated with metadata from the top row, and it starts the tap immediately on page load.

Fixes #1461.