### PR TITLE
Use sidebar namespace filter together with content in main page

### DIFF
--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -6,18 +6,25 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Spin } from 'antd';
 import withREST from './util/withREST.jsx';
-import { metricsPropType, processSingleResourceRollup } from './util/MetricUtils.jsx';
+import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
+import { filterNamespacesFromRollup, metricsPropType, processSingleResourceRollup } from './util/MetricUtils.jsx';
 import 'whatwg-fetch';
+
+const urlPropsQueryConfig = {
+  namespaceURLFilter: { type: UrlQueryParamTypes.string, queryParam: 'namespace' },
+};
 
 export class ResourceListBase extends React.Component {
   static defaultProps = {
-    error: null
+    error: null,
+    namespaceURLFilter: ''
   }
 
   static propTypes = {
     data: PropTypes.arrayOf(metricsPropType.isRequired).isRequired,
     error:  apiErrorPropType,
     loading: PropTypes.bool.isRequired,
+    namespaceURLFilter: PropTypes.string,
     resource: PropTypes.string.isRequired,
   }
 
@@ -40,7 +47,7 @@ export class ResourceListBase extends React.Component {
 
     let processedMetrics = [];
     if (_.has(data, '[0]')) {
-      processedMetrics = processSingleResourceRollup(data[0]);
+      processedMetrics = filterNamespacesFromRollup(processSingleResourceRollup(data[0]), this.props.namespaceURLFilter, this.props.resource);
     }
 
     return (
@@ -63,10 +70,10 @@ export class ResourceListBase extends React.Component {
   }
 }
 
-export default withREST(
+export default addUrlProps({ urlPropsQueryConfig })(withREST(
   ResourceListBase,
   ({api, resource}) => [api.fetchMetrics(api.urlsForResource(resource))],
   {
     resetProps: ['resource'],
   },
-);
+));

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import Version from './Version.jsx';
 import { withContext } from './util/AppContext.jsx';
+import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
 import { Badge, Form, Icon, Layout, Menu, Select } from 'antd';
 import {
   excludeResourcesFromRollup,
@@ -24,9 +25,15 @@ const classificationLabels = {
   default: "default"
 };
 
+const urlPropsQueryConfig = {
+  namespaceURLFilter: { type: UrlQueryParamTypes.string, queryParam: 'namespace' },
+};
+
 class Sidebar extends React.Component {
   static defaultProps = {
-    productName: 'controller'
+    namespaceURLFilter: '',
+    productName: 'controller',
+    onChangeNamespaceURLFilter: _.noop
   }
 
   static propTypes = {
@@ -34,6 +41,8 @@ class Sidebar extends React.Component {
       PrefixedLink: PropTypes.func.isRequired,
     }).isRequired,
     location: ReactRouterPropTypes.location.isRequired,
+    namespaceURLFilter: PropTypes.string,
+    onChangeNamespaceURLFilter: PropTypes.func,
     pathPrefix: PropTypes.string.isRequired,
     productName: PropTypes.string,
     releaseVersion: PropTypes.string.isRequired,
@@ -60,7 +69,7 @@ class Sidebar extends React.Component {
       latestVersion: '',
       isLatest: true,
       pendingRequests: false,
-      namespaceFilter: "all"
+      namespaceFilter: this.props.namespaceURLFilter || "all"
     };
   }
 
@@ -148,8 +157,14 @@ class Sidebar extends React.Component {
 
   handleNamespaceSelector(value) {
     this.setState({
-      namespaceFilter: value
+      namespaceFilter: value,
     });
+    if (value !== 'all') {
+      this.props.onChangeNamespaceURLFilter(value);
+    } else {
+      this.props.onChangeNamespaceURLFilter('');
+    }
+
   }
 
   filterResourcesByNamespace(resources, namespace) {
@@ -179,7 +194,7 @@ class Sidebar extends React.Component {
         <div className="sidebar">
 
           <div className={`sidebar-menu-header ${this.state.collapsed ? "collapsed" : ""}`}>
-            <PrefixedLink to="/overview">
+            <PrefixedLink to={`/overview${this.props.location.search}`}>
               {this.state.collapsed ? linkerdLogoOnly : linkerdWordLogo}
             </PrefixedLink>
           </div>
@@ -190,28 +205,28 @@ class Sidebar extends React.Component {
             selectedKeys={[normalizedPath]}>
 
             <Menu.Item className="sidebar-menu-item" key="/overview">
-              <PrefixedLink to="/overview">
+              <PrefixedLink to={`/overview${this.props.location.search}`}>
                 <Icon type="home" />
                 <span>Overview</span>
               </PrefixedLink>
             </Menu.Item>
 
             <Menu.Item className="sidebar-menu-item" key="/tap">
-              <PrefixedLink to="/tap">
+              <PrefixedLink to={`/tap${this.props.location.search}`}>
                 <Icon><i className="fas fa-microscope" /></Icon>
                 <span>Tap</span>
               </PrefixedLink>
             </Menu.Item>
 
             <Menu.Item className="sidebar-menu-item" key="/top">
-              <PrefixedLink to="/top">
+              <PrefixedLink to={`/top${this.props.location.search}`}>
                 <Icon><i className="fas fa-stream" /></Icon>
                 <span>Top</span>
               </PrefixedLink>
             </Menu.Item>
 
             <Menu.Item className="sidebar-menu-item" key="/servicemesh">
-              <PrefixedLink to="/servicemesh">
+              <PrefixedLink to={`/servicemesh${this.props.location.search}`}>
                 <Icon type="cloud" />
                 <span>Service mesh</span>
               </PrefixedLink>
@@ -221,11 +236,11 @@ class Sidebar extends React.Component {
               className="sidebar-menu-item"
               key="byresource"
               title={<span className="sidebar-title"><Icon type="bars" />{this.state.collapsed ? "" : "Resources"}</span>}>
-              <Menu.Item><PrefixedLink to="/authorities">Authorities</PrefixedLink></Menu.Item>
-              <Menu.Item><PrefixedLink to="/deployments">Deployments</PrefixedLink></Menu.Item>
-              <Menu.Item><PrefixedLink to="/namespaces">Namespaces</PrefixedLink></Menu.Item>
-              <Menu.Item><PrefixedLink to="/pods">Pods</PrefixedLink></Menu.Item>
-              <Menu.Item><PrefixedLink to="/replicationcontrollers">Replication Controllers</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to={`/authorities${this.props.location.search}`}>Authorities</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to={`/deployments${this.props.location.search}`}>Deployments</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to={`/namespaces${this.props.location.search}`}>Namespaces</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to={`/pods${this.props.location.search}`}>Pods</PrefixedLink></Menu.Item>
+              <Menu.Item><PrefixedLink to={`/replicationcontrollers${this.props.location.search}`}>Replication Controllers</PrefixedLink></Menu.Item>
             </Menu.SubMenu>
             <Menu.Divider />
           </Menu>
@@ -327,4 +342,4 @@ class Sidebar extends React.Component {
   }
 }
 
-export default withContext(Sidebar);
+export default addUrlProps({ urlPropsQueryConfig })(withContext(Sidebar));

--- a/web/app/js/components/Sidebar.jsx
+++ b/web/app/js/components/Sidebar.jsx
@@ -73,6 +73,15 @@ class Sidebar extends React.Component {
     };
   }
 
+  static getDerivedStateFromProps(props) {
+    if (props.namespaceURLFilter === "") {
+      return {
+        namespaceFilter: "all"
+      };
+    }
+    return null;
+  }
+
   componentDidMount() {
     this.fetchVersion();
     this.startServerPolling();
@@ -257,7 +266,7 @@ class Sidebar extends React.Component {
                   <Form layout="inline">
                     <Form.Item>
                       <Select
-                        defaultValue={this.state.namespaceFilter || "All Namespaces"}
+                        value={this.state.namespaceFilter || "all"}
                         dropdownMatchSelectWidth={true}
                         onChange={this.handleNamespaceSelector}>
                         {

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -209,6 +209,14 @@ export const excludeResourcesFromRollup = (rollupMetrics, resourcesToExclude) =>
   return rollupMetrics;
 };
 
+export const filterNamespacesFromRollup = (rollupMetrics, filter, resourceType) => {
+  // Check to see if the resource is not a namespace resource since it has a the
+  // name property that uniquely identifies what namespace it is in.
+  let resourceFilter = resourceType === "namespace" ?
+    m => m.name === filter : m => m.namespace === filter;
+  return filter ? _.filter(rollupMetrics, resourceFilter) : rollupMetrics;
+};
+
 export const metricsPropType = PropTypes.shape({
   ok: PropTypes.shape({
     statTables: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
In an effort to make the dashboard to have a similar user experience with the Kubernetes dashboard. This PR changes the way the sidebar namespace filtering interacts with the rest of the content in the dashboard. Not only does this filter the resources in the sidebar, the sidebar selector now filters content in the Resource List view. It also selects the corresponding namespace in the Overview page.

There is further work that needs to be done in making the filter more persistent. If select a namespace in the sidebar and then select a resource URL e.g. a particular pod in the emojivoto namespace, the URL will no longer have the namespace filter. When you then go back to a Resource List page, the filter is no longer applied but the sidebar still shows the selected namespace.


Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>