### PR TITLE
Better handle not-found resources in the Web UI

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -176,14 +176,15 @@ const columnDefinitions = (resource, namespaces, onFilterClick, showNamespaceCol
 /** @extends React.Component */
 export class MetricsTableBase extends BaseTable {
   static defaultProps = {
-    showNamespaceColumn: true
+    showNamespaceColumn: true,
+    metrics: []
   }
 
   static propTypes = {
     api: PropTypes.shape({
       PrefixedLink: PropTypes.func.isRequired,
     }).isRequired,
-    metrics: PropTypes.arrayOf(processedMetricsPropType.isRequired).isRequired,
+    metrics: PropTypes.arrayOf(processedMetricsPropType),
     resource: PropTypes.string.isRequired,
     showNamespaceColumn: PropTypes.bool
   }

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -112,6 +112,10 @@ export default class Octopus extends React.Component {
   render() {
     let { resource, neighbors, unmeshedSources } = this.props;
 
+    if (_.isEmpty(resource)) {
+      return null;
+    }
+
     let upstreams = _.sortBy(neighbors.upstream, "resource.name");
     let downstreams = _.sortBy(neighbors.downstream, "resource.name");
 


### PR DESCRIPTION
When I deleted a resource, I noticed that hard refreshing the page resulted in js errors that would break the UI (e.g. if you were on a pod page, and the pod's deployment was deleted, the pod would no longer be found, and the page would error). This PR better handles not-present resources so that the UI still shows up and shows you that there aren't metrics for that resource. Also clean up the undefined/undefined octopus node that would show up in that case.

Before:
![screen shot 2018-09-25 at 12 46 38 pm](https://user-images.githubusercontent.com/549258/46038963-57db2180-c0c1-11e8-8100-bed7cce14e56.png)

After:
![screen shot 2018-09-25 at 12 46 26 pm](https://user-images.githubusercontent.com/549258/46038964-57db2180-c0c1-11e8-9553-afb31ed9b770.png)
