### PR TITLE
Rewrite octopus arm code to be more parameterized and flexible.

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -59,8 +59,8 @@ div.octopus-graph-container {
 }
 
 div.octopus-graph {
-  max-width: 980px;
-  min-width: 980px;
+  max-width: 974px;
+  min-width: 974px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -55,6 +55,7 @@ div.success-rate-dot {
 
 div.octopus-graph-container {
   overflow-x: scroll;
+  padding: 16px 0;
 }
 
 div.octopus-graph {

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -59,12 +59,15 @@ div.octopus-graph-container {
 }
 
 div.octopus-graph {
-  max-width: 1000px;
-  min-width:1000px;
+  max-width: 980px;
+  min-width: 980px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.octopus-body-node {
-  width: 232px;
+.octopus-body-node.neighbor {
+  width: 220px;
+}
+.octopus-body-node.main {
+  width: 244px;
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -59,12 +59,12 @@ div.octopus-graph-container {
 }
 
 div.octopus-graph {
-  max-width: 1126px;
-  min-width:1126px;
+  max-width: 1000px;
+  min-width:1000px;
   margin-left: auto;
   margin-right: auto;
 }
 
-.octopus-body.neighbor {
-  width: 256px;
+.octopus-body-node {
+  width: 232px;
 }

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -53,8 +53,13 @@ div.success-rate-dot {
   }
 }
 
+div.octopus-graph-container {
+  overflow-x: scroll;
+}
+
 div.octopus-graph {
-  max-width: 1180px;
+  max-width: 1126px;
+  min-width:1126px;
 }
 
 .octopus-body.neighbor {

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -52,3 +52,11 @@ div.success-rate-dot {
     margin-bottom: 12px;
   }
 }
+
+div.octopus-graph {
+  max-width: 1180px;
+}
+
+.octopus-body.neighbor {
+  width: 256px;
+}

--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -60,6 +60,8 @@ div.octopus-graph-container {
 div.octopus-graph {
   max-width: 1126px;
   min-width:1126px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .octopus-body.neighbor {

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -74,10 +74,10 @@ export default class Octopus extends React.Component {
 
     return (
       <Grid item key={resource.name} >
-        <Card className={`octopus-body ${type}`} title={display}>
+        <Card className={`octopus-body-node ${type}`} title={display}>
           <CardContent>
 
-            <Typography variant={type === "neighbor" ? "h6" : "h4"} align="center">
+            <Typography variant={type === "neighbor" ? "subtitle1" : "h6"} align="center">
               { this.linkedResourceTitle(resource, display) }
             </Typography>
 
@@ -108,15 +108,15 @@ export default class Octopus extends React.Component {
   renderUnmeshedResources = unmeshedResources => {
     return (
       <Grid item>
-        <Card key="unmeshed-resources" className="octopus-body neighbor">
+        <Card key="unmeshed-resources" className="octopus-body-node neighbor">
           <CardContent>
-            <Typography variant="h6">Unmeshed</Typography>
+            <Typography variant="subtitle1">Unmeshed</Typography>
             {
-            _.map(unmeshedResources, r => {
-              let display = displayName(r);
-              return <Typography key={display} variant="body2" title={display}>{display}</Typography>;
-            })
-          }
+              _.map(unmeshedResources, r => {
+                let display = displayName(r);
+                return <Typography key={display} variant="body2" title={display}>{display}</Typography>;
+              })
+            }
           </CardContent>
         </Card>
       </Grid>
@@ -126,14 +126,14 @@ export default class Octopus extends React.Component {
   renderCollapsedNeighbors = neighbors => {
     return (
       <Grid item>
-        <Card className="octopus-body neighbor">
+        <Card className="octopus-body-node neighbor">
           <CardContent>
             {
-          _.map(neighbors, r => {
-            let display = displayName(r);
-            return <Typography key={display}>{this.linkedResourceTitle(r, display)}</Typography>;
-          })
-        }
+              _.map(neighbors, r => {
+                let display = displayName(r);
+                return <Typography key={display}>{this.linkedResourceTitle(r, display)}</Typography>;
+              })
+            }
           </CardContent>
         </Card>
       </Grid>
@@ -141,7 +141,7 @@ export default class Octopus extends React.Component {
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let width = 94;
+    let width = 80;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
     let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);
@@ -217,7 +217,7 @@ export default class Octopus extends React.Component {
             </Grid>
 
 
-            <Grid item xs={4}>
+            <Grid item xs={3}>
               {this.renderResourceCard(resource, "main")}
             </Grid>
 

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -141,7 +141,7 @@ export default class Octopus extends React.Component {
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let width = 82;
+    let width = 80;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
     let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -193,7 +193,6 @@ export default class Octopus extends React.Component {
       <div className="octopus-graph">
         <Grid
           container
-          spacing={0}
           direction="row"
           justify="center"
           alignItems="center">

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -141,7 +141,7 @@ export default class Octopus extends React.Component {
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let width = 80;
+    let width = 82;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
     let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -190,53 +190,54 @@ export default class Octopus extends React.Component {
 
 
     return (
-      <div className="octopus-graph">
-        <Grid
-          container
-          direction="row"
-          justify="center"
-          alignItems="center">
-
-
+      <div className="octopus-graph-container">
+        <div className="octopus-graph">
           <Grid
             container
-            spacing={24}
-            direction="column"
+            direction="row"
             justify="center"
-            alignItems="center"
-            item
-            xs={3}>
-            {_.map(display.upstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
-            {_.isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources)}
-            {_.isEmpty(display.upstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.upstreams.collapsed)}
+            alignItems="center">
+
+
+            <Grid
+              container
+              spacing={24}
+              direction="column"
+              justify="center"
+              alignItems="center"
+              item
+              xs={3}>
+              {_.map(display.upstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
+              {_.isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources)}
+              {_.isEmpty(display.upstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.upstreams.collapsed)}
+            </Grid>
+
+            <Grid item xs={1}>
+              {this.renderArrowCol(numUpstreams, false)}
+            </Grid>
+
+
+            <Grid item xs={4}>
+              {this.renderResourceCard(resource, "main")}
+            </Grid>
+
+            <Grid item xs={1}>
+              {this.renderArrowCol(numDownstreams, true)}
+            </Grid>
+
+            <Grid
+              container
+              spacing={24}
+              direction="column"
+              justify="center"
+              alignItems="center"
+              item
+              xs={3}>
+              {_.map(display.downstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
+              {_.isEmpty(display.downstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.downstreams.collapsed)}
+            </Grid>
           </Grid>
-
-
-          <Grid item xs={1}>
-            {this.renderArrowCol(numUpstreams, false)}
-          </Grid>
-
-
-          <Grid item xs={4}>
-            {this.renderResourceCard(resource, "main")}
-          </Grid>
-
-          <Grid item xs={1}>
-            {this.renderArrowCol(numDownstreams, true)}
-          </Grid>
-
-          <Grid
-            container
-            spacing={24}
-            direction="column"
-            justify="center"
-            alignItems="center"
-            item
-            xs={3}>
-            {_.map(display.downstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
-            {_.isEmpty(display.downstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.downstreams.collapsed)}
-          </Grid>
-        </Grid>
+        </div>
       </div>
     );
   }

--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -1,9 +1,9 @@
+import { OctopusArms, baseHeight } from './util/OctopusArms.jsx';
 import { displayName, metricToFormatter } from './util/Utils.js';
 
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Grid from '@material-ui/core/Grid';
-import OctopusArms from './util/OctopusArms.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { StyledProgress } from './util/Progress.jsx';
@@ -16,7 +16,6 @@ import _ from 'lodash';
 import { getSuccessRateClassification } from './util/MetricUtils.jsx' ;
 
 const maxNumNeighbors = 6; // max number of neighbor nodes to show in the octopus graph
-
 
 export default class Octopus extends React.Component {
   static defaultProps = {
@@ -84,8 +83,12 @@ export default class Octopus extends React.Component {
 
             <Progress variant="determinate" value={resource.successRate * 100} />
 
-            <Table>
+            <Table padding="dense">
               <TableBody>
+                <TableRow>
+                  <TableCell><Typography>SR</Typography></TableCell>
+                  <TableCell numeric={true}><Typography>{metricToFormatter["SUCCESS_RATE"](resource.successRate)}</Typography></TableCell>
+                </TableRow>
                 <TableRow>
                   <TableCell><Typography>RPS</Typography></TableCell>
                   <TableCell numeric={true}><Typography>{metricToFormatter["NO_UNIT"](resource.requestRate)}</Typography></TableCell>
@@ -105,7 +108,7 @@ export default class Octopus extends React.Component {
   renderUnmeshedResources = unmeshedResources => {
     return (
       <Grid item>
-        <Card key="unmeshed-resources">
+        <Card key="unmeshed-resources" className="octopus-body neighbor">
           <CardContent>
             <Typography variant="h6">Unmeshed</Typography>
             {
@@ -122,20 +125,23 @@ export default class Octopus extends React.Component {
 
   renderCollapsedNeighbors = neighbors => {
     return (
-      <Grid item key="unmeshed-resources">
-        {
+      <Grid item>
+        <Card className="octopus-body neighbor">
+          <CardContent>
+            {
           _.map(neighbors, r => {
             let display = displayName(r);
-            return <div key={display}>{this.linkedResourceTitle(r, display)}</div>;
+            return <Typography key={display}>{this.linkedResourceTitle(r, display)}</Typography>;
           })
         }
+          </CardContent>
+        </Card>
       </Grid>
     );
   }
 
   renderArrowCol = (numNeighbors, isOutbound) => {
-    let baseHeight = 180;
-    let width = 75;
+    let width = 94;
     let showArrow = numNeighbors > 0;
     let isEven = numNeighbors % 2 === 0;
     let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _.floor(numNeighbors / 2);
@@ -159,7 +165,7 @@ export default class Octopus extends React.Component {
         {
           _.map(arrowTypes, arrow => {
             let arrowType = isOutbound ? arrow.type : arrow.inboundType;
-            return OctopusArms[arrowType](width, height, arrow.height, isOutbound);
+            return OctopusArms[arrowType](width, height, arrow.height, isOutbound, isEven);
           })
         }
       </svg>
@@ -179,17 +185,19 @@ export default class Octopus extends React.Component {
 
     let numUpstreams = _.size(display.upstreams.displayed) + (_.isEmpty(unmeshedSources) ? 0 : 1) +
       (_.isEmpty(display.upstreams.collapsed) ? 0 : 1);
-    let hasUpstreams = numUpstreams > 0;
+
     let numDownstreams = _.size(display.downstreams.displayed) + (_.isEmpty(display.downstreams.collapsed) ? 0 : 1);
-    let hasDownstreams = numDownstreams > 0;
+
 
     return (
       <div className="octopus-graph">
         <Grid
           container
+          spacing={0}
           direction="row"
           justify="center"
           alignItems="center">
+
 
           <Grid
             container
@@ -198,22 +206,23 @@ export default class Octopus extends React.Component {
             justify="center"
             alignItems="center"
             item
-            xs={3}
-            className={`octopus-col ${hasUpstreams ? "resource-col" : ""}`}>
+            xs={3}>
             {_.map(display.upstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
             {_.isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources)}
             {_.isEmpty(display.upstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.upstreams.collapsed)}
           </Grid>
 
-          <Grid item xs={1} className="octopus-col">
+
+          <Grid item xs={1}>
             {this.renderArrowCol(numUpstreams, false)}
           </Grid>
 
-          <Grid item xs={4} className="octopus-col resource-col">
+
+          <Grid item xs={4}>
             {this.renderResourceCard(resource, "main")}
           </Grid>
 
-          <Grid item xs={1} className="octopus-col">
+          <Grid item xs={1}>
             {this.renderArrowCol(numDownstreams, true)}
           </Grid>
 
@@ -224,8 +233,7 @@ export default class Octopus extends React.Component {
             justify="center"
             alignItems="center"
             item
-            xs={3}
-            className={`octopus-col ${hasDownstreams ? "resource-col" : ""}`}>
+            xs={3}>
             {_.map(display.downstreams.displayed, n => this.renderResourceCard(n, "neighbor"))}
             {_.isEmpty(display.downstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.downstreams.collapsed)}
           </Grid>

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -49,6 +49,29 @@ const generateSvgComponents = (y1, width, height) => {
   };
 };
 
+const arrowG = (id, arm, transform) => {
+  return (
+    <g key={id} id={id} fill="none" strokeWidth="1">
+      <path
+        d={arm.arrowPath}
+        stroke={arrowColor}
+        transform={transform}
+        strokeOpacity={strokeOpacity} />
+      <circle
+        cx={arm.circle.cx}
+        cy={arm.circle.cy}
+        transform={transform}
+        fill={arrowColor}
+        r="4" />
+      <polyline
+        points={arm.arrowHead}
+        stroke={arrowColor}
+        strokeLinecap="round"
+        transform={transform} />
+    </g>
+  );
+};
+
 const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
   let height = arrowHeight + (isEven ? 0 : halfBoxHeight);
 
@@ -59,17 +82,7 @@ const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
 
   let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment})`;
 
-  return (
-    <g key={`up-arrow-${height}`} id="downstream-up" fill="none" strokeWidth="1">
-      <path
-        d={arm.arrowPath}
-        stroke={arrowColor}
-        transform={translate}
-        strokeOpacity={strokeOpacity} />
-      <circle cx={arm.circle.cx} cy={arm.circle.cy} fill={arrowColor} r="4" transform={translate} />
-      <polyline points={arm.arrowHead} stroke={arrowColor} strokeLinecap="round" transform={translate} />
-    </g>
-  );
+  return arrowG(`up-arrow-${height}`, arm, translate);
 };
 
 const flat = (width, height) => {
@@ -102,28 +115,9 @@ const down = (width, svgHeight, arrowHeight, isOutbound) => {
 
   let translate = `translate(0, ${isOutbound ? svgHeight : svgHeight / 2 - height + halfBoxHeight - inboundAlignment})`;
   let reflect = "scale(1, -1)";
+  let transform = `${translate} ${reflect}`;
 
-  return (
-    <g key={`down-arrow-${height}`} id="downstream-down" fill="none" strokeWidth="1">
-      <path
-        d={arm.arrowPath}
-        stroke={arrowColor}
-        transform={`${translate} ${reflect}`}
-        strokeOpacity={strokeOpacity} />
-      <circle
-        cx={arm.circle.cx}
-        cy={arm.circle.cy}
-        transform={`${translate} ${reflect}`}
-        fill={arrowColor}
-        r="4" />
-      <polyline
-        points={arm.arrowHead}
-        stroke={arrowColor}
-        strokeLinecap="round"
-        transform={`${translate} ${reflect}`} />
-    </g>
-
-  );
+  return arrowG(`down-arrow-${height}`, arm, transform);
 };
 
 export const OctopusArms = {

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -1,65 +1,74 @@
 import React from 'react';
+import _ from 'lodash';
+import grey from '@material-ui/core/colors/grey';
 
-const stroke = "#000000";
-const strokeOpacity = "0.2";
+const strokeOpacity = "0.7";
+const arrowColor = grey[500];
 
-const svgArrow = (x1, y1, width, height, direction) => {
-  let segmentWidth = width / 2 - 10;
+export const baseHeight = 220; // the height of the neighbor node box
+const halfBoxHeight = baseHeight / 2;
+const controlPoint = 10; // width and height of the control points for the bezier curves
+const inboundAlignment = controlPoint * 2;
 
-  let x2 = x1 + segmentWidth + 10;
-  let y2 = y1 + 10;
+const generateSvgComponents = (y1, width, height) => {
+  let segmentWidth = width / 2 - controlPoint; // width of each horizontal arrow segment
 
-  let x3 = x2 + 10;
-  let y3 = y2 + height + 10;
+  let x1 = 0;
 
-  let horizLine1 = `M ${x1},${y1} L ${x1+segmentWidth},${y1}`;
-  let curve1 = `C ${x1+segmentWidth+7},${y1} ${x2},${y1+3} ${x2},${y2}`;
-  let verticalLine = `L ${x2}, ${y2+height}`;
-  let curve2 = `C ${x2},${y2+height+6} ${x2+2},${y3} ${x3},${y3}`;
-  let horizLine2 = `L ${x3 + segmentWidth},${y3}`;
-  let arrow = `${horizLine1} ${curve1} ${verticalLine} ${curve2} ${horizLine2}`;
+  let x2 = x1 + segmentWidth;
+  let x3 = x2 + controlPoint;
+
+  let y2 = y1 - controlPoint;
+  let y3 = y2 - height;
+  let y4 = y3 - controlPoint;
+
+  let x4 = x3 + controlPoint;
+  let x5 = x4 + segmentWidth;
+
+  let start = `M ${x1},${y1}`;
+  let horizLine1 = `L ${x2},${y1}`;
+  let curve1 = `C ${x3},${y1} ${x3},${y1}`;
+  let curve1End = `${x3},${y2}`;
+  let verticalLineEnd = `L ${x3},${y3}`;
+  let curve2 = `C ${x3},${y4} ${x3},${y4}`;
+  let curve2End = `${x4},${y4}`;
+  let horizLine2 = `L ${x5},${y4}`;
+
+  let arrowPath = _.join([start, horizLine1, curve1, curve1End, verticalLineEnd, curve2, curve2End, horizLine2], " ");
 
   let arrowEndX = width;
-  let arrowEndY = direction === "up" ? y1 : y3;
+  let arrowEndY = y4;
   let arrowHead = `${arrowEndX - 4} ${arrowEndY - 4} ${arrowEndX} ${arrowEndY} ${arrowEndX - 4} ${arrowEndY + 4}`;
 
-  let circle = {
-    cx: x1,
-    cy: direction === "up" ? y3 : y1
-  };
+  let circle = { cx: x1, cy: y1 };
 
   return {
-    arrow,
-    arrowHead,
-    circle
+    arrowPath,
+    circle,
+    arrowHead
   };
 };
 
-const up = (width, svgHeight, arrowHeight, isOutbound) => {
-  let height = (svgHeight / 2) - arrowHeight;
+const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
+  let height = arrowHeight + (isEven ? 0 : halfBoxHeight);
 
-  let x1 = 0;
-  let y1;
+  // up arrows start and the center of the middle node for outbound arms,
+  // and at the noce position for inbound arms
+  let y1 = isOutbound ? svgHeight / 2 : arrowHeight;
+  let arm = generateSvgComponents(y1, width, height, "up");
 
-  if (isOutbound) {
-    y1 = arrowHeight - 20; // I don't know where we intoduced that 20 but we need to match the other arrow
-  } else {
-    y1 = svgHeight / 2 ;
-  }
-
-  let svgPaths = svgArrow(x1, y1, width, height, "up");
+  let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment})`;
 
   return (
-    <g key={`up-arrow-${height}`} id="downstream-up" fill="none" stroke="none" strokeWidth="1">
+    <g key={`up-arrow-${height}`} id="downstream-up" fill="none" strokeWidth="1">
       <path
-        d={svgPaths.arrow}
-        stroke={stroke}
-        strokeOpacity={strokeOpacity}
-        transform="translate(31, 54) scale(-1, 1) translate(-44, -54) " />
-      <circle cx={svgPaths.circle.cx} cy={svgPaths.circle.cy} fill="#CCCCCC" r="4" />
-      <polyline points={svgPaths.arrowHead} stroke="#CCCCCC" strokeLinecap="round" />
+        d={arm.arrowPath}
+        stroke={arrowColor}
+        transform={translate}
+        strokeOpacity={strokeOpacity} />
+      <circle cx={arm.circle.cx} cy={arm.circle.cy} fill={arrowColor} r="4" transform={translate} />
+      <polyline points={arm.arrowHead} stroke={arrowColor} strokeLinecap="round" transform={translate} />
     </g>
-
   );
 };
 
@@ -72,10 +81,10 @@ const flat = (width, height) => {
     <g key="flat-arrow" id="downstream-flat" fill="none" stroke="none" strokeWidth="1">
       <path
         d={`M0,${arrowY} L${arrowEndX},${arrowY}`}
-        stroke={stroke}
+        stroke={arrowColor}
         strokeOpacity={strokeOpacity} />
-      <circle cx="0" cy={arrowY} fill="#CCCCCC" r="4" />
-      <polyline points={polylinePoints} stroke="#CCCCCC" strokeLinecap="round" />
+      <circle cx="0" cy={arrowY} fill={arrowColor} r="4" />
+      <polyline points={polylinePoints} stroke={arrowColor} strokeLinecap="round" />
     </g>
   );
 };
@@ -85,36 +94,40 @@ const down = (width, svgHeight, arrowHeight, isOutbound) => {
   // have end of block n at (1/2 block height) + (block height * n-1)
   let height = (svgHeight / 2) - arrowHeight;
 
-  let x1 = 0;
-  let y1;
-
   // inbound arrows start at the offset of the card, and end in the center of the middle card
   // outbound arrows start in the center of the middle card, and end at the card's height
-  if (isOutbound) {
-    y1 = svgHeight / 2;
-  } else {
-    y1 = arrowHeight - 20; // I don't know where we intoduced that 20 but we need to match the other arrow
-  }
+  let y1 = isOutbound ? svgHeight / 2 : halfBoxHeight;
 
-  let svg = svgArrow(x1, y1, width, height, "down");
+  let arm = generateSvgComponents(y1, width, height, "down");
+
+  let translate = `translate(0, ${isOutbound ? svgHeight : svgHeight / 2 - height + halfBoxHeight - inboundAlignment})`;
+  let reflect = "scale(1, -1)";
 
   return (
-    <g key={`down-arrow-${height}`} id="downstream-down" fill="none" stroke="none" strokeWidth="1">
+    <g key={`down-arrow-${height}`} id="downstream-down" fill="none" strokeWidth="1">
       <path
-        d={svg.arrow}
-        stroke={stroke}
+        d={arm.arrowPath}
+        stroke={arrowColor}
+        transform={`${translate} ${reflect}`}
         strokeOpacity={strokeOpacity} />
-      <circle cx={svg.circle.cx} cy={svg.circle.cy} fill="#CCCCCC" r="4" />
-      <polyline points={svg.arrowHead} stroke="#CCCCCC" strokeLinecap="round" />
+      <circle
+        cx={arm.circle.cx}
+        cy={arm.circle.cy}
+        transform={`${translate} ${reflect}`}
+        fill={arrowColor}
+        r="4" />
+      <polyline
+        points={arm.arrowHead}
+        stroke={arrowColor}
+        strokeLinecap="round"
+        transform={`${translate} ${reflect}`} />
     </g>
 
   );
 };
 
-const OctopusArms = {
+export const OctopusArms = {
   up,
   flat,
   down
 };
-
-export default OctopusArms;

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -55,7 +55,7 @@ const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
   // up arrows start and the center of the middle node for outbound arms,
   // and at the noce position for inbound arms
   let y1 = isOutbound ? svgHeight / 2 : arrowHeight;
-  let arm = generateSvgComponents(y1, width, height, "up");
+  let arm = generateSvgComponents(y1, width, height);
 
   let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment})`;
 
@@ -98,7 +98,7 @@ const down = (width, svgHeight, arrowHeight, isOutbound) => {
   // outbound arrows start in the center of the middle card, and end at the card's height
   let y1 = isOutbound ? svgHeight / 2 : halfBoxHeight;
 
-  let arm = generateSvgComponents(y1, width, height, "down");
+  let arm = generateSvgComponents(y1, width, height);
 
   let translate = `translate(0, ${isOutbound ? svgHeight : svgHeight / 2 - height + halfBoxHeight - inboundAlignment})`;
   let reflect = "scale(1, -1)";


### PR DESCRIPTION
As a result, displays better in the material UI version of the dashboard.
Also adds Success rate to data displayed on neighbour nodes.

I also limited the width of the chart so it doesn't expand super wide when in fullscreen. There's still about a 10px gap if you do expand it, but I think that could be easily fixed later.

# Before
![screen shot 2018-10-31 at 3 12 36 pm](https://user-images.githubusercontent.com/549258/47822647-13771d00-dd22-11e8-812d-09514a4cf1ab.png)


# After
![screen shot 2018-10-31 at 3 26 54 pm](https://user-images.githubusercontent.com/549258/47822661-27228380-dd22-11e8-8f23-c1f53d4ae3af.png)
