### PR TITLE
Put back the docs removed by mistake

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -257,6 +257,13 @@ DOCKER_TRACE=1 bin/docker-build-proxy
 
 # Dependencies
 
+## Updating protobuf dependencies	
+ If you make Protobuf changes, run:	
+ ```bash	
+bin/dep ensure	
+bin/protoc-go.sh	
+```
+
 ## Updating Docker dependencies
 
 The go Docker images rely on base dependency images with


### PR DESCRIPTION
I believe this part of docs was removed by mistake in this commit https://github.com/linkerd/linkerd2/commit/37f8490edb13afc8b01bcb397dbf3cf35846f20e#diff-c21202b241d0cd40822db520c8b00770L303

Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>