### PR TITLE
Key rows of top table on the resource type being requested

### DIFF
--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -17,6 +17,15 @@ import { defaultMaxRps, httpMethods, tapQueryProps, tapQueryPropType } from './u
 const colSpan = 5;
 const rowGutter = 16;
 
+// you can also tap resources to tap all pods in the resource
+const resourceTypes = [
+  "deployment",
+  "daemonset",
+  "pod",
+  "replicationcontroller",
+  "statefulset"
+];
+
 const getResourceList = (resourcesByNs, ns) => {
   return resourcesByNs[ns] || _.uniq(_.flatten(_.values(resourcesByNs)));
 };
@@ -252,6 +261,7 @@ class TapQueryForm extends React.Component {
     let nsEmpty = _.isNil(selectedNs) || _.isEmpty(selectedNs);
 
     let resourceOptions = _.concat(
+      resourceTypes,
       this.state.autocomplete[resourceKey] || [],
       nsEmpty ? [] : [`namespace/${selectedNs}`]
     );

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -114,30 +114,26 @@ class TopModule extends React.Component {
   }
 
   topEventKey = event => {
-    let resType = this.props.query.resource.split("/")[0];
-    let sourceKey = _.has(event, ["sourceMeta", "labels", resType]) ?
-      event.sourceMeta.labels[resType] : _.has(event.source, "pod") ? event.source.pod : event.source.str;
-
-    let dstKey =  _.has(event, ["destinationMeta", "labels", resType]) ?
-      event.destinationMeta.labels[resType] : _.has(event.destination, "pod") ? event.destination.pod : event.destination.str;
+    let sourceKey = event.source.owner || event.source.pod || event.source.str;
+    let dstKey = event.destination.owner || event.destination.pod || event.destination.str;
 
     return [sourceKey, dstKey, event.http.requestInit.path].join("_");
   }
 
   initialTopResult(d, eventKey) {
-    // in the event that we key on resources with multiple ips, store and display them
+    // in the event that we key on resources with multiple pods/ips, store them so we can display
     let sourceDisplay = {
       ips: {},
       pods: {}
     };
     sourceDisplay.ips[d.base.source.str] = true;
-    sourceDisplay.pods[d.requestInit.sourceMeta.labels.pod] = d.requestInit.sourceMeta.labels.namespace;
+    sourceDisplay.pods[d.base.source.pod] = d.base.source.namespace;
     let destinationDisplay = {
       ips: {},
       pods: {}
     };
     destinationDisplay.ips[d.base.destination.str] = true;
-    destinationDisplay.pods[d.requestInit.destinationMeta.labels.pod] = d.requestInit.destinationMeta.labels.namespace;
+    destinationDisplay.pods[d.base.destination.pod] = d.base.destination.namespace;
 
     return {
       count: 1,

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -127,13 +127,18 @@ class TopModule extends React.Component {
       pods: {}
     };
     sourceDisplay.ips[d.base.source.str] = true;
-    sourceDisplay.pods[d.base.source.pod] = d.base.source.namespace;
+    if (!_.isNil(d.base.source.pod)) {
+      sourceDisplay.pods[d.base.source.pod] = d.base.source.namespace;
+    }
+
     let destinationDisplay = {
       ips: {},
       pods: {}
     };
     destinationDisplay.ips[d.base.destination.str] = true;
-    destinationDisplay.pods[d.base.destination.pod] = d.base.destination.namespace;
+    if (!_.isNil(d.base.destination.pod)) {
+      destinationDisplay.pods[d.base.destination.pod] = d.base.destination.namespace;
+    }
 
     return {
       count: 1,
@@ -174,9 +179,14 @@ class TopModule extends React.Component {
     }
 
     result.sourceDisplay.ips[d.base.source.str] = true;
-    result.sourceDisplay.pods[d.requestInit.sourceMeta.labels.pod] = d.requestInit.sourceMeta.labels.namespace;
+    if (!_.isNil(d.requestInit.sourceMeta.labels.pod)) {
+      result.sourceDisplay.pods[d.requestInit.sourceMeta.labels.pod] = d.requestInit.sourceMeta.labels.namespace;
+    }
     result.destinationDisplay.ips[d.base.destination.str] = true;
-    result.destinationDisplay.pods[d.requestInit.destinationMeta.labels.pod] = d.requestInit.destinationMeta.labels.namespace;
+    if (!_.isNil(d.requestInit.destinationMeta.labels.pod)) {
+      result.destinationDisplay.pods[d.requestInit.destinationMeta.labels.pod] = d.requestInit.destinationMeta.labels.namespace;
+    }
+
     result.lastUpdated = Date.now();
   }
 

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -126,10 +126,18 @@ class TopModule extends React.Component {
 
   initialTopResult(d, eventKey) {
     // in the event that we key on resources with multiple ips, store and display them
-    let sourceIps = {};
-    sourceIps[d.base.source.str] = true;
-    let destinationIps = {};
-    destinationIps[d.base.destination.str] = true;
+    let sourceDisplay = {
+      ips: {},
+      pods: {}
+    };
+    sourceDisplay.ips[d.base.source.str] = true;
+    sourceDisplay.pods[d.requestInit.sourceMeta.labels.pod] = d.requestInit.sourceMeta.labels.namespace;
+    let destinationDisplay = {
+      ips: {},
+      pods: {}
+    };
+    destinationDisplay.ips[d.base.destination.str] = true;
+    destinationDisplay.pods[d.requestInit.destinationMeta.labels.pod] = d.requestInit.destinationMeta.labels.namespace;
 
     return {
       count: 1,
@@ -142,10 +150,10 @@ class TopModule extends React.Component {
       direction: d.base.proxyDirection,
       source: d.requestInit.source,
       sourceLabels: d.requestInit.sourceMeta.labels,
-      sourceIps,
+      sourceDisplay,
       destination: d.requestInit.destination,
       destinationLabels: d.requestInit.destinationMeta.labels,
-      destinationIps,
+      destinationDisplay,
       path: d.requestInit.http.requestInit.path,
       key: eventKey,
       lastUpdated: Date.now()
@@ -169,8 +177,10 @@ class TopModule extends React.Component {
       result.worst = d.responseEnd.latency;
     }
 
-    result.sourceIps[d.base.source.str] = true;
-    result.destinationIps[d.base.destination.str] = true;
+    result.sourceDisplay.ips[d.base.source.str] = true;
+    result.sourceDisplay.pods[d.requestInit.sourceMeta.labels.pod] = d.requestInit.sourceMeta.labels.namespace;
+    result.destinationDisplay.ips[d.base.destination.str] = true;
+    result.destinationDisplay.pods[d.requestInit.destinationMeta.labels.pod] = d.requestInit.destinationMeta.labels.namespace;
     result.lastUpdated = Date.now();
   }
 

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -157,22 +157,38 @@ const publicAddressToString = ipv4 => {
 */
 const resourceShortLink = (resourceType, labels, ResourceLink) => (
   <ResourceLink
+    key={labels[resourceType]}
     resource={{ type: resourceType, name: labels[resourceType], namespace: labels.namespace}}
     linkText={toShortResourceName(resourceType) + "/" + labels[resourceType]} />
 );
 
-const resourceSection = (ips, labels, ResourceLink) => {
-  // don't display more than three ips.... it'd be a long list
-  let ipList = _(ips).keys().take(3).value().join(", ") + (_.size(ips) > 3 ? "..." : "");
+const resourceSection = (display, labels, ResourceLink) => {
+  // don't display more than three ips/pods.... it could be a long list
+  let ipList = _(display.ips).keys().take(3).value().join(", ") + (_.size(display.ips) > 3 ? "..." : "");
+  let podList = (
+    <div>
+      {
+        _.map(display.pods, (namespace, pod, i) => {
+          if (i > 3) {
+            return null;
+          } else {
+            return <div key={pod}>{resourceShortLink("pod", { pod, namespace }, ResourceLink)}</div>;
+          }
+        })
+      }
+      { (_.size(display.pods) > 3 ? "..." : "") }
+    </div>
+  );
   return (
     <React.Fragment>
       {
         _.map(labels, (labelVal, labelName) => {
-          if (_.has(shortNameLookup, labelName) && labelName !== "namespace" && labelName !== "service") {
+          if (_.has(shortNameLookup, labelName) && labelName !== "namespace" && labelName !== "service" && labelName!== "pod") {
             return <div key={labelName + "-" + labelVal}>{ resourceShortLink(labelName, labels, ResourceLink) }</div>;
           }
         })
       }
+      {podList}
       <div>{ipList}</div>
     </React.Fragment>
   );
@@ -201,10 +217,10 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
   let content = (
     <React.Fragment>
       <h3>Source</h3>
-      {resourceSection(d.sourceIps, d.sourceLabels, ResourceLink)}
+      {resourceSection(d.sourceDisplay, d.sourceLabels, ResourceLink)}
       <br />
       <h3>Destination</h3>
-      {resourceSection(d.destinationIps, d.destinationLabels, ResourceLink)}
+      {resourceSection(d.destinationDisplay, d.destinationLabels, ResourceLink)}
     </React.Fragment>
   );
 

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -212,7 +212,7 @@ const resourceSection = (endpoint, display, labels, ResourceLink) => {
 
 export const extractPodOwner = labels => {
   let podOwner = "";
-  _.map(labels, (labelVal, labelName) => {
+  _.each(labels, (labelVal, labelName) => {
     if (_.has(podOwnerLookup, labelName)) {
       podOwner = labelName + "/" + labelVal;
     }

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -176,7 +176,7 @@ const resourceSection = (endpoint, display, labels, ResourceLink) => {
 
   if (!display) {
     ipList = endpoint.str;
-    podList = <div>{resourceShortLink("pod", { pod: endpoint.pod, namespace: endpoint.namespace }, ResourceLink)}</div>;
+    podList = !endpoint.pod ? null : <div>{resourceShortLink("pod", { pod: endpoint.pod, namespace: endpoint.namespace }, ResourceLink)}</div>;
   } else {
     // don't display more than three ips/pods.... it could be a long list
     ipList = _(display.ips).keys().take(3).value().join(", ") + (_.size(display.ips) > 3 ? "..." : "");
@@ -205,7 +205,7 @@ const resourceSection = (endpoint, display, labels, ResourceLink) => {
           }
         })
       }
-      {podList}
+      { podList }
       <div>{ipList}</div>
     </React.Fragment>
   );

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -169,6 +169,7 @@ const resourceShortLink = (resourceType, labels, ResourceLink) => (
 );
 
 // display consists of a list of ips and pods for aggregated displays (Top)
+const displayLimit = 3;
 const resourceSection = (endpoint, display, labels, ResourceLink) => {
   let ipList = null;
   let podList = null;
@@ -178,19 +179,20 @@ const resourceSection = (endpoint, display, labels, ResourceLink) => {
     podList = !endpoint.pod ? null : <div>{resourceShortLink("pod", { pod: endpoint.pod, namespace: endpoint.namespace }, ResourceLink)}</div>;
   } else {
     // don't display more than three ips/pods.... it could be a long list
-    ipList = _(display.ips).keys().take(3).value().join(", ") + (_.size(display.ips) > 3 ? "..." : "");
+    ipList = _(display.ips).keys().take(displayLimit).value().join(", ") +
+      (_.size(display.ips) > displayLimit ? "..." : "");
     podList = (
       <div>
         {
           _.map(display.pods, (namespace, pod, i) => {
-            if (i > 3) {
+            if (i > displayLimit) {
               return null;
             } else {
               return <div key={pod}>{resourceShortLink("pod", { pod, namespace }, ResourceLink)}</div>;
             }
           })
         }
-        { (_.size(display.pods) > 3 ? "..." : "") }
+        { (_.size(display.pods) > displayLimit ? "..." : "") }
       </div>
     );
   }

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -5,7 +5,6 @@ import TapLink from '../TapLink.jsx';
 import { podOwnerLookup, toShortResourceName } from './Utils.js';
 import { Popover, Tooltip } from 'antd';
 
-
 export const httpMethods = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"];
 
 export const defaultMaxRps = "100.0";

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -161,7 +161,9 @@ const resourceShortLink = (resourceType, labels, ResourceLink) => (
     linkText={toShortResourceName(resourceType) + "/" + labels[resourceType]} />
 );
 
-const resourceSection = (ip, labels, ResourceLink) => {
+const resourceSection = (ips, labels, ResourceLink) => {
+  // don't display more than three ips.... it'd be a long list
+  let ipList = _(ips).keys().take(3).value().join(", ") + (_.size(ips) > 3 ? "..." : "");
   return (
     <React.Fragment>
       {
@@ -171,7 +173,7 @@ const resourceSection = (ip, labels, ResourceLink) => {
           }
         })
       }
-      <div>{ip}</div>
+      <div>{ipList}</div>
     </React.Fragment>
   );
 };
@@ -199,10 +201,10 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
   let content = (
     <React.Fragment>
       <h3>Source</h3>
-      {resourceSection(d.source.str, d.sourceLabels, ResourceLink)}
+      {resourceSection(d.sourceIps, d.sourceLabels, ResourceLink)}
       <br />
       <h3>Destination</h3>
-      {resourceSection(d.destination.str, d.destinationLabels, ResourceLink)}
+      {resourceSection(d.destinationIps, d.destinationLabels, ResourceLink)}
     </React.Fragment>
   );
 

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -170,6 +170,14 @@ export const shortNameLookup = {
   "authority": "au"
 };
 
+export const podOwnerLookup = {
+  "deployment": "deploy",
+  "daemonset": "ds",
+  "replicationcontroller": "rc",
+  "replicaset": "rs",
+  "statefulset": "sts",
+};
+
 export const toShortResourceName = name => shortNameLookup[name] || name;
 
 export const isResource = name => {


### PR DESCRIPTION
*Problem*
Previously, we'd display one row in top per sourcePod -> dstPod. When viewing resources at a higher level though (e.g. deployments with multiple pods) the src/dst column displays the resource at that level, and displaying multiple rows with `deploy/foo` is confusing. 

*Solution*
Key the top table off of the resource currently being requested, so that all the rows are rolled up appropriately.
In the popover for that column, display a list of pods/ips that are rolled up.

This branch also adds a generic list of resources to the tap/top dropdown (you were always able to tap them, but when I switched from autocomplete to select for this dropdown, you lost the ability to type in arbitrary resources).

![screen shot 2018-09-14 at 1 01 21 pm](https://user-images.githubusercontent.com/549258/45572526-52a6e880-b81e-11e8-954f-da339c943362.png)

Fixes #1636