### PR TITLE
Update check command to work with older versions

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -91,9 +91,9 @@ func GetLatestVersion(uuid string, source string) (string, error) {
 		return "", err
 	}
 
-	channel, err := parseChannel(Version)
-	if err != nil {
-		return "", err
+	channel := parseChannel(Version)
+	if channel == "" {
+		return "", fmt.Errorf("Unsupported version format: %s", Version)
 	}
 
 	version, ok := versionRsp[channel]
@@ -104,36 +104,30 @@ func GetLatestVersion(uuid string, source string) (string, error) {
 	return version, nil
 }
 
-func parseVersion(version string) (string, error) {
+func parseVersion(version string) string {
 	if parts := strings.SplitN(version, "-", 2); len(parts) == 2 {
-		return parts[1], nil
+		return parts[1]
 	}
-	return "", fmt.Errorf("Unsupported version format: %s", version)
+	return version
 }
 
-func parseChannel(version string) (string, error) {
+func parseChannel(version string) string {
 	if parts := strings.SplitN(version, "-", 2); len(parts) == 2 {
-		return parts[0], nil
+		return parts[0]
 	}
-	return "", fmt.Errorf("Unsupported version format: %s", version)
+	return ""
 }
 
 func versionMismatchError(expectedVersion, actualVersion string) error {
-	channel, err := parseChannel(expectedVersion)
-	if err != nil {
-		return err
-	}
+	channel := parseChannel(expectedVersion)
+	expectedVersionStr := parseVersion(expectedVersion)
+	actualVersionStr := parseVersion(actualVersion)
 
-	expectedVersionStr, err := parseVersion(expectedVersion)
-	if err != nil {
-		return err
+	if channel != "" {
+		return fmt.Errorf("is running version %s but the latest %s version is %s",
+			actualVersionStr, channel, expectedVersionStr)
+	} else {
+		return fmt.Errorf("is running version %s but the latest version is %s",
+			actualVersionStr, expectedVersionStr)
 	}
-
-	actualVersionStr, err := parseVersion(actualVersion)
-	if err != nil {
-		return err
-	}
-
-	return fmt.Errorf("is running version %s but the latest %s version is %s",
-		actualVersionStr, channel, expectedVersionStr)
 }


### PR DESCRIPTION
This branch allows our `linkerd check` code to parse older version strings that may not include a release channel. This will allow us to print more helpful error messages when the error check fails.

As of the `edge-18.8.2` release, the error message looked like this when running `linkerd check` against `v18.8.1`:

```
kubernetes-api: can initialize the client..................................[ok]
kubernetes-api: can query the Kubernetes API...............................[ok]
kubernetes-api: is running the minimum Kubernetes API version..............[ok]
linkerd-api: control plane namespace exists................................[ok]
linkerd-api: control plane pods are ready..................................[ok]
linkerd-api: can initialize the client.....................................[ok]
linkerd-api: can query the control plane API...............................[ok]
linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
linkerd-version: can determine the latest version..........................[ok]
linkerd-version: cli is up-to-date.........................................[ok]
linkerd-version: control plane is up-to-date...............................[FAIL] -- Unsupported version format: v18.9.1

Status check results are [FAIL]
```

With this change, it now looks like this:

```
kubernetes-api: can initialize the client..................................[ok]
kubernetes-api: can query the Kubernetes API...............................[ok]
kubernetes-api: is running the minimum Kubernetes API version..............[ok]
linkerd-api: control plane namespace exists................................[ok]
linkerd-api: control plane pods are ready..................................[ok]
linkerd-api: can initialize the client.....................................[ok]
linkerd-api: can query the control plane API...............................[ok]
linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
linkerd-version: can determine the latest version..........................[ok]
linkerd-version: cli is up-to-date.........................................[ok]
linkerd-version: control plane is up-to-date...............................[FAIL] -- is running version v18.9.1 but the latest edge version is 18.9.2

Status check results are [FAIL]
```