### PR TITLE
Add support for inbound route metrics

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-21887e5}"
+PROXY_VERSION="${PROXY_VERSION:-663eab4}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION

--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -13,7 +13,7 @@ import (
 const (
 	routeReqQuery             = "sum(increase(route_response_total%s[%s])) by (%s, classification, tls)"
 	routeLatencyQuantileQuery = "histogram_quantile(%s, sum(irate(route_response_latency_ms_bucket%s[%s])) by (le, %s))"
-	dstLabel                  = `dst=~"%s(:\\d+)?"`
+	dstLabel                  = `dst=~"%s.%s.svc.cluster.local(:\\d+)?"`
 )
 
 func (s *grpcServer) TopRoutes(ctx context.Context, req *pb.TopRoutesRequest) (*pb.TopRoutesResponse, error) {
@@ -107,7 +107,6 @@ func buildRouteLabels(req *pb.TopRoutesRequest) string {
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	default:
-		labels = labels.Merge(promQueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("inbound"))
 	}
 
@@ -115,7 +114,7 @@ func buildRouteLabels(req *pb.TopRoutesRequest) string {
 	for k, v := range labels {
 		pairs = append(pairs, fmt.Sprintf("%s=%q", k, v))
 	}
-	pairs = append(pairs, fmt.Sprintf(dstLabel, req.Selector.Resource.Name))
+	pairs = append(pairs, fmt.Sprintf(dstLabel, req.Selector.Resource.Name, req.Selector.Resource.Namespace))
 
 	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
 }


### PR DESCRIPTION
The `linkerd` routes command only supports outbound metrics queries (i.e. ones with the `--from` flag).  Inbound queries (i.e. ones without the `--from` flag) never return any metrics.

We update the proxy version and use the new canonicalized form for dst labels to gain support for inbound metrics as well.

```
$ bin/linkerd routes webapp
               ROUTE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
              /books    53.76%   1.6rps          42ms         110ms         182ms    0%
     /book/{id}/edit    43.64%   0.9rps          75ms         185ms         197ms    0%
         /books/{id}   100.00%   0.8rps          67ms         180ms         196ms    0%
       /authors/{id}   100.00%   0.4rps          50ms         380ms         396ms    0%
  /books/{id}/delete   100.00%   0.4rps          25ms          48ms          50ms    0%
           [UNKNOWN]   100.00%   0.4rps          75ms         185ms         197ms    0%
            /authors   100.00%   0.4rps          30ms          93ms          99ms    0%
/authors/{id}/delete   100.00%   0.4rps          81ms         175ms         195ms    0%
```

Signed-off-by: Alex Leong <alex@buoyant.io>