### PR TITLE
Revert proxy upgrade

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-4625302}"
+PROXY_VERSION="${PROXY_VERSION:-51db6f8}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This branch reverts the proxy upgrade from #1815, since the latest version of the proxy introduces a regression with how failing grpc responses are classified (will write up an issue shortly).