### PR TITLE
Bump default check retry time to 5 minutes

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -62,7 +62,7 @@ non-zero exit code.`,
 	cmd.PersistentFlags().StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
 	cmd.PersistentFlags().BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
 	cmd.PersistentFlags().BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
-	cmd.PersistentFlags().BoolVar(&options.wait, "wait", true, "Retry and wait for some checks to succeed if they don't pass the first time")
+	cmd.PersistentFlags().BoolVar(&options.wait, "wait", options.wait, "Retry and wait for some checks to succeed if they don't pass the first time")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 
 	return cmd

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -111,7 +111,7 @@ func newCmdDashboard() *cobra.Command {
 	// This is identical to what `kubectl proxy --help` reports, `--port 0` indicates a random port.
 	cmd.PersistentFlags().IntVarP(&options.dashboardProxyPort, "port", "p", options.dashboardProxyPort, "The port on which to run the proxy (when set to 0, a random port will be used)")
 	cmd.PersistentFlags().StringVar(&options.dashboardShow, "show", options.dashboardShow, "Open a dashboard in a browser or show URLs in the CLI (one of: linkerd, grafana, url)")
-	cmd.PersistentFlags().BoolVar(&options.wait, "wait", true, "Wait for dashboard to become available if it's not available when the command is run")
+	cmd.PersistentFlags().BoolVar(&options.wait, "wait", options.wait, "Wait for dashboard to become available if it's not available when the command is run")
 
 	return cmd
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -59,7 +59,7 @@ const (
 )
 
 var (
-	maxRetries  = 10
+	maxRetries  = 60
 	retryWindow = 5 * time.Second
 )
 


### PR DESCRIPTION
Per #1586, we're going to modify the `--wait` flag to accept a duration to wait for checks to pass. In the meantime, however, I'm going to bump the hardcoded retry duration to 5 minutes, since 50 seconds isn't long enough for post-install checks to pass on some clusters.