### PR TITLE
Added ability to configure sidecar CPU + Memory requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -856,6 +856,7 @@
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:6a07271e as golang
+FROM gcr.io/linkerd-io/go-deps:64a32a2a as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -19,6 +19,11 @@ func TestInjectYAML(t *testing.T) {
 	tlsOptions.linkerdVersion = "testinjectversion"
 	tlsOptions.tls = "optional"
 
+	proxyRequestOptions := newInjectOptions()
+	proxyRequestOptions.linkerdVersion = "testinjectversion"
+	proxyRequestOptions.proxyCpuRequest = "110m"
+	proxyRequestOptions.proxyMemoryRequest = "100Mi"
+
 	testCases := []struct {
 		inputFileName     string
 		goldenFileName    string
@@ -66,6 +71,12 @@ func TestInjectYAML(t *testing.T) {
 			goldenFileName:    "inject_emojivoto_pod.golden.yml",
 			reportFileName:    "inject_emojivoto_pod.report",
 			testInjectOptions: defaultOptions,
+		},
+		{
+			inputFileName:     "inject_emojivoto_pod_with_requests.input.yml",
+			goldenFileName:    "inject_emojivoto_pod_with_requests.golden.yml",
+			reportFileName:    "inject_emojivoto_pod_with_requests.report",
+			testInjectOptions: proxyRequestOptions,
 		},
 		{
 			inputFileName:     "inject_emojivoto_deployment.input.yml",

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -137,6 +138,8 @@ type proxyConfigOptions struct {
 	proxyAPIPort          uint
 	proxyControlPort      uint
 	proxyMetricsPort      uint
+	proxyCpuRequest       string
+	proxyMemoryRequest    string
 	proxyOutboundCapacity map[string]uint
 	tls                   string
 }
@@ -160,6 +163,8 @@ func newProxyConfigOptions() *proxyConfigOptions {
 		proxyControlPort:      4190,
 		proxyMetricsPort:      4191,
 		proxyOutboundCapacity: map[string]uint{},
+		proxyCpuRequest:       "",
+		proxyMemoryRequest:    "",
 		tls:                   "",
 	}
 }
@@ -168,18 +173,35 @@ func (options *proxyConfigOptions) validate() error {
 	if !alphaNumDashDot.MatchString(options.linkerdVersion) {
 		return fmt.Errorf("%s is not a valid version", options.linkerdVersion)
 	}
+
 	if !alphaNumDashDotSlash.MatchString(options.dockerRegistry) {
 		return fmt.Errorf("%s is not a valid Docker registry", options.dockerRegistry)
 	}
+
 	if options.imagePullPolicy != "Always" && options.imagePullPolicy != "IfNotPresent" && options.imagePullPolicy != "Never" {
 		return fmt.Errorf("--image-pull-policy must be one of: Always, IfNotPresent, Never")
 	}
+
 	if _, err := time.ParseDuration(options.proxyBindTimeout); err != nil {
 		return fmt.Errorf("Invalid duration '%s' for --proxy-bind-timeout flag", options.proxyBindTimeout)
 	}
+
+	if options.proxyCpuRequest != "" {
+		if _, err := k8sResource.ParseQuantity(options.proxyCpuRequest); err != nil {
+			return fmt.Errorf("Invalid cpu request '%s' for --proxy-cpu flag", options.proxyCpuRequest)
+		}
+	}
+
+	if options.proxyMemoryRequest != "" {
+		if _, err := k8sResource.ParseQuantity(options.proxyMemoryRequest); err != nil {
+			return fmt.Errorf("Invalid memory request '%s' for --proxy-memory flag", options.proxyMemoryRequest)
+		}
+	}
+
 	if options.tls != "" && options.tls != optionalTLS {
 		return fmt.Errorf("--tls must be blank or set to \"%s\"", optionalTLS)
 	}
+
 	return nil
 }
 
@@ -210,4 +232,7 @@ func addProxyConfigFlags(cmd *cobra.Command, options *proxyConfigOptions) {
 	cmd.PersistentFlags().UintVar(&options.proxyControlPort, "control-port", options.proxyControlPort, "Proxy port to use for control")
 	cmd.PersistentFlags().UintVar(&options.proxyMetricsPort, "metrics-port", options.proxyMetricsPort, "Proxy port to serve metrics on")
 	cmd.PersistentFlags().StringVar(&options.tls, "tls", options.tls, "Enable TLS; valid settings: \"optional\"")
+
+	cmd.PersistentFlags().StringVar(&options.proxyCpuRequest, "proxy-cpu", options.proxyCpuRequest, "Amount of CPU units that the proxy sidecar requests")
+	cmd.PersistentFlags().StringVar(&options.proxyMemoryRequest, "proxy-memory", options.proxyMemoryRequest, "Amount of Memory that the proxy sidecar requests")
 }

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/proxy-version: testinjectversion
+  creationTimestamp: null
+  labels:
+    app: vote-bot
+    linkerd.io/control-plane-ns: linkerd
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v3
+    name: vote-bot
+    resources: {}
+  - env:
+    - name: LINKERD2_PROXY_LOG
+      value: warn,linkerd2_proxy=info
+    - name: LINKERD2_PROXY_BIND_TIMEOUT
+      value: 10s
+    - name: LINKERD2_PROXY_CONTROL_URL
+      value: tcp://proxy-api.linkerd.svc.cluster.local:8086
+    - name: LINKERD2_PROXY_CONTROL_LISTENER
+      value: tcp://0.0.0.0:4190
+    - name: LINKERD2_PROXY_METRICS_LISTENER
+      value: tcp://0.0.0.0:4191
+    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
+      value: tcp://127.0.0.1:4140
+    - name: LINKERD2_PROXY_INBOUND_LISTENER
+      value: tcp://0.0.0.0:4143
+    - name: LINKERD2_PROXY_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    image: gcr.io/linkerd-io/proxy:testinjectversion
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
+    name: linkerd-proxy
+    ports:
+    - containerPort: 4143
+      name: linkerd-proxy
+    - containerPort: 4191
+      name: linkerd-metrics
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 4191
+      initialDelaySeconds: 10
+    resources:
+      requests:
+        cpu: 110m
+        memory: 100Mi
+    securityContext:
+      runAsUser: 2102
+    terminationMessagePolicy: FallbackToLogsOnError
+  initContainers:
+  - args:
+    - --incoming-proxy-port
+    - "4143"
+    - --outgoing-proxy-port
+    - "4140"
+    - --proxy-uid
+    - "2102"
+    - --inbound-ports-to-ignore
+    - 4190,4191
+    image: gcr.io/linkerd-io/proxy-init:testinjectversion
+    imagePullPolicy: IfNotPresent
+    name: linkerd-init
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: false
+    terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vote-bot
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v3
+    name: vote-bot

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
@@ -1,0 +1,9 @@
+
+hostNetwork: pods do not use host networking...............................[ok]
+sidecar: pods do not have a proxy or initContainer already injected........[ok]
+supported: at least one resource injected..................................[ok]
+udp: pod specs do not include UDP ports....................................[ok]
+
+Summary: 1 of 1 YAML document(s) injected
+  pod/vote-bot
+

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:6a07271e as golang
+FROM gcr.io/linkerd-io/go-deps:64a32a2a as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:6a07271e as golang
+FROM gcr.io/linkerd-io/go-deps:64a32a2a as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV production
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:6a07271e as golang
+FROM gcr.io/linkerd-io/go-deps:64a32a2a as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY web web
 COPY controller controller


### PR DESCRIPTION
Horizontal Pod Autoscaling does not work when container definitions in pods do not all have resource requests, so here's the ability to add CPU + Memory requests to install + inject commands by proving proxy options `--proxy-cpu` + `--proxy-memory`

Fixes #1480

Signed-off-by: Ben Lambert <ben@blam.sh>