### PR TITLE
Make permission checks non-fatal, add check for CRDs

### DIFF
--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -9,6 +9,7 @@ kubernetes-setup: can create ServiceAccounts...............................[ok]
 kubernetes-setup: can create Services......................................[ok]
 kubernetes-setup: can create Deployments...................................[ok]
 kubernetes-setup: can create ConfigMaps....................................[ok]
+kubernetes-setup: can create CustomResourceDefinitions.....................[ok]
 linkerd-version: can determine the latest version..........................[ok]
 linkerd-version: cli is up-to-date.........................................[ok]
 


### PR DESCRIPTION
In the process of debugging #1846, I realized that the permission checks that we execute when running `linkerd check --pre` are marked as fatal, meaning that the check run will abort as soon as the first permission check fails. In this branch I'm marking all of the permission checks as non-fatal, so that we'll run all of them, even if some of them fail. I've also updated the healthcheck documentation for each of the fields in the `checkers` struct, and I've added a permission check for creating CRDs.