### PR TITLE
Make version checks warning

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -406,6 +406,7 @@ func (hc *HealthChecker) addLinkerdVersionChecks() {
 		category:    LinkerdVersionCategory,
 		description: "cli is up-to-date",
 		fatal:       false,
+		warning:     true,
 		check: func() error {
 			return version.CheckClientVersion(hc.latestVersion)
 		},
@@ -416,6 +417,7 @@ func (hc *HealthChecker) addLinkerdVersionChecks() {
 			category:    LinkerdVersionCategory,
 			description: "control plane is up-to-date",
 			fatal:       false,
+			warning:     true,
 			check: func() error {
 				return version.CheckServerVersion(hc.apiClient, hc.latestVersion)
 			},
@@ -427,6 +429,7 @@ func (hc *HealthChecker) addLinkerdVersionChecks() {
 			category:    LinkerdVersionCategory,
 			description: "data plane is up-to-date",
 			fatal:       false,
+			warning:     true,
 			check: func() error {
 				pods, err := hc.getDataPlanePods()
 				if err != nil {


### PR DESCRIPTION
In #1807 the notion of warnings was introduced into linkerd check. This PR changes versions checks to be always treated as warnings and never fail the check result.

Fixes #1550

Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>