### PR TITLE
Add linkerd profile --template command

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -2,10 +2,9 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"os"
-	"strings"
 	"text/template"
 
 	"github.com/linkerd/linkerd2/cli/profile"
@@ -18,10 +17,21 @@ type templateConfig struct {
 	ServiceName           string
 }
 
+type profileOptions struct {
+	namespace string
+	template  bool
+}
+
+func newProfileOptions() *profileOptions {
+	return &profileOptions{
+		namespace: "default",
+		template:  false,
+	}
+}
+
 func newCmdProfile() *cobra.Command {
 
-	var namespace string
-	var template bool
+	options := newProfileOptions()
 
 	cmd := &cobra.Command{
 		Use:   "profile [flags] --template (SERVICE)",
@@ -33,52 +43,35 @@ func newCmdProfile() *cobra.Command {
 		service.
 
 		Example:
-		linkerd profile --template web-svc.emojivoto > web-svc-profile.yaml
+		linkerd profile -n emojivoto --template web-svc > web-svc-profile.yaml
 		# (edit web-svc-profile.yaml manually)
 		kubectl apply -f web-svc-profile.yaml
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config, err := buildConfig(namespace, args[0])
-			if err != nil {
-				return err
+			if !options.template {
+				return errors.New("only template mode is currently supported, please run with --template")
 			}
-			return renderProfileTemplate(config, os.Stdout)
+
+			return renderProfileTemplate(buildConfig(options.namespace, args[0]), os.Stdout)
 		},
 	}
 
-	cmd.PersistentFlags().BoolVar(&template, "template", true, "Output a service profile template")
-	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the service")
+	cmd.PersistentFlags().BoolVar(&options.template, "template", options.template, "Output a service profile template")
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the service")
 
 	return cmd
 }
 
-func buildConfig(namespace, service string) (templateConfig, error) {
-
-	serviceParts := strings.Split(service, ".")
-
-	serviceName := serviceParts[0]
-	serviceNamespace := "default"
-
-	if len(serviceParts) >= 2 && namespace != "" && serviceParts[1] != namespace {
-		return templateConfig{}, fmt.Errorf("service namespace cannot be specified by namespace flag (%s) and by service name (%s)", namespace, serviceParts[1])
+func buildConfig(namespace, service string) *templateConfig {
+	return &templateConfig{
+		ControlPlaneNamespace: controlPlaneNamespace,
+		ServiceNamespace:      namespace,
+		ServiceName:           service,
 	}
-
-	if len(serviceParts) >= 2 {
-		serviceNamespace = serviceParts[1]
-	}
-
-	if namespace != "" {
-		serviceNamespace = namespace
-	}
-	return templateConfig{
-		controlPlaneNamespace,
-		serviceNamespace,
-		serviceName,
-	}, nil
 }
 
-func renderProfileTemplate(config templateConfig, w io.Writer) error {
+func renderProfileTemplate(config *templateConfig, w io.Writer) error {
 	template, err := template.New("profile").Parse(profile.Template)
 	if err != nil {
 		return err

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/linkerd/linkerd2/cli/profile"
+	"github.com/spf13/cobra"
+)
+
+type templateConfig struct {
+	ControlPlaneNamespace string
+	ServiceNamespace      string
+	ServiceName           string
+}
+
+func newCmdProfile() *cobra.Command {
+
+	var namespace string
+	var template bool
+
+	cmd := &cobra.Command{
+		Use:   "profile [flags] --template (SERVICE)",
+		Short: "Output template service profile config for Kubernetes",
+		Long: `Output template service profile config for Kubernetes.
+		
+		This outputs a service profile template for the given service.  Edit the
+		template and then apply it with kubectl to add a service profile to a
+		service.
+
+		Example:
+		linkerd profile --template web-svc.emojivoto > web-svc-profile.yaml
+		# (edit web-svc-profile.yaml manually)
+		kubectl apply -f web-svc-profile.yaml
+		`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := buildConfig(namespace, args[0])
+			if err != nil {
+				return err
+			}
+			return renderProfileTemplate(config, os.Stdout)
+		},
+	}
+
+	cmd.PersistentFlags().BoolVar(&template, "template", true, "Output a service profile template")
+	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the service")
+
+	return cmd
+}
+
+func buildConfig(namespace, service string) (templateConfig, error) {
+
+	serviceParts := strings.Split(service, ".")
+
+	serviceName := serviceParts[0]
+	serviceNamespace := "default"
+
+	if len(serviceParts) >= 2 && namespace != "" && serviceParts[1] != namespace {
+		return templateConfig{}, fmt.Errorf("service namespace cannot be specified by namespace flag (%s) and by service name (%s)", namespace, serviceParts[1])
+	}
+
+	if len(serviceParts) >= 2 {
+		serviceNamespace = serviceParts[1]
+	}
+
+	if namespace != "" {
+		serviceNamespace = namespace
+	}
+	return templateConfig{
+		controlPlaneNamespace,
+		serviceNamespace,
+		serviceName,
+	}, nil
+}
+
+func renderProfileTemplate(config templateConfig, w io.Writer) error {
+	template, err := template.New("profile").Parse(profile.Template)
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	err = template.Execute(buf, config)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(buf.Bytes())
+	return err
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -75,6 +75,7 @@ func init() {
 	RootCmd.AddCommand(newCmdGet())
 	RootCmd.AddCommand(newCmdInject())
 	RootCmd.AddCommand(newCmdInstall())
+	RootCmd.AddCommand(newCmdProfile())
 	RootCmd.AddCommand(newCmdStat())
 	RootCmd.AddCommand(newCmdTap())
 	RootCmd.AddCommand(newCmdTop())

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -1,0 +1,70 @@
+package profile
+
+// Template provides the base template for the `linkerd profile --template` command.
+const Template = `### Service Profile for {{.ServiceName}}.{{.ServiceNamespace}} ###
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  name: {{.ServiceName}}.{{.ServiceNamespace}}
+  namespace: {{.ControlPlaneNamespace}}
+spec:
+  # A service profile defines a list of routes.  Linkerd can aggregate metrics
+  # like request volume, latency, and success rate by route.
+  routes:
+  - name: '/authors/{id}'
+
+    # Each route must define a condition.  All requests that match the
+    # condition will be counted as belonging to that route.  If a request
+    # matches more than one route, the first match wins.
+    condition:
+      # The simplest condition is a path regular expression.
+      path: '/authors/\d+'
+
+      # This is a condition that checks that request method.
+      # method: POST
+
+      # To define a condition that requires both path and method, use the
+      # 'all' condition.
+      # all:
+      # - method: POST
+      # - path: '/authors/\d+'
+
+      # Conditions can be combined using 'all', 'any', and 'not'.
+      # any:
+      # - all:
+      #   - method: POST
+      #   - path: '/authors/\d+'
+      # - all:
+      #   - not:
+      #       method: DELETE
+      #   - path: /info.txt
+
+    # A route may optionally define a list of response classes which describe
+    # how responses from this route will be classified.
+    responseClasses:
+
+    # Each response class must define a condition.  All responses from this
+    # route that match the condition will be classified as this response class.
+    - condition:
+      # The simplest condition is a HTTP status code range.
+      status:
+        min: 500
+        max: 599
+      
+      # Specifying only one of min or max matches just that one status code.
+      # status:
+      #   min: 404 # This matches 404s only.
+
+      # Conditions can be combined using 'all', 'any', and 'not'.
+      # all:
+      # - status:
+      #     min: 500
+      #     max: 599
+      # - not:
+      #     status:
+      #       min: 503
+
+      # The response class defines whether responses should be counted as
+      # successes or failures.
+      isSuccess: false
+`

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -1,7 +1,7 @@
 package profile
 
 // Template provides the base template for the `linkerd profile --template` command.
-const Template = `### Service Profile for {{.ServiceName}}.{{.ServiceNamespace}} ###
+const Template = `### ServiceProfile for {{.ServiceName}}.{{.ServiceNamespace}} ###
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
@@ -20,7 +20,7 @@ spec:
       # The simplest condition is a path regular expression.
       path: '/authors/\d+'
 
-      # This is a condition that checks that request method.
+      # This is a condition that checks the request method.
       # method: POST
 
       # To define a condition that requires both path and method, use the

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -46,23 +46,23 @@ spec:
     # Each response class must define a condition.  All responses from this
     # route that match the condition will be classified as this response class.
     - condition:
-      # The simplest condition is a HTTP status code range.
-      status:
-        min: 500
-        max: 599
+        # The simplest condition is a HTTP status code range.
+        status:
+          min: 500
+          max: 599
       
-      # Specifying only one of min or max matches just that one status code.
-      # status:
-      #   min: 404 # This matches 404s only.
+        # Specifying only one of min or max matches just that one status code.
+        # status:
+        #   min: 404 # This matches 404s only.
 
-      # Conditions can be combined using 'all', 'any', and 'not'.
-      # all:
-      # - status:
-      #     min: 500
-      #     max: 599
-      # - not:
-      #     status:
-      #       min: 503
+        # Conditions can be combined using 'all', 'any', and 'not'.
+        # all:
+        # - status:
+        #     min: 500
+        #     max: 599
+        # - not:
+        #     status:
+        #       min: 503
 
       # The response class defines whether responses should be counted as
       # successes or failures.

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -41,7 +41,7 @@ spec:
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.
-    responseClasses:
+    responses:
 
     # Each response class must define a condition.  All responses from this
     # route that match the condition will be classified as this response class.


### PR DESCRIPTION
Add a new CLI command: `linkerd profile --template` which outputs a sample service profile yaml.  Users can edit this sample and then `kubectl apply` it to add a service profile.  The sample serves as "documentation by example" of what service profiles may contain.

Example usage:
```bash
linkerd profile --template web-svc.emojivoto > web-svc-profile.yaml
# edit web-svc-profile.yaml in your favorite editor
kubectl apply -f web-svc-profile.yaml
```

Signed-off-by: Alex Leong <alex@buoyant.io>