### PR TITLE
Stop trying to call setState on unmounted Tap and Top components

### DIFF
--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -147,7 +147,9 @@ class Top extends React.Component {
   }
 
   updateTapClosingState(isTapClosing) {
-    this.setState({tapIsClosing: isTapClosing});
+    this.setState({
+      tapIsClosing: isTapClosing
+    });
   }
 
   render() {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -39,6 +39,7 @@ class TopModule extends React.Component {
     this.tapResultsById = {};
     this.topEventIndex = {};
     this.throttledWebsocketRecvHandler = _.throttle(this.updateTapEventIndexState, 500);
+    this.updateTapClosingState = this.props.updateTapClosingState;
 
     this.state = {
       error: null,
@@ -64,6 +65,7 @@ class TopModule extends React.Component {
   componentWillUnmount() {
     this.throttledWebsocketRecvHandler.cancel();
     this.stopTapStreaming();
+    this.updateTapClosingState = _.noop;
   }
 
   onWebsocketOpen = () => {
@@ -86,7 +88,7 @@ class TopModule extends React.Component {
   }
 
   onWebsocketClose = e => {
-    this.props.updateTapClosingState(false);
+    this.updateTapClosingState(false);
     /* We ignore any abnormal closure since it doesn't matter as long as
     the connection to the websocket is closed. This is also a workaround
     where Chrome browsers incorrectly displays a 1006 close code


### PR DESCRIPTION
We were getting react errors because we were calling setState in Tap and Top after the component unmounted (surprise!). 

In Top, when we unmount the component, we close the websocket. The websocket close handler calls updateTapClosingState which.. updates the state. But we shouldn't update the state on closing components. Fix this by changing updateTapClosingState to a `_.noop` if the component is unmounting.

In Tap, similarly, `stopTapStreaming` calls `setState`, so we shouldn't call `stopTapStreaming` when the component is unmounting. Instead, add an `_isMounted` variable so we can avoid setting state when the component is unmounting.

Fixes #1664 