### PR TITLE
Rename path to path_regex in ServiceProfile CRD

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -196,14 +196,13 @@ func mkRouteSpec(path, pathRegex string, method string, responses *spec.Response
 
 func pathToRegex(path string) string {
 	escaped := regexp.QuoteMeta(path)
-	replaced := pathParamRegex.ReplaceAllLiteralString(escaped, "[^/]*")
-	return fmt.Sprintf("^%s$", replaced)
+	return pathParamRegex.ReplaceAllLiteralString(escaped, "[^/]*")
 }
 
 func toReqMatch(path string, method string) *sp.RequestMatch {
 	return &sp.RequestMatch{
-		Path:   path,
-		Method: method,
+		PathRegex: path,
+		Method:    method,
 	}
 }
 

--- a/controller/api/proxy/profile_listener_test.go
+++ b/controller/api/proxy/profile_listener_test.go
@@ -18,7 +18,7 @@ var (
 			},
 			&sp.RequestMatch{
 				Not: &sp.RequestMatch{
-					Path: "/private/.*",
+					PathRegex: "/private/.*",
 				},
 			},
 		},
@@ -54,7 +54,7 @@ var (
 	}
 
 	login = &sp.RequestMatch{
-		Path: "/login",
+		PathRegex: "/login",
 	}
 
 	pbLogin = &pb.RequestMatch{
@@ -181,8 +181,8 @@ var (
 				&sp.RouteSpec{
 					Name: "multipleRequestMatches",
 					Condition: &sp.RequestMatch{
-						Method: "GET",
-						Path:   "/my/path",
+						Method:    "GET",
+						PathRegex: "/my/path",
 					},
 				},
 			},

--- a/controller/api/proxy/profile_watcher_test.go
+++ b/controller/api/proxy/profile_watcher_test.go
@@ -26,7 +26,7 @@ metadata:
 spec:
   routes:
   - condition:
-      path: "/x/y/z"
+      path_regex: "/x/y/z"
     response_classes:
     - condition:
         status:
@@ -39,7 +39,7 @@ spec:
 					Routes: []*sp.RouteSpec{
 						&sp.RouteSpec{
 							Condition: &sp.RequestMatch{
-								Path: "/x/y/z",
+								PathRegex: "/x/y/z",
 							},
 							ResponseClasses: []*sp.ResponseClass{
 								&sp.ResponseClass{

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -36,11 +36,11 @@ type RouteSpec struct {
 }
 
 type RequestMatch struct {
-	All    []*RequestMatch `json:"all,omitempty"`
-	Not    *RequestMatch   `json:"not,omitempty"`
-	Any    []*RequestMatch `json:"any,omitempty"`
-	Path   string          `json:"path,omitempty"`
-	Method string          `json:"method,omitempty"`
+	All       []*RequestMatch `json:"all,omitempty"`
+	Not       *RequestMatch   `json:"not,omitempty"`
+	Any       []*RequestMatch `json:"any,omitempty"`
+	PathRegex string          `json:"path_regex,omitempty"`
+	Method    string          `json:"method,omitempty"`
 }
 
 type ResponseClass struct {

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -201,11 +201,11 @@ func ToRequestMatch(reqMatch *sp.RequestMatch) (*pb.RequestMatch, error) {
 		})
 	}
 
-	if reqMatch.Path != "" {
+	if reqMatch.PathRegex != "" {
 		matches = append(matches, &pb.RequestMatch{
 			Match: &pb.RequestMatch_Path{
 				Path: &pb.PathMatch{
-					Regex: reqMatch.Path,
+					Regex: reqMatch.PathRegex,
 				},
 			},
 		})
@@ -256,7 +256,7 @@ func ValidateRequestMatch(reqMatch *sp.RequestMatch) error {
 			return err
 		}
 	}
-	if reqMatch.Path != "" {
+	if reqMatch.PathRegex != "" {
 		matchKindSet = true
 	}
 

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -18,7 +18,7 @@ spec:
     # matches more than one route, the first match wins.
     condition:
       # The simplest condition is a path regular expression.
-      path: '^/authors/\d+$'
+      path_regex: '/authors/\d+'
 
       # This is a condition that checks the request method.
       method: POST
@@ -26,18 +26,18 @@ spec:
       # If more than one condition field is set, all of them must be satisfied.
       # This is equivalent to using the 'all' condition:
       # all:
-      # - path: '^/authors/\d+$'
+      # - path: '/authors/\d+'
       # - method: POST
 
       # Conditions can be combined using 'all', 'any', and 'not'.
       # any:
       # - all:
       #   - method: POST
-      #   - path: '^/authors/\d+$'
+      #   - path: '/authors/\d+'
       # - all:
       #   - not:
       #       method: DELETE
-      #   - path: ^/info.txt$
+      #   - path: /info.txt
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -26,18 +26,18 @@ spec:
       # If more than one condition field is set, all of them must be satisfied.
       # This is equivalent to using the 'all' condition:
       # all:
-      # - path: '/authors/\d+'
+      # - path_regex: '/authors/\d+'
       # - method: POST
 
       # Conditions can be combined using 'all', 'any', and 'not'.
       # any:
       # - all:
       #   - method: POST
-      #   - path: '/authors/\d+'
+      #   - path_regex: '/authors/\d+'
       # - all:
       #   - not:
       #       method: DELETE
-      #   - path: /info.txt
+      #   - path_regex: /info.txt
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.

--- a/pkg/profiles/test_helper.go
+++ b/pkg/profiles/test_helper.go
@@ -24,8 +24,8 @@ func GenServiceProfile(service, namespace, controlPlaneNamespace string) v1alpha
 				&v1alpha1.RouteSpec{
 					Name: "/authors/{id}",
 					Condition: &v1alpha1.RequestMatch{
-						Path:   "^/authors/\\d+$",
-						Method: "POST",
+						PathRegex: "/authors/\\d+",
+						Method:    "POST",
 					},
 					ResponseClasses: []*v1alpha1.ResponseClass{
 						&v1alpha1.ResponseClass{


### PR DESCRIPTION
We rename `path` to `path_regex` in the ServiceProfile CRD to make it clear that this field accepts a regular expression.  We also take this opportunity to remove unnecessary line anchors from regular expressions now that these anchors are added in the proxy.

Signed-off-by: Alex Leong <alex@buoyant.io>