### PR TITLE
Allow retrying control plane API check

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -307,9 +307,10 @@ func (hc *HealthChecker) addLinkerdAPIChecks() {
 	})
 
 	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdAPICategory,
-		description: "can query the control plane API",
-		fatal:       true,
+		category:      LinkerdAPICategory,
+		description:   "can query the control plane API",
+		fatal:         true,
+		retryDeadline: hc.RetryDeadline,
 		checkRPC: func() (*healthcheckPb.SelfCheckResponse, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()


### PR DESCRIPTION
Fixes #1851

Allows retrying on control plane API check (e.g. when it fails because of HTTP 503 when provisioning).

Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>