### PR TITLE
proxy: Update for debug logging

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-f3f959b}"
+PROXY_VERSION="${PROXY_VERSION:-68f42c3}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
commit 68f42c337f2580f3b33ddab2e01540f6849d0d1a (HEAD -> master, origin/master)
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Dec 4 07:45:20 2018 -0800

    Log discovery updates in the outbound proxy (#153)

    When debugging issues that users believe is related to discovery, it's
    helpful to get a narrow set of logs out to determine whether the proxy
    is observing discovery updates.

    With this change, a user can inject the proxy with
    ```
    LINKERD2_PROXY_LOG='warn,linkerd2_proxy=info,linkerd2_proxy::app::outbound::discovery=debug'
    ```
    and the proxy's logs will include messages like:

    ```
    DBUG voting-svc.emojivoto.svc.cluster.local:8080 linkerd2_proxy::app::outbound::discovery adding 10.233.70.98:8080 to voting-svc.emojivoto.svc.cluster.local:8080
    DBUG voting-svc.emojivoto.svc.cluster.local:8080 linkerd2_proxy::app::outbound::discovery removing 10.233.66.36:8080 from voting-svc.emojivoto.svc.cluster.local:8080
    ```

    This change also turns-down some overly chatty INFO logging in main.