### PR TITLE
Fix errors on the tap form when clearing items

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -7,7 +7,7 @@ import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
-import { httpMethods, processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
+import { processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const urlPropsQueryConfig = {
@@ -109,19 +109,6 @@ class Tap extends React.Component {
     });
 
     this.stopTapStreaming();
-  }
-
-  getInitialTapFilterOptions() {
-    return {
-      source: {},
-      destination: {},
-      path: {},
-      authority: {},
-      scheme: {},
-      httpStatus: {},
-      tls: {},
-      httpMethod: httpMethods
-    };
   }
 
   getResourcesByNs(rsp) {

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -67,7 +67,7 @@ const methodCol = {
   render: d => !d ? <Icon type="loading" /> : _.get(d, "method.registered")
 };
 
-const topLevelColumns = (resourceType, filterOptions, ResourceLink) => [
+const topLevelColumns = (resourceType, ResourceLink) => [
   {
     title: "Direction",
     key: "direction",
@@ -96,9 +96,9 @@ const topLevelColumns = (resourceType, filterOptions, ResourceLink) => [
   }
 ];
 
-const tapColumns = (resourceType, filterOptions, ResourceLink) => {
+const tapColumns = (resourceType, ResourceLink) => {
   return _.concat(
-    topLevelColumns(resourceType, filterOptions, ResourceLink),
+    topLevelColumns(resourceType, ResourceLink),
     [ methodCol, pathCol, responseInitLatencyCol, httpStatusCol, grpcStatusCol ]
   );
 };
@@ -181,13 +181,12 @@ class TapEventTable extends React.Component {
     api: PropTypes.shape({
       ResourceLink: PropTypes.func.isRequired,
     }).isRequired,
-    filterOptions: PropTypes.shape({}),
-    resource: PropTypes.string.isRequired,
+    resource: PropTypes.string,
     tableRows: PropTypes.arrayOf(PropTypes.shape({})),
   }
 
   static defaultProps = {
-    filterOptions: {},
+    resource: "",
     tableRows: []
   }
 
@@ -196,7 +195,7 @@ class TapEventTable extends React.Component {
     return (
       <Table
         dataSource={this.props.tableRows}
-        columns={tapColumns(resourceType, this.props.filterOptions, this.props.api.ResourceLink)}
+        columns={tapColumns(resourceType, this.props.api.ResourceLink)}
         expandedRowRender={expandedRowRender} // hide extra info in expandable row
         expandRowByClick={true} // click anywhere on row to expand
         rowKey={r => r.base.id}

--- a/web/app/js/components/TapQueryCliCmd.jsx
+++ b/web/app/js/components/TapQueryCliCmd.jsx
@@ -54,7 +54,9 @@ export default class TapQueryCliCmd extends React.Component {
               linkerd {this.props.cmdName} {resource}
               { resource.indexOf("namespace") === 0 ? null : this.renderCliItem("--namespace", namespace) }
               { this.renderCliItem("--to", toResource) }
-              { toResource.indexOf("namespace") === 0 ? null : this.renderCliItem("--to-namespace", toNamespace) }
+              { _.isEmpty(toResource) || toResource.indexOf("namespace") === 0 ? null :
+                this.renderCliItem("--to-namespace", toNamespace)
+              }
               { this.renderCliItem("--method", method) }
               { this.renderCliItem("--scheme", scheme) }
               { this.renderCliItem("--authority", authority) }


### PR DESCRIPTION
If you select a from namespace and from resource in `/tap` and try to clear them using the little x in the form field, there would be a huge js error causing the app to not render. Fix this. 

Also removes `filterOptions` which wasn't being used any more. This will probably make parsing tap results ever so slightly faster as we're now not trying to also aggregate potential filter options.