### PR TITLE
Adding a --ha flag to install cli

### DIFF
--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -2,9 +2,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: Namespace
-  labels:
-    ProxyAutoInjectLabel: disabled
+  name: linkerd
 
 ### Service Account Controller ###
 ---
@@ -12,14 +10,14 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-controller
-  namespace: Namespace
+  namespace: linkerd
 
 ### Controller RBAC ###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -35,15 +33,15 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: Namespace
+  namespace: linkerd
 
 ### Service Account Prometheus ###
 ---
@@ -51,14 +49,14 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
-  namespace: Namespace
+  namespace: linkerd
 
 ### Prometheus RBAC ###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -68,15 +66,15 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: Namespace
+  namespace: linkerd
 
 ### Controller ###
 ---
@@ -84,15 +82,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: api
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   ports:
   - name: http
     port: 8085
@@ -103,55 +101,54 @@ kind: Service
 apiVersion: v1
 metadata:
   name: proxy-api
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   ports:
   - name: grpc
-    port: 123
-    targetPort: 123
+    port: 8086
+    targetPort: 8086
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   name: controller
-  namespace: Namespace
+  namespace: linkerd
 spec:
-  replicas: 1
+  replicas: 3
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: controller
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: controller
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: controller
     spec:
       containers:
       - args:
         - public-api
-        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
-        - -controller-namespace=Namespace
+        - -prometheus-url=http://prometheus.linkerd.svc.cluster.local:9090
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -168,16 +165,19 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - args:
         - proxy-api
-        - -addr=:123
-        - -controller-namespace=Namespace
+        - -addr=:8086
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=true
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -enable-tls=false
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -185,7 +185,7 @@ spec:
           initialDelaySeconds: 10
         name: proxy-api
         ports:
-        - containerPort: 123
+        - containerPort: 8086
           name: grpc
         - containerPort: 9996
           name: admin-http
@@ -194,14 +194,17 @@ spec:
           httpGet:
             path: /ready
             port: 9996
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - args:
         - tap
-        - -controller-namespace=Namespace
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -218,7 +221,10 @@ spec:
           httpGet:
             path: /ready
             port: 9998
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -256,7 +262,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -287,9 +296,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: Namespace
+  namespace: linkerd
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -307,15 +316,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: web
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   ports:
   - name: http
     port: 8084
@@ -329,35 +338,34 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   name: web
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: web
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: web
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: web
     spec:
       containers:
       - args:
-        - -api-addr=api.Namespace.svc.cluster.local:8085
-        - -uuid=UUID
-        - -controller-namespace=Namespace
-        - -log-level=ControllerLogLevel
-        image: WebImage
-        imagePullPolicy: ImagePullPolicy
+        - -api-addr=api.linkerd.svc.cluster.local:8085
+        - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
+        - -controller-namespace=linkerd
+        - -log-level=info
+        image: gcr.io/linkerd-io/web:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -374,14 +382,17 @@ spec:
           httpGet:
             path: /ready
             port: 9994
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -412,7 +423,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -442,15 +456,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   ports:
   - name: admin-http
     port: 9090
@@ -461,33 +475,32 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   name: prometheus
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: prometheus
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: prometheus
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: prometheus
     spec:
       containers:
       - args:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        image: PrometheusImage
-        imagePullPolicy: ImagePullPolicy
+        image: prom/prometheus:v2.4.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -504,7 +517,10 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
-        resources: {}
+        resources:
+          requests:
+            cpu: 300m
+            memory: 300Mi
         volumeMounts:
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -515,7 +531,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -548,7 +564,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -583,11 +602,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 data:
   prometheus.yml: |-
     global:
@@ -604,7 +623,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['Namespace']
+          names: ['linkerd']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -615,7 +634,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['Namespace']
+          names: ['linkerd']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
@@ -635,7 +654,7 @@ data:
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^ProxyContainerName;linkerd-metrics;Namespace$
+        regex: ^linkerd-proxy;linkerd-metrics;linkerd$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -667,15 +686,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: grafana
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   ports:
   - name: http
     port: 3000
@@ -686,30 +705,29 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   name: grafana
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: grafana
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: grafana
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: grafana
     spec:
       containers:
-      - image: GrafanaImage
-        imagePullPolicy: ImagePullPolicy
+      - image: gcr.io/linkerd-io/grafana:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /api/health
@@ -726,7 +744,10 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 30
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
         volumeMounts:
         - mountPath: /etc/grafana
           name: grafana-config
@@ -737,7 +758,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -768,7 +789,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -809,17 +833,17 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: grafana-config
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana
 
     [server]
-    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/Namespace/services/grafana:http/proxy/
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/linkerd/services/grafana:http/proxy/
 
     [auth]
     disable_login_form = true
@@ -841,7 +865,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.Namespace.svc.cluster.local:9090
+      url: http://prometheus.linkerd.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -860,460 +884,4 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: linkerd-top-line
-
-### Service Account CA ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-ca
-  namespace: Namespace
-
-### CA RBAC ###
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: linkerd-Namespace-ca
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: [TLSTrustAnchorConfigMapName]
-  verbs: ["update"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["replicasets"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "update"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["list", "get", "watch"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: linkerd-Namespace-ca
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: linkerd-Namespace-ca
-subjects:
-- kind: ServiceAccount
-  name: linkerd-ca
-  namespace: Namespace
-
-### CA ###
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  annotations:
-    CreatedByAnnotation: CliVersion
-  creationTimestamp: null
-  labels:
-    ControllerComponentLabel: ca
-  name: ca
-  namespace: Namespace
-spec:
-  replicas: 1
-  strategy: {}
-  template:
-    metadata:
-      annotations:
-        CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
-      creationTimestamp: null
-      labels:
-        ControllerComponentLabel: ca
-        linkerd.io/control-plane-ns: Namespace
-        linkerd.io/proxy-deployment: ca
-    spec:
-      containers:
-      - args:
-        - ca
-        - -controller-namespace=Namespace
-        - -single-namespace=false
-        - -proxy-auto-inject=true
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9997
-          initialDelaySeconds: 10
-        name: ca
-        ports:
-        - containerPort: 9997
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9997
-        resources: {}
-      - env:
-        - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd2_proxy=info
-        - name: LINKERD2_PROXY_BIND_TIMEOUT
-          value: 10s
-        - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
-        - name: LINKERD2_PROXY_CONTROL_LISTENER
-          value: tcp://0.0.0.0:4190
-        - name: LINKERD2_PROXY_METRICS_LISTENER
-          value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-          value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_INBOUND_LISTENER
-          value: tcp://0.0.0.0:4143
-        - name: LINKERD2_PROXY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        name: linkerd-proxy
-        ports:
-        - containerPort: 4143
-          name: linkerd-proxy
-        - containerPort: 4191
-          name: linkerd-metrics
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        resources: {}
-        securityContext:
-          runAsUser: 2102
-        terminationMessagePolicy: FallbackToLogsOnError
-      initContainers:
-      - args:
-        - --incoming-proxy-port
-        - "4143"
-        - --outgoing-proxy-port
-        - "4140"
-        - --proxy-uid
-        - "2102"
-        - --inbound-ports-to-ignore
-        - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
-        imagePullPolicy: IfNotPresent
-        name: linkerd-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: false
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccount: linkerd-ca
-status: {}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    CreatedByAnnotation: CliVersion
-  creationTimestamp: null
-  labels:
-    ControllerComponentLabel: proxy-injector
-  name: proxy-injector
-  namespace: Namespace
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      ControllerComponentLabel: proxy-injector
-  strategy: {}
-  template:
-    metadata:
-      annotations:
-        CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
-      creationTimestamp: null
-      labels:
-        ControllerComponentLabel: proxy-injector
-        linkerd.io/control-plane-ns: Namespace
-        linkerd.io/proxy-deployment: proxy-injector
-    spec:
-      containers:
-      - args:
-        - proxy-injector
-        - -controller-namespace=Namespace
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9995
-          initialDelaySeconds: 10
-        name: proxy-injector
-        ports:
-        - containerPort: 443
-          name: proxy-injector
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9995
-        resources: {}
-        volumeMounts:
-        - mountPath: /var/linkerd-io/trust-anchors
-          name: linkerd-trust-anchors
-          readOnly: true
-        - mountPath: /var/linkerd-io/identity
-          name: webhook-secrets
-          readOnly: true
-        - mountPath: /var/linkerd-io/config
-          name: proxy-spec
-      - env:
-        - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd2_proxy=info
-        - name: LINKERD2_PROXY_BIND_TIMEOUT
-          value: 10s
-        - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
-        - name: LINKERD2_PROXY_CONTROL_LISTENER
-          value: tcp://0.0.0.0:4190
-        - name: LINKERD2_PROXY_METRICS_LISTENER
-          value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-          value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_INBOUND_LISTENER
-          value: tcp://0.0.0.0:4143
-        - name: LINKERD2_PROXY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        name: linkerd-proxy
-        ports:
-        - containerPort: 4143
-          name: linkerd-proxy
-        - containerPort: 4191
-          name: linkerd-metrics
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        resources: {}
-        securityContext:
-          runAsUser: 2102
-        terminationMessagePolicy: FallbackToLogsOnError
-      initContainers:
-      - args:
-        - --incoming-proxy-port
-        - "4143"
-        - --outgoing-proxy-port
-        - "4140"
-        - --proxy-uid
-        - "2102"
-        - --inbound-ports-to-ignore
-        - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
-        imagePullPolicy: IfNotPresent
-        name: linkerd-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: false
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccount: linkerd-proxy-injector
-      volumes:
-      - name: webhook-secrets
-        secret:
-          optional: true
-          secretName: ProxyInjectorTLSSecret
-      - configMap:
-          name: ProxyInjectorSidecarConfig
-        name: proxy-spec
-status: {}
----
-### Proxy Injector Service Account ###
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: Namespace
-
----
-### Proxy Injector RBAC ###
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "watch"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-subjects:
-- kind: ServiceAccount
-  name: linkerd-proxy-injector
-  namespace: Namespace
-  apiGroup: ""
-roleRef:
-  kind: ClusterRole
-  name: linkerd-Namespace-proxy-injector
-  apiGroup: rbac.authorization.k8s.io
-
----
-### Proxy Injector Service ###
-kind: Service
-apiVersion: v1
-metadata:
-  name: proxy-injector
-  namespace: Namespace
-  labels:
-    ControllerComponentLabel: proxy-injector
-  annotations:
-    CreatedByAnnotation: CliVersion
-spec:
-  type: ClusterIP
-  selector:
-    ControllerComponentLabel: proxy-injector
-  ports:
-  - name: proxy-injector
-    port: 443
-    targetPort: proxy-injector
-
----
-### Proxy Sidecar Container Spec ###
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ProxyInjectorSidecarConfig
-  namespace: Namespace
-  labels:
-    ControllerComponentLabel: proxy-injector
-  annotations:
-    CreatedByAnnotation: CliVersion
-data:
-  ProxyInitSpecFileName: |
-    args:
-    - --incoming-proxy-port
-    - 4143
-    - --outgoing-proxy-port
-    - 4140
-    - --proxy-uid
-    - 2102
-    - --inbound-ports-to-ignore
-    - 4190,4191,1,2,3
-    - --outbound-ports-to-ignore
-    - 2,3,4
-    image: ProxyInitImage
-    imagePullPolicy: IfNotPresent
-    name: linkerd-init
-    securityContext:
-      capabilities:
-        add:
-        - NET_ADMIN
-      privileged: false
-    terminationMessagePolicy: FallbackToLogsOnError
-  ProxySpecFileName: |
-    env:
-    - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd2_proxy=info
-    - name: LINKERD2_PROXY_BIND_TIMEOUT
-      value: 1m
-    - name: LINKERD2_PROXY_CONTROL_URL
-      value: tcp://proxy-api.Namespace.svc.cluster.local:123
-    - name: LINKERD2_PROXY_CONTROL_LISTENER
-      value: tcp://0.0.0.0:4190
-    - name: LINKERD2_PROXY_METRICS_LISTENER
-      value: tcp://0.0.0.0:4191
-    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-      value: tcp://127.0.0.1:4140
-    - name: LINKERD2_PROXY_INBOUND_LISTENER
-      value: tcp://0.0.0.0:4143
-    - name: LINKERD2_PROXY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
-      value: /var/linkerd-io/trust-anchors/TLSTrustAnchorFileName
-    - name: LINKERD2_PROXY_TLS_CERT
-      value: /var/linkerd-io/identity/TLSCertFileName
-    - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
-      value: /var/linkerd-io/identity/TLSPrivateKeyFileName
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-      value: "" # this value will be computed by the webhook
-    - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
-      value: Namespace
-    - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
-      value: "" # this value will be computed by the webhook
-    image: ProxyImage
-    imagePullPolicy: IfNotPresent
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: 4191
-      initialDelaySeconds: 10
-    name: linkerd-proxy
-    ports:
-    - containerPort: 4143
-      name: linkerd-proxy
-    - containerPort: 4191
-      name: linkerd-metrics
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: 4191
-      initialDelaySeconds: 10
-    resources:
-      requests:
-        cpu: RequestCPU
-        memory: RequestMemory
-    securityContext:
-      runAsUser: 2102
-    terminationMessagePolicy: FallbackToLogsOnError
-    volumeMounts:
-    - mountPath: /var/linkerd-io/trust-anchors
-      name: linkerd-trust-anchors
-      readOnly: true
-    - mountPath: /var/linkerd-io/identity
-      name: linkerd-secrets
-      readOnly: true
-  TLSTrustAnchorVolumeSpecFileName: |
-    name: linkerd-trust-anchors
-    configMap:
-      name: TLSTrustAnchorConfigMapName
-      optional: true
-  TLSIdentityVolumeSpecFileName: |
-    name: linkerd-secrets
-    secret:
-      secretName: "" # this value will be computed by the webhook
-      optional: true
 ---

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -2,9 +2,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: Namespace
-  labels:
-    ProxyAutoInjectLabel: disabled
+  name: linkerd
 
 ### Service Account Controller ###
 ---
@@ -12,14 +10,14 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-controller
-  namespace: Namespace
+  namespace: linkerd
 
 ### Controller RBAC ###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments", "replicasets"]
@@ -35,15 +33,15 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-Namespace-controller
+  name: linkerd-linkerd-controller
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: Namespace
+  namespace: linkerd
 
 ### Service Account Prometheus ###
 ---
@@ -51,14 +49,14 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
-  namespace: Namespace
+  namespace: linkerd
 
 ### Prometheus RBAC ###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -68,15 +66,15 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-Namespace-prometheus
+  name: linkerd-linkerd-prometheus
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: Namespace
+  namespace: linkerd
 
 ### Controller ###
 ---
@@ -84,15 +82,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: api
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   ports:
   - name: http
     port: 8085
@@ -103,55 +101,54 @@ kind: Service
 apiVersion: v1
 metadata:
   name: proxy-api
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   ports:
   - name: grpc
-    port: 123
-    targetPort: 123
+    port: 8086
+    targetPort: 8086
 
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: controller
+    linkerd.io/control-plane-component: controller
   name: controller
-  namespace: Namespace
+  namespace: linkerd
 spec:
-  replicas: 1
+  replicas: 2
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: controller
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: controller
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: controller
     spec:
       containers:
       - args:
         - public-api
-        - -prometheus-url=http://prometheus.Namespace.svc.cluster.local:9090
-        - -controller-namespace=Namespace
+        - -prometheus-url=http://prometheus.linkerd.svc.cluster.local:9090
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -168,16 +165,19 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - args:
         - proxy-api
-        - -addr=:123
-        - -controller-namespace=Namespace
+        - -addr=:8086
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=true
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -enable-tls=false
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -185,7 +185,7 @@ spec:
           initialDelaySeconds: 10
         name: proxy-api
         ports:
-        - containerPort: 123
+        - containerPort: 8086
           name: grpc
         - containerPort: 9996
           name: admin-http
@@ -194,14 +194,17 @@ spec:
           httpGet:
             path: /ready
             port: 9996
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - args:
         - tap
-        - -controller-namespace=Namespace
+        - -controller-namespace=linkerd
         - -single-namespace=false
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
+        - -log-level=info
+        image: gcr.io/linkerd-io/controller:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -218,7 +221,10 @@ spec:
           httpGet:
             path: /ready
             port: 9998
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -256,7 +262,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 400m
+            memory: 300Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -287,9 +296,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: Namespace
+  namespace: linkerd
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -307,15 +316,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: web
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   ports:
   - name: http
     port: 8084
@@ -329,35 +338,34 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: web
+    linkerd.io/control-plane-component: web
   name: web
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: web
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: web
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: web
     spec:
       containers:
       - args:
-        - -api-addr=api.Namespace.svc.cluster.local:8085
-        - -uuid=UUID
-        - -controller-namespace=Namespace
-        - -log-level=ControllerLogLevel
-        image: WebImage
-        imagePullPolicy: ImagePullPolicy
+        - -api-addr=api.linkerd.svc.cluster.local:8085
+        - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
+        - -controller-namespace=linkerd
+        - -log-level=info
+        image: gcr.io/linkerd-io/web:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /ping
@@ -374,14 +382,17 @@ spec:
           httpGet:
             path: /ready
             port: 9994
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -412,7 +423,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 400m
+            memory: 300Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -442,15 +456,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   ports:
   - name: admin-http
     port: 9090
@@ -461,33 +475,32 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   name: prometheus
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: prometheus
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: prometheus
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: prometheus
     spec:
       containers:
       - args:
         - --storage.tsdb.retention=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        image: PrometheusImage
-        imagePullPolicy: ImagePullPolicy
+        image: prom/prometheus:v2.4.0
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -504,7 +517,10 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
-        resources: {}
+        resources:
+          requests:
+            cpu: 300m
+            memory: 300Mi
         volumeMounts:
         - mountPath: /etc/prometheus
           name: prometheus-config
@@ -515,7 +531,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -548,7 +564,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 400m
+            memory: 300Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -583,11 +602,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: prometheus
+    linkerd.io/control-plane-component: prometheus
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 data:
   prometheus.yml: |-
     global:
@@ -604,7 +623,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['Namespace']
+          names: ['linkerd']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -615,7 +634,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['Namespace']
+          names: ['linkerd']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
@@ -635,7 +654,7 @@ data:
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^ProxyContainerName;linkerd-metrics;Namespace$
+        regex: ^linkerd-proxy;linkerd-metrics;linkerd$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -667,15 +686,15 @@ kind: Service
 apiVersion: v1
 metadata:
   name: grafana
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 spec:
   type: ClusterIP
   selector:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   ports:
   - name: http
     port: 3000
@@ -686,30 +705,29 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
   creationTimestamp: null
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   name: grafana
-  namespace: Namespace
+  namespace: linkerd
 spec:
   replicas: 1
   strategy: {}
   template:
     metadata:
       annotations:
-        CreatedByAnnotation: CliVersion
         linkerd.io/created-by: linkerd/cli undefined
         linkerd.io/proxy-version: undefined
       creationTimestamp: null
       labels:
-        ControllerComponentLabel: grafana
-        linkerd.io/control-plane-ns: Namespace
+        linkerd.io/control-plane-component: grafana
+        linkerd.io/control-plane-ns: linkerd
         linkerd.io/proxy-deployment: grafana
     spec:
       containers:
-      - image: GrafanaImage
-        imagePullPolicy: ImagePullPolicy
+      - image: gcr.io/linkerd-io/grafana:undefined
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /api/health
@@ -726,7 +744,10 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 30
-        resources: {}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
         volumeMounts:
         - mountPath: /etc/grafana
           name: grafana-config
@@ -737,7 +758,7 @@ spec:
         - name: LINKERD2_PROXY_BIND_TIMEOUT
           value: 10s
         - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
+          value: tcp://proxy-api.linkerd.svc.cluster.local:8086
         - name: LINKERD2_PROXY_CONTROL_LISTENER
           value: tcp://0.0.0.0:4190
         - name: LINKERD2_PROXY_METRICS_LISTENER
@@ -768,7 +789,10 @@ spec:
             path: /metrics
             port: 4191
           initialDelaySeconds: 10
-        resources: {}
+        resources:
+          requests:
+            cpu: 400m
+            memory: 300Mi
         securityContext:
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
@@ -809,17 +833,17 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: grafana-config
-  namespace: Namespace
+  namespace: linkerd
   labels:
-    ControllerComponentLabel: grafana
+    linkerd.io/control-plane-component: grafana
   annotations:
-    CreatedByAnnotation: CliVersion
+    linkerd.io/created-by: linkerd/cli undefined
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana
 
     [server]
-    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/Namespace/services/grafana:http/proxy/
+    root_url = %(protocol)s://%(domain)s:/api/v1/namespaces/linkerd/services/grafana:http/proxy/
 
     [auth]
     disable_login_form = true
@@ -841,7 +865,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://prometheus.Namespace.svc.cluster.local:9090
+      url: http://prometheus.linkerd.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -860,460 +884,4 @@ data:
       options:
         path: /var/lib/grafana/dashboards
         homeDashboardId: linkerd-top-line
-
-### Service Account CA ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-ca
-  namespace: Namespace
-
-### CA RBAC ###
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: linkerd-Namespace-ca
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["create"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: [TLSTrustAnchorConfigMapName]
-  verbs: ["update"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: ["extensions", "apps"]
-  resources: ["replicasets"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "update"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["list", "get", "watch"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: linkerd-Namespace-ca
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: linkerd-Namespace-ca
-subjects:
-- kind: ServiceAccount
-  name: linkerd-ca
-  namespace: Namespace
-
-### CA ###
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  annotations:
-    CreatedByAnnotation: CliVersion
-  creationTimestamp: null
-  labels:
-    ControllerComponentLabel: ca
-  name: ca
-  namespace: Namespace
-spec:
-  replicas: 1
-  strategy: {}
-  template:
-    metadata:
-      annotations:
-        CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
-      creationTimestamp: null
-      labels:
-        ControllerComponentLabel: ca
-        linkerd.io/control-plane-ns: Namespace
-        linkerd.io/proxy-deployment: ca
-    spec:
-      containers:
-      - args:
-        - ca
-        - -controller-namespace=Namespace
-        - -single-namespace=false
-        - -proxy-auto-inject=true
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9997
-          initialDelaySeconds: 10
-        name: ca
-        ports:
-        - containerPort: 9997
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9997
-        resources: {}
-      - env:
-        - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd2_proxy=info
-        - name: LINKERD2_PROXY_BIND_TIMEOUT
-          value: 10s
-        - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
-        - name: LINKERD2_PROXY_CONTROL_LISTENER
-          value: tcp://0.0.0.0:4190
-        - name: LINKERD2_PROXY_METRICS_LISTENER
-          value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-          value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_INBOUND_LISTENER
-          value: tcp://0.0.0.0:4143
-        - name: LINKERD2_PROXY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        name: linkerd-proxy
-        ports:
-        - containerPort: 4143
-          name: linkerd-proxy
-        - containerPort: 4191
-          name: linkerd-metrics
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        resources: {}
-        securityContext:
-          runAsUser: 2102
-        terminationMessagePolicy: FallbackToLogsOnError
-      initContainers:
-      - args:
-        - --incoming-proxy-port
-        - "4143"
-        - --outgoing-proxy-port
-        - "4140"
-        - --proxy-uid
-        - "2102"
-        - --inbound-ports-to-ignore
-        - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
-        imagePullPolicy: IfNotPresent
-        name: linkerd-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: false
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccount: linkerd-ca
-status: {}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    CreatedByAnnotation: CliVersion
-  creationTimestamp: null
-  labels:
-    ControllerComponentLabel: proxy-injector
-  name: proxy-injector
-  namespace: Namespace
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      ControllerComponentLabel: proxy-injector
-  strategy: {}
-  template:
-    metadata:
-      annotations:
-        CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
-      creationTimestamp: null
-      labels:
-        ControllerComponentLabel: proxy-injector
-        linkerd.io/control-plane-ns: Namespace
-        linkerd.io/proxy-deployment: proxy-injector
-    spec:
-      containers:
-      - args:
-        - proxy-injector
-        - -controller-namespace=Namespace
-        - -log-level=ControllerLogLevel
-        image: ControllerImage
-        imagePullPolicy: ImagePullPolicy
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9995
-          initialDelaySeconds: 10
-        name: proxy-injector
-        ports:
-        - containerPort: 443
-          name: proxy-injector
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9995
-        resources: {}
-        volumeMounts:
-        - mountPath: /var/linkerd-io/trust-anchors
-          name: linkerd-trust-anchors
-          readOnly: true
-        - mountPath: /var/linkerd-io/identity
-          name: webhook-secrets
-          readOnly: true
-        - mountPath: /var/linkerd-io/config
-          name: proxy-spec
-      - env:
-        - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd2_proxy=info
-        - name: LINKERD2_PROXY_BIND_TIMEOUT
-          value: 10s
-        - name: LINKERD2_PROXY_CONTROL_URL
-          value: tcp://proxy-api.Namespace.svc.cluster.local:8086
-        - name: LINKERD2_PROXY_CONTROL_LISTENER
-          value: tcp://0.0.0.0:4190
-        - name: LINKERD2_PROXY_METRICS_LISTENER
-          value: tcp://0.0.0.0:4191
-        - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-          value: tcp://127.0.0.1:4140
-        - name: LINKERD2_PROXY_INBOUND_LISTENER
-          value: tcp://0.0.0.0:4143
-        - name: LINKERD2_PROXY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        name: linkerd-proxy
-        ports:
-        - containerPort: 4143
-          name: linkerd-proxy
-        - containerPort: 4191
-          name: linkerd-metrics
-        readinessProbe:
-          httpGet:
-            path: /metrics
-            port: 4191
-          initialDelaySeconds: 10
-        resources: {}
-        securityContext:
-          runAsUser: 2102
-        terminationMessagePolicy: FallbackToLogsOnError
-      initContainers:
-      - args:
-        - --incoming-proxy-port
-        - "4143"
-        - --outgoing-proxy-port
-        - "4140"
-        - --proxy-uid
-        - "2102"
-        - --inbound-ports-to-ignore
-        - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
-        imagePullPolicy: IfNotPresent
-        name: linkerd-init
-        resources: {}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: false
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccount: linkerd-proxy-injector
-      volumes:
-      - name: webhook-secrets
-        secret:
-          optional: true
-          secretName: ProxyInjectorTLSSecret
-      - configMap:
-          name: ProxyInjectorSidecarConfig
-        name: proxy-spec
-status: {}
----
-### Proxy Injector Service Account ###
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: Namespace
-
----
-### Proxy Injector RBAC ###
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "watch"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-subjects:
-- kind: ServiceAccount
-  name: linkerd-proxy-injector
-  namespace: Namespace
-  apiGroup: ""
-roleRef:
-  kind: ClusterRole
-  name: linkerd-Namespace-proxy-injector
-  apiGroup: rbac.authorization.k8s.io
-
----
-### Proxy Injector Service ###
-kind: Service
-apiVersion: v1
-metadata:
-  name: proxy-injector
-  namespace: Namespace
-  labels:
-    ControllerComponentLabel: proxy-injector
-  annotations:
-    CreatedByAnnotation: CliVersion
-spec:
-  type: ClusterIP
-  selector:
-    ControllerComponentLabel: proxy-injector
-  ports:
-  - name: proxy-injector
-    port: 443
-    targetPort: proxy-injector
-
----
-### Proxy Sidecar Container Spec ###
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: ProxyInjectorSidecarConfig
-  namespace: Namespace
-  labels:
-    ControllerComponentLabel: proxy-injector
-  annotations:
-    CreatedByAnnotation: CliVersion
-data:
-  ProxyInitSpecFileName: |
-    args:
-    - --incoming-proxy-port
-    - 4143
-    - --outgoing-proxy-port
-    - 4140
-    - --proxy-uid
-    - 2102
-    - --inbound-ports-to-ignore
-    - 4190,4191,1,2,3
-    - --outbound-ports-to-ignore
-    - 2,3,4
-    image: ProxyInitImage
-    imagePullPolicy: IfNotPresent
-    name: linkerd-init
-    securityContext:
-      capabilities:
-        add:
-        - NET_ADMIN
-      privileged: false
-    terminationMessagePolicy: FallbackToLogsOnError
-  ProxySpecFileName: |
-    env:
-    - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd2_proxy=info
-    - name: LINKERD2_PROXY_BIND_TIMEOUT
-      value: 1m
-    - name: LINKERD2_PROXY_CONTROL_URL
-      value: tcp://proxy-api.Namespace.svc.cluster.local:123
-    - name: LINKERD2_PROXY_CONTROL_LISTENER
-      value: tcp://0.0.0.0:4190
-    - name: LINKERD2_PROXY_METRICS_LISTENER
-      value: tcp://0.0.0.0:4191
-    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
-      value: tcp://127.0.0.1:4140
-    - name: LINKERD2_PROXY_INBOUND_LISTENER
-      value: tcp://0.0.0.0:4143
-    - name: LINKERD2_PROXY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
-      value: /var/linkerd-io/trust-anchors/TLSTrustAnchorFileName
-    - name: LINKERD2_PROXY_TLS_CERT
-      value: /var/linkerd-io/identity/TLSCertFileName
-    - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
-      value: /var/linkerd-io/identity/TLSPrivateKeyFileName
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-      value: "" # this value will be computed by the webhook
-    - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
-      value: Namespace
-    - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
-      value: "" # this value will be computed by the webhook
-    image: ProxyImage
-    imagePullPolicy: IfNotPresent
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: 4191
-      initialDelaySeconds: 10
-    name: linkerd-proxy
-    ports:
-    - containerPort: 4143
-      name: linkerd-proxy
-    - containerPort: 4191
-      name: linkerd-metrics
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: 4191
-      initialDelaySeconds: 10
-    resources:
-      requests:
-        cpu: RequestCPU
-        memory: RequestMemory
-    securityContext:
-      runAsUser: 2102
-    terminationMessagePolicy: FallbackToLogsOnError
-    volumeMounts:
-    - mountPath: /var/linkerd-io/trust-anchors
-      name: linkerd-trust-anchors
-      readOnly: true
-    - mountPath: /var/linkerd-io/identity
-      name: linkerd-secrets
-      readOnly: true
-  TLSTrustAnchorVolumeSpecFileName: |
-    name: linkerd-trust-anchors
-    configMap:
-      name: TLSTrustAnchorConfigMapName
-      optional: true
-  TLSIdentityVolumeSpecFileName: |
-    name: linkerd-secrets
-    secret:
-      secretName: "" # this value will be computed by the webhook
-      optional: true
 ---

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -338,7 +338,7 @@ metadata:
   name: web
   namespace: Namespace
 spec:
-  replicas: 2
+  replicas: 1
   strategy: {}
   template:
     metadata:
@@ -470,7 +470,7 @@ metadata:
   name: prometheus
   namespace: Namespace
 spec:
-  replicas: 3
+  replicas: 1
   strategy: {}
   template:
     metadata:

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -179,6 +179,12 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
       - name: proxy-api
         ports:
         - name: grpc
@@ -204,6 +210,12 @@ spec:
             path: /ready
             port: 9996
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
       - name: tap
         ports:
         - name: grpc
@@ -227,6 +239,12 @@ spec:
             path: /ready
             port: 9998
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
 
 ### Service Profile CRD ###
 ---
@@ -282,7 +300,7 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
-  replicas: {{.WebReplicas}}
+  replicas: 1
   template:
     metadata:
       labels:
@@ -314,6 +332,12 @@ spec:
             path: /ready
             port: 9994
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
 
 ### Prometheus ###
 ---
@@ -346,7 +370,7 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
-  replicas: {{.PrometheusReplicas}}
+  replicas: 1
   template:
     metadata:
       labels:
@@ -385,6 +409,12 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 300m
+            memory: 300Mi
+        {{- end }}
 
 ---
 kind: ConfigMap
@@ -546,7 +576,12 @@ spec:
           timeoutSeconds: 30
           failureThreshold: 10
           periodSeconds: 10
-
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -675,7 +710,7 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: 1
   template:
     metadata:
       labels:
@@ -709,6 +744,12 @@ spec:
             path: /ready
             port: 9997
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
 `
 
 const ProxyInjectorTemplate = `
@@ -724,7 +765,7 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: 1
   selector:
     matchLabels:
       {{.ControllerComponentLabel}}: proxy-injector
@@ -774,6 +815,12 @@ spec:
       - name: proxy-spec
         configMap:
           name: {{.ProxyInjectorSidecarConfig}}
+      {{- if .EnableHA }}
+      resources:
+        requests:
+          cpu: 20m
+          memory: 50Mi
+      {{- end }}
 
 ---
 ### Proxy Injector Service Account ###


### PR DESCRIPTION
This change allows some advised production config to be applied to the install of the control plane.
Currently this runs 3x replicas of the controller and adds some pretty sane requests to each of the components + containers of the control plane.

Fixes #1101

Signed-off-by: Ben Lambert <ben@blam.sh>