### PR TITLE
proxy-api: Expose a flag to control auto-h2-upgrade

### DIFF
--- a/controller/api/proxy/server.go
+++ b/controller/api/proxy/server.go
@@ -14,9 +14,10 @@ import (
 )
 
 type server struct {
-	k8sAPI    *k8s.API
-	resolvers []streamingDestinationResolver
-	enableTLS bool
+	k8sAPI          *k8s.API
+	resolvers       []streamingDestinationResolver
+	enableH2Upgrade bool
+	enableTLS       bool
 }
 
 // The proxy-api service serves service discovery and other information to the
@@ -29,16 +30,17 @@ type server struct {
 //
 // Addresses for the given destination are fetched from the Kubernetes Endpoints
 // API.
-func NewServer(addr, k8sDNSZone string, controllerNamespace string, enableTLS bool, k8sAPI *k8s.API, done chan struct{}) (*grpc.Server, net.Listener, error) {
+func NewServer(addr, k8sDNSZone string, controllerNamespace string, enableTLS, enableH2Upgrade bool, k8sAPI *k8s.API, done chan struct{}) (*grpc.Server, net.Listener, error) {
 	resolvers, err := buildResolversList(k8sDNSZone, controllerNamespace, k8sAPI)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	srv := server{
-		k8sAPI:    k8sAPI,
-		resolvers: resolvers,
-		enableTLS: enableTLS,
+		k8sAPI:          k8sAPI,
+		resolvers:       resolvers,
+		enableH2Upgrade: enableH2Upgrade,
+		enableTLS:       enableTLS,
 	}
 
 	lis, err := net.Listen("tcp", addr)
@@ -91,7 +93,7 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 }
 
 func (s *server) streamResolutionUsingCorrectResolverFor(host string, port int, stream pb.Destination_GetServer) error {
-	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableTLS)
+	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableTLS, s.enableH2Upgrade)
 
 	for _, resolver := range s.resolvers {
 		resolverCanResolve, err := resolver.canResolve(host, port)

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -18,6 +18,7 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
+	enableH2Upgrade := flag.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
 	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
@@ -53,7 +54,7 @@ func main() {
 	done := make(chan struct{})
 	ready := make(chan struct{})
 
-	server, lis, err := proxy.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, k8sAPI, done)
+	server, lis, err := proxy.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, k8sAPI, done)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When debugging issues, it's helpful to disable HTTP/2 upgrading to
simplify diagnostics.

This change adds an `enable-h2-ugprade` flag to _proxy-api_. When this
flag is set to false, the proxy-api will not suggest that meshed
endpoints are upgraded to use HTTP/2.

As a follow-up, a flag should be added to `install` to control how the
proxy-api is initialized.