### PR TITLE
Replace some sidebar icons with Font Awesome

### DIFF
--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -122,8 +122,8 @@ const styles = theme => {
       paddingRight: `${contentPadding}px`,
     },
     shrinkIcon: {
-      fontSize: "20px",
-      paddingLeft: "2px",
+      fontSize: "18px",
+      paddingLeft: "3px",
     }
   };
 };

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -121,6 +121,10 @@ const styles = theme => {
       paddingLeft: `${contentPadding}px`,
       paddingRight: `${contentPadding}px`,
     },
+    shrinkIcon: {
+      fontSize: "20px",
+      paddingLeft: "2px",
+    }
   };
 };
 
@@ -228,9 +232,9 @@ class NavigationBase extends React.Component {
 
           <MenuList>
             { this.menuItem("/overview", "Overview", <HomeIcon />) }
-            { this.menuItem("/tap", "Tap", <Icon className="fas fa-microscope" />) }
-            { this.menuItem("/top", "Top", <Icon className="fas fa-stream" />) }
-            { this.menuItem("/servicemesh", "Service Mesh", <CloudQueueIcon />) }
+            { this.menuItem("/tap", "Tap", <Icon className={classNames("fas fa-microscope", classes.shrinkIcon)} />) }
+            { this.menuItem("/top", "Top", <Icon className={classNames("fas fa-stream", classes.shrinkIcon)} />) }
+            { this.menuItem("/servicemesh", "Service Mesh", <CloudQueueIcon className={classes.shrinkIcon} />) }
             <NavigationResources />
           </MenuList>
 

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -22,16 +22,15 @@ import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import HomeIcon from '@material-ui/icons/Home';
+import Icon from '@material-ui/core/Icon';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
 import { Link } from 'react-router-dom';
 import MenuIcon from '@material-ui/icons/Menu';
 import NavigationResources from './NavigationResources.jsx';
-import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import Version from './Version.jsx';
-import VisibilityIcon from '@material-ui/icons/Visibility';
 import classNames from 'classnames';
 import { withContext } from './util/AppContext.jsx';
 import { withStyles } from '@material-ui/core/styles';
@@ -93,7 +92,7 @@ const styles = theme => {
     navToolbar: {
       display: 'flex',
       alignItems: 'center',
-      padding: `0 ${theme.spacing.unit}px`,
+      padding: `0 0 0 ${theme.spacing.unit*2}px`,
       boxShadow: theme.shadows[4], // to match elevation == 4 on main AppBar
       ...theme.mixins.toolbar,
       backgroundColor: theme.palette.primary.main,
@@ -115,7 +114,7 @@ const styles = theme => {
     },
     linkerdNavLogoClose: {
       opacity: "0",
-      marginLeft: `-${navLogoWidth-theme.spacing.unit/2}px`,
+      marginLeft: `-${navLogoWidth+theme.spacing.unit/2}px`,
       transition: leavingFn(['margin', 'opacity']),
     },
     navMenuItem: {
@@ -229,8 +228,8 @@ class NavigationBase extends React.Component {
 
           <MenuList>
             { this.menuItem("/overview", "Overview", <HomeIcon />) }
-            { this.menuItem("/tap", "Tap", <VisibilityIcon />) }
-            { this.menuItem("/top", "Top", <NetworkCheckIcon />) }
+            { this.menuItem("/tap", "Tap", <Icon className="fas fa-microscope" />) }
+            { this.menuItem("/top", "Top", <Icon className="fas fa-stream" />) }
             { this.menuItem("/servicemesh", "Service Mesh", <CloudQueueIcon />) }
             <NavigationResources />
           </MenuList>


### PR DESCRIPTION
This replaces a couple of the MaterialUI icons introduced in #1776 with
their original counterparts in Font Awesome, but wrapped in a MaterialUI
`Icon` tag. Also fix Linkerd logo padding in sidebar.

Part of #1781.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2018-10-30 at 1 59 57 pm](https://user-images.githubusercontent.com/236915/47750416-975ed580-dc4c-11e8-9c2e-de42df1b9163.png)
