### PR TITLE
Make room for columns in `linkerd top`

### DIFF
--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -348,30 +348,44 @@ func renderHeaders(withSource bool) {
 	}
 }
 
+func max(i, j int) int {
+	if i > j {
+		return i
+	}
+	return j
+}
+
 func renderTableBody(table *[]tableRow, withSource bool) {
 	sort.SliceStable(*table, func(i, j int) bool {
 		return (*table)[i].count > (*table)[j].count
 	})
+	adjustedColumnWidths := columnWidths
+	for _, row := range *table {
+		adjustedColumnWidths[0] = max(adjustedColumnWidths[0], runewidth.StringWidth(row.source))
+		adjustedColumnWidths[1] = max(adjustedColumnWidths[1], runewidth.StringWidth(row.destination))
+		adjustedColumnWidths[3] = max(adjustedColumnWidths[3], runewidth.StringWidth(row.by))
+
+	}
 	for i, row := range *table {
 		x := 0
 		if withSource {
-			tbprint(x, i+headerHeight, row.source)
-			x += columnWidths[0] + 1
+			tbprint(x, i+headerHeight, runewidth.Truncate(row.source, adjustedColumnWidths[0], ""))
+			x += adjustedColumnWidths[0] + 1
 		}
-		tbprint(x, i+headerHeight, row.destination)
-		x += columnWidths[1] + 1
+		tbprint(x, i+headerHeight, runewidth.Truncate(row.destination, adjustedColumnWidths[1], ""))
+		x += adjustedColumnWidths[1] + 1
 		tbprint(x, i+headerHeight, row.method)
-		x += columnWidths[2] + 1
-		tbprint(x, i+headerHeight, row.by)
-		x += columnWidths[3] + 1
+		x += adjustedColumnWidths[2] + 1
+		tbprint(x, i+headerHeight, runewidth.Truncate(row.by, adjustedColumnWidths[3], ""))
+		x += adjustedColumnWidths[3] + 1
 		tbprint(x, i+headerHeight, strconv.Itoa(row.count))
-		x += columnWidths[4] + 1
+		x += adjustedColumnWidths[4] + 1
 		tbprint(x, i+headerHeight, formatDuration(row.best))
-		x += columnWidths[5] + 1
+		x += adjustedColumnWidths[5] + 1
 		tbprint(x, i+headerHeight, formatDuration(row.worst))
-		x += columnWidths[6] + 1
+		x += adjustedColumnWidths[6] + 1
 		tbprint(x, i+headerHeight, formatDuration(row.last))
-		x += columnWidths[7] + 1
+		x += adjustedColumnWidths[7] + 1
 		successRate := fmt.Sprintf("%.2f%%", 100.0*float32(row.successes)/float32(row.successes+row.failures))
 		tbprint(x, i+headerHeight, successRate)
 	}

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -369,14 +369,14 @@ func renderTableBody(table *[]tableRow, withSource bool) {
 	for i, row := range *table {
 		x := 0
 		if withSource {
-			tbprint(x, i+headerHeight, runewidth.Truncate(row.source, adjustedColumnWidths[0], ""))
+			tbprint(x, i+headerHeight, row.source)
 			x += adjustedColumnWidths[0] + 1
 		}
-		tbprint(x, i+headerHeight, runewidth.Truncate(row.destination, adjustedColumnWidths[1], ""))
+		tbprint(x, i+headerHeight, row.destination)
 		x += adjustedColumnWidths[1] + 1
 		tbprint(x, i+headerHeight, row.method)
 		x += adjustedColumnWidths[2] + 1
-		tbprint(x, i+headerHeight, runewidth.Truncate(row.by, adjustedColumnWidths[3], ""))
+		tbprint(x, i+headerHeight, row.by)
 		x += adjustedColumnWidths[3] + 1
 		tbprint(x, i+headerHeight, strconv.Itoa(row.count))
 		x += adjustedColumnWidths[4] + 1


### PR DESCRIPTION
Not only there wasn't enough padding, but also column data were bleeding out into other columns.
I set the column width dynamically upon each table update, taking into account the row with the longest data so everything fits.