### PR TITLE
Add --single-namespace install flag for restricted permissions

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -21,6 +21,7 @@ type checkOptions struct {
 	dataPlaneOnly   bool
 	wait            time.Duration
 	namespace       string
+	singleNamespace bool
 }
 
 func newCheckOptions() *checkOptions {
@@ -30,6 +31,7 @@ func newCheckOptions() *checkOptions {
 		dataPlaneOnly:   false,
 		wait:            300 * time.Second,
 		namespace:       "",
+		singleNamespace: false,
 	}
 }
 
@@ -65,6 +67,7 @@ non-zero exit code.`,
 	cmd.PersistentFlags().BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
 	cmd.PersistentFlags().DurationVar(&options.wait, "wait", options.wait, "Retry and wait for some checks to succeed if they don't pass the first time")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Only check the permissions required to operate the control plane in a single namespace")
 
 	return cmd
 }
@@ -94,6 +97,7 @@ func configureAndRunChecks(options *checkOptions) {
 		ShouldCheckKubeVersion:         true,
 		ShouldCheckControlPlaneVersion: !(options.preInstallOnly || options.dataPlaneOnly),
 		ShouldCheckDataPlaneVersion:    options.dataPlaneOnly,
+		SingleNamespace:                options.singleNamespace,
 	})
 
 	success := runChecks(os.Stdout, hc)

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -67,7 +67,7 @@ non-zero exit code.`,
 	cmd.PersistentFlags().BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
 	cmd.PersistentFlags().DurationVar(&options.wait, "wait", options.wait, "Retry and wait for some checks to succeed if they don't pass the first time")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
-	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Only check the permissions required to operate the control plane in a single namespace")
+	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "When running pre-installation checks (--pre), only check the permissions required to operate the control plane in a single namespace")
 
 	return cmd
 }

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -107,8 +107,8 @@ func newCmdInstall() *cobra.Command {
 	cmd.PersistentFlags().UintVar(&options.webReplicas, "web-replicas", options.webReplicas, "Replicas of the web server to deploy")
 	cmd.PersistentFlags().UintVar(&options.prometheusReplicas, "prometheus-replicas", options.prometheusReplicas, "Replicas of prometheus to deploy")
 	cmd.PersistentFlags().StringVar(&options.controllerLogLevel, "controller-log-level", options.controllerLogLevel, "Log level for the controller and web components")
-	cmd.PersistentFlags().BoolVar(&options.proxyAutoInject, "proxy-auto-inject", options.proxyAutoInject, "Enable proxy sidecar auto-injection webhook; default to false")
-	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Configure the control plane to only operate in the installed namespace")
+	cmd.PersistentFlags().BoolVar(&options.proxyAutoInject, "proxy-auto-inject", options.proxyAutoInject, "Experimental: Enable proxy sidecar auto-injection webhook (default false)")
+	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Experimental: Configure the control plane to only operate in the installed namespace (default false)")
 
 	return cmd
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -19,7 +19,8 @@ func TestRender(t *testing.T) {
 	defaultConfig.UUID = "deaab91a-f4ab-448a-b7d1-c832a2fa0a60"
 
 	// A configuration that shows that all config setting strings are honored
-	// by `render()`.
+	// by `render()`. Note that `SingleNamespace` is tested in a separate
+	// configuration, since it's incompatible with `ProxyAutoInjectEnabled`.
 	metaConfig := installConfig{
 		Namespace:                        "Namespace",
 		ControllerImage:                  "ControllerImage",
@@ -64,6 +65,33 @@ func TestRender(t *testing.T) {
 		ProxyBindTimeout:                 "1m",
 	}
 
+	singleNamespaceConfig := installConfig{
+		Namespace:                        "Namespace",
+		ControllerImage:                  "ControllerImage",
+		WebImage:                         "WebImage",
+		PrometheusImage:                  "PrometheusImage",
+		GrafanaImage:                     "GrafanaImage",
+		ControllerReplicas:               1,
+		WebReplicas:                      2,
+		PrometheusReplicas:               3,
+		ImagePullPolicy:                  "ImagePullPolicy",
+		UUID:                             "UUID",
+		CliVersion:                       "CliVersion",
+		ControllerLogLevel:               "ControllerLogLevel",
+		ControllerComponentLabel:         "ControllerComponentLabel",
+		CreatedByAnnotation:              "CreatedByAnnotation",
+		ProxyAPIPort:                     123,
+		EnableTLS:                        true,
+		TLSTrustAnchorConfigMapName:      "TLSTrustAnchorConfigMapName",
+		ProxyContainerName:               "ProxyContainerName",
+		TLSTrustAnchorFileName:           "TLSTrustAnchorFileName",
+		TLSCertFileName:                  "TLSCertFileName",
+		TLSPrivateKeyFileName:            "TLSPrivateKeyFileName",
+		TLSTrustAnchorVolumeSpecFileName: "TLSTrustAnchorVolumeSpecFileName",
+		TLSIdentityVolumeSpecFileName:    "TLSIdentityVolumeSpecFileName",
+		SingleNamespace:                  true,
+	}
+
 	testCases := []struct {
 		config                installConfig
 		controlPlaneNamespace string
@@ -71,6 +99,7 @@ func TestRender(t *testing.T) {
 	}{
 		{*defaultConfig, defaultControlPlaneNamespace, "testdata/install_default.golden"},
 		{metaConfig, metaConfig.Namespace, "testdata/install_output.golden"},
+		{singleNamespaceConfig, singleNamespaceConfig.Namespace, "testdata/install_single_namespace_output.golden"},
 	}
 
 	for i, tc := range testCases {
@@ -92,4 +121,41 @@ func TestRender(t *testing.T) {
 			diffCompare(t, content, expectedContent)
 		})
 	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("Accepts the default options as valid", func(t *testing.T) {
+		if err := newInstallOptions().validate(); err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	})
+
+	t.Run("Rejects invalid log level", func(t *testing.T) {
+		options := newInstallOptions()
+		options.controllerLogLevel = "super"
+		expected := "--controller-log-level must be one of: panic, fatal, error, warn, info, debug"
+
+		err := options.validate()
+		if err == nil {
+			t.Fatalf("Expected error, got nothing")
+		}
+		if err.Error() != expected {
+			t.Fatalf("Expected error string\"%s\", got \"%s\"", expected, err)
+		}
+	})
+
+	t.Run("Rejects single namespace install with auto inject", func(t *testing.T) {
+		options := newInstallOptions()
+		options.proxyAutoInject = true
+		options.singleNamespace = true
+		expected := "The --proxy-auto-inject and --single-namespace flags cannot both be specified together"
+
+		err := options.validate()
+		if err == nil {
+			t.Fatalf("Expected error, got nothing")
+		}
+		if err.Error() != expected {
+			t.Fatalf("Expected error string\"%s\", got \"%s\"", expected, err)
+		}
+	})
 }

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -145,6 +145,7 @@ spec:
         - public-api
         - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
         - -controller-namespace=Namespace
+        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -167,6 +168,8 @@ spec:
         resources: {}
       - args:
         - destination
+        - -controller-namespace=Namespace
+        - -single-namespace=false
         - -enable-tls=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
@@ -213,8 +216,9 @@ spec:
         resources: {}
       - args:
         - tap
-        - -log-level=ControllerLogLevel
         - -controller-namespace=Namespace
+        - -single-namespace=false
+        - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         livenessProbe:
@@ -938,6 +942,7 @@ spec:
       - args:
         - ca
         - -controller-namespace=Namespace
+        - -single-namespace=false
         - -proxy-auto-inject=true
         - -log-level=ControllerLogLevel
         image: ControllerImage

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -2,7 +2,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: linkerd
+  name: Namespace
 
 ### Service Account Controller ###
 ---
@@ -10,14 +10,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-controller
-  namespace: linkerd
+  namespace: Namespace
 
 ### Controller RBAC ###
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-linkerd-controller
+  name: linkerd-Namespace-controller
+  namespace: Namespace
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -27,18 +28,19 @@ rules:
   verbs: ["list", "get", "watch"]
 
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-linkerd-controller
+  name: linkerd-Namespace-controller
+  namespace: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: linkerd-linkerd-controller
+  kind: Role
+  name: linkerd-Namespace-controller
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: linkerd
+  namespace: Namespace
 
 ### Service Account Prometheus ###
 ---
@@ -46,32 +48,34 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
-  namespace: linkerd
+  namespace: Namespace
 
 ### Prometheus RBAC ###
 ---
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-linkerd-prometheus
+  name: linkerd-Namespace-prometheus
+  namespace: Namespace
 rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
 
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-linkerd-prometheus
+  name: linkerd-Namespace-prometheus
+  namespace: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: linkerd-linkerd-prometheus
+  kind: Role
+  name: linkerd-Namespace-prometheus
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: linkerd
+  namespace: Namespace
 
 ### Controller ###
 ---
@@ -79,15 +83,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: api
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: controller
+    ControllerComponentLabel: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/control-plane-component: controller
+    ControllerComponentLabel: controller
   ports:
   - name: http
     port: 8085
@@ -98,54 +102,55 @@ kind: Service
 apiVersion: v1
 metadata:
   name: proxy-api
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: controller
+    ControllerComponentLabel: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/control-plane-component: controller
+    ControllerComponentLabel: controller
   ports:
   - name: grpc
-    port: 8086
-    targetPort: 8086
+    port: 123
+    targetPort: 123
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
   creationTimestamp: null
   labels:
-    linkerd.io/control-plane-component: controller
+    ControllerComponentLabel: controller
   name: controller
-  namespace: linkerd
+  namespace: Namespace
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
+        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        linkerd.io/control-plane-component: controller
-        linkerd.io/control-plane-ns: linkerd
+        ControllerComponentLabel: controller
+        linkerd.io/control-plane-ns: Namespace
         linkerd.io/proxy-deployment: controller
     spec:
       containers:
       - args:
         - public-api
-        - -prometheus-url=http://prometheus.linkerd.svc.cluster.local:9090
-        - -controller-namespace=linkerd
-        - -single-namespace=false
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
-        imagePullPolicy: IfNotPresent
+        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
+        - -controller-namespace=Namespace
+        - -single-namespace=true
+        - -log-level=ControllerLogLevel
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /ping
@@ -165,12 +170,12 @@ spec:
         resources: {}
       - args:
         - destination
-        - -controller-namespace=linkerd
-        - -single-namespace=false
-        - -enable-tls=false
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
-        imagePullPolicy: IfNotPresent
+        - -controller-namespace=Namespace
+        - -single-namespace=true
+        - -enable-tls=true
+        - -log-level=ControllerLogLevel
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /ping
@@ -190,10 +195,10 @@ spec:
         resources: {}
       - args:
         - proxy-api
-        - -addr=:8086
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
-        imagePullPolicy: IfNotPresent
+        - -addr=:123
+        - -log-level=ControllerLogLevel
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /ping
@@ -201,7 +206,7 @@ spec:
           initialDelaySeconds: 10
         name: proxy-api
         ports:
-        - containerPort: 8086
+        - containerPort: 123
           name: grpc
         - containerPort: 9996
           name: admin-http
@@ -213,11 +218,11 @@ spec:
         resources: {}
       - args:
         - tap
-        - -controller-namespace=linkerd
-        - -single-namespace=false
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
-        imagePullPolicy: IfNotPresent
+        - -controller-namespace=Namespace
+        - -single-namespace=true
+        - -log-level=ControllerLogLevel
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /ping
@@ -303,15 +308,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: web
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: web
+    ControllerComponentLabel: web
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/control-plane-component: web
+    ControllerComponentLabel: web
   ports:
   - name: http
     port: 8084
@@ -325,36 +330,37 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
   creationTimestamp: null
   labels:
-    linkerd.io/control-plane-component: web
+    ControllerComponentLabel: web
   name: web
-  namespace: linkerd
+  namespace: Namespace
 spec:
-  replicas: 1
+  replicas: 2
   strategy: {}
   template:
     metadata:
       annotations:
+        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        linkerd.io/control-plane-component: web
-        linkerd.io/control-plane-ns: linkerd
+        ControllerComponentLabel: web
+        linkerd.io/control-plane-ns: Namespace
         linkerd.io/proxy-deployment: web
     spec:
       containers:
       - args:
-        - -api-addr=api.linkerd.svc.cluster.local:8085
+        - -api-addr=api.Namespace.svc.cluster.local:8085
         - -static-dir=/dist
         - -template-dir=/templates
-        - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
-        - -controller-namespace=linkerd
-        - -log-level=info
-        image: gcr.io/linkerd-io/web:undefined
-        imagePullPolicy: IfNotPresent
+        - -uuid=UUID
+        - -controller-namespace=Namespace
+        - -log-level=ControllerLogLevel
+        image: WebImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /ping
@@ -378,7 +384,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -439,15 +445,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: prometheus
+    ControllerComponentLabel: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/control-plane-component: prometheus
+    ControllerComponentLabel: prometheus
   ports:
   - name: admin-http
     port: 9090
@@ -458,32 +464,33 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
   creationTimestamp: null
   labels:
-    linkerd.io/control-plane-component: prometheus
+    ControllerComponentLabel: prometheus
   name: prometheus
-  namespace: linkerd
+  namespace: Namespace
 spec:
-  replicas: 1
+  replicas: 3
   strategy: {}
   template:
     metadata:
       annotations:
+        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        linkerd.io/control-plane-component: prometheus
-        linkerd.io/control-plane-ns: linkerd
+        ControllerComponentLabel: prometheus
+        linkerd.io/control-plane-ns: Namespace
         linkerd.io/proxy-deployment: prometheus
     spec:
       containers:
       - args:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        image: prom/prometheus:v2.4.0
-        imagePullPolicy: IfNotPresent
+        image: PrometheusImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -511,7 +518,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -579,11 +586,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: prometheus
+    ControllerComponentLabel: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 data:
   prometheus.yml: |-
     global:
@@ -600,7 +607,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['linkerd']
+          names: ['Namespace']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -611,7 +618,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['linkerd']
+          names: ['Namespace']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
@@ -625,13 +632,15 @@ data:
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod
+        namespaces:
+          names: ['Namespace']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^linkerd-proxy;linkerd-metrics;linkerd$
+        regex: ^ProxyContainerName;linkerd-metrics;Namespace$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -663,15 +672,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: grafana
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: grafana
+    ControllerComponentLabel: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/control-plane-component: grafana
+    ControllerComponentLabel: grafana
   ports:
   - name: http
     port: 3000
@@ -682,29 +691,30 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
   creationTimestamp: null
   labels:
-    linkerd.io/control-plane-component: grafana
+    ControllerComponentLabel: grafana
   name: grafana
-  namespace: linkerd
+  namespace: Namespace
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
+        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        linkerd.io/control-plane-component: grafana
-        linkerd.io/control-plane-ns: linkerd
+        ControllerComponentLabel: grafana
+        linkerd.io/control-plane-ns: Namespace
         linkerd.io/proxy-deployment: grafana
     spec:
       containers:
-      - image: gcr.io/linkerd-io/grafana:undefined
-        imagePullPolicy: IfNotPresent
+      - image: GrafanaImage
+        imagePullPolicy: ImagePullPolicy
         livenessProbe:
           httpGet:
             path: /api/health
@@ -732,7 +742,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -804,17 +814,17 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: grafana-config
-  namespace: linkerd
+  namespace: Namespace
   labels:
-    linkerd.io/control-plane-component: grafana
+    ControllerComponentLabel: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    CreatedByAnnotation: CliVersion
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana
 
     [server]
-    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/linkerd/services/grafana:http/proxy/
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/Namespace/services/grafana:http/proxy/
 
     [auth]
     disable_login_form = true
@@ -836,7 +846,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.linkerd.svc.cluster.local:9090
+      url: http://prometheus.Namespace.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -855,4 +865,166 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: linkerd-top-line
+
+### Service Account CA ###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-ca
+  namespace: Namespace
+
+### CA RBAC ###
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd-Namespace-ca
+  namespace: Namespace
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: [TLSTrustAnchorConfigMapName]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["replicasets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "update"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd-Namespace-ca
+  namespace: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linkerd-Namespace-ca
+subjects:
+- kind: ServiceAccount
+  name: linkerd-ca
+  namespace: Namespace
+
+### CA ###
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    CreatedByAnnotation: CliVersion
+  creationTimestamp: null
+  labels:
+    ControllerComponentLabel: ca
+  name: ca
+  namespace: Namespace
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        CreatedByAnnotation: CliVersion
+        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/proxy-version: undefined
+      creationTimestamp: null
+      labels:
+        ControllerComponentLabel: ca
+        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/proxy-deployment: ca
+    spec:
+      containers:
+      - args:
+        - ca
+        - -controller-namespace=Namespace
+        - -single-namespace=true
+        - -log-level=ControllerLogLevel
+        image: ControllerImage
+        imagePullPolicy: ImagePullPolicy
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9997
+          initialDelaySeconds: 10
+        name: ca
+        ports:
+        - containerPort: 9997
+          name: admin-http
+        readinessProbe:
+          failureThreshold: 7
+          httpGet:
+            path: /ready
+            port: 9997
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_BIND_TIMEOUT
+          value: 10s
+        - name: LINKERD2_PROXY_CONTROL_URL
+          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTENER
+          value: tcp://0.0.0.0:4190
+        - name: LINKERD2_PROXY_METRICS_LISTENER
+          value: tcp://0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
+          value: tcp://127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
+          value: tcp://0.0.0.0:4143
+        - name: LINKERD2_PROXY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/linkerd-io/proxy:undefined
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:undefined
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+        terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccount: linkerd-ca
+status: {}
 ---

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -24,8 +24,10 @@ metadata:
 kind: {{if not .SingleNamespace}}Cluster{{end}}Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-controller{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-controller
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -38,8 +40,10 @@ rules:
 kind: {{if not .SingleNamespace}}Cluster{{end}}RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-controller{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-controller
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{if not .SingleNamespace}}Cluster{{end}}Role
@@ -62,8 +66,10 @@ metadata:
 kind: {{if not .SingleNamespace}}Cluster{{end}}Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-prometheus{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-prometheus
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -73,8 +79,10 @@ rules:
 kind: {{if not .SingleNamespace}}Cluster{{end}}RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-prometheus{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-prometheus
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{if not .SingleNamespace}}Cluster{{end}}Role
@@ -428,9 +436,11 @@ data:
 
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
-      - role: pod{{ if .SingleNamespace }}
+      - role: pod
+        {{- if .SingleNamespace}}
         namespaces:
-          names: ['{{.Namespace}}']{{ end }}
+          names: ['{{.Namespace}}']
+        {{- end}}
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -609,8 +619,10 @@ metadata:
 kind: {{if not .SingleNamespace}}Cluster{{end}}Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-ca{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-ca
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -638,8 +650,10 @@ rules:
 kind: {{if not .SingleNamespace}}Cluster{{end}}RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-{{.Namespace}}-ca{{if .SingleNamespace}}
-  namespace: {{.Namespace}}{{end}}
+  name: linkerd-{{.Namespace}}-ca
+  {{- if .SingleNamespace}}
+  namespace: {{.Namespace}}
+  {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{if not .SingleNamespace}}Cluster{{end}}Role

--- a/controller/cmd/ca/main.go
+++ b/controller/cmd/ca/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	metricsAddr := flag.String("metrics-addr", ":9997", "address to serve scrapable metrics on")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	proxyAutoInject := flag.Bool("proxy-auto-inject", false, "if true, watch for the add and update events of mutating webhook configurations")
 	flags.ConfigureAndParse()
@@ -28,11 +29,16 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	restrictToNamespace := ""
+	if *singleNamespace {
+		restrictToNamespace = *controllerNamespace
+	}
+
 	var k8sAPI *k8s.API
 	if *proxyAutoInject {
-		k8sAPI = k8s.NewAPI(k8sClient, k8s.Pod, k8s.RS, k8s.MWC)
+		k8sAPI = k8s.NewAPI(k8sClient, restrictToNamespace, k8s.Pod, k8s.RS, k8s.MWC)
 	} else {
-		k8sAPI = k8s.NewAPI(k8sClient, k8s.Pod, k8s.RS)
+		k8sAPI = k8s.NewAPI(k8sClient, restrictToNamespace, k8s.Pod, k8s.RS)
 	}
 
 	controller, err := ca.NewCertificateController(*controllerNamespace, k8sAPI, *proxyAutoInject)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -19,6 +19,8 @@ func main() {
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
 	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
+	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
@@ -28,8 +30,13 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+	restrictToNamespace := ""
+	if *singleNamespace {
+		restrictToNamespace = *controllerNamespace
+	}
 	k8sAPI := k8s.NewAPI(
 		k8sClient,
+		restrictToNamespace,
 		k8s.Endpoint,
 		k8s.Pod,
 		k8s.RS,

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -24,6 +24,7 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
 	tapAddr := flag.String("tap-addr", "127.0.0.1:8088", "address of tap service")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	ignoredNamespaces := flag.String("ignore-namespaces", "kube-system", "comma separated list of namespaces to not list pods from")
 	flags.ConfigureAndParse()
 
@@ -40,10 +41,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+	restrictToNamespace := ""
+	if *singleNamespace {
+		restrictToNamespace = *controllerNamespace
+	}
 	k8sAPI := k8s.NewAPI(
 		k8sClient,
+		restrictToNamespace,
 		k8s.Deploy,
-		k8s.NS,
 		k8s.Pod,
 		k8s.RC,
 		k8s.RS,

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -18,6 +18,7 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	tapPort := flag.Uint("tap-port", 4190, "proxy tap port to connect to")
 	flags.ConfigureAndParse()
 
@@ -28,10 +29,14 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create Kubernetes client: %s", err)
 	}
+	restrictToNamespace := ""
+	if *singleNamespace {
+		restrictToNamespace = *controllerNamespace
+	}
 	k8sAPI := k8s.NewAPI(
 		clientSet,
+		restrictToNamespace,
 		k8s.Deploy,
-		k8s.NS,
 		k8s.Pod,
 		k8s.RC,
 		k8s.Svc,

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -25,10 +25,10 @@ func NewFakeAPI(configs ...string) (*API, error) {
 	clientSet := fake.NewSimpleClientset(objs...)
 	return NewAPI(
 		clientSet,
+		"",
 		CM,
 		Deploy,
 		Endpoint,
-		NS,
 		Pod,
 		RC,
 		RS,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -94,6 +94,7 @@ type HealthCheckOptions struct {
 	ShouldCheckKubeVersion         bool
 	ShouldCheckControlPlaneVersion bool
 	ShouldCheckDataPlaneVersion    bool
+	SingleNamespace                bool
 }
 
 type HealthChecker struct {
@@ -197,23 +198,43 @@ func (hc *HealthChecker) addLinkerdPreInstallChecks() {
 		},
 	})
 
-	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdPreInstallCategory,
-		description: "can create ClusterRoles",
-		fatal:       true,
-		check: func() error {
-			return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRole")
-		},
-	})
+	if hc.SingleNamespace {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdPreInstallCategory,
+			description: "can create Roles",
+			fatal:       true,
+			check: func() error {
+				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "Role")
+			},
+		})
 
-	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdPreInstallCategory,
-		description: "can create ClusterRoleBindings",
-		fatal:       true,
-		check: func() error {
-			return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRoleBinding")
-		},
-	})
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdPreInstallCategory,
+			description: "can create RoleBindings",
+			fatal:       true,
+			check: func() error {
+				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
+			},
+		})
+	} else {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdPreInstallCategory,
+			description: "can create ClusterRoles",
+			fatal:       true,
+			check: func() error {
+				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRole")
+			},
+		})
+
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdPreInstallCategory,
+			description: "can create ClusterRoleBindings",
+			fatal:       true,
+			check: func() error {
+				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRoleBinding")
+			},
+		})
+	}
 
 	hc.checkers = append(hc.checkers, &checker{
 		category:    LinkerdPreInstallCategory,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -198,43 +198,30 @@ func (hc *HealthChecker) addLinkerdPreInstallChecks() {
 		},
 	})
 
+	roleType := "ClusterRole"
+	roleBindingType := "ClusterRoleBinding"
 	if hc.SingleNamespace {
-		hc.checkers = append(hc.checkers, &checker{
-			category:    LinkerdPreInstallCategory,
-			description: "can create Roles",
-			fatal:       true,
-			check: func() error {
-				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "Role")
-			},
-		})
-
-		hc.checkers = append(hc.checkers, &checker{
-			category:    LinkerdPreInstallCategory,
-			description: "can create RoleBindings",
-			fatal:       true,
-			check: func() error {
-				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
-			},
-		})
-	} else {
-		hc.checkers = append(hc.checkers, &checker{
-			category:    LinkerdPreInstallCategory,
-			description: "can create ClusterRoles",
-			fatal:       true,
-			check: func() error {
-				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRole")
-			},
-		})
-
-		hc.checkers = append(hc.checkers, &checker{
-			category:    LinkerdPreInstallCategory,
-			description: "can create ClusterRoleBindings",
-			fatal:       true,
-			check: func() error {
-				return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRoleBinding")
-			},
-		})
+		roleType = "Role"
+		roleBindingType = "RoleBinding"
 	}
+
+	hc.checkers = append(hc.checkers, &checker{
+		category:    LinkerdPreInstallCategory,
+		description: fmt.Sprintf("can create %ss", roleType),
+		fatal:       true,
+		check: func() error {
+			return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", roleType)
+		},
+	})
+
+	hc.checkers = append(hc.checkers, &checker{
+		category:    LinkerdPreInstallCategory,
+		description: fmt.Sprintf("can create %ss", roleBindingType),
+		fatal:       true,
+		check: func() error {
+			return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", roleBindingType)
+		},
+	})
 
 	hc.checkers = append(hc.checkers, &checker{
 		category:    LinkerdPreInstallCategory,


### PR DESCRIPTION
This branch updates the `linkerd install` and `linkerd check` commands to accept a `--single-namespace` boolean flag, which if provided will modify the linkerd install YAML to use Roles instead of ClusterRoles, and it will adjust the pre-install check accordingly.

The bulk of the code changes required for conditionally switching to Roles happens in `controller/k8s/api.go`, where we configure the shared informers used by all of our controller components for reading from the Kubernetes API. If the `--single-namespace` flag is specified, all watches established in this file are scoped to an individual namespace.

Fixes #1705.