### PR TITLE
Change the proxy-init container ordering during auto proxy injection

### DIFF
--- a/controller/proxy-injector/patch.go
+++ b/controller/proxy-injector/patch.go
@@ -1,13 +1,15 @@
 package injector
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	patchPathContainer         = "/spec/template/spec/containers/0"
 	patchPathInitContainerRoot = "/spec/template/spec/initContainers"
-	patchPathInitContainer     = "/spec/template/spec/initContainers/0"
+	patchPathInitContainer     = "/spec/template/spec/initContainers/%d"
 	patchPathVolumeRoot        = "/spec/template/spec/volumes"
 	patchPathVolume            = "/spec/template/spec/volumes/0"
 	patchPathPodLabel          = "/spec/template/metadata/labels"
@@ -42,10 +44,10 @@ func (p *Patch) addInitContainerRoot() {
 	})
 }
 
-func (p *Patch) addInitContainer(container *corev1.Container) {
+func (p *Patch) addInitContainer(container *corev1.Container, index int) {
 	p.patchOps = append(p.patchOps, &patchOp{
 		Op:    "add",
-		Path:  patchPathInitContainer,
+		Path:  fmt.Sprintf(patchPathInitContainer, index),
 		Value: container,
 	})
 }

--- a/controller/proxy-injector/patch_test.go
+++ b/controller/proxy-injector/patch_test.go
@@ -1,6 +1,7 @@
 package injector
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -35,12 +36,13 @@ func TestPatch(t *testing.T) {
 	var (
 		controllerNamespace = "linkerd"
 		createdBy           = "linkerd/cli v18.8.4"
+		initContainerIndex  = 5
 	)
 
 	actual := NewPatch()
 	actual.addContainer(sidecar)
 	actual.addInitContainerRoot()
-	actual.addInitContainer(init)
+	actual.addInitContainer(init, initContainerIndex)
 	actual.addVolumeRoot()
 	actual.addVolume(trustAnchors)
 	actual.addVolume(secrets)
@@ -56,7 +58,7 @@ func TestPatch(t *testing.T) {
 	expected.patchOps = []*patchOp{
 		&patchOp{Op: "add", Path: patchPathContainer, Value: sidecar},
 		&patchOp{Op: "add", Path: patchPathInitContainerRoot, Value: []*v1.Container{}},
-		&patchOp{Op: "add", Path: patchPathInitContainer, Value: init},
+		&patchOp{Op: "add", Path: fmt.Sprintf(patchPathInitContainer, initContainerIndex), Value: init},
 		&patchOp{Op: "add", Path: patchPathVolumeRoot, Value: []*v1.Volume{}},
 		&patchOp{Op: "add", Path: patchPathVolume, Value: trustAnchors},
 		&patchOp{Op: "add", Path: patchPathVolume, Value: secrets},

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -144,7 +144,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	if len(deployment.Spec.Template.Spec.InitContainers) == 0 {
 		patch.addInitContainerRoot()
 	}
-	patch.addInitContainer(proxyInit)
+	patch.addInitContainer(proxyInit, len(deployment.Spec.Template.Spec.InitContainers))
 
 	if len(deployment.Spec.Template.Spec.Volumes) == 0 {
 		patch.addVolumeRoot()


### PR DESCRIPTION
This PR changes the ordering of the proxy-init container during the auto proxy injection process, by always appending it to the end of the list of existing init containers. This ensures that the proxy-init won't interfere with other init containers that need to access the network as described in #1760.

I was able to reproduce the issue and test the fix with [this deployment](https://gist.github.com/ihcsim/5c2b5a3d745f8fdce879cdb1da87a66f). 