### PR TITLE
Display the correct tap/top command in the Tap/Top pages

### DIFF
--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -303,6 +303,7 @@ class Tap extends React.Component {
         <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: null })} />}
 
         <TapQueryForm
+          cmdName="tap"
           tapRequestInProgress={this.state.tapRequestInProgress}
           tapIsClosing={this.state.tapIsClosing}
           handleTapStart={this.handleTapStart}

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -85,6 +85,7 @@ const styles = theme => ({
 class TapQueryForm extends React.Component {
   static propTypes = {
     classes: PropTypes.shape({}).isRequired,
+    cmdName: PropTypes.string.isRequired,
     enableAdvancedForm: PropTypes.bool,
     handleTapClear: PropTypes.func,
     handleTapStart: PropTypes.func.isRequired,
@@ -432,7 +433,7 @@ class TapQueryForm extends React.Component {
           </Grid>
         </CardContent>
 
-        <QueryToCliCmd cmdName="tap" query={this.state.query} resource={this.state.query.resource} displayOrder={cliQueryDisplayOrder} />
+        <QueryToCliCmd cmdName={this.props.cmdName} query={this.state.query} resource={this.state.query.resource} displayOrder={cliQueryDisplayOrder} />
 
         { !this.props.enableAdvancedForm ? null : this.renderAdvancedTapForm() }
 

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -155,6 +155,7 @@ class Top extends React.Component {
         <ErrorBanner message={this.state.error} onHideMessage={() => this.setState({ error: null })} />}
         <TapQueryForm
           enableAdvancedForm={false}
+          cmdName="top"
           handleTapStart={this.handleTapStart}
           handleTapStop={this.handleTapStop}
           handleTapClear={this.handleTapClear}


### PR DESCRIPTION
Previously, we were passing in "tap" as the command name for both the tap and top forms, resulting in the equivalent CLI command always being `linkerd tap` regardless of whether you were in the Tap or Top view.

Fix this to correctly pass in tap or top depending on the page.