### PR TITLE
Add filtering by job in stat, tap, top; fix panic

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -66,16 +66,17 @@ func newCmdStat() *cobra.Command {
   * au/my-authority
   * po/mypod1 rc/my-replication-controller
   * po mypod1 mypod2
+  * deploy/ po/
   * all
 
-Valid resource types include:
-
+  Valid resource types include:
   * deployments
   * namespaces
   * pods
   * replicationcontrollers
   * authorities (not supported in --from)
   * services (only supported if a --from is also specified, or as a --to)
+  * jobs (only supported as a --from or --to)
   * all (all resource types, not supported in --from or --to)
 
 This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases.

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -59,12 +59,12 @@ func newCmdTap() *cobra.Command {
   * ns/my-ns
 
   Valid resource types include:
-
   * deployments
   * namespaces
   * pods
   * replicationcontrollers
-  * services (only supported as a "--to" resource)`,
+  * services (only supported as a --to resource)
+  * jobs (only supported as a --from or --to)`,
 		Example: `  # tap the web deployment in the default namespace
   linkerd tap deploy/web
 

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -64,7 +64,7 @@ func newCmdTap() *cobra.Command {
   * pods
   * replicationcontrollers
   * services (only supported as a --to resource)
-  * jobs (only supported as a --from or --to)`,
+  * jobs (only supported as a --to resource)`,
 		Example: `  # tap the web deployment in the default namespace
   linkerd tap deploy/web
 

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -644,6 +644,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -668,6 +668,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -668,6 +668,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -649,6 +649,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -653,6 +653,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -106,7 +106,7 @@ func newCmdTop() *cobra.Command {
   * pods
   * replicationcontrollers
   * services (only supported as a --to resource)
-  * jobs (only supported as a --from or --to)`,
+  * jobs (only supported as a --to resource)`,
 		Example: `  # display traffic for the web deployment in the default namespace
   linkerd top deploy/web
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -101,12 +101,12 @@ func newCmdTop() *cobra.Command {
   * ns/my-ns
 
   Valid resource types include:
-
   * deployments
   * namespaces
   * pods
   * replicationcontrollers
-  * services (only supported as a "--to" resource)`,
+  * services (only supported as a --to resource)
+  * jobs (only supported as a --from or --to)`,
 		Example: `  # display traffic for the web deployment in the default namespace
   linkerd top deploy/web
 

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -491,6 +491,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_linkerd_io_proxy_job]
         action: replace
         target_label: k8s_job
+      # drop __meta_kubernetes_pod_label_linkerd_io_proxy_job
+      - action: labeldrop
+        regex: __meta_kubernetes_pod_label_linkerd_io_proxy_job
       # __meta_kubernetes_pod_label_linkerd_io_proxy_deployment=foo =>
       # deployment=foo
       - action: labelmap

--- a/controller/api/public/prometheus.go
+++ b/controller/api/public/prometheus.go
@@ -125,7 +125,8 @@ func promDirectionLabels(direction string) model.LabelSet {
 }
 
 func promResourceType(resource *pb.Resource) model.LabelName {
-	return model.LabelName(resource.Type)
+	l5dLabel := k8s.KindToL5DLabel(resource.Type)
+	return model.LabelName(l5dLabel)
 }
 
 func (s *grpcServer) getPrometheusMetrics(ctx context.Context, volumeQueryTemplate, latencyQueryTemplate, labels, timeWindow, groupBy string) ([]promResult, error) {

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -29,18 +29,18 @@ var (
 	// target resource on an outbound 'to' query
 	// destination resource on an outbound 'from' query
 	ValidTargets = []string{
+		k8s.Authority,
 		k8s.Deployment,
 		k8s.Namespace,
 		k8s.Pod,
 		k8s.ReplicationController,
-		k8s.Authority,
 	}
 
-	// ValidDestinations specifies resource types allowed as a destination:
+	// ValidTapDestinations specifies resource types allowed as a tap destination:
 	// destination resource on an outbound 'to' query
-	// target resource on an outbound 'from' query
-	ValidDestinations = []string{
+	ValidTapDestinations = []string{
 		k8s.Deployment,
+		k8s.Job,
 		k8s.Namespace,
 		k8s.Pod,
 		k8s.ReplicationController,
@@ -281,6 +281,10 @@ func validateFromResourceType(resourceType string) (string, error) {
 // It's the same as BuildResources but only admits one arg and only returns one resource
 func BuildResource(namespace, arg string) (pb.Resource, error) {
 	res, err := BuildResources(namespace, []string{arg})
+	if err != nil {
+		return pb.Resource{}, err
+	}
+
 	return res[0], err
 }
 
@@ -386,8 +390,8 @@ func BuildTapByResourceRequest(params TapRequestParams) (*pb.TapByResourceReques
 		if err != nil {
 			return nil, fmt.Errorf("destination resource invalid: %s", err)
 		}
-		if !contains(ValidDestinations, destination.Type) {
-			return nil, fmt.Errorf("unsupported resource type [%s]", target.Type)
+		if !contains(ValidTapDestinations, destination.Type) {
+			return nil, fmt.Errorf("unsupported resource type [%s]", destination.Type)
 		}
 
 		match := pb.TapByResourceRequest_Match{

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -203,7 +203,8 @@ func makeByResourceMatch(match *public.TapByResourceRequest_Match) (*proxy.Obser
 func destinationLabels(resource *public.Resource) map[string]string {
 	dstLabels := map[string]string{}
 	if resource.Name != "" {
-		dstLabels[resource.Type] = resource.Name
+		l5dLabel := pkgK8s.KindToL5DLabel(resource.Type)
+		dstLabels[l5dLabel] = resource.Name
 	}
 	if resource.Type != pkgK8s.Namespace && resource.Namespace != "" {
 		dstLabels["namespace"] = resource.Namespace

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -175,11 +175,9 @@ func CreatedByAnnotationValue() string {
 // GetPodLabels returns the set of prometheus owner labels for a given pod
 func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]string {
 	labels := map[string]string{"pod": pod.Name}
-	if ownerKind == "job" {
-		labels["k8s_job"] = ownerName
-	} else {
-		labels[ownerKind] = ownerName
-	}
+
+	l5dLabel := KindToL5DLabel(ownerKind)
+	labels[l5dLabel] = ownerName
 
 	if controllerNS := pod.Labels[ControllerNSLabel]; controllerNS != "" {
 		labels["control_plane_ns"] = controllerNS

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -66,7 +66,7 @@ func TestCheckPreInstall(t *testing.T) {
 }
 
 func TestInstall(t *testing.T) {
-	cmd := []string{"install", "--linkerd-version", TestHelper.GetVersion()}
+	cmd := []string{"install", "--controller-log-level", "debug", "--linkerd-version", TestHelper.GetVersion()}
 	if TestHelper.TLS() {
 		cmd = append(cmd, []string{"--tls", "optional"}...)
 		linkerdDeployReplicas["ca"] = 1
@@ -188,7 +188,7 @@ func TestInject(t *testing.T) {
 		t.Fatalf("kubectl apply command failed\n%s", out)
 	}
 
-	for _, deploy := range []string{"smoke-test-terminus","smoke-test-gateway"} {
+	for _, deploy := range []string{"smoke-test-terminus", "smoke-test-gateway"} {
 		err = TestHelper.CheckPods(prefixedNs, deploy, 1)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)

--- a/test/tap/testdata/tap_application.yaml
+++ b/test/tap/testdata/tap_application.yaml
@@ -167,7 +167,8 @@ metadata:
 spec:
   template:
     metadata:
-      name: slow-cooker
+      labels:
+        app: slow-cooker
     spec:
       containers:
       - name: slow-cooker
@@ -178,5 +179,19 @@ spec:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          slow_cooker http://gateway-svc:8080
+          slow_cooker -metric-addr 0.0.0.0:9999 http://gateway-svc:8080
+        ports:
+        - containerPort: 9999
       restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slow-cooker
+spec:
+  selector:
+    app: slow-cooker
+  ports:
+  - name: metrics
+    port: 9999
+    targetPort: 9999


### PR DESCRIPTION
Filtering by Kubernetes job was not supported. Also filtering by any unknown
type caused a panic.

Add filtering support by Kubernetes job, with special case mapping `job` to
`k8s_job`, to not conflict with Prometheus' job label.

Fix panic when unknown type specified as a `--from` or `--to` flag.

Fix `job` label from `linkerd-proxy` overwriting Prometheus `job` label at
collection time. This caused all metrics collected by proxy sidecars in
Kubernetes jobs to be collected into an incorrect Prometheus job, rather than
the expected `linkerd-proxy` Prometheus job.

Fix `unsupported resource type` tap error message incorrectly printing the
target resource rather than the destination.

Set `--controller-log-level debug` in `install_test.go` for easier debugging.

Expose `slow-cooker`'s metrics via a k8s service in the tap integration test, to
validate proxy requests with a job as destination.

Fixes #1872
Part of #627

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

## Validating commands

### Deploy integration tests
```bash
bin/fast-build
bin/test-run `pwd`/bin/linkerd
```

### Send traffic to a Kubernetes job
```bash
kubectl -n linkerd-tap-test exec -it $(kubectl -n linkerd-tap-test get po --selector=app=t1 -o jsonpath='{.items[*].metadata.name}') -c t1 -- bash -c "while true; do curl slow-cooker:9999/metrics; sleep 1; done"
```

### View traffic to/from Kubernetes job
```bash
$ bin/linkerd stat deploy -n linkerd-tap-test --to job/slow-cooker
NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
t1        1/1   100.00%   1.0rps           4ms           9ms          10ms    0%

$ bin/linkerd stat deploy -n linkerd-tap-test --from job/slow-cooker
NAME      MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TLS
gateway      1/1     0.00%   1.0rps          23ms          38ms          40ms    0%

$ bin/linkerd tap deploy -n linkerd-tap-test --to job/slow-cooker
req id=0:1259 proxy=out src=10.1.7.175:47410 dst=10.1.7.179:9999 tls=no_identity :method=GET :authority=slow-cooker:9999 :path=/metrics
rsp id=0:1259 proxy=out src=10.1.7.175:47410 dst=10.1.7.179:9999 tls=no_identity :status=200 latency=7696µs
end id=0:1259 proxy=out src=10.1.7.175:47410 dst=10.1.7.179:9999 tls=no_identity duration=279µs response-length=7630B
```