### PR TITLE
Add an initializing status icon when pods are initializing

### DIFF
--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -85,16 +85,7 @@ td div.status-dot {
   color: var(--red);
 }
 .controller-init-icon {
-
-  & .ant-badge-status-processing {
-    background-color: var(--orange);
-    margin-left: 5px;
-  }
-
-  & .ant-badge-status-processing::after {
-    border: 1px solid var(--orange);
-  }
-
+  margin-left: 5px;
 }
 
 .controller-pod-error {

--- a/web/app/css/service-mesh.css
+++ b/web/app/css/service-mesh.css
@@ -84,6 +84,18 @@ td div.status-dot {
   margin-left: 5px;
   color: var(--red);
 }
+.controller-init-icon {
+
+  & .ant-badge-status-processing {
+    background-color: var(--orange);
+    margin-left: 5px;
+  }
+
+  & .ant-badge-status-processing::after {
+    border: 1px solid var(--orange);
+  }
+
+}
 
 .controller-pod-error {
   margin-bottom: calc(3 * var(--base-width));

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { friendlyTitle } from './util/Utils.js';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Badge, Button, Icon, Modal, Switch } from 'antd';
+import { Button, Icon, Modal, Switch, Tooltip } from 'antd';
 
 // max characters we display for error messages before truncating them
 const maxErrorLength = 500;
@@ -125,19 +125,27 @@ export default class ErrorModal extends React.Component {
   }
 
   renderIconStatus = errors => {
-    let containers = errors.byPodAndContainer;
-    let showInit = _.flatten(_.map(containers, container => {
-      return _.map(container.byContainer, con => {
-        return con[0].reason;
+    let showInit = true;
+
+    _.each(errors.byPodAndContainer, container => {
+      _.each(container.byContainer, con => {
+        if (con[0].reason !== "PodInitializing") {
+          showInit = false;
+        }
       });
-    }));
-    if (_.every(showInit, status => status === "PodInitializing")) {
-      return <Badge status="processing" className="controller-init-icon" onClick={this.showModal} />;
+    });
+
+    if (showInit) {
+      return (
+        <Tooltip
+          title="Pods are initializing"
+          overlayStyle={{ fontSize: "12px" }}>
+          <Icon type="loading" theme="outlined" className="controller-init-icon" />
+        </Tooltip>
+      );
     } else {
       return <Icon type="warning" className="controller-error-icon" onClick={this.showModal} />;
-
     }
-
   }
 
   render() {

--- a/web/app/js/components/ErrorModal.jsx
+++ b/web/app/js/components/ErrorModal.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { friendlyTitle } from './util/Utils.js';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, Icon, Modal, Switch } from 'antd';
+import { Badge, Button, Icon, Modal, Switch } from 'antd';
 
 // max characters we display for error messages before truncating them
 const maxErrorLength = 500;
@@ -124,12 +124,27 @@ export default class ErrorModal extends React.Component {
     });
   }
 
+  renderIconStatus = errors => {
+    let containers = errors.byPodAndContainer;
+    let showInit = _.flatten(_.map(containers, container => {
+      return _.map(container.byContainer, con => {
+        return con[0].reason;
+      });
+    }));
+    if (_.every(showInit, status => status === "PodInitializing")) {
+      return <Badge status="processing" className="controller-init-icon" onClick={this.showModal} />;
+    } else {
+      return <Icon type="warning" className="controller-error-icon" onClick={this.showModal} />;
+
+    }
+
+  }
+
   render() {
     let errors = this.processErrorData(this.props.errors);
-
     return (
       <React.Fragment>
-        <Icon type="warning" className="controller-error-icon" onClick={this.showModal} />
+        {this.renderIconStatus(errors)}
         <Modal
           className="controller-pod-error-modal"
           title={`Errors in ${friendlyTitle(this.props.resourceType).singular} ${this.props.resourceName}`}


### PR DESCRIPTION
When pods or deployments are in an "Initialization" phase we currently see a "warning" icon that represents pods going under some kind of change. This may sometimes seem alarming when initially injecting pods after installing Linkerd.

This PR adds a new icon that shows up when pods are in the "PodInitializing" phase and shows the former "warning" icon when there is an error in starting pods.

(Image is a gif and takes a few seconds to start.)

![pod-init-status](https://user-images.githubusercontent.com/2197104/45783647-338fc880-bc1b-11e8-96a6-e3d1cdff2ce2.gif)

fixes #1652

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>