### PR TITLE
Improve docker layer caching for web image

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -348,8 +348,6 @@ spec:
       containers:
       - args:
         - -api-addr=api.linkerd.svc.cluster.local:8085
-        - -static-dir=/dist
-        - -template-dir=/templates
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
         - -log-level=info

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -352,8 +352,6 @@ spec:
       containers:
       - args:
         - -api-addr=api.Namespace.svc.cluster.local:8085
-        - -static-dir=/dist
-        - -template-dir=/templates
         - -uuid=UUID
         - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -354,8 +354,6 @@ spec:
       containers:
       - args:
         - -api-addr=api.Namespace.svc.cluster.local:8085
-        - -static-dir=/dist
-        - -template-dir=/templates
         - -uuid=UUID
         - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -299,8 +299,6 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - "-api-addr=api.{{.Namespace}}.svc.cluster.local:8085"
-        - "-static-dir=/dist"
-        - "-template-dir=/templates"
         - "-uuid={{.UUID}}"
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -38,7 +38,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o web/web ./web
 
 ## package it all up
 FROM gcr.io/linkerd-io/base:2017-10-30.01
-COPY LICENSE /linkerd/LICENSE
+WORKDIR /linkerd
+
+COPY LICENSE .
 COPY --from=golang /go/src/github.com/linkerd/linkerd2/web/web .
 RUN mkdir -p app
 COPY --from=webpack-bundle /go/src/github.com/linkerd/linkerd2/web/app/dist app/dist

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,24 +9,28 @@ ENV PROJECT github.com/linkerd/linkerd2
 ENV PACKAGE $PROJECT/web/app
 ENV ROOT $GOPATH/src/$PROJECT
 ENV PACKAGEDIR $GOPATH/src/$PACKAGE
-
-COPY web/app $PACKAGEDIR
-COPY bin/web $ROOT/bin/web
 WORKDIR $PACKAGEDIR
 
-# node dependencies
-RUN $ROOT/bin/web setup --pure-lockfile
+# copy build script
+COPY bin/web $ROOT/bin/web
 
-# frontend assets
+# install yarn dependencies
+COPY web/app/package.json web/app/yarn.lock ./
+RUN $ROOT/bin/web setup install --frozen-lockfile
+
+# build frontend assets
 # set the env to production *after* yarn has done an install, to make sure all
 # libraries required for building are included.
 ENV NODE_ENV production
+COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
 FROM gcr.io/linkerd-io/go-deps:b6861b6c as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
-COPY web web
+RUN mkdir -p web
+COPY web/main.go web
+COPY web/srv web/srv
 COPY controller controller
 COPY pkg pkg
 
@@ -35,9 +39,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o web/web ./web
 ## package it all up
 FROM gcr.io/linkerd-io/base:2017-10-30.01
 COPY LICENSE /linkerd/LICENSE
-COPY --from=golang /go/src/github.com/linkerd/linkerd2/web .
-RUN mkdir -p ./dist
-COPY --from=webpack-bundle /go/src/github.com/linkerd/linkerd2/web/app/dist ./dist
+COPY --from=golang /go/src/github.com/linkerd/linkerd2/web/web .
+RUN mkdir -p app
+COPY --from=webpack-bundle /go/src/github.com/linkerd/linkerd2/web/app/dist app/dist
+COPY web/templates templates
 
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}


### PR DESCRIPTION
Our web Dockerfile was previously setup to reinstall all yarn dependencies and rebuild the go binary any time any of our css or js files changed.

In this branch I've tweaked the layers in the Dockerfile so that yarn dependencies are only rebuilt when package.json or yarn.lock changes, and the go binary is only rebuilt when go source files change.

I also realized that our production web image included all of our unbundled javascript and css files, which aren't used when running the app in production, so I've removed them.

And in the process I change the file layout of the web image to match the defaults expected by the web server, which means we can remove the `-static-dir` and `-template-dir` flags from our install configs.

Testing locally, prior to make this change, making a modification to `web/app/js/index.js` would cause the docker build to take about 3m15s. After making this change, it rebuilds in about 1m5s.

This branch doesn't modify webpack, which accounts for the bulk of the remaining time required to build the web image (relates to #1662).