### PR TITLE
Fix the debug message in endpoints watcher

### DIFF
--- a/controller/destination/endpoints_watcher.go
+++ b/controller/destination/endpoints_watcher.go
@@ -2,6 +2,7 @@ package destination
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	net "github.com/linkerd/linkerd2-proxy-api/go/net"
@@ -341,7 +342,13 @@ func (sp *servicePort) updateService(newService *v1.Service) {
 
 func (sp *servicePort) updateAddresses(endpoints *v1.Endpoints, port intstr.IntOrString) {
 	newAddresses := sp.endpointsToAddresses(endpoints, port)
-	log.Debugf("Updating %s:%d to %v", sp.service, sp.port, newAddresses)
+	if log.GetLevel() >= log.DebugLevel {
+		var s []string
+		for _, v := range newAddresses {
+			s = append(s, fmt.Sprintf("%v", *v))
+		}
+		log.Debugf("Updating %s:%d to [%v]", sp.service, sp.port, strings.Join(s, ", "))
+	}
 
 	if len(newAddresses) == 0 {
 		for _, listener := range sp.listeners {

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -1,6 +1,8 @@
 package destination
 
 import (
+	"fmt"
+
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	net "github.com/linkerd/linkerd2-proxy-api/go/net"
 	"github.com/linkerd/linkerd2/pkg/addr"
@@ -24,6 +26,10 @@ type ownerKindAndNameFn func(*coreV1.Pod) (string, string)
 type updateAddress struct {
 	address *net.TcpAddress
 	pod     *coreV1.Pod
+}
+
+func (ua updateAddress) String() string {
+	return fmt.Sprintf("{address:%v, pod:%s.%s}", ua.address, ua.pod.Namespace, ua.pod.Name)
 }
 
 func diffUpdateAddresses(oldAddrs, newAddrs []*updateAddress) ([]*updateAddress, []*updateAddress) {

--- a/controller/destination/listener.go
+++ b/controller/destination/listener.go
@@ -29,7 +29,7 @@ type updateAddress struct {
 }
 
 func (ua updateAddress) String() string {
-	return fmt.Sprintf("{address:%v, pod:%s.%s}", ua.address, ua.pod.Namespace, ua.pod.Name)
+	return fmt.Sprintf("{address:%v, pod:%s.%s}", addr.ProxyAddressToString(ua.address), ua.pod.Namespace, ua.pod.Name)
 }
 
 func diffUpdateAddresses(oldAddrs, newAddrs []*updateAddress) ([]*updateAddress, []*updateAddress) {


### PR DESCRIPTION
This is how the log line looks like after this change `Updating name1.ns:8989 to [{address:ip:<ipv4:183059183 > port:8989 , pod:ns.name1-f748fb6b4-hpwpw}, {address:ip:<ipv4:183064820 > port:8989 , pod:ns.name1-f748fb6b4-6vcmw}]`

Closes #1606

Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>