### PR TITLE
Remove RPS unit, fix Tap and Top in sidebar

### DIFF
--- a/web/app/css/sidebar.css
+++ b/web/app/css/sidebar.css
@@ -44,10 +44,6 @@ ul.ant-menu.ant-menu-sub {
     & .ant-select-selection {
       width: 220px;
     }
-
-    & .fas {
-      margin-right: 10px;
-    }
   }
 
   & .sidebar-submenu-item {

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -19,12 +19,12 @@ import { processedMetricsPropType, successRateWithMiniChart } from './util/Metri
 */
 const smMetricColWidth = "70px";
 
-const withTooltip = (d, metricName) => {
+const withTooltip = (d, metricName, hideUnit) => {
   return (
     <Tooltip
       title={metricToFormatter["UNTRUNCATED"](d)}
       overlayStyle={{ fontSize: "12px" }}>
-      <span>{metricToFormatter[metricName](d)}</span>
+      <span>{ !hideUnit ? metricToFormatter[metricName](d) : metricToFormatter["NO_UNIT"](d)}</span>
     </Tooltip>
   );
 };
@@ -130,7 +130,7 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       className: "numeric",
       width: smMetricColWidth,
       sorter: (a, b) => numericSort(a.requestRate, b.requestRate),
-      render: d => withTooltip(d, "REQUEST_RATE")
+      render: d => withTooltip(d, "REQUEST_RATE", true)
     },
     {
       title: formatTitle("P50", "P50 Latency"),

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -19,16 +19,6 @@ import { processedMetricsPropType, successRateWithMiniChart } from './util/Metri
 */
 const smMetricColWidth = "70px";
 
-const withTooltip = (d, metricName, hideUnit) => {
-  return (
-    <Tooltip
-      title={metricToFormatter["UNTRUNCATED"](d)}
-      overlayStyle={{ fontSize: "12px" }}>
-      <span>{ !hideUnit ? metricToFormatter[metricName](d) : metricToFormatter["NO_UNIT"](d)}</span>
-    </Tooltip>
-  );
-};
-
 const formatTitle = (title, tooltipText) => {
   if (!tooltipText) {
     return title;
@@ -130,7 +120,7 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       className: "numeric",
       width: smMetricColWidth,
       sorter: (a, b) => numericSort(a.requestRate, b.requestRate),
-      render: d => withTooltip(d, "REQUEST_RATE", true)
+      render: metricToFormatter["NO_UNIT"]
     },
     {
       title: formatTitle("P50", "P50 Latency"),

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -193,14 +193,14 @@ class Sidebar extends React.Component {
 
             <Menu.Item className="sidebar-menu-item" key="/tap">
               <PrefixedLink to="/tap">
-                <i className="fas fa-microscope" />
+                <Icon><i className="fas fa-microscope" /></Icon>
                 <span>Tap</span>
               </PrefixedLink>
             </Menu.Item>
 
             <Menu.Item className="sidebar-menu-item" key="/top">
               <PrefixedLink to="/top">
-                <i className="fas fa-stream" />
+                <Icon><i className="fas fa-stream" /></Icon>
                 <span>Top</span>
               </PrefixedLink>
             </Menu.Item>

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -51,7 +51,8 @@ export const metricToFormatter = {
   "REQUEST_RATE": m => _.isNil(m) ? "---" : styleNum(m, " RPS", true),
   "SUCCESS_RATE": m => _.isNil(m) ? "---" : successRateFormatter(m),
   "LATENCY": formatLatencyMs,
-  "UNTRUNCATED": m => styleNum(m, "", false)
+  "UNTRUNCATED": m => styleNum(m, "", false),
+  "NO_UNIT": m => _.isNil(m) ? "---" : styleNum(m, "", true)
 };
 
 /*


### PR DESCRIPTION
- Don't display RPS as a unit in RPS column
- Fix tap and top sidebar items not being minimized correctly

Before:

![screen shot 2018-09-17 at 11 02 47 am](https://user-images.githubusercontent.com/549258/45641216-b96c1200-ba69-11e8-8cab-e99174d02be5.png)
![screen shot 2018-09-17 at 11 06 06 am](https://user-images.githubusercontent.com/549258/45641220-bc670280-ba69-11e8-9a82-6135656448b7.png)


After:
![screen shot 2018-09-17 at 11 04 23 am](https://user-images.githubusercontent.com/549258/45641226-bffa8980-ba69-11e8-9105-609673337cad.png)
![screen shot 2018-09-17 at 11 02 02 am](https://user-images.githubusercontent.com/549258/45641232-c2f57a00-ba69-11e8-9598-87fc54f40110.png)

Fixes #1651 
