### PR TITLE
Display the popover Source/Destination info side-by-side

### DIFF
--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -30,3 +30,9 @@
     }
   }
 }
+
+.metric-table {
+  & .popover-td {
+    padding: 5px;
+  }
+}


### PR DESCRIPTION
Previously, we would display source and destination info in the Top/Tap table popovers in a vertical format. This PR places them in a table so that each type of source/dest (ip, pod, pod owner) can be read left to right.

![screen shot 2018-09-24 at 12 58 18 pm](https://user-images.githubusercontent.com/549258/45975922-35ca9c00-bffa-11e8-8861-2bce23fb4add.png)
![screen shot 2018-09-24 at 12 58 05 pm](https://user-images.githubusercontent.com/549258/45975923-35ca9c00-bffa-11e8-8a62-cb373230515e.png)
![screen shot 2018-09-24 at 12 57 58 pm](https://user-images.githubusercontent.com/549258/45975926-395e2300-bffa-11e8-95a3-4eba51696982.png)

Fixes #1661 
