### PR TITLE
Fix web rendering when errors are encountered

### DIFF
--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -43,13 +43,12 @@ func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httpro
 		params.ErrorMessage = err.Error()
 		log.Error(err.Error())
 	} else {
-		params.Data = version
+		params.Data = *version
 	}
 
 	err = h.render(w, "app.tmpl.html", "base", params)
 
 	if err != nil {
 		log.Error(err.Error())
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 }

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -37,7 +37,7 @@ type (
 		Contents interface{}
 	}
 	appParams struct {
-		Data                *pb.VersionInfo
+		Data                pb.VersionInfo
 		UUID                string
 		ControllerNamespace string
 		Error               bool

--- a/web/templates/app.tmpl.html
+++ b/web/templates/app.tmpl.html
@@ -11,9 +11,11 @@
 {{ end }}
 
 {{ define "script-tags" }}
-  {{ if .Context.WebpackDevServer }}
-    <script type="text/javascript" src="{{.Context.WebpackDevServer}}/dist/index_bundle.js" async></script>
-  {{else}}
-    <script type="text/javascript" src="{{.Contents.PathPrefix}}dist/index_bundle.js" async></script>
+  {{ if not .Contents.Error }}
+    {{ if .Context.WebpackDevServer }}
+      <script type="text/javascript" src="{{.Context.WebpackDevServer}}/dist/index_bundle.js" async></script>
+    {{else}}
+      <script type="text/javascript" src="{{.Contents.PathPrefix}}dist/index_bundle.js" async></script>
+    {{end}}
   {{end}}
 {{end}}


### PR DESCRIPTION
This branch updates the web server's HTML rendering to better handle errors talking to the public API. Previously when an error was encountered, we'd display a blank page. Now we display:

![image](https://user-images.githubusercontent.com/9226/45987480-8657ee80-c026-11e8-9b36-b22ab4c4afbe.png)

This relates to #1702.