### PR TITLE
Fix unresponsive tap button when no data is available.

### DIFF
--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -158,14 +158,14 @@ func (h *handler) handleApiTap(w http.ResponseWriter, req *http.Request, p httpr
 		return
 	}
 
-	tapClient, err := h.apiClient.TapByResource(req.Context(), tapReq)
-	if err != nil {
-		websocketError(ws, websocket.CloseInternalServerErr, err.Error())
-		return
-	}
-	defer tapClient.CloseSend()
-
 	go func() {
+		tapClient, err := h.apiClient.TapByResource(req.Context(), tapReq)
+		if err != nil {
+			websocketError(ws, websocket.CloseInternalServerErr, err.Error())
+			return
+		}
+		defer tapClient.CloseSend()
+
 		for {
 			rsp, err := tapClient.Recv()
 			if err == io.EOF {
@@ -195,6 +195,7 @@ func (h *handler) handleApiTap(w http.ResponseWriter, req *http.Request, p httpr
 	for {
 		_, _, err := ws.ReadMessage()
 		if err != nil {
+			log.Debugf("Received close frame: %v", err)
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
 				log.Errorf("Unexpected close error: %s", err)
 			}


### PR DESCRIPTION
When a resource has no tap events being streamed to the Tap UI, and a user hits the "Stop" button in the Tap page, the tap stream is left open due to the WebSocket connection not being closed.

It looks like the web server's tap client that is created to stream events from the tap server blocks the main request thread in the web server. This causes the web server to stop receiving any subsequent close frames from the UI i.e. when the "Stop" button is clicked. 

This PR moves the tapClient initialization code to a separate goroutine, specifically, the goroutine that reads tap events from the incoming grpc tap stream. This allows the main thread to continue reading messages from the WebSocket connection and allow it to receive close frames.

fixes #1665

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>