### PR TITLE
Draw SVG octopus arms in ResourceDetail inbound/outbound chart

### DIFF
--- a/web/app/css/octopus.css
+++ b/web/app/css/octopus.css
@@ -2,6 +2,7 @@
 
 .octopus-graph {
   max-width: 940px;
+  padding: calc(var(--base-width) * 2);
   margin-left: auto;
   margin-right: auto;
   background-color: #FAFAFA;

--- a/web/app/css/octopus.css
+++ b/web/app/css/octopus.css
@@ -17,7 +17,9 @@
     text-align: center;
 
     & .neighbor {
-      height: 240px;
+      height: 200px;
+      margin-top: 5px;
+      margin-bottom: 5px;
     }
   }
 
@@ -28,7 +30,11 @@
       font-size: 24px;
       font-weight: var(--font-weight-extra-bold);
     }
+
     &.neighbor-title {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow-x: hidden;
       font-size: 16px;
       font-weight: var(--font-weight-bold);
     }

--- a/web/app/css/octopus.css
+++ b/web/app/css/octopus.css
@@ -1,30 +1,33 @@
 @import 'styles.css';
 
 .octopus-graph {
-  padding: calc(var(--base-width) * 4);
+  max-width: 940px;
+  margin-left: auto;
+  margin-right: auto;
   background-color: #FAFAFA;
 
   & .octopus-body {
     background-color: white;
-    margin-bottom: calc(var(--base-width) * 3);
     border: 1px solid #F2F2F2;
+    padding: var(--base-width);
   }
 
   & .octopus-col {
     text-align: center;
-  }
-  & .resource-col {
-    padding: 32px;
+
+    & .neighbor {
+      height: 240px;
+    }
   }
 
   & .octopus-title {
     padding: 8px 0;
 
-    &.main {
+    &.main-title {
       font-size: 24px;
       font-weight: var(--font-weight-extra-bold);
     }
-    &.neighbor {
+    &.neighbor-title {
       font-size: 16px;
       font-weight: var(--font-weight-bold);
     }

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -74,8 +74,8 @@ export default class Octopus extends React.Component {
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let baseHeight = 184;
-    let width = 78;
+    let baseHeight = 222;
+    let width = 75;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
     let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -1,7 +1,8 @@
 import _ from 'lodash';
+import OctopusArms from './util/OctopusArms.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Col, Icon, Progress, Row } from 'antd';
+import { Col, Progress, Row } from 'antd';
 import { getSuccessRateClassification, srArcClassLabels } from './util/MetricUtils.jsx' ;
 import { metricToFormatter, toShortResourceName } from './util/Utils.js';
 import './../../css/octopus.css';
@@ -23,8 +24,6 @@ Metric.propTypes = {
   value: PropTypes.string.isRequired
 };
 
-const ArrowCol = ({showArrow}) => <Col span={2} className="octopus-col">{!showArrow ? " " : <Icon type="arrow-right" />}</Col>;
-ArrowCol.propTypes = PropTypes.bool.isRequired;
 export default class Octopus extends React.Component {
   static defaultProps = {
     neighbors: {},
@@ -38,59 +37,108 @@ export default class Octopus extends React.Component {
     unmeshedSources: PropTypes.arrayOf(PropTypes.shape({})),
   }
 
-  renderResourceSummary(resource, type, unmeshed) {
+  renderResourceSummary(resource, type) {
     return (
       <div key={resource.name} className={`octopus-body ${type}`}>
-        <div className={`octopus-title ${type}`}>
+        <div className={`octopus-title ${type}-title`}>
           { _.isNil(resource.namespace) ? displayName(resource) :
           <this.props.api.ResourceLink
             resource={resource}
             linkText={displayName(resource)} />
           }
         </div>
-        {
-          unmeshed ? <div>Unmeshed</div> :
-          <div>
-            <div className="octopus-sr-gauge">
-              <Progress
-                className={`success-rate-arc ${getSuccessRateClassification(resource.successRate, srArcClassLabels)}`}
-                type="dashboard"
-                format={() => metricToFormatter["SUCCESS_RATE"](resource.successRate)}
-                width={type === "main" ? 132 : 64}
-                percent={resource.successRate * 100}
-                gapDegree={180} />
-            </div>
-            <Metric title="RPS" value={metricToFormatter["REQUEST_RATE"](resource.requestRate)} />
-            <Metric title="P99" value={metricToFormatter["LATENCY"](_.get(resource, "latency.P99"))} />
+        <div>
+          <div className="octopus-sr-gauge">
+            <Progress
+              className={`success-rate-arc ${getSuccessRateClassification(resource.successRate, srArcClassLabels)}`}
+              type="dashboard"
+              format={() => metricToFormatter["SUCCESS_RATE"](resource.successRate)}
+              width={type === "main" ? 132 : 64}
+              percent={resource.successRate * 100}
+              gapDegree={180} />
           </div>
-        }
+          <Metric title="RPS" value={metricToFormatter["REQUEST_RATE"](resource.requestRate)} />
+          <Metric title="P99" value={metricToFormatter["LATENCY"](_.get(resource, "latency.P99"))} />
+        </div>
       </div>
     );
   }
 
+  renderUnmeshedResources = unmeshedResources => {
+    return (
+      <div key="unmeshed-resources" className="octopus-body neighbor unmeshed">
+        <div className="octopus-title neighbor-title">Unmeshed</div>
+        { _.map(unmeshedResources, r => <div key={r}>{displayName(r)}</div>) }
+      </div>
+    );
+  }
+
+  renderArrowCol = (numNeighbors, isOutbound) => {
+    let baseHeight = 184;
+    let width = 78;
+    let showArrow = numNeighbors > 0;
+    let isEven = numNeighbors % 2 === 0;
+    let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);
+
+    let arrowTypes = _.map(_.times(numNeighbors), i => {
+      if (i < middleElementIndex) {
+        let height = (_.ceil(middleElementIndex - i) - 1) * baseHeight + (baseHeight / 2);
+        return { type: "up", inboundType: "down", height };
+      } else if (i === middleElementIndex) {
+        return { type: "flat", inboundType: "flat", height: baseHeight };
+      } else {
+        let height = (_.ceil(i - middleElementIndex) - 1) * baseHeight + (baseHeight / 2);
+        return { type: "down", inboundType: "up", height };
+      }
+    });
+
+    let height = numNeighbors * baseHeight;
+    let svg = (
+      <svg height={height} width={width} version="1.1" viewBox={`0 0 ${width} ${height}`}>
+        <defs />
+        {
+          _.map(arrowTypes, arrow => {
+            let arrowType = isOutbound ? arrow.type : arrow.inboundType;
+            return OctopusArms[arrowType](width, height, arrow.height, isOutbound);
+          })
+        }
+      </svg>
+    );
+
+    return !showArrow ? null : svg;
+  }
+
   render() {
     let { resource, neighbors, unmeshedSources } = this.props;
-    let hasUpstreams = _.size(neighbors.upstream) > 0 || _.size(unmeshedSources) > 0;
+
+    let upstreams = _.sortBy(neighbors.upstream, "resource.name");
+    let downstreams = _.sortBy(neighbors.downstream, "resource.name");
+    let numUpstreams = _.size(upstreams) + (_.isEmpty(unmeshedSources) ? 0 : 1);
+    let hasUpstreams = numUpstreams > 0;
     let hasDownstreams = _.size(neighbors.downstream) > 0;
 
     return (
       <div className="octopus-graph">
-        <Row type="flex" justify="center" gutter={32} align="middle">
+        <Row type="flex" justify="center" align="middle">
           <Col span={6} className={`octopus-col ${hasUpstreams ? "resource-col" : ""}`}>
-            {_.map(_.sortBy(neighbors.upstream, "resource.name"), n => this.renderResourceSummary(n, "neighbor"))}
-            {_.map(_.sortBy(unmeshedSources, "name"), n => this.renderResourceSummary(n, "neighbor", true))}
+            {_.map(upstreams, n => this.renderResourceSummary(n, "neighbor"))}
+            {_.isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources)}
           </Col>
 
-          <ArrowCol showArrow={hasUpstreams} />
+          <Col span={2} className="octopus-col">
+            {this.renderArrowCol(numUpstreams, false)}
+          </Col>
 
           <Col span={8} className="octopus-col resource-col">
             {this.renderResourceSummary(resource, "main")}
           </Col>
 
-          <ArrowCol showArrow={hasDownstreams} />
+          <Col span={2} className="octopus-col">
+            {this.renderArrowCol(_.size(downstreams), true)}
+          </Col>
 
           <Col span={6} className={`octopus-col ${hasDownstreams ? "resource-col" : ""}`}>
-            {_.map(_.sortBy(neighbors.downstream, "resource.name"), n => this.renderResourceSummary(n, "neighbor"))}
+            {_.map(downstreams, n => this.renderResourceSummary(n, "neighbor"))}
           </Col>
         </Row>
       </div>

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -38,13 +38,14 @@ export default class Octopus extends React.Component {
   }
 
   renderResourceSummary(resource, type) {
+    let display = displayName(resource);
     return (
-      <div key={resource.name} className={`octopus-body ${type}`}>
+      <div key={resource.name} className={`octopus-body ${type}`} title={display}>
         <div className={`octopus-title ${type}-title`}>
-          { _.isNil(resource.namespace) ? displayName(resource) :
+          { _.isNil(resource.namespace) ? display :
           <this.props.api.ResourceLink
             resource={resource}
-            linkText={displayName(resource)} />
+            linkText={display} />
           }
         </div>
         <div>
@@ -68,13 +69,13 @@ export default class Octopus extends React.Component {
     return (
       <div key="unmeshed-resources" className="octopus-body neighbor unmeshed">
         <div className="octopus-title neighbor-title">Unmeshed</div>
-        { _.map(unmeshedResources, r => <div key={r}>{displayName(r)}</div>) }
+        { _.map(unmeshedResources, r => <div key={r} title={displayName(r)}>{displayName(r)}</div>) }
       </div>
     );
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let baseHeight = 222;
+    let baseHeight = 180;
     let width = 75;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
@@ -113,6 +114,7 @@ export default class Octopus extends React.Component {
 
     let upstreams = _.sortBy(neighbors.upstream, "resource.name");
     let downstreams = _.sortBy(neighbors.downstream, "resource.name");
+
     let numUpstreams = _.size(upstreams) + (_.isEmpty(unmeshedSources) ? 0 : 1);
     let hasUpstreams = numUpstreams > 0;
     let hasDownstreams = _.size(neighbors.downstream) > 0;

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+
+const stroke = "#000000";
+const strokeOpacity = "0.2";
+
+const svgArrow = (x1, y1, width, height, direction) => {
+  let segmentWidth = width / 2;
+
+  let x2 = x1 + segmentWidth + 10;
+  let y2 = y1 + 10;
+
+  let x3 = x2 + 10;
+  let y3 = y2 + height + 10;
+
+  let horizLine1 = `M ${x1},${y1} L ${x1+segmentWidth},${y1}`;
+  let curve1 = `C ${x1+segmentWidth+7},${y1} ${x2},${y1+3} ${x2},${y2}`;
+  let verticalLine = `L ${x2}, ${y2+height}`;
+  let curve2 = `C ${x2},${y2+height+6} ${x2+2},${y3} ${x3},${y3}`;
+  let horizLine2 = `L ${x3 + segmentWidth},${y3}`;
+  let arrow = `${horizLine1} ${curve1} ${verticalLine} ${curve2} ${horizLine2}`;
+
+  let arrowEndX = width;
+  let arrowEndY = direction === "up" ? y1 : y3;
+  let arrowHead = `${arrowEndX - 4} ${arrowEndY - 4} ${arrowEndX} ${arrowEndY} ${arrowEndX - 4} ${arrowEndY + 4}`;
+
+  let circle = {
+    cx: x1,
+    cy: direction === "up" ? y3 : y1
+  };
+
+  return {
+    arrow,
+    arrowHead,
+    circle
+  };
+};
+
+const up = (width, svgHeight, arrowHeight, isOutbound) => {
+  let height = (svgHeight / 2) - arrowHeight;
+
+  let x1 = 0;
+  let y1;
+
+  if (isOutbound) {
+    y1 = arrowHeight - 20; // I don't know where we intoduced that 20 but we need to match the other arrow
+  } else {
+    y1 = svgHeight / 2 ;
+  }
+
+  let svgPaths = svgArrow(x1, y1, width, height, "up");
+
+  return (
+    <g key={`up-arrow-${height}`} id="downstream-up" fill="none" stroke="none" strokeWidth="1">
+      <path
+        d={svgPaths.arrow}
+        stroke={stroke}
+        strokeOpacity={strokeOpacity}
+        transform="translate(54.000000, 54.000000) scale(-1, 1) translate(-44.000000, -54.000000) " />
+      <circle cx={svgPaths.circle.cx} cy={svgPaths.circle.cy} fill="#CCCCCC" r="4" />
+      <polyline points={svgPaths.arrowHead} stroke="#CCCCCC" strokeLinecap="round" />
+    </g>
+
+  );
+};
+
+const flat = (width, height) => {
+  let arrowY = height / 2;
+  let arrowEndX = width;
+  let polylinePoints = `${arrowEndX - 4} ${arrowY - 4} ${arrowEndX} ${arrowY} ${arrowEndX - 4} ${arrowY + 4}`;
+
+  return (
+    <g key="flat-arrow" id="downstream-flat" fill="none" stroke="none" strokeWidth="1">
+      <path
+        d={`M0,${arrowY} L${arrowEndX},${arrowY}`}
+        stroke={stroke}
+        strokeOpacity={strokeOpacity} />
+      <circle cx="0" cy={arrowY} fill="#CCCCCC" r="4" />
+      <polyline points={polylinePoints} stroke="#CCCCCC" strokeLinecap="round" />
+    </g>
+  );
+};
+
+const down = (width, svgHeight, arrowHeight, isOutbound) => {
+  // down outbound arrows start at the middle of the svg's height, and
+  // have end of block n at (1/2 block height) + (block height * n-1)
+  let height = (svgHeight / 2) - arrowHeight;
+
+  let x1 = 0;
+  let y1;
+
+  // inbound arrows start at the offset of the card, and end in the center of the middle card
+  // outbound arrows start in the center of the middle card, and end at the card's height
+  if (isOutbound) {
+    y1 = svgHeight / 2;
+  } else {
+    y1 = arrowHeight - 20; // I don't know where we intoduced that 20 but we need to match the other arrow
+  }
+
+  let svg = svgArrow(x1, y1, width, height, "down");
+
+  return (
+    <g key={`down-arrow-${height}`} id="downstream-down" fill="none" stroke="none" strokeWidth="1">
+      <path
+        d={svg.arrow}
+        stroke={stroke}
+        strokeOpacity={strokeOpacity} />
+      <circle cx={svg.circle.cx} cy={svg.circle.cy} fill="#CCCCCC" r="4" />
+      <polyline points={svg.arrowHead} stroke="#CCCCCC" strokeLinecap="round" />
+    </g>
+
+  );
+};
+
+const OctopusArms = {
+  up,
+  flat,
+  down
+};
+
+export default OctopusArms;

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -4,7 +4,7 @@ const stroke = "#000000";
 const strokeOpacity = "0.2";
 
 const svgArrow = (x1, y1, width, height, direction) => {
-  let segmentWidth = width / 2;
+  let segmentWidth = width / 2 - 10;
 
   let x2 = x1 + segmentWidth + 10;
   let y2 = y1 + 10;
@@ -55,7 +55,7 @@ const up = (width, svgHeight, arrowHeight, isOutbound) => {
         d={svgPaths.arrow}
         stroke={stroke}
         strokeOpacity={strokeOpacity}
-        transform="translate(54.000000, 54.000000) scale(-1, 1) translate(-44.000000, -54.000000) " />
+        transform="translate(31, 54) scale(-1, 1) translate(-44, -54) " />
       <circle cx={svgPaths.circle.cx} cy={svgPaths.circle.cy} fill="#CCCCCC" r="4" />
       <polyline points={svgPaths.arrowHead} stroke="#CCCCCC" strokeLinecap="round" />
     </g>


### PR DESCRIPTION
Draw customizable SVG paths for octopus arms.

This also combines all the unmeshed resources into a list and displays them in one resource box, instead of adding one box per unmeshed resource. This helps keep the box heights constant, which I want to draw the arrows.

The SVG point generation is a bit inscrutable, I have a diagram at my desk that could be helpful. More svg articles:
SVG Links:
https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths
https://www.sarasoueidan.com/blog/svg-coordinate-systems/
http://blogs.sitepointstatic.com/examples/tech/svg-curves/cubic-curve.html

![screen shot 2018-09-21 at 11 28 08 am](https://user-images.githubusercontent.com/549258/45903895-146e7380-bda0-11e8-9e24-964f9d3c2ea0.png)
![screen shot 2018-09-21 at 10 17 02 am](https://user-images.githubusercontent.com/549258/45903898-19332780-bda0-11e8-8a70-b581a5875c6b.png)
![screen shot 2018-09-21 at 10 15 31 am](https://user-images.githubusercontent.com/549258/45903907-1e907200-bda0-11e8-8e85-a06de95f1c0f.png)

Fixes #1587
