### PR TITLE
Left-align the routes column and sort by route name

### DIFF
--- a/cli/cmd/testdata/routes_one_output.golden
+++ b/cli/cmd/testdata/routes_one_output.golden
@@ -1,5 +1,5 @@
-    ROUTE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99    TLS
-       /a   100.00%   1.5rps         123ms         123ms         123ms   100%
-       /b   100.00%   1.0rps         123ms         123ms         123ms   100%
+ROUTE       SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99    TLS
+/a          100.00%   1.5rps         123ms         123ms         123ms   100%
+/b          100.00%   1.0rps         123ms         123ms         123ms   100%
+/c            0.00%   0.0rps         123ms         123ms         123ms     0%
 [UNKNOWN]   100.00%   0.5rps         123ms         123ms         123ms   100%
-       /c     0.00%   0.0rps         123ms         123ms         123ms     0%

--- a/cli/cmd/testdata/routes_one_output_json.golden
+++ b/cli/cmd/testdata/routes_one_output_json.golden
@@ -18,15 +18,6 @@
     "tls": 1
   },
   {
-    "route": "[UNKNOWN]",
-    "success": 1,
-    "rps": 0.5,
-    "latency_ms_p50": 123,
-    "latency_ms_p95": 123,
-    "latency_ms_p99": 123,
-    "tls": 1
-  },
-  {
     "route": "/c",
     "success": 0,
     "rps": 0,
@@ -34,5 +25,14 @@
     "latency_ms_p95": 123,
     "latency_ms_p99": 123,
     "tls": 0
+  },
+  {
+    "route": "[UNKNOWN]",
+    "success": 1,
+    "rps": 0.5,
+    "latency_ms_p50": 123,
+    "latency_ms_p95": 123,
+    "latency_ms_p99": 123,
+    "tls": 1
   }
 ]


### PR DESCRIPTION
```
ROUTE                  SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
/authors               100.00%   0.5rps          16ms          27ms          29ms    0%
/authors/{id}          100.00%   0.5rps          24ms          29ms          30ms    0%
/authors/{id}/delete   100.00%   0.5rps          43ms          90ms          98ms    0%
/books                  50.42%   2.0rps          28ms          57ms          91ms    0%
/books/{id}            100.00%   1.0rps          24ms          85ms          97ms    0%
/books/{id}/delete     100.00%   0.6rps          16ms          78ms          96ms    0%
/books/{id}/edit        52.31%   1.1rps          54ms         135ms         187ms    0%
[UNKNOWN]              100.00%   0.5rps          40ms          93ms          99ms    0%
```

Signed-off-by: Alex Leong <alex@buoyant.io>