### PR TITLE
Fix incorrect test wording

### DIFF
--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1062,7 +1062,7 @@ status:
 		testStatSummary(t, expectations)
 	})
 
-	t.Run("Queries prometheus for authority stats when --from authority is used", func(t *testing.T) {
+	t.Run("Queries prometheus for authority stats when --from deployment is used", func(t *testing.T) {
 		expectations := []statSumExpected{
 			statSumExpected{
 				err: nil,


### PR DESCRIPTION
You can't query stats `--from` an authority. This test was confusingly worded. Changed wording to reflect the actual setup of the test.