### PR TITLE
Make service profile validation a warning instead of an error

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	retryStatus = "[retry]"
-	failStatus  = "[FAIL]"
+	retryStatus   = "[retry]"
+	failStatus    = "[FAIL]"
+	warningStatus = "[warning]"
 )
 
 type checkOptions struct {
@@ -128,7 +129,11 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 		}
 
 		if result.Err != nil {
-			fmt.Fprintf(w, "%s%s%s -- %s%s", checkLabel, filler, failStatus, result.Err, lineBreak)
+			status := failStatus
+			if result.Warning {
+				status = warningStatus
+			}
+			fmt.Fprintf(w, "%s%s%s -- %s%s", checkLabel, filler, status, result.Err, lineBreak)
 			return
 		}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -106,7 +106,7 @@ func validatedPublicAPIClient(retryDeadline time.Time) pb.ApiClient {
 			return
 		}
 
-		if result.Err != nil {
+		if result.Err != nil && !result.Warning {
 			var msg string
 			switch result.Category {
 			case healthcheck.KubernetesAPICategory:


### PR DESCRIPTION
The existence of an invalid service profile causes `linkerd check` to fail.  This means that it is not possible to open the Linkerd dashboard with the `linkerd dashboard` command.  While service profile validation is useful, it should not lock users out.

Add the ability to designate health checks as warnings.  A failed warning health check will display a warning output in `linkerd check` but will not affect the overall success of the command.  Switch the service profile validation to be a warning.

```
$ bin/linkerd check -l alex --expected-version dev-1922dc0a-alex
kubernetes-api: can initialize the client..................................[ok]
kubernetes-api: can query the Kubernetes API...............................[ok]
kubernetes-api: is running the minimum Kubernetes API version..............[ok]
linkerd-api: control plane namespace exists................................[ok]
linkerd-api: control plane pods are ready..................................[ok]
linkerd-api: can initialize the client.....................................[ok]
linkerd-api: can query the control plane API...............................[ok]
linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
linkerd-api: no invalid service profiles...................................[warning] -- ServiceProfile "voting-poopoo.emojivoto" has unknown service: services "voting-poopoo" not found
linkerd-version: can determine the latest version..........................[ok]
linkerd-version: cli is up-to-date.........................................[ok]
linkerd-version: control plane is up-to-date...............................[ok]

Status check results are [ok]
```

Signed-off-by: Alex Leong <alex@buoyant.io>