### PR TITLE
grafana: Show TCP closes by errno

### DIFF
--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -706,10 +706,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_close_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\",classification=\"failure\"}",
+              "expr": "tcp_close_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"inbound\",errno!=\"\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{peer}} {{classification}}",
+              "legendFormat": "{{peer}} {{errno}}",
               "refId": "A"
             }
           ],
@@ -1571,10 +1571,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_close_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\",classification=\"failure\"}",
+              "expr": "tcp_close_total{namespace=\"$namespace\", deployment=\"$deployment\", direction=\"outbound\",errno!=\"\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{peer}} {{classification}}",
+              "legendFormat": "{{peer}} {{errno}}",
               "refId": "A"
             }
           ],

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -694,7 +694,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_close_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\",classification=\"failure\"}",
+              "expr": "tcp_close_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\",errno=\"\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -694,9 +694,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "tcp_close_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\",errno=\"\"}",
+              "expr": "tcp_close_total{deployment=\"$deployment\", namespace=\"$namespace\", direction=\"inbound\",errno!=\"\"}",
               "format": "time_series",
               "intervalFactor": 1,
+              "legendFormat": "{{peer}} {{errno}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
linkerd/linkerd2-proxy#116 removes the `classification` label for the
`tcp_close_total` metric because TCP sockets that close with an error
do not actually indicate any sort of failure -- many graceful shutdown
situations can still cause a socket error.

This change uses the `errno` label to enumerate tcp_close_total metrics.

Relates to #1832