### PR TITLE
Disable the tap start button if no ns/resource is selected

### DIFF
--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -296,7 +296,14 @@ class TapQueryForm extends React.Component {
     } else if (tapInProgress) {
       return (<Button type="primary" className="tap-stop" onClick={this.props.handleTapStop}>Stop</Button>);
     } else {
-      return (<Button type="primary" className="tap-start" onClick={this.props.handleTapStart}>Start</Button>);
+      return (
+        <Button
+          type="primary"
+          className="tap-start"
+          disabled={!this.state.query.namespace || !this.state.query.resource}
+          onClick={this.props.handleTapStart}>
+          Start
+        </Button>);
     }
   }
 


### PR DESCRIPTION
Prevent error when trying to tap without having a namespace and resource
selected by disabling the tap button.

Fixes #1670

Signed-off-by: Mathis Wiehl <mathis.wiehl@sinnerschrader.com>