### PR TITLE
Use fqdn for service profile name

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -15,6 +15,7 @@ type templateConfig struct {
 	ControlPlaneNamespace string
 	ServiceNamespace      string
 	ServiceName           string
+	ClusterZone           string
 }
 
 type profileOptions struct {
@@ -68,6 +69,7 @@ func buildConfig(namespace, service string) *templateConfig {
 		ControlPlaneNamespace: controlPlaneNamespace,
 		ServiceNamespace:      namespace,
 		ServiceName:           service,
+		ClusterZone:           "svc.cluster.local",
 	}
 }
 

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -5,7 +5,7 @@ const Template = `### ServiceProfile for {{.ServiceName}}.{{.ServiceNamespace}} 
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  name: {{.ServiceName}}.{{.ServiceNamespace}}
+  name: {{.ServiceName}}.{{.ServiceNamespace}}.{{.ClusterZone}}
   namespace: {{.ControlPlaneNamespace}}
 spec:
   # A service profile defines a list of routes.  Linkerd can aggregate metrics

--- a/controller/destination/k8s_resolver.go
+++ b/controller/destination/k8s_resolver.go
@@ -68,24 +68,12 @@ func (k *k8sResolver) streamResolution(host string, port int, listener endpointU
 }
 
 func (k *k8sResolver) streamProfiles(host string, listener profileUpdateListener) error {
-	svcId, err := k.localKubernetesServiceIdFromDNSName(host)
-	if err != nil {
-		log.Error(err)
-		return err
-	}
-
-	if svcId == nil {
-		err = fmt.Errorf("cannot resolve service that isn't a local Kubernetes service: %s", host)
-		log.Error(err)
-		return err
-	}
-
 	id := profileId{
 		namespace: k.controllerNamespace,
-		name:      fmt.Sprintf("%s.%s", svcId.name, svcId.namespace),
+		name:      host,
 	}
 
-	err = k.profileWatcher.subscribeToProfile(id, listener)
+	err := k.profileWatcher.subscribeToProfile(id, listener)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -64,8 +64,9 @@ const (
 )
 
 var (
-	maxRetries  = 60
-	retryWindow = 5 * time.Second
+	maxRetries        = 60
+	retryWindow       = 5 * time.Second
+	clusterZoneSuffix = []string{"svc", "cluster", "local"}
 )
 
 type checker struct {
@@ -632,8 +633,13 @@ func (hc *HealthChecker) validateServiceProfiles() error {
 
 	for _, p := range svcProfiles.Items {
 		nameParts := strings.Split(p.Name, ".")
-		if len(nameParts) != 2 {
-			return fmt.Errorf("ServiceProfile \"%s\" has invalid name (must be \"<service>.<namespace>\")", p.Name)
+		if len(nameParts) != 2+len(clusterZoneSuffix) {
+			return fmt.Errorf("ServiceProfile \"%s\" has invalid name (must be \"<service>.<namespace>.svc.cluster.local\")", p.Name)
+		}
+		for i, part := range nameParts[2:] {
+			if part != clusterZoneSuffix[i] {
+				return fmt.Errorf("ServiceProfile \"%s\" has invalid name (must be \"<service>.<namespace>.svc.cluster.local\")", p.Name)
+			}
 		}
 		service := nameParts[0]
 		namespace := nameParts[1]


### PR DESCRIPTION
Service profiles must be named in the form `"<service>.<namespace>"`.  This is inconsistent with the fully normalized domain name that the proxy sends to the controller.  It also does not permit creating service profiles for non-Kubernetes services.

We switch to requiring that service profiles must be named with the FQDN of their service.  For Kubernetes services, this is `"<service>.<namespace>.svc.cluster.local"`.

This change alone is not sufficient for allowing service profile for non-Kubernetes services because the k8s resolver will ignore any DNS names which are not Kubernetes services.  Further refactoring of the resolver will be required to allow looking up non-Kubernetes service profiles in Kuberenetes.

Signed-off-by: Alex Leong <alex@buoyant.io>