### PR TITLE
Increase retry timeout for retryable tests, refactor RetryFor

### DIFF
--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -16,6 +16,14 @@ import (
 
 var TestHelper *testutil.TestHelper
 
+var egressHttpDeployments = []string{
+	"egress-test-https-post",
+	"egress-test-http-post",
+	"egress-test-https-get",
+	"egress-test-http-get",
+	"egress-test-not-www-get",
+}
+
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
 	os.Exit(m.Run())
@@ -35,6 +43,13 @@ func TestEgressHttp(t *testing.T) {
 	out, err = TestHelper.KubectlApply(out, prefixedNs)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+	}
+
+	for _, deploy := range egressHttpDeployments {
+		err = TestHelper.CheckPods(prefixedNs, deploy, 1)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 	}
 
 	test_case := func(serviceName, dnsName, protocolToUse, methodToUse string) {

--- a/test/egress/testdata/proxy.yaml
+++ b/test/egress/testdata/proxy.yaml
@@ -165,7 +165,7 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: egress-test-http-get
+  name: egress-test-not-www-get
 spec:
   replicas: 1
   selector:

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
 )
@@ -68,16 +67,10 @@ func TestCliGet(t *testing.T) {
 	}
 
 	// wait for pods to start
-	err = TestHelper.RetryFor(30*time.Second, func() error {
-		for deploy, replicas := range deployReplicas {
-			if err := TestHelper.CheckPods(prefixedNs, deploy, replicas); err != nil {
-				return fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err)
-			}
+	for deploy, replicas := range deployReplicas {
+		if err := TestHelper.CheckPods(prefixedNs, deploy, replicas); err != nil {
+			t.Error(fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
 		}
-		return nil
-	})
-	if err != nil {
-		t.Error(err)
 	}
 
 	t.Run("get pods from --all-namespaces", func(t *testing.T) {

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -119,7 +119,7 @@ func TestInstall(t *testing.T) {
 }
 
 func TestVersionPostInstall(t *testing.T) {
-	err := TestHelper.RetryFor(30*time.Second, func() error {
+	err := TestHelper.RetryFor(60*time.Second, func() error {
 		return TestHelper.CheckVersion(TestHelper.GetVersion())
 	})
 	if err != nil {
@@ -130,7 +130,7 @@ func TestVersionPostInstall(t *testing.T) {
 func TestCheckPostInstall(t *testing.T) {
 	var out string
 	var err error
-	overallErr := TestHelper.RetryFor(30*time.Second, func() error {
+	overallErr := TestHelper.RetryFor(60*time.Second, func() error {
 		out, _, err = TestHelper.LinkerdRun(
 			"check",
 			"--expected-version",
@@ -226,7 +226,7 @@ func TestInject(t *testing.T) {
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
 	var out string
-	err := TestHelper.RetryFor(2*time.Minute, func() error {
+	err := TestHelper.RetryFor(60*time.Second, func() error {
 		var err error
 		out, _, err = TestHelper.LinkerdRun(
 			"check",

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -98,10 +98,10 @@ func TestInstall(t *testing.T) {
 	// Tests Pods and Deployments
 	for deploy, replicas := range linkerdDeployReplicas {
 		if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
-			t.Error(fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
+			t.Fatal(fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
 		}
 		if err := TestHelper.CheckDeployment(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
-			t.Error(fmt.Errorf("Error validating deploy [%s]:\n%s", deploy, err))
+			t.Fatal(fmt.Errorf("Error validating deploy [%s]:\n%s", deploy, err))
 		}
 	}
 }

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -89,57 +89,39 @@ func TestInstall(t *testing.T) {
 	}
 
 	// Tests Services
-	err = TestHelper.RetryFor(10*time.Second, func() error {
-		for _, svc := range linkerdSvcs {
-			if err := TestHelper.CheckService(TestHelper.GetLinkerdNamespace(), svc); err != nil {
-				return fmt.Errorf("Error validating service [%s]:\n%s", svc, err)
-			}
+	for _, svc := range linkerdSvcs {
+		if err := TestHelper.CheckService(TestHelper.GetLinkerdNamespace(), svc); err != nil {
+			t.Error(fmt.Errorf("Error validating service [%s]:\n%s", svc, err))
 		}
-		return nil
-	})
-	if err != nil {
-		t.Error(err)
 	}
 
 	// Tests Pods and Deployments
-	err = TestHelper.RetryFor(2*time.Minute, func() error {
-		for deploy, replicas := range linkerdDeployReplicas {
-			if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
-				return fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err)
-			}
-			if err := TestHelper.CheckDeployment(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
-				return fmt.Errorf("Error validating deploy [%s]:\n%s", deploy, err)
-			}
+	for deploy, replicas := range linkerdDeployReplicas {
+		if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
+			t.Error(fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
 		}
-		return nil
-	})
-	if err != nil {
-		t.Error(err)
+		if err := TestHelper.CheckDeployment(TestHelper.GetLinkerdNamespace(), deploy, replicas); err != nil {
+			t.Error(fmt.Errorf("Error validating deploy [%s]:\n%s", deploy, err))
+		}
 	}
 }
 
 func TestVersionPostInstall(t *testing.T) {
-	err := TestHelper.RetryFor(60*time.Second, func() error {
-		return TestHelper.CheckVersion(TestHelper.GetVersion())
-	})
+	err := TestHelper.CheckVersion(TestHelper.GetVersion())
 	if err != nil {
 		t.Fatalf("Version command failed\n%s", err.Error())
 	}
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	var out string
-	var err error
-	overallErr := TestHelper.RetryFor(60*time.Second, func() error {
-		out, _, err = TestHelper.LinkerdRun(
-			"check",
-			"--expected-version",
-			TestHelper.GetVersion(),
-			"--wait=0",
-			)
-		return err
-	})
-	if overallErr != nil {
+	out, _, err := TestHelper.LinkerdRun(
+		"check",
+		"--expected-version",
+		TestHelper.GetVersion(),
+		"--wait=0",
+	)
+
+	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)
 	}
 
@@ -216,6 +198,13 @@ func TestInject(t *testing.T) {
 		t.Fatalf("Unexpected error: %v %s", err, output)
 	}
 
+	for _, deploy := range []string{"smoke-test-terminus","smoke-test-gateway"} {
+		err = TestHelper.CheckPods(TestHelper.GetTestNamespace("smoke-test"),deploy, 1)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
 	expectedStringInPayload := "\"payload\":\"BANANA\""
 	if !strings.Contains(output, expectedStringInPayload) {
 		t.Fatalf("Expected application response to contain string [%s], but it was [%s]",
@@ -225,20 +214,15 @@ func TestInject(t *testing.T) {
 
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	var out string
-	err := TestHelper.RetryFor(60*time.Second, func() error {
-		var err error
-		out, _, err = TestHelper.LinkerdRun(
-			"check",
-			"--proxy",
-			"--expected-version",
-			TestHelper.GetVersion(),
-			"--namespace",
-			prefixedNs,
-			"--wait=0",
-		)
-		return err
-	})
+	out, _, err := TestHelper.LinkerdRun(
+		"check",
+		"--proxy",
+		"--expected-version",
+		TestHelper.GetVersion(),
+		"--namespace",
+		prefixedNs,
+		"--wait=0",
+	)
 
 	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -188,6 +188,13 @@ func TestInject(t *testing.T) {
 		t.Fatalf("kubectl apply command failed\n%s", out)
 	}
 
+	for _, deploy := range []string{"smoke-test-terminus","smoke-test-gateway"} {
+		err = TestHelper.CheckPods(prefixedNs, deploy, 1)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
 	svcURL, err := TestHelper.ProxyURLFor(prefixedNs, "smoke-test-gateway-svc", "http")
 	if err != nil {
 		t.Fatalf("Failed to get proxy URL: %s", err)
@@ -196,13 +203,6 @@ func TestInject(t *testing.T) {
 	output, err := TestHelper.HTTPGetURL(svcURL)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v %s", err, output)
-	}
-
-	for _, deploy := range []string{"smoke-test-terminus","smoke-test-gateway"} {
-		err = TestHelper.CheckPods(TestHelper.GetTestNamespace("smoke-test"),deploy, 1)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
 	}
 
 	expectedStringInPayload := "\"payload\":\"BANANA\""

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
 )
@@ -121,7 +120,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		},
 	} {
 		t.Run("linkerd "+strings.Join(tt.args, " "), func(t *testing.T) {
-			err := TestHelper.RetryFor(20*time.Second, func() error {
+			err := TestHelper.RetryFor(func() error {
 				out, _, err := TestHelper.LinkerdRun(tt.args...)
 				if err != nil {
 					t.Fatalf("Unexpected stat error: %s\n%s", err, out)

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/linkerd/linkerd2/testutil"
+	"time"
 )
 
 //////////////////////
@@ -120,7 +121,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		},
 	} {
 		t.Run("linkerd "+strings.Join(tt.args, " "), func(t *testing.T) {
-			err := TestHelper.RetryFor(func() error {
+			err := TestHelper.RetryFor(60*time.Second, func() error {
 				out, _, err := TestHelper.LinkerdRun(tt.args...)
 				if err != nil {
 					t.Fatalf("Unexpected stat error: %s\n%s", err, out)

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
-	"time"
 )
 
 //////////////////////
@@ -121,7 +121,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		},
 	} {
 		t.Run("linkerd "+strings.Join(tt.args, " "), func(t *testing.T) {
-			err := TestHelper.RetryFor(60*time.Second, func() error {
+			err := TestHelper.RetryFor(20*time.Second, func() error {
 				out, _, err := TestHelper.LinkerdRun(tt.args...)
 				if err != nil {
 					t.Fatalf("Unexpected stat error: %s\n%s", err, out)

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -85,16 +85,10 @@ func TestCliTap(t *testing.T) {
 	}
 
 	// wait for deployments to start
-	err = TestHelper.RetryFor(30*time.Second, func() error {
-		for _, deploy := range []string{"t1", "t2", "t3", "gateway"} {
-			if err := TestHelper.CheckDeployment(prefixedNs, deploy, 1); err != nil {
-				return fmt.Errorf("Error validating deployment [%s]:\n%s", deploy, err)
-			}
+	for _, deploy := range []string{"t1", "t2", "t3", "gateway"} {
+		if err := TestHelper.CheckDeployment(prefixedNs, deploy, 1); err != nil {
+			t.Error(fmt.Errorf("Error validating deployment [%s]:\n%s", deploy, err))
 		}
-		return nil
-	})
-	if err != nil {
-		t.Error(err)
 	}
 
 	t.Run("tap a deployment", func(t *testing.T) {

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -86,6 +86,10 @@ func TestCliTap(t *testing.T) {
 
 	// wait for deployments to start
 	for _, deploy := range []string{"t1", "t2", "t3", "gateway"} {
+		if err := TestHelper.CheckPods(prefixedNs, deploy, 1); err != nil {
+			t.Error(err)
+		}
+
 		if err := TestHelper.CheckDeployment(prefixedNs, deploy, 1); err != nil {
 			t.Error(fmt.Errorf("Error validating deployment [%s]:\n%s", deploy, err))
 		}

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	coreV1 "k8s.io/api/core/v1"
@@ -14,7 +15,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	// Loads the GCP auth plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"time"
 )
 
 // KubernetesHelper provides Kubernetes-related test helpers. It connects to the
@@ -104,7 +104,7 @@ func (h *KubernetesHelper) getDeployments(namespace string) (map[string]int, err
 // CheckDeployment checks that a deployment in a namespace contains the expected
 // number of replicas.
 func (h *KubernetesHelper) CheckDeployment(namespace string, deploymentName string, replicas int) error {
-	err := h.retryFor(60*time.Second, func() error {
+	return h.retryFor(30*time.Second, func() error {
 		deploys, err := h.getDeployments(namespace)
 		if err != nil {
 			return err
@@ -123,58 +123,49 @@ func (h *KubernetesHelper) CheckDeployment(namespace string, deploymentName stri
 
 		return nil
 	})
-	return err
-}
-
-// getPods gets all pods with their pod status in the specified namespace.
-func (h *KubernetesHelper) getPods(namespace string) (map[string]coreV1.PodPhase, error) {
-	pods, err := h.clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	podData := make(map[string]coreV1.PodPhase)
-	for _, pod := range pods.Items {
-		podData[pod.GetName()] = pod.Status.Phase
-	}
-	return podData, nil
 }
 
 // CheckPods checks that a deployment in a namespace contains the expected
 // number of pods in the Running state.
 func (h *KubernetesHelper) CheckPods(namespace string, deploymentName string, replicas int) error {
-	err := h.retryFor(60*time.Second, func() error {
-		podData, err := h.getPods(namespace)
+	return h.retryFor(3*time.Minute, func() error {
+		pods, err := h.clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
 
-		var runningPods []string
-		for name, status := range podData {
-			if strings.Contains(name, deploymentName) {
-				if status == "Running" {
-					runningPods = append(runningPods, name)
+		var deploymentReplicas int
+		for _, pod := range pods.Items {
+			if strings.HasPrefix(pod.Name, deploymentName){
+				deploymentReplicas++
+				if pod.Status.Phase != "Running" {
+					return fmt.Errorf("Pod [%s] in namespace [%s] is not running",
+						pod.Name, pod.Namespace)
+				}
+				for _, container := range pod.Status.ContainerStatuses {
+					if !container.Ready {
+						return fmt.Errorf("Container [%s] in pod [%s] in namespace [%s] is not running",
+							container.Name, pod.Name, pod.Namespace)
+					}
 				}
 			}
 		}
 
-		if len(runningPods) != replicas {
+		if deploymentReplicas != replicas {
 			return fmt.Errorf("Expected deployment [%s] in namespace [%s] to have [%d] running pods, but found [%d]",
-				deploymentName, namespace, replicas, len(runningPods))
+				deploymentName, namespace, replicas, deploymentReplicas)
 		}
 
 		return nil
 	})
-	return err
 }
 
 // CheckService checks that a service exists in a namespace.
 func (h *KubernetesHelper) CheckService(namespace string, serviceName string) error {
-	err := h.retryFor(60*time.Second, func() error {
+	return h.retryFor(10*time.Second, func() error {
 		_, err := h.clientset.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
 		return err
 	})
-	return err
 }
 
 // GetPodsForDeployment returns all pods for the given deployment

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -179,7 +179,7 @@ func (h *TestHelper) ValidateOutput(out, fixtureFile string) error {
 
 // CheckVersion validates the the output of the "linkerd version" command.
 func (h *TestHelper) CheckVersion(serverVersion string) error {
-	err := h.RetryFor(func() error {
+	err := h.RetryFor(30*time.Second, func() error {
 		out, _, err := h.LinkerdRun("version")
 		if err != nil {
 			return fmt.Errorf("Unexpected error: %s\n%s", err.Error(), out)
@@ -198,8 +198,7 @@ func (h *TestHelper) CheckVersion(serverVersion string) error {
 // RetryFor retries a given function every second until the function returns
 // without an error, or a timeout is reached. If the timeout is reached, it
 // returns the last error received from the function.
-func (h *TestHelper) RetryFor(fn func() error) error {
-	timeout := 2 * time.Minute
+func (h *TestHelper) RetryFor(timeout time.Duration, fn func() error) error {
 	err := fn()
 	if err == nil {
 		return nil
@@ -227,7 +226,7 @@ func (h *TestHelper) RetryFor(fn func() error) error {
 // giving pods time to start.
 func (h *TestHelper) HTTPGetURL(url string) (string, error) {
 	var body string
-	err := h.RetryFor(func() error {
+	err := h.RetryFor(30*time.Second, func() error {
 		resp, err := h.httpClient.Get(url)
 		if err != nil {
 			return err

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -179,20 +179,17 @@ func (h *TestHelper) ValidateOutput(out, fixtureFile string) error {
 
 // CheckVersion validates the the output of the "linkerd version" command.
 func (h *TestHelper) CheckVersion(serverVersion string) error {
-	err := h.RetryFor(30*time.Second, func() error {
-		out, _, err := h.LinkerdRun("version")
-		if err != nil {
-			return fmt.Errorf("Unexpected error: %s\n%s", err.Error(), out)
-		}
-		if !strings.Contains(out, fmt.Sprintf("Client version: %s", h.version)) {
-			return fmt.Errorf("Expected client version [%s], got:\n%s", h.version, out)
-		}
-		if !strings.Contains(out, fmt.Sprintf("Server version: %s", serverVersion)) {
-			return fmt.Errorf("Expected server version [%s], got:\n%s", serverVersion, out)
-		}
-		return nil
-	})
-	return err
+	out, _, err := h.LinkerdRun("version")
+	if err != nil {
+		return fmt.Errorf("Unexpected error: %s\n%s", err.Error(), out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("Client version: %s", h.version)) {
+		return fmt.Errorf("Expected client version [%s], got:\n%s", h.version, out)
+	}
+	if !strings.Contains(out, fmt.Sprintf("Server version: %s", serverVersion)) {
+		return fmt.Errorf("Expected server version [%s], got:\n%s", serverVersion, out)
+	}
+	return nil
 }
 
 // RetryFor retries a given function every second until the function returns


### PR DESCRIPTION
When running integration tests in a Kubernetes cluster that sometimes takes a little longer to get pods ready, the integration tests fail tests too early because most tests have a retry timeout of 30 seconds. 

This PR bumps up this retry timeout for `TestInstall` to 3 minutes. This gives the test enough time to download any new docker images that it needs to complete succesfully and also reduces the need to have large timeout values for subsequent tests. This PR also refactors `CheckPods` to check that all containers in a pods for a deployment are in a`Ready` state. This helps also helps in ensuring that all docker images have been downloaded and the pods are in a good state.

Tests were run on the community cluster and all were successful.

Fixes #1735, #622 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>