### PR TITLE
Bump the proxy version to fix integration tests

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-872f78d}"
+PROXY_VERSION="${PROXY_VERSION:-f3f959b}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
A Tap integration test fails and has been fixed by
linkerd/linkerd2-proxy#152.

This change bumps the proxy version to get this change, as well as an
upgrade to the `h2` library for bugfixes.