### PR TITLE
Add --open-api option to linkerd profiles command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,6 +22,22 @@
   revision = "1ff28809256a84bb6966640ff3d0371af82ccba4"
 
 [[projects]]
+  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:331a419049c2be691e5ba1d24342fc77c7e767a80c666a18fd8a9f7b82419c1c"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  pruneopts = ""
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
   branch = "master"
   digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
@@ -52,6 +68,38 @@
   pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:c8052dcf3ec378a9a6bc4f00ecc10d6d5eb3cc1f8faaf6b2f70f047e8881d446"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
+  version = "v0.17.2"
+
+[[projects]]
+  digest = "1:1824e5330b35b2a2418d06aa55629cc59ad454b72e338aa125ba8ff98f16298b"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  pruneopts = ""
+  revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
+  version = "v0.17.2"
+
+[[projects]]
+  digest = "1:d4680b89600466e543754c838cbc987ed58b962417a88600881cd0ed88d6b4cc"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5bae59e25b21498baea7f9d46e9c147ec106a42e"
+  version = "v0.17.2"
+
+[[projects]]
+  digest = "1:062de20b7d299ae95c902a5c472c4bc87a2f3ae707751fe155ecf640d99074b4"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5899d5c5e619fda5fa86e14795a835f473ca284c"
+  version = "v0.17.2"
 
 [[projects]]
   digest = "1:0a3f6a0c68ab8f3d455f8892295503b179e571b7fefe47cc6c556405d1f83411"
@@ -219,6 +267,18 @@
   pruneopts = ""
   revision = "4fe4a6294fc68d1ed83948ddbc5d4f86aec6c5ef"
   version = "v0.1.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:212bebc561f4f654a653225868b2a97353cd5e160dc0b0bbc7232b06608474ec"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = ""
+  revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
   digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
@@ -446,6 +506,7 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
+    "width",
   ]
   pruneopts = ""
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
@@ -877,6 +938,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/ghodss/yaml",
+    "github.com/go-openapi/spec",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:0d7c8b9b as golang
+FROM gcr.io/linkerd-io/go-deps:caa0345d as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -3,12 +3,20 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
+	"regexp"
 	"text/template"
 
+	"github.com/ghodss/yaml"
+	"github.com/go-openapi/spec"
 	"github.com/linkerd/linkerd2/cli/profile"
+	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
 	"github.com/spf13/cobra"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type templateConfig struct {
@@ -18,15 +26,21 @@ type templateConfig struct {
 	ClusterZone           string
 }
 
+var pathParamRegex = regexp.MustCompile(`\\{[^\}]*\\}`)
+
 type profileOptions struct {
+	name      string
 	namespace string
 	template  bool
+	openAPI   string
 }
 
 func newProfileOptions() *profileOptions {
 	return &profileOptions{
+		name:      "",
 		namespace: "default",
 		template:  false,
+		openAPI:   "",
 	}
 }
 
@@ -35,30 +49,55 @@ func newCmdProfile() *cobra.Command {
 	options := newProfileOptions()
 
 	cmd := &cobra.Command{
-		Use:   "profile [flags] --template (SERVICE)",
+		Use:   "profile [flags] (--template | --open-api file) (SERVICE)",
 		Short: "Output template service profile config for Kubernetes",
 		Long: `Output template service profile config for Kubernetes.
 		
-		This outputs a service profile template for the given service.  Edit the
-		template and then apply it with kubectl to add a service profile to a
-		service.
+		This outputs a service profile for the given service.
+		
+		If the --template flag is specified, it outputs a service profile template.
+		Edit the template and then apply it with kubectl to add a service profile to
+		a service.
 
 		Example:
 		linkerd profile -n emojivoto --template web-svc > web-svc-profile.yaml
 		# (edit web-svc-profile.yaml manually)
 		kubectl apply -f web-svc-profile.yaml
+
+		If the --open-api flag is specified, it reads the given OpenAPI
+		specification file and outputs a corresponding service profile.
+
+		Example:
+		linkerd profile -n emojivoto --open-api web-svc.swagger web-svc | kubectl apply -f -
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !options.template {
-				return errors.New("only template mode is currently supported, please run with --template")
+			options.name = args[0]
+
+			if !options.template && options.openAPI == "" {
+				return errors.New("You must specify exactly one of --template or --open-api")
 			}
 
-			return renderProfileTemplate(buildConfig(options.namespace, args[0]), os.Stdout)
+			if options.template {
+				if options.openAPI != "" {
+					return errors.New("You must specify exactly one of --template or --open-api")
+				}
+				return renderProfileTemplate(buildConfig(options.namespace, args[0]), os.Stdout)
+			}
+
+			if options.openAPI != "" {
+				if options.template {
+					return errors.New("You must specify exactly one of --template or --open-api")
+				}
+				return renderOpenAPI(options, os.Stdout)
+			}
+
+			return errors.New("You must specify exactly one of --template or --open-api")
 		},
 	}
 
 	cmd.PersistentFlags().BoolVar(&options.template, "template", options.template, "Output a service profile template")
+	cmd.PersistentFlags().StringVar(&options.openAPI, "open-api", options.openAPI, "Output a service profile based on the given OpenAPI spec file")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the service")
 
 	return cmd
@@ -86,4 +125,130 @@ func renderProfileTemplate(config *templateConfig, w io.Writer) error {
 
 	_, err = w.Write(buf.Bytes())
 	return err
+}
+
+func renderOpenAPI(options *profileOptions, w io.Writer) error {
+	var input io.Reader
+	if options.openAPI == "-" {
+		input = os.Stdin
+	} else {
+		var err error
+		input, err = os.Open(options.openAPI)
+		if err != nil {
+			return err
+		}
+	}
+
+	bytes, err := ioutil.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("Error reading file: %s", err)
+	}
+	json, err := yaml.YAMLToJSON(bytes)
+	if err != nil {
+		return fmt.Errorf("Error parsing yaml: %s", err)
+	}
+
+	swagger := spec.Swagger{}
+	err = swagger.UnmarshalJSON(json)
+	if err != nil {
+		return fmt.Errorf("Error parsing OpenAPI spec: %s", err)
+	}
+
+	profile := sp.ServiceProfile{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", options.name, options.namespace),
+			Namespace: controlPlaneNamespace,
+		},
+		TypeMeta: meta_v1.TypeMeta{
+			APIVersion: "linkerd.io/v1alpha1",
+			Kind:       "ServiceProfile",
+		},
+	}
+
+	routes := make([]*sp.RouteSpec, 0)
+	for path, item := range swagger.Paths.Paths {
+		pathRegex := pathToRegex(path)
+		if item.Delete != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodDelete, item.Delete.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Get != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodGet, item.Get.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Head != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodHead, item.Head.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Options != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodOptions, item.Options.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Patch != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodPatch, item.Patch.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Post != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodPost, item.Post.Responses)
+			routes = append(routes, spec)
+		}
+		if item.Put != nil {
+			spec := mkRouteSpec(path, pathRegex, http.MethodPut, item.Put.Responses)
+			routes = append(routes, spec)
+		}
+	}
+
+	profile.Spec.Routes = routes
+	output, err := yaml.Marshal(profile)
+	if err != nil {
+		return fmt.Errorf("Error writing Service Profile: %s", err)
+	}
+	w.Write(output)
+
+	return nil
+}
+
+func mkRouteSpec(path, pathRegex string, method string, responses *spec.Responses) *sp.RouteSpec {
+	return &sp.RouteSpec{
+		Name:            fmt.Sprintf("%s %s", method, path),
+		Condition:       toReqMatch(pathRegex, method),
+		ResponseClasses: toRspClasses(responses),
+	}
+}
+
+func pathToRegex(path string) string {
+	escaped := regexp.QuoteMeta(path)
+	replaced := pathParamRegex.ReplaceAllLiteralString(escaped, "[^/]*")
+	return fmt.Sprintf("^%s$", replaced)
+}
+
+func toReqMatch(path string, method string) *sp.RequestMatch {
+	return &sp.RequestMatch{
+		Path:   path,
+		Method: method,
+	}
+}
+
+func toRspClasses(responses *spec.Responses) []*sp.ResponseClass {
+	if responses == nil {
+		return nil
+	}
+	classes := make([]*sp.ResponseClass, 0)
+	for status := range responses.StatusCodeResponses {
+		cond := &sp.ResponseMatch{
+			Status: &sp.Range{
+				Min: uint32(status),
+				Max: uint32(status),
+			},
+		}
+		failure := false
+		if status >= 500 {
+			failure = true
+		}
+		classes = append(classes, &sp.ResponseClass{
+			Condition: cond,
+			IsFailure: !failure,
+		})
+	}
+	return classes
 }

--- a/cli/cmd/profile_test.go
+++ b/cli/cmd/profile_test.go
@@ -40,7 +40,7 @@ func TestParseProfile(t *testing.T) {
 				&v1alpha1.RouteSpec{
 					Name: "/authors/{id}",
 					Condition: &v1alpha1.RequestMatch{
-						Path:   "/authors/\\d+",
+						Path:   "^/authors/\\d+$",
 						Method: "POST",
 					},
 					ResponseClasses: []*v1alpha1.ResponseClass{

--- a/cli/profile/template.go
+++ b/cli/profile/template.go
@@ -18,7 +18,7 @@ spec:
     # matches more than one route, the first match wins.
     condition:
       # The simplest condition is a path regular expression.
-      path: '/authors/\d+'
+      path: '^/authors/\d+$'
 
       # This is a condition that checks the request method.
       method: POST
@@ -26,18 +26,18 @@ spec:
       # If more than one condition field is set, all of them must be satisfied.
       # This is equivalent to using the 'all' condition:
       # all:
-      # - path: '/authors/\d+'
+      # - path: '^/authors/\d+$'
       # - method: POST
 
       # Conditions can be combined using 'all', 'any', and 'not'.
       # any:
       # - all:
       #   - method: POST
-      #   - path: '/authors/\d+'
+      #   - path: '^/authors/\d+$'
       # - all:
       #   - not:
       #       method: DELETE
-      #   - path: /info.txt
+      #   - path: ^/info.txt$
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:0d7c8b9b as golang
+FROM gcr.io/linkerd-io/go-deps:caa0345d as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -32,32 +32,32 @@ type ServiceProfileSpec struct {
 type RouteSpec struct {
 	Name            string           `json:"name"`
 	Condition       *RequestMatch    `json:"condition"`
-	ResponseClasses []*ResponseClass `json:"response_classes"`
+	ResponseClasses []*ResponseClass `json:"response_classes,omitempty"`
 }
 
 type RequestMatch struct {
-	All    []*RequestMatch `json:"all"`
-	Not    *RequestMatch   `json:"not"`
-	Any    []*RequestMatch `json:"any"`
-	Path   string          `json:"path"`
-	Method string          `json:"method"`
+	All    []*RequestMatch `json:"all,omitempty"`
+	Not    *RequestMatch   `json:"not,omitempty"`
+	Any    []*RequestMatch `json:"any,omitempty"`
+	Path   string          `json:"path,omitempty"`
+	Method string          `json:"method,omitempty"`
 }
 
 type ResponseClass struct {
 	Condition *ResponseMatch `json:"condition"`
-	IsFailure bool           `json:"is_failure"`
+	IsFailure bool           `json:"is_failure,omitempty"`
 }
 
 type ResponseMatch struct {
-	All    []*ResponseMatch `json:"all"`
-	Not    *ResponseMatch   `json:"not"`
-	Any    []*ResponseMatch `json:"any"`
-	Status *Range           `json:"status"`
+	All    []*ResponseMatch `json:"all,omitempty"`
+	Not    *ResponseMatch   `json:"not,omitempty"`
+	Any    []*ResponseMatch `json:"any,omitempty"`
+	Status *Range           `json:"status,omitempty"`
 }
 
 type Range struct {
-	Min uint32 `json:"min"`
-	Max uint32 `json:"max"`
+	Min uint32 `json:"min,omitempty"`
+	Max uint32 `json:"max,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:0d7c8b9b as golang
+FROM gcr.io/linkerd-io/go-deps:caa0345d as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:0d7c8b9b as golang
+FROM gcr.io/linkerd-io/go-deps:caa0345d as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
The `--open-api` flag is an alternative to the `--template` flag for the `linkerd profile` command.  It reads an OpenAPI specification file (also called a swagger file) and uses it to generate a corresponding service profile.

```
$ linkerd profile --open-api pet.swagger pet
apiVersion: linkerd.io/v1alpha1
kind: ServiceProfile
metadata:
  creationTimestamp: null
  name: pet.default.svc.cluster.local
  namespace: linkerd
spec:
  routes:
  - condition:
      method: GET
      path: ^/sample/pet/[^/]*$
    name: GET /sample/pet/{petId}
  - condition:
      method: POST
      path: ^/sample/pet$
    name: POST /sample/pet
```

Signed-off-by: Alex Leong <alex@buoyant.io>