### PR TITLE
Make zero success rate more noticeable in chart

### DIFF
--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -46,7 +46,7 @@ export const successRateWithMiniChart = sr => (
       showInfo={false}
       width={32}
       strokeWidth={12}
-      percent={sr * 100}
+      percent={sr === 0 ? 100 : sr * 100} // if success rate is 0, we want a red chart, not a gray chart
       gapDegree={180} />
   </div>
 );


### PR DESCRIPTION
The success rate mini chart shows a colour based on SR, and also shows the SR via the proportion of the chart that's filled out. If the success rate is 0% (as in the VotePoop endpoint), the chart would be zero percent filled out, causing it to be entirely gray. Really, it should be entirely red, since zero SR is pretty bad.

Fix: fully fill the bar with red if there is a zero SR

Before:
![screen shot 2018-09-18 at 2 00 03 pm](https://user-images.githubusercontent.com/549258/45716303-65d1f500-bb4b-11e8-9229-55432a23ddb5.png)


After:
![screen shot 2018-09-18 at 1 59 10 pm](https://user-images.githubusercontent.com/549258/45716313-69657c00-bb4b-11e8-9f68-3ab28c9b17d1.png)

