### PR TITLE
controller: use GetConfig from pkg/k8s package

### DIFF
--- a/controller/k8s/clientset.go
+++ b/controller/k8s/clientset.go
@@ -2,15 +2,14 @@ package k8s
 
 import (
 	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	// Load all the auth plugins for the cloud providers.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func NewClientSet(kubeConfig string) (*kubernetes.Clientset, error) {
-	config, err := parseConfig(kubeConfig)
+	config, err := k8s.GetConfig(kubeConfig, "")
 	if err != nil {
 		return nil, err
 	}
@@ -19,28 +18,10 @@ func NewClientSet(kubeConfig string) (*kubernetes.Clientset, error) {
 }
 
 func NewSpClientSet(kubeConfig string) (*spclient.Clientset, error) {
-	config, err := parseConfig(kubeConfig)
+	config, err := k8s.GetConfig(kubeConfig, "")
 	if err != nil {
 		return nil, err
 	}
 
 	return spclient.NewForConfig(config)
-}
-
-func parseConfig(kubeConfig string) (*rest.Config, error) {
-	var config *rest.Config
-	var err error
-
-	if kubeConfig == "" {
-		// configure client while running inside the k8s cluster
-		// uses Service Acct token mounted in the Pod
-		config, err = rest.InClusterConfig()
-	} else {
-		// configure access to the cluster from outside
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return config, nil
 }

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -145,7 +145,7 @@ func (kubeAPI *KubernetesAPI) getRequest(ctx context.Context, client *http.Clien
 // NewAPI validates a Kubernetes config and returns a client for accessing the
 // configured cluster
 func NewAPI(configPath, kubeContext string) (*KubernetesAPI, error) {
-	config, err := getConfig(configPath, kubeContext)
+	config, err := GetConfig(configPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
 	}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -60,7 +60,11 @@ func generateBaseKubernetesApiUrl(schemeHostAndPort string) (*url.URL, error) {
 	return url, nil
 }
 
-func getConfig(fpath, kubeContext string) (*rest.Config, error) {
+// GetConfig returns kubernetes config based on the current environment.
+// If fpath is provided, loads configuration from that file. Otherwise,
+// GetConfig uses default strategy to load configuration from $KUBECONFIG,
+// .kube/config, or just returns in-cluster config.
+func GetConfig(fpath, kubeContext string) (*rest.Config, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if fpath != "" {
 		rules.ExplicitPath = fpath

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -60,7 +60,7 @@ func TestGenerateBaseKubernetesApiUrl(t *testing.T) {
 
 func TestGetConfig(t *testing.T) {
 	t.Run("Gets host correctly form existing file", func(t *testing.T) {
-		config, err := getConfig("testdata/config.test", "")
+		config, err := GetConfig("testdata/config.test", "")
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -72,7 +72,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("Returns error if configuration cannot be found", func(t *testing.T) {
-		_, err := getConfig("/this/doest./not/exist.config", "")
+		_, err := GetConfig("/this/doest./not/exist.config", "")
 		if err == nil {
 			t.Fatalf("Expecting error when config file doesnt exist, got nothing")
 		}

--- a/pkg/k8s/proxy.go
+++ b/pkg/k8s/proxy.go
@@ -20,7 +20,7 @@ type KubernetesProxy struct {
 // NewProxy returns a new KubernetesProxy object and starts listening on a
 // network address.
 func NewProxy(configPath, kubeContext string, proxyPort int) (*KubernetesProxy, error) {
-	config, err := getConfig(configPath, kubeContext)
+	config, err := GetConfig(configPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
 	}


### PR DESCRIPTION
This removes duplicate logic that loads Kubernetes config and replaces it with GetConfig from pkg/k8s. This also allows to load config from default sources like `$KUBECONFIG` instead of explicitly passing `-kubeconfig` option to controller components.