### PR TITLE
cli: Use updated proxy config environment vars

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -227,7 +227,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		Image:                    options.taggedProxyInitImage(),
 		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-		Args:                     initArgs,
+		Args: initArgs,
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{
 				Add: []v1.Capability{v1.Capability("NET_ADMIN")},
@@ -280,8 +280,8 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 			},
 			{Name: "LINKERD2_PROXY_CONTROL_LISTENER", Value: fmt.Sprintf("tcp://0.0.0.0:%d", options.proxyControlPort)},
 			{Name: "LINKERD2_PROXY_METRICS_LISTENER", Value: fmt.Sprintf("tcp://0.0.0.0:%d", options.proxyMetricsPort)},
-			{Name: "LINKERD2_PROXY_PRIVATE_LISTENER", Value: fmt.Sprintf("tcp://127.0.0.1:%d", options.outboundPort)},
-			{Name: "LINKERD2_PROXY_PUBLIC_LISTENER", Value: fmt.Sprintf("tcp://0.0.0.0:%d", options.inboundPort)},
+			{Name: "LINKERD2_PROXY_OUTBOUND_LISTENER", Value: fmt.Sprintf("tcp://127.0.0.1:%d", options.outboundPort)},
+			{Name: "LINKERD2_PROXY_INBOUND_LISTENER", Value: fmt.Sprintf("tcp://0.0.0.0:%d", options.inboundPort)},
 			{
 				Name:      PodNamespaceEnvVarName,
 				ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -37,9 +37,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -37,9 +37,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -128,9 +128,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -37,9 +37,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -48,9 +48,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -48,9 +48,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -150,9 +150,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -49,9 +49,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
@@ -48,9 +48,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -50,9 +50,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -50,9 +50,9 @@ items:
             value: tcp://0.0.0.0:4190
           - name: LINKERD2_PROXY_METRICS_LISTENER
             value: tcp://0.0.0.0:4191
-          - name: LINKERD2_PROXY_PRIVATE_LISTENER
+          - name: LINKERD2_PROXY_OUTBOUND_LISTENER
             value: tcp://127.0.0.1:4140
-          - name: LINKERD2_PROXY_PUBLIC_LISTENER
+          - name: LINKERD2_PROXY_INBOUND_LISTENER
             value: tcp://0.0.0.0:4143
           - name: LINKERD2_PROXY_POD_NAMESPACE
             valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -31,9 +31,9 @@ spec:
       value: tcp://0.0.0.0:4190
     - name: LINKERD2_PROXY_METRICS_LISTENER
       value: tcp://0.0.0.0:4191
-    - name: LINKERD2_PROXY_PRIVATE_LISTENER
+    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
       value: tcp://127.0.0.1:4140
-    - name: LINKERD2_PROXY_PUBLIC_LISTENER
+    - name: LINKERD2_PROXY_INBOUND_LISTENER
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_POD_NAMESPACE
       valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
@@ -31,9 +31,9 @@ spec:
       value: tcp://0.0.0.0:4190
     - name: LINKERD2_PROXY_METRICS_LISTENER
       value: tcp://0.0.0.0:4191
-    - name: LINKERD2_PROXY_PRIVATE_LISTENER
+    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
       value: tcp://127.0.0.1:4140
-    - name: LINKERD2_PROXY_PUBLIC_LISTENER
+    - name: LINKERD2_PROXY_INBOUND_LISTENER
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_POD_NAMESPACE
       valueFrom:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -48,9 +48,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -50,9 +50,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -154,9 +154,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -242,9 +242,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -379,9 +379,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -512,9 +512,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -733,9 +733,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -243,9 +243,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -381,9 +381,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -515,9 +515,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -737,9 +737,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:
@@ -962,9 +962,9 @@ spec:
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
           value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_PRIVATE_LISTENER
+        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
           value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_PUBLIC_LISTENER
+        - name: LINKERD2_PROXY_INBOUND_LISTENER
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
In linkerd/linkerd2-proxy#99, several proxy configuration variables were
deprecated.

This change updates the CLI to use the updated names to avoid
deprecation warnings during startup.