### PR TITLE
Add check for service profile validation

### DIFF
--- a/controller/destination/profile_listener.go
+++ b/controller/destination/profile_listener.go
@@ -88,7 +88,7 @@ func toResponseClass(rc *sp.ResponseClass) (*pb.ResponseClass, error) {
 }
 
 func toResponseMatch(rspMatch *sp.ResponseMatch) (*pb.ResponseMatch, error) {
-	err := validateResponseMatch(rspMatch)
+	err := ValidateResponseMatch(rspMatch)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func toResponseMatch(rspMatch *sp.ResponseMatch) (*pb.ResponseMatch, error) {
 }
 
 func toRequestMatch(reqMatch *sp.RequestMatch) (*pb.RequestMatch, error) {
-	err := validateRequestMatch(reqMatch)
+	err := ValidateRequestMatch(reqMatch)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func toRequestMatch(reqMatch *sp.RequestMatch) (*pb.RequestMatch, error) {
 	return nil, errors.New("A request match must have a field set")
 }
 
-func validateRequestMatch(reqMatch *sp.RequestMatch) error {
+func ValidateRequestMatch(reqMatch *sp.RequestMatch) error {
 	tooManyKindsErr := errors.New("A request match may not have more than two fields set")
 	matchKindSet := false
 	if reqMatch.All != nil {
@@ -236,12 +236,24 @@ func validateRequestMatch(reqMatch *sp.RequestMatch) error {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		for _, child := range reqMatch.All {
+			err := ValidateRequestMatch(child)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if reqMatch.Any != nil {
 		if matchKindSet {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		for _, child := range reqMatch.Any {
+			err := ValidateRequestMatch(child)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if reqMatch.Method != "" {
 		if matchKindSet {
@@ -254,6 +266,10 @@ func validateRequestMatch(reqMatch *sp.RequestMatch) error {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		err := ValidateRequestMatch(reqMatch.Not)
+		if err != nil {
+			return err
+		}
 	}
 	if reqMatch.Path != "" {
 		if matchKindSet {
@@ -269,7 +285,7 @@ func validateRequestMatch(reqMatch *sp.RequestMatch) error {
 	return nil
 }
 
-func validateResponseMatch(rspMatch *sp.ResponseMatch) error {
+func ValidateResponseMatch(rspMatch *sp.ResponseMatch) error {
 	tooManyKindsErr := errors.New("A response match may not have more than two fields set")
 	invalidRangeErr := errors.New("Range maximum cannot be smaller than minimum")
 	matchKindSet := false
@@ -278,12 +294,24 @@ func validateResponseMatch(rspMatch *sp.ResponseMatch) error {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		for _, child := range rspMatch.All {
+			err := ValidateResponseMatch(child)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if rspMatch.Any != nil {
 		if matchKindSet {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		for _, child := range rspMatch.Any {
+			err := ValidateResponseMatch(child)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	if rspMatch.Status != nil {
 		if matchKindSet {
@@ -299,6 +327,10 @@ func validateResponseMatch(rspMatch *sp.ResponseMatch) error {
 			return tooManyKindsErr
 		}
 		matchKindSet = true
+		err := ValidateResponseMatch(rspMatch.Not)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !matchKindSet {

--- a/controller/destination/profile_listener.go
+++ b/controller/destination/profile_listener.go
@@ -88,6 +88,9 @@ func toResponseClass(rc *sp.ResponseClass) (*pb.ResponseClass, error) {
 }
 
 func toResponseMatch(rspMatch *sp.ResponseMatch) (*pb.ResponseMatch, error) {
+	if rspMatch == nil {
+		return nil, errors.New("missing response match")
+	}
 	err := ValidateResponseMatch(rspMatch)
 	if err != nil {
 		return nil, err
@@ -155,6 +158,9 @@ func toResponseMatch(rspMatch *sp.ResponseMatch) (*pb.ResponseMatch, error) {
 }
 
 func toRequestMatch(reqMatch *sp.RequestMatch) (*pb.RequestMatch, error) {
+	if reqMatch == nil {
+		return nil, errors.New("missing request match")
+	}
 	err := ValidateRequestMatch(reqMatch)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add a check to `linkerd check` which validates all service profile resources.  In particular it checks:
* does the service profile refer to an existent service
* is the service profile valid

Signed-off-by: Alex Leong <alex@buoyant.io>