### PR TITLE
Add a clear button to the tap and top query forms

### DIFF
--- a/web/app/css/tap.css
+++ b/web/app/css/tap.css
@@ -2,6 +2,10 @@
 
 .tap-form {
   & button.ant-btn-primary {
+    &.tap-ctrl {
+      margin-right: var(--base-width);
+    }
+
     &.tap-start {
       background-color: var(--green);
       border-color: var(--green);

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -67,7 +67,11 @@ export default class Octopus extends React.Component {
     return (
       <div key="unmeshed-resources" className="octopus-body neighbor unmeshed">
         <div className="octopus-title neighbor-title">Unmeshed</div>
-        { _.map(unmeshedResources, r => <div key={r} title={displayName(r)}>{displayName(r)}</div>) }
+        { _.map(unmeshedResources, r => {
+          let display = displayName(r);
+            return <div key={display} title={display}>{display}</div>;
+          })
+        }
       </div>
     );
   }

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -7,7 +7,7 @@ import TapQueryCliCmd from './TapQueryCliCmd.jsx';
 import TapQueryForm from './TapQueryForm.jsx';
 import { withContext } from './util/AppContext.jsx';
 import { addUrlProps, UrlQueryParamTypes } from 'react-url-query';
-import { processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
+import { emptyTapQuery, processTapEvent, setMaxRps, wsCloseCodes } from './util/TapUtils.jsx';
 import './../../css/tap.css';
 
 const urlPropsQueryConfig = {
@@ -241,6 +241,21 @@ class Tap extends React.Component {
     this.setState({ tapIsClosing: true });
   }
 
+  handleTapClear = () => {
+    this.resetTapResults();
+    this.setState({
+      query: emptyTapQuery()
+    });
+  }
+
+  resetTapResults = () => {
+    this.tapResultsById = {};
+    this.setState({
+      tapResultsById: {},
+      query: emptyTapQuery()
+    });
+  }
+
   loadFromServer() {
     if (this.state.pendingRequests) {
       return; // don't make more requests if the ones we sent haven't completed
@@ -276,6 +291,7 @@ class Tap extends React.Component {
   }
 
   updateQuery = query => {
+    this.resetTapResults();
     this.setState({
       query
     });
@@ -295,6 +311,7 @@ class Tap extends React.Component {
           tapIsClosing={this.state.tapIsClosing}
           handleTapStart={this.handleTapStart}
           handleTapStop={this.handleTapStop}
+          handleTapClear={this.handleTapClear}
           resourcesByNs={this.state.resourcesByNs}
           authoritiesByNs={this.state.authoritiesByNs}
           updateQuery={this.updateQuery}

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { emptyTapQuery } from './util/TapUtils.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -26,17 +27,7 @@ class Top extends React.Component {
       error: null,
       resourcesByNs: {},
       authoritiesByNs: {},
-      query: {
-        resource: "",
-        namespace: "",
-        toResource: "",
-        toNamespace: "",
-        method: "",
-        path: "",
-        scheme: "",
-        authority: "",
-        maxRps: ""
-      },
+      query: emptyTapQuery(),
       pollingInterval: 10000,
       tapRequestInProgress: false,
       pendingRequests: false
@@ -146,6 +137,13 @@ class Top extends React.Component {
     });
   }
 
+  handleTapClear = () => {
+    this.setState({
+      error: null,
+      query: emptyTapQuery()
+    });
+  }
+
   updateTapClosingState(isTapClosing) {
     this.setState({
       tapIsClosing: isTapClosing
@@ -161,6 +159,7 @@ class Top extends React.Component {
           enableAdvancedForm={false}
           handleTapStart={this.handleTapStart}
           handleTapStop={this.handleTapStop}
+          handleTapClear={this.handleTapClear}
           resourcesByNs={this.state.resourcesByNs}
           authoritiesByNs={this.state.authoritiesByNs}
           tapRequestInProgress={this.state.tapRequestInProgress}

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -60,6 +60,9 @@ class TopModule extends React.Component {
     if (!this.props.startTap && prevProps.startTap) {
       this.stopTapStreaming();
     }
+    if (!_.isEqual(this.props.query, prevProps.query)) {
+      this.clearTopTable();
+    }
   }
 
   componentWillUnmount() {
@@ -294,9 +297,16 @@ class TopModule extends React.Component {
     delete resultIndex[oldestId];
   }
 
-  startTapStreaming() {
+  clearTopTable() {
     this.tapResultsById = {};
     this.topEventIndex = {};
+    this.setState({
+      topEventIndex: {}
+    });
+  }
+
+  startTapStreaming() {
+    this.clearTopTable();
 
     let protocol = window.location.protocol === "https:" ? "wss" : "ws";
     let tapWebSocket = `${protocol}://${window.location.host}${this.props.pathPrefix}/api/tap`;

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -16,6 +16,19 @@ export const setMaxRps = query => {
   }
 };
 
+// use a generator to get this object, to prevent it from being overwritten
+export const emptyTapQuery = () => ({
+  resource: "",
+  namespace: "",
+  toResource: "",
+  toNamespace: "",
+  method: "",
+  path: "",
+  scheme: "",
+  authority: "",
+  maxRps: ""
+});
+
 export const tapQueryProps = {
   resource: PropTypes.string,
   namespace: PropTypes.string,


### PR DESCRIPTION
Fixes #1433. Next I want to tackle pausing in tap / figuring out how to cope visually with a large stream of results.

![screen shot 2018-09-26 at 5 06 00 pm](https://user-images.githubusercontent.com/549258/46116097-32c4dc80-c1af-11e8-92e0-dbb4e864f5ad.png)


Add clear functionality to Tap
Add clear functionality to Top
Fix a react key error when there were multiple unmeshed upstreams
Fix bug where tap results from other queries persisted when changing the query
Fix key error in autocomplete dropdown