### PR TITLE
Add LICENSE files to all Docker images

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -12,6 +12,7 @@ RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION); \
 
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
+COPY --from=fetch /build/target/proxy/LICENSE ./LICENSE
 COPY --from=fetch /build/linkerd2-proxy ./linkerd2-proxy
 COPY --from=fetch /build/version.txt ./linkerd2-proxy-version.txt
 ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -37,6 +37,7 @@ if [ -n "$latest_sha" ]; then
 fi
 
 tar -C "$builddir" -zxvf "$archive" >&2
+mv "$builddir/linkerd2-proxy-$version/LICENSE" "$builddir"
 mv "$builddir/linkerd2-proxy-$version/bin/linkerd2-proxy" "$builddir"
 rm -r "$archive" "$builddir/linkerd2-proxy-$version"
 mv "$builddir/linkerd2-proxy" "$builddir/linkerd2-proxy-$version"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -22,6 +22,7 @@ RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd-windows -ldflags "${GO_L
 ## export without sources & dependencies
 FROM scratch
 COPY --from=golang /out /out
+COPY LICENSE /linkerd/LICENSE
 # `ENTRYPOINT` prevents `docker build` from otherwise failing with "Error
 # response from daemon: No command specified."
 ENTRYPOINT ["/out/linkerd-linux"]

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux go install ./controller/cmd/...
 FROM scratch
 ENV PATH=$PATH:/go/bin
 COPY --from=golang /go/bin /go/bin
+COPY LICENSE /linkerd/LICENSE
 
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -2,3 +2,4 @@ FROM grafana/grafana:5.2.4
 
 COPY grafana/dashboards               /var/lib/grafana/dashboards
 COPY grafana/dashboards/top-line.json /usr/share/grafana/public/dashboards/home.json
+COPY LICENSE                          /linkerd/LICENSE

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/
 ## package runtime
 FROM gcr.io/linkerd-io/base:2017-10-30.01
 COPY --from=golang /go/bin/proxy-init /usr/local/bin/proxy-init
+COPY LICENSE /linkerd/LICENSE
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -37,6 +37,7 @@ FROM gcr.io/linkerd-io/base:2017-10-30.01
 COPY --from=golang /go/src/github.com/linkerd/linkerd2/web .
 RUN mkdir -p ./dist
 COPY --from=webpack-bundle /go/src/github.com/linkerd/linkerd2/web/app/dist ./dist
+COPY LICENSE /linkerd/LICENSE
 
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}


### PR DESCRIPTION
To comply with certain environments, include our LICENSE file in all
Docker images.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

```bash
$ docker run -it --entrypoint=/bin/cat gcr.io/linkerd-io/proxy:git-891d8be0 /linkerd/LICENSE | head -n1
                                 Apache License
$ docker run -it --entrypoint=/bin/cat gcr.io/linkerd-io/web:git-891d8be0 /linkerd/LICENSE | head -n1
                                 Apache License
$ docker run -it --entrypoint=/bin/cat gcr.io/linkerd-io/proxy-init:git-891d8be0 /linkerd/LICENSE | head -n1
                                 Apache License
$ docker run -it --entrypoint=/bin/cat gcr.io/linkerd-io/grafana:git-891d8be0 /linkerd/LICENSE | head -n1
                                 Apache License
$ docker cp $(docker create -ti gcr.io/linkerd-io/controller:git-891d8be0 sh):/linkerd/LICENSE /tmp/LICENSE && head -n1 /tmp/LICENSE
                                 Apache License
$ docker cp $(docker create -ti gcr.io/linkerd-io/cli-bin:git-891d8be0 bash):/linkerd/LICENSE /tmp/LICENSE && head -n1 /tmp/LICENSE
                                 Apache License
```