### PR TITLE
Allow stat summary to query for multiple resources

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -46,11 +46,11 @@ func newCmdStat() *cobra.Command {
 	options := newStatOptions()
 
 	cmd := &cobra.Command{
-		Use:   "stat [flags] (RESOURCE)",
+		Use:   "stat [flags] (RESOURCES)",
 		Short: "Display traffic stats about one or many resources",
 		Long: `Display traffic stats about one or many resources.
 
-  The RESOURCE argument specifies the target resource(s) to aggregate stats over:
+  The RESOURCES argument specifies the target resource(s) to aggregate stats over:
   (TYPE [NAME] | TYPE/NAME)
 
   Examples:
@@ -100,7 +100,7 @@ If no resource name is specified, displays stats about all resources of the spec
 
   # Get all inbound stats to the test namespace.
   linkerd stat ns/test`,
-		Args:      cobra.RangeArgs(1, 2),
+		Args:      cobra.MinimumNArgs(1),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			req, err := buildStatSummaryRequest(args, options)
@@ -392,13 +392,13 @@ func getNamePrefix(resourceType string) string {
 	}
 }
 
-func buildStatSummaryRequest(resource []string, options *statOptions) (*pb.StatSummaryRequest, error) {
-	target, err := util.BuildResource(options.namespace, resource...)
+func buildStatSummaryRequest(resources []string, options *statOptions) (*pb.StatSummaryRequest, error) {
+	targets, err := util.BuildResources(options.namespace, resources)
 	if err != nil {
 		return nil, err
 	}
 
-	err = options.validate(target.Type)
+	err = options.validate(targets[0].Type)
 	if err != nil {
 		return nil, err
 	}
@@ -419,8 +419,8 @@ func buildStatSummaryRequest(resource []string, options *statOptions) (*pb.StatS
 
 	requestParams := util.StatSummaryRequestParams{
 		TimeWindow:    options.timeWindow,
-		ResourceName:  target.Name,
-		ResourceType:  target.Type,
+		ResourceName:  targets[0].Name,
+		ResourceType:  targets[0].Type,
 		Namespace:     options.namespace,
 		ToName:        toRes.Name,
 		ToType:        toRes.Type,

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -305,7 +305,7 @@ func printStatTables(statTables map[string]map[string]*row, w *tabwriter.Writer,
 	}
 
 	firstDisplayedStat := true // don't print a newline before the first stat
-	for _, resourceType := range k8s.SortedRes {
+	for _, resourceType := range k8s.AllResources {
 		if stats, ok := statTables[resourceType]; ok {
 			if !firstDisplayedStat {
 				fmt.Fprint(w, "\n")
@@ -403,7 +403,7 @@ type jsonStats struct {
 func printStatJson(statTables map[string]map[string]*row, w *tabwriter.Writer) {
 	// avoid nil initialization so that if there are not stats it gets marshalled as an empty array vs null
 	entries := []*jsonStats{}
-	for _, resourceType := range k8s.SortedRes {
+	for _, resourceType := range k8s.AllResources {
 		if stats, ok := statTables[resourceType]; ok {
 			sortedKeys := sortStatsKeys(stats)
 			for _, key := range sortedKeys {

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -52,6 +52,8 @@ func newCmdStat() *cobra.Command {
 
   The RESOURCES argument specifies the target resource(s) to aggregate stats over:
   (TYPE [NAME] | TYPE/NAME)
+  or (TYPE [NAME1] [NAME2]...)
+  or (TYPE1/NAME1 TYPE2/NAME2...)
 
   Examples:
   * deploy
@@ -60,6 +62,8 @@ func newCmdStat() *cobra.Command {
   * ns/my-ns
   * authority
   * au/my-authority
+  * po/mypod1 rc/my-replication-controller
+  * po mypod1 mypod2
   * all
 
 Valid resource types include:
@@ -85,6 +89,12 @@ If no resource name is specified, displays stats about all resources of the spec
 
   # Get all inbound stats to the web deployment.
   linkerd stat deploy/web
+
+  # Getl all inbound stats to the pod1 and pod2 pods
+  linkerd stat po pod1 pod2
+
+  # Getl all inbound stats to the pod1 pod and the web deployment
+  linkerd stat po/pod1 deploy/web
 
   # Get all pods in all namespaces that call the hello1 deployment in the test namesapce.
   linkerd stat pods --to deploy/hello1 --to-namespace test --all-namespaces

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -31,12 +31,12 @@ func TestStat(t *testing.T) {
 
 		options := newStatOptions()
 		args := []string{"ns"}
-		req, err := buildStatSummaryRequest(args, options)
+		reqs, err := buildStatSummaryRequests(args, options)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		output, err := requestStatsFromAPI(mockClient, req, options)
+		output, err := requestStatsFromAPI(mockClient, reqs[0], options)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -69,12 +69,12 @@ func TestStat(t *testing.T) {
 		options := newStatOptions()
 		options.allNamespaces = true
 		args := []string{"ns"}
-		req, err := buildStatSummaryRequest(args, options)
+		reqs, err := buildStatSummaryRequests(args, options)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		output, err := requestStatsFromAPI(mockClient, req, options)
+		output, err := requestStatsFromAPI(mockClient, reqs[0], options)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -90,7 +90,7 @@ func TestStat(t *testing.T) {
 		args := []string{"po", "web"}
 		expectedError := "stats for a resource cannot be retrieved by name across all namespaces"
 
-		_, err := buildStatSummaryRequest(args, options)
+		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
@@ -103,7 +103,7 @@ func TestStat(t *testing.T) {
 		args := []string{"ns", "test"}
 		expectedError := "--to and --from flags are mutually exclusive"
 
-		_, err := buildStatSummaryRequest(args, options)
+		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
@@ -116,7 +116,7 @@ func TestStat(t *testing.T) {
 		args := []string{"po"}
 		expectedError := "--to-namespace and --from-namespace flags are mutually exclusive"
 
-		_, err := buildStatSummaryRequest(args, options)
+		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
@@ -128,7 +128,7 @@ func TestStat(t *testing.T) {
 		args := []string{"ns", "foo"}
 		expectedError := "--to-namespace flag is incompatible with namespace resource type"
 
-		_, err := buildStatSummaryRequest(args, options)
+		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
@@ -140,7 +140,7 @@ func TestStat(t *testing.T) {
 		args := []string{"ns/bar"}
 		expectedError := "--from-namespace flag is incompatible with namespace resource type"
 
-		_, err := buildStatSummaryRequest(args, options)
+		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}

--- a/cli/cmd/testdata/stat_all_output_json.golden
+++ b/cli/cmd/testdata/stat_all_output_json.golden
@@ -1,0 +1,26 @@
+[
+  {
+    "namespace": "emojivoto1",
+    "kind": "namespace",
+    "name": "emoji",
+    "meshed": "1/2",
+    "success": 1,
+    "rps": 2.05,
+    "latency_ms_p50": 123,
+    "latency_ms_p95": 123,
+    "latency_ms_p99": 123,
+    "tls": 1
+  },
+  {
+    "namespace": "emojivoto2",
+    "kind": "namespace",
+    "name": "emoji",
+    "meshed": "1/2",
+    "success": 1,
+    "rps": 2.05,
+    "latency_ms_p50": 123,
+    "latency_ms_p95": 123,
+    "latency_ms_p99": 123,
+    "tls": 1
+  }
+]

--- a/cli/cmd/testdata/stat_one_output_json.golden
+++ b/cli/cmd/testdata/stat_one_output_json.golden
@@ -1,0 +1,14 @@
+[
+  {
+    "namespace": "emojivoto1",
+    "kind": "namespace",
+    "name": "emoji",
+    "meshed": "1/2",
+    "success": 1,
+    "rps": 2.05,
+    "latency_ms_p50": 123,
+    "latency_ms_p95": 123,
+    "latency_ms_p99": 123,
+    "tls": 1
+  }
+]

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -255,7 +255,7 @@ func validateResources(resType string, args []string) error {
 		}
 	}
 	if len(set) < len(args) {
-		return errors.New("supplied duped resources")
+		return errors.New("cannot supply duplicate resources")
 	}
 	if all && len(args) > 1 {
 		return errors.New("'all' can't be supplied alongside other resources")

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -205,27 +205,57 @@ func validateFromResourceType(resourceType string) (string, error) {
 
 // BuildResource parses input strings, typically from CLI flags, to build a
 // Resource object for use in the protobuf API.
-func BuildResource(namespace string, args ...string) (pb.Resource, error) {
+// It's the same as BuildResources but only admits one arg and only returns one resource
+func BuildResource(namespace, arg string) (pb.Resource, error) {
+	res, err := BuildResources(namespace, []string{arg})
+	return res[0], err
+}
+
+// BuildResources parses input strings, typically from CLI flags, to build a
+// slice of Resource objects for use in the protobuf API.
+// It's the same as BuildResource but it admits any number of args and returns multiple resources
+func BuildResources(namespace string, args []string) ([]pb.Resource, error) {
 	switch len(args) {
 	case 0:
-		return pb.Resource{}, errors.New("No resource arguments provided")
+		return []pb.Resource{pb.Resource{}}, errors.New("No resource arguments provided")
 	case 1:
-		elems := strings.Split(args[0], "/")
-		switch len(elems) {
-		case 1:
-			// --namespace my-ns deploy
-			return buildResource(namespace, elems[0], "")
-		case 2:
-			// --namespace my-ns deploy/foo
-			return buildResource(namespace, elems[0], elems[1])
-		default:
-			return pb.Resource{}, errors.New("Invalid resource string: " + args[0])
-		}
-	case 2:
-		// --namespace my-ns deploy foo
-		return buildResource(namespace, args[0], args[1])
+		return parseResources(namespace, "", args)
 	default:
-		return pb.Resource{}, errors.New("Too many arguments provided for resource: " + strings.Join(args, "/"))
+		if _, err := k8s.CanonicalResourceNameFromFriendlyName(args[0]); err == nil {
+			// --namespace my-ns deploy foo1 foo2 ...
+			return parseResources(namespace, args[0], args[1:])
+		} else {
+			return parseResources(namespace, "", args)
+		}
+	}
+}
+
+func parseResources(namespace string, resType string, args []string) ([]pb.Resource, error) {
+	resources := make([]pb.Resource, 0)
+	for _, arg := range args {
+		res, err := parseResource(namespace, resType, arg)
+		if err != nil {
+			return []pb.Resource{pb.Resource{}}, err
+		}
+		resources = append(resources, res)
+	}
+	return resources, nil
+}
+
+func parseResource(namespace, resType string, arg string) (pb.Resource, error) {
+	if resType != "" {
+		return buildResource(namespace, resType, arg)
+	}
+	elems := strings.Split(arg, "/")
+	switch len(elems) {
+	case 1:
+		// --namespace my-ns deploy
+		return buildResource(namespace, elems[0], "")
+	case 2:
+		// --namespace my-ns deploy/foo
+		return buildResource(namespace, elems[0], elems[1])
+	default:
+		return pb.Resource{}, errors.New("Invalid resource string: " + arg)
 	}
 }
 

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -217,11 +217,11 @@ func BuildResource(namespace, arg string) (pb.Resource, error) {
 func BuildResources(namespace string, args []string) ([]pb.Resource, error) {
 	switch len(args) {
 	case 0:
-		return []pb.Resource{pb.Resource{}}, errors.New("No resource arguments provided")
+		return nil, errors.New("No resource arguments provided")
 	case 1:
 		return parseResources(namespace, "", args)
 	default:
-		if _, err := k8s.CanonicalResourceNameFromFriendlyName(args[0]); err == nil {
+		if res, err := k8s.CanonicalResourceNameFromFriendlyName(args[0]); err == nil && res != k8s.All {
 			// --namespace my-ns deploy foo1 foo2 ...
 			return parseResources(namespace, args[0], args[1:])
 		} else {
@@ -231,15 +231,36 @@ func BuildResources(namespace string, args []string) ([]pb.Resource, error) {
 }
 
 func parseResources(namespace string, resType string, args []string) ([]pb.Resource, error) {
+	if err := validateResources(resType, args); err != nil {
+		return nil, err
+	}
 	resources := make([]pb.Resource, 0)
 	for _, arg := range args {
 		res, err := parseResource(namespace, resType, arg)
 		if err != nil {
-			return []pb.Resource{pb.Resource{}}, err
+			return nil, err
 		}
 		resources = append(resources, res)
 	}
 	return resources, nil
+}
+
+func validateResources(resType string, args []string) error {
+	set := make(map[string]bool)
+	all := false
+	for _, arg := range args {
+		set[arg] = true
+		if arg == k8s.All {
+			all = true
+		}
+	}
+	if len(set) < len(args) {
+		return errors.New("supplied duped resources")
+	}
+	if all && len(args) > 1 {
+		return errors.New("'all' can't be supplied alongside other resources")
+	}
+	return nil
 }
 
 func parseResource(namespace, resType string, arg string) (pb.Resource, error) {

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -137,7 +137,7 @@ func TestBuildResource(t *testing.T) {
 	}
 
 	t.Run("Rejects duped resources", func(t *testing.T) {
-		msg := "supplied duped resources"
+		msg := "cannot supply duplicate resources"
 		expectations := []resourceExp{
 			resourceExp{
 				namespace: "test-ns",

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -186,13 +186,13 @@ func TestBuildResource(t *testing.T) {
 		}
 
 		for _, exp := range expectations {
-			res, err := BuildResource(exp.namespace, exp.args...)
+			res, err := BuildResources(exp.namespace, exp.args)
 			if err != nil {
-				t.Fatalf("Unexpected error from BuildResource(%+v) => %s", exp, err)
+				t.Fatalf("Unexpected error from BuildResources(%+v) => %s", exp, err)
 			}
 
-			if !reflect.DeepEqual(exp.resource, res) {
-				t.Fatalf("Expected resource to be [%+v] but was [%+v]", exp.resource, res)
+			if !reflect.DeepEqual(exp.resource, res[0]) {
+				t.Fatalf("Expected resource to be [%+v] but was [%+v]", exp.resource, res[0])
 			}
 		}
 	})

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -136,6 +136,58 @@ func TestBuildResource(t *testing.T) {
 		resource  pb.Resource
 	}
 
+	t.Run("Rejects duped resources", func(t *testing.T) {
+		msg := "supplied duped resources"
+		expectations := []resourceExp{
+			resourceExp{
+				namespace: "test-ns",
+				args:      []string{"foo", "foo"},
+			},
+			resourceExp{
+				namespace: "test-ns",
+				args:      []string{"all", "all"},
+			},
+		}
+
+		for _, exp := range expectations {
+			_, err := BuildResources(exp.namespace, exp.args)
+			if err == nil {
+				t.Fatalf("BuildResource called with duped resources unexpectedly succeeded, should have returned %s", msg)
+			}
+			if err.Error() != msg {
+				t.Fatalf("BuildResource called with duped resources should have returned: %s but got unexpected message: %s", msg, err)
+			}
+		}
+	})
+
+	t.Run("Ensures 'all' can't be supplied alongside other resources", func(t *testing.T) {
+		msg := "'all' can't be supplied alongside other resources"
+		expectations := []resourceExp{
+			resourceExp{
+				namespace: "test-ns",
+				args:      []string{"po", "foo", "all"},
+			},
+			resourceExp{
+				namespace: "test-ns",
+				args:      []string{"foo", "all"},
+			},
+			resourceExp{
+				namespace: "test-ns",
+				args:      []string{"all", "foo"},
+			},
+		}
+
+		for _, exp := range expectations {
+			_, err := BuildResources(exp.namespace, exp.args)
+			if err == nil {
+				t.Fatalf("BuildResource called with 'all' and another resource unexpectedly succeeded, should have returned %s", msg)
+			}
+			if err.Error() != msg {
+				t.Fatalf("BuildResource called with 'all' and another resource should have returned: %s but got unexpected message: %s", msg, err)
+			}
+		}
+	})
+
 	t.Run("Correctly parses Kubernetes resources from the command line", func(t *testing.T) {
 		expectations := []resourceExp{
 			resourceExp{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -22,7 +22,19 @@ const (
 	StatefulSet           = "statefulset"
 )
 
-var SortedRes = []string{Authority, DaemonSet, Deployment, Namespace, Pod, ReplicationController, ReplicaSet, Service, ServiceProfile, StatefulSet}
+// AllResources is a sorted list of all resources defined as constants above.
+var AllResources = []string{
+	Authority,
+	DaemonSet,
+	Deployment,
+	Namespace,
+	Pod,
+	ReplicationController,
+	ReplicaSet,
+	Service,
+	ServiceProfile,
+	StatefulSet,
+}
 
 // resources to query in StatSummary when Resource.Type is "all"
 var StatAllResourceTypes = []string{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -22,6 +22,8 @@ const (
 	StatefulSet           = "statefulset"
 )
 
+var SortedRes = []string{Authority, DaemonSet, Deployment, Namespace, Pod, ReplicationController, ReplicaSet, Service, ServiceProfile, StatefulSet}
+
 // resources to query in StatSummary when Resource.Type is "all"
 var StatAllResourceTypes = []string{
 	// TODO: add Namespace here to decrease queries from the web process


### PR DESCRIPTION
Howdy folks,

This will allow us to query multiple resources of different types in a single call (#1487), like
```
linkerd stat deploy/web po/emoji-694f94cdff-j44qs
```
or multiple resources of the same type by specifying the type at the beginning:
```
linkerd stat po emoji-694f94cdff-j44qs vote-bot-546746cb47-fswth voting-5f6b976c9f-krtsm
```
- The first commit prepares `util.BuildResource` to be able to deal with multiple resources.
- The second commit updates the `linkerd stat` cli help text.
- The third commit is the real implementation, consisting on firing parallel requests to the controller api, one for each resource. This stroke me as a much simpler approach than generalizing the controller api to accept multiple resources. I couldn't notice any performance degradation through preliminary testing.

Still pending is merging the tables in the results; currently each resource is producing a separate table even if they're of the same resource type. And adding more test cases for this of course :-) I'll wait for your feedback before I tackle those.

