### PR TITLE
ResourceDetail: display unmeshed sources in the inbound table 

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Tooltip } from 'antd';
 import { withContext } from './util/AppContext.jsx';
 import {
+  displayName,
   friendlyTitle,
   metricToFormatter,
   numericSort
@@ -36,11 +37,10 @@ const formatTitle = (title, tooltipText) => {
 
 const meshedColumn = {
   title: formatTitle("Meshed"),
-  dataIndex: "pods",
   key: "pods",
   className: "numeric",
   sorter: (a, b) => numericSort(a.pods.totalPods, b.pods.totalPods),
-  render: p => p.meshedPods + "/" + p.totalPods
+  render: d => d.unmeshed ? "unmeshed" : d.pods.meshedPods + "/" + d.pods.totalPods
 };
 
 const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceColumn, PrefixedLink) => {
@@ -55,9 +55,7 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       onFilterDropdownVisibleChange: onFilterClick,
       onFilter: (value, row) => row.namespace.indexOf(value) === 0,
       sorter: (a, b) => (a.namespace || "").localeCompare(b.namespace),
-      render: ns => {
-        return <PrefixedLink to={"/namespaces/" + ns}>{ns}</PrefixedLink>;
-      }
+      render: ns => !ns ? "---" : <PrefixedLink to={"/namespaces/" + ns}>{ns}</PrefixedLink>
     }
   ];
 
@@ -84,6 +82,10 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       defaultSortOrder: 'ascend',
       sorter: (a, b) => (a.name || "").localeCompare(b.name),
       render: row => {
+        if (row.unmeshed) {
+          return displayName(row);
+        }
+
         let nameContents;
         if (resource === "namespace") {
           nameContents = <PrefixedLink to={"/namespaces/" + row.name}>{row.name}</PrefixedLink>;

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -37,10 +37,11 @@ const formatTitle = (title, tooltipText) => {
 
 const meshedColumn = {
   title: formatTitle("Meshed"),
+  dataIndex: "pods",
   key: "pods",
   className: "numeric",
   sorter: (a, b) => numericSort(a.pods.totalPods, b.pods.totalPods),
-  render: d => d.unmeshed ? "unmeshed" : d.pods.meshedPods + "/" + d.pods.totalPods
+  render: p => p.meshedPods + "/" + p.totalPods
 };
 
 const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceColumn, PrefixedLink) => {

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import { Tooltip } from 'antd';
 import { withContext } from './util/AppContext.jsx';
 import {
-  displayName,
   friendlyTitle,
   metricToFormatter,
   numericSort
@@ -83,10 +82,6 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
       defaultSortOrder: 'ascend',
       sorter: (a, b) => (a.name || "").localeCompare(b.name),
       render: row => {
-        if (row.unmeshed) {
-          return displayName(row);
-        }
-
         let nameContents;
         if (resource === "namespace") {
           nameContents = <PrefixedLink to={"/namespaces/" + row.name}>{row.name}</PrefixedLink>;

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -3,11 +3,9 @@ import OctopusArms from './util/OctopusArms.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Col, Progress, Row } from 'antd';
+import { displayName, metricToFormatter } from './util/Utils.js';
 import { getSuccessRateClassification, srArcClassLabels } from './util/MetricUtils.jsx' ;
-import { metricToFormatter, toShortResourceName } from './util/Utils.js';
 import './../../css/octopus.css';
-
-const displayName = resource => `${toShortResourceName(resource.type)}/${resource.name}`;
 
 const Metric = ({title, value, className}) => {
   return (

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -4,12 +4,12 @@ import ErrorBanner from './ErrorBanner.jsx';
 import MetricsTable from './MetricsTable.jsx';
 import Octopus from './Octopus.jsx';
 import { processNeighborData } from './util/TapUtils.jsx';
-import { processSingleResourceRollup } from './util/MetricUtils.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Spin } from 'antd';
 import TopModule from './TopModule.jsx';
 import { withContext } from './util/AppContext.jsx';
+import { emptyMetric, processSingleResourceRollup } from './util/MetricUtils.jsx';
 import { resourceTypeToCamelCase, singularResource } from './util/Utils.js';
 import 'whatwg-fetch';
 
@@ -193,6 +193,12 @@ export class ResourceDetailBase extends React.Component {
       namespace: this.state.namespace
     };
 
+    let unmeshed = _.map(this.state.unmeshedSources, d => {
+      return _.merge(emptyMetric, d, { unmeshed: true });
+    });
+
+    let upstreams = _.concat(this.state.neighborMetrics.upstream, unmeshed);
+
     return (
       <div>
         {
@@ -224,12 +230,12 @@ export class ResourceDetailBase extends React.Component {
           </div>
         }
 
-        { _.isEmpty(this.state.neighborMetrics.upstream) ? null : (
+        { _.isEmpty(upstreams) ? null : (
           <div className="page-section">
             <h2 className="subsection-header">Inbound</h2>
             <MetricsTable
               resource={this.state.resource.type}
-              metrics={this.state.neighborMetrics.upstream} />
+              metrics={upstreams} />
           </div>
           )
         }

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -193,9 +193,16 @@ export class ResourceDetailBase extends React.Component {
       namespace: this.state.namespace
     };
 
-    let unmeshed = _.map(this.state.unmeshedSources, d => {
-      return _.merge(emptyMetric, d, { unmeshed: true });
-    });
+    let unmeshed = _.chain(this.state.unmeshedSources)
+      .filter(['type', this.state.resourceType])
+      .map(d => _.merge({}, emptyMetric, d, {
+        unmeshed: true,
+        pods: {
+          totalPods: _.size(d.pods),
+          meshedPods: 0
+        }
+      }))
+      .value();
 
     let upstreams = _.concat(this.state.neighborMetrics.upstream, unmeshed);
 

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -209,28 +209,45 @@ export const excludeResourcesFromRollup = (rollupMetrics, resourcesToExclude) =>
   return rollupMetrics;
 };
 
+export const emptyMetric = {
+  name: "",
+  namespace: "",
+  type: "",
+  totalRequests: null,
+  requestRate: null,
+  successRate: null,
+  latency: null,
+  tlsRequestPercent: null,
+  added: false,
+  pods: {
+    totalPods: null,
+    meshedPods: null,
+    meshedPercentage: null
+  }
+};
+
 export const metricsPropType = PropTypes.shape({
   ok: PropTypes.shape({
     statTables: PropTypes.arrayOf(PropTypes.shape({
       podGroup: PropTypes.shape({
         rows: PropTypes.arrayOf(PropTypes.shape({
           failedPodCount: PropTypes.string,
-          meshedPodCount: PropTypes.string.isRequired,
+          meshedPodCount: PropTypes.string,
           resource: PropTypes.shape({
-            name: PropTypes.string.isRequired,
-            namespace: PropTypes.string.isRequired,
-            type: PropTypes.string.isRequired,
+            name: PropTypes.string,
+            namespace: PropTypes.string,
+            type: PropTypes.string,
           }).isRequired,
-          runningPodCount: PropTypes.string.isRequired,
+          runningPodCount: PropTypes.string,
           stats: PropTypes.shape({
-            failureCount: PropTypes.string.isRequired,
-            latencyMsP50: PropTypes.string.isRequired,
-            latencyMsP95: PropTypes.string.isRequired,
-            latencyMsP99: PropTypes.string.isRequired,
-            tlsRequestCount: PropTypes.string.isRequired,
-            successCount: PropTypes.string.isRequired,
+            failureCount: PropTypes.string,
+            latencyMsP50: PropTypes.string,
+            latencyMsP95: PropTypes.string,
+            latencyMsP99: PropTypes.string,
+            tlsRequestCount: PropTypes.string,
+            successCount: PropTypes.string,
           }),
-          timeWindow: PropTypes.string.isRequired,
+          timeWindow: PropTypes.string,
         }).isRequired),
       }),
     }).isRequired).isRequired,
@@ -240,7 +257,7 @@ export const metricsPropType = PropTypes.shape({
 export const processedMetricsPropType = PropTypes.shape({
   name: PropTypes.string.isRequired,
   namespace: PropTypes.string.isRequired,
-  totalRequests: PropTypes.number.isRequired,
+  totalRequests: PropTypes.number,
   requestRate: PropTypes.number,
   successRate: PropTypes.number,
 });

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -80,15 +80,16 @@ export const processNeighborData = (source, labels, resourceAgg, resourceType) =
 
   // keep track of pods under this resource to display the number of unmeshed source pods
   neighb.pods = {};
-  !labels.pod ? null : neighb.pods[labels.pod] = true;
+  if (labels.pod) {
+    neighb.pods[labels.pod] = true;
+  }
 
   let key = neighb.type + "/" + neighb.name;
   if (_.has(labels, "control_plane_ns")) {
     delete resourceAgg[key];
   } else {
     if (_.has(resourceAgg, key)) {
-      neighb.pods = resourceAgg[key].pods;
-      !labels.pod ? null : neighb.pods[labels.pod] = true;
+      _.merge(neighb.pods, resourceAgg[key].pods);
     }
     resourceAgg[key] = neighb;
   }

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -181,6 +181,8 @@ export const podOwnerLookup = {
 
 export const toShortResourceName = name => shortNameLookup[name] || name;
 
+export const displayName = resource => `${toShortResourceName(resource.type)}/${resource.name}`;
+
 export const isResource = name => {
   let singularResourceName = singularResource(name);
   return _.has(shortNameLookup, singularResourceName);


### PR DESCRIPTION
Use the same tap data we use to display the unmeshed resources in the Octopus graph to add the unmeshed rows to the Inbound stat table.

The unmeshed rows are filtered by resource type, so if we're on a Deployments page, only upstreams which are deployments will show in the table. (Others, such as IPs, will still show in the octopus graph).

![screen shot 2018-09-21 at 3 10 26 pm](https://user-images.githubusercontent.com/549258/45909151-1c84de00-bdb5-11e8-9ab1-f24ca80a29e2.png)

Fixes #1650
