### PR TITLE
Send metric labels in profile API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -208,7 +208,7 @@
   version = "v1.1"
 
 [[projects]]
-  digest = "1:f029e20034db28ab1c26f3dc565b11d66d0281c779daa434928322350a0604c0"
+  digest = "1:60ac029fe58265f1c1d045813810bb88676057c646da0cb7ce14a50cf82ffcf8"
   name = "github.com/linkerd/linkerd2-proxy-api"
   packages = [
     "go/destination",
@@ -217,8 +217,7 @@
     "go/tap",
   ]
   pruneopts = ""
-  revision = "9fde83574d39e055932885803e677c60642c0bdf"
-  version = "v0.1.2"
+  revision = "9f5c62278bc10b7bf9bb9facba8ea46b904bc0e8"
 
 [[projects]]
   digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@ required = [
 
 [[constraint]]
   name = "github.com/linkerd/linkerd2-proxy-api"
-  version = "v0.1.2"
+  revision = "9f5c62278bc10b7bf9bb9facba8ea46b904bc0e8"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:b6861b6c as golang
+FROM gcr.io/linkerd-io/go-deps:8ef6d4c5 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:b6861b6c as golang
+FROM gcr.io/linkerd-io/go-deps:8ef6d4c5 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/destination/profile_listener_test.go
+++ b/controller/destination/profile_listener_test.go
@@ -112,6 +112,7 @@ var (
 	}
 
 	route1 = &sp.RouteSpec{
+		Name:      "route1",
 		Condition: getButNotPrivate,
 		Responses: []*sp.ResponseClass{
 			&sp.ResponseClass{
@@ -122,6 +123,9 @@ var (
 	}
 
 	pbRoute1 = &pb.Route{
+		MetricsLabels: map[string]string{
+			"route": "route1",
+		},
 		Condition: pbGetButNotPrivate,
 		ResponseClasses: []*pb.ResponseClass{
 			&pb.ResponseClass{
@@ -132,6 +136,7 @@ var (
 	}
 
 	route2 = &sp.RouteSpec{
+		Name:      "route2",
 		Condition: login,
 		Responses: []*sp.ResponseClass{
 			&sp.ResponseClass{
@@ -142,6 +147,9 @@ var (
 	}
 
 	pbRoute2 = &pb.Route{
+		MetricsLabels: map[string]string{
+			"route": "route2",
+		},
 		Condition: pbLogin,
 		ResponseClasses: []*pb.ResponseClass{
 			&pb.ResponseClass{

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -24,7 +24,7 @@ func ToRoute(route *sp.RouteSpec) (*pb.Route, error) {
 	return &pb.Route{
 		Condition:       cond,
 		ResponseClasses: rcs,
-		// TODO: set route->name metric label.
+		MetricsLabels:   map[string]string{"route": route.Name},
 	}, nil
 }
 

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:b6861b6c as golang
+FROM gcr.io/linkerd-io/go-deps:8ef6d4c5 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:b6861b6c as golang
+FROM gcr.io/linkerd-io/go-deps:8ef6d4c5 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
Bump our dependency on the Linkerd2-proxy-api and start sending the route name as a metric label.

Signed-off-by: Alex Leong <alex@buoyant.io>