### PR TITLE
Ignore websockets error code 1006

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -46,6 +46,7 @@ class Tap extends React.Component {
       },
       maxLinesToDisplay: 40,
       tapRequestInProgress: false,
+      tapIsClosing: false,
       pollingInterval: 10000,
       pendingRequests: false
     };
@@ -85,7 +86,7 @@ class Tap extends React.Component {
   onWebsocketClose = e => {
     this.stopTapStreaming();
 
-    if (!e.wasClean) {
+    if (!e.wasClean && e.code !== 1006) {
       this.setState({
         error: {
           error: `Websocket close error [${e.code}: ${wsCloseCodes[e.code]}] ${e.reason ? ":" : ""} ${e.reason}`
@@ -284,7 +285,8 @@ class Tap extends React.Component {
 
   stopTapStreaming() {
     this.setState({
-      tapRequestInProgress: false
+      tapRequestInProgress: false,
+      tapIsClosing: false
     });
   }
 
@@ -295,6 +297,7 @@ class Tap extends React.Component {
 
   handleTapStop = () => {
     this.ws.close(1000);
+    this.setState({ tapIsClosing: true });
   }
 
   loadFromServer() {
@@ -348,6 +351,7 @@ class Tap extends React.Component {
 
         <TapQueryForm
           tapRequestInProgress={this.state.tapRequestInProgress}
+          tapIsClosing={this.state.tapIsClosing}
           handleTapStart={this.handleTapStart}
           handleTapStop={this.handleTapStop}
           resourcesByNs={this.state.resourcesByNs}

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -85,7 +85,11 @@ class Tap extends React.Component {
 
   onWebsocketClose = e => {
     this.stopTapStreaming();
-
+    /* We ignore any abnormal closure since it doesn't matter as long as
+    the connection to the websocket is closed. This is also a workaround
+    where Chrome browsers incorrectly displays a 1006 close code
+    https://github.com/linkerd/linkerd2/issues/1630
+    */
     if (!e.wasClean && e.code !== 1006) {
       this.setState({
         error: {

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -31,13 +31,14 @@ class TapQueryForm extends React.Component {
     handleTapStart: PropTypes.func.isRequired,
     handleTapStop: PropTypes.func.isRequired,
     query: tapQueryPropType.isRequired,
-    tapIsClosing: PropTypes.bool.isRequired,
+    tapIsClosing: PropTypes.bool,
     tapRequestInProgress: PropTypes.bool.isRequired,
     updateQuery: PropTypes.func.isRequired
   }
 
   static defaultProps = {
-    enableAdvancedForm: true
+    enableAdvancedForm: true,
+    tapIsClosing: false
   }
 
   constructor(props) {

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -31,6 +31,7 @@ class TapQueryForm extends React.Component {
     handleTapStart: PropTypes.func.isRequired,
     handleTapStop: PropTypes.func.isRequired,
     query: tapQueryPropType.isRequired,
+    tapIsClosing: PropTypes.bool.isRequired,
     tapRequestInProgress: PropTypes.bool.isRequired,
     updateQuery: PropTypes.func.isRequired
   }
@@ -278,6 +279,16 @@ class TapQueryForm extends React.Component {
     );
   }
 
+  renderTapButton(tapInProgress, tapIsClosing) {
+    if (tapIsClosing) {
+      return (<Button type="primary" className="top-stop" disabled={true}>Stop</Button>);
+    } else if (tapInProgress) {
+      return (<Button type="primary" className="tap-stop" onClick={this.props.handleTapStop}>Stop</Button>);
+    } else {
+      return (<Button type="primary" className="tap-start" onClick={this.props.handleTapStart}>Start</Button>);
+    }
+  }
+
   render() {
     return (
       <Form className="tap-form">
@@ -308,11 +319,7 @@ class TapQueryForm extends React.Component {
 
           <Col span={colSpan}>
             <Form.Item>
-              {
-                this.props.tapRequestInProgress ?
-                  <Button type="primary" className="tap-stop" onClick={this.props.handleTapStop}>Stop</Button> :
-                  <Button type="primary" className="tap-start" onClick={this.props.handleTapStart}>Start</Button>
-              }
+              { this.renderTapButton(this.props.tapRequestInProgress, this.props.tapIsClosing) }
             </Form.Item>
           </Col>
         </Row>

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -20,6 +20,7 @@ class Top extends React.Component {
     super(props);
     this.api = this.props.api;
     this.loadFromServer = this.loadFromServer.bind(this);
+    this.updateTapClosingState = this.updateTapClosingState.bind(this);
 
     this.state = {
       error: null,
@@ -140,8 +141,13 @@ class Top extends React.Component {
 
   handleTapStop = () => {
     this.setState({
-      tapRequestInProgress: false
+      tapRequestInProgress: false,
+      tapIsClosing: true
     });
+  }
+
+  updateTapClosingState(isTapClosing) {
+    this.setState({tapIsClosing: isTapClosing});
   }
 
   render() {
@@ -156,6 +162,7 @@ class Top extends React.Component {
           resourcesByNs={this.state.resourcesByNs}
           authoritiesByNs={this.state.authoritiesByNs}
           tapRequestInProgress={this.state.tapRequestInProgress}
+          tapIsClosing={this.state.tapIsClosing}
           updateQuery={this.updateQuery}
           query={this.state.query} />
 
@@ -163,7 +170,8 @@ class Top extends React.Component {
         <TopModule
           pathPrefix={this.props.pathPrefix}
           query={this.state.query}
-          startTap={this.state.tapRequestInProgress} />
+          startTap={this.state.tapRequestInProgress}
+          updateTapClosingState={this.updateTapClosingState} />
       </div>
     );
   }

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -16,7 +16,8 @@ class TopModule extends React.Component {
       resource: PropTypes.string.isRequired
     }).isRequired,
     startTap: PropTypes.bool.isRequired,
-    updateNeighbors: PropTypes.func
+    updateNeighbors: PropTypes.func,
+    updateTapClosingState: PropTypes.func.isRequired
   }
 
   static defaultProps = {
@@ -81,7 +82,8 @@ class TopModule extends React.Component {
   }
 
   onWebsocketClose = e => {
-    if (!e.wasClean) {
+    this.props.updateTapClosingState(false);
+    if (!e.wasClean && e.code !== 1006) {
       this.setState({
         error: {
           error: `Websocket close error [${e.code}: ${wsCloseCodes[e.code]}] ${e.reason ? ":" : ""} ${e.reason}`

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -83,6 +83,11 @@ class TopModule extends React.Component {
 
   onWebsocketClose = e => {
     this.props.updateTapClosingState(false);
+    /* We ignore any abnormal closure since it doesn't matter as long as
+    the connection to the websocket is closed. This is also a workaround
+    where Chrome browsers incorrectly displays a 1006 close code
+    https://github.com/linkerd/linkerd2/issues/1630
+    */
     if (!e.wasClean && e.code !== 1006) {
       this.setState({
         error: {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -17,7 +17,7 @@ class TopModule extends React.Component {
     }).isRequired,
     startTap: PropTypes.bool.isRequired,
     updateNeighbors: PropTypes.func,
-    updateTapClosingState: PropTypes.func.isRequired
+    updateTapClosingState: PropTypes.func
   }
 
   static defaultProps = {
@@ -27,7 +27,8 @@ class TopModule extends React.Component {
     // - un-ended tap results, pre-aggregation into the top counts
     // - aggregated top rows
     maxRowsToStore: 50,
-    updateNeighbors: _.noop
+    updateNeighbors: _.noop,
+    updateTapClosingState: _.noop
   }
 
   constructor(props) {


### PR DESCRIPTION
When a websocket connection is closed between Chrome and a server, we get a `1006` error code signifying abnormal closure of the websocket connection. It seems as if we only get this error on Chrome web clients. Firefox and Safari do not encounter this issue.

The solution is to suppress `1006` errors that occur in the web browser since the connection is closed anyway. There is no negative side effect that occurs when the connection is closed abnormally and so the error message is benign. 

![tap-output](https://user-images.githubusercontent.com/2197104/45576718-38c0d200-b82d-11e8-8ed9-19ff46f9f78f.gif)


fixes #1630 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>