### PR TITLE
Pin the proxy version to a SHA

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -13,6 +13,7 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-PROXY_VERSION="${PROXY_VERSION:-latest}"
+# Default to a pinned commit SHA of the proxy.
+PROXY_VERSION="${PROXY_VERSION:-977ff25}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
Pin the proxy version to a specific SHA instead of floating on latest.  This allows breaking changes in the proxy repo to not break the main Linkerd 2 repo.

Signed-off-by: Alex Leong <alex@buoyant.io>