### PR TITLE
install: Add a -disable-h2-upgrade flag

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -57,6 +57,7 @@ type installConfig struct {
 	ProxyBindTimeout                 string
 	SingleNamespace                  bool
 	EnableHA                         bool
+	EnableH2Upgrade                  bool
 }
 
 type installOptions struct {
@@ -65,6 +66,7 @@ type installOptions struct {
 	proxyAutoInject    bool
 	singleNamespace    bool
 	highAvailability   bool
+	disableH2Upgrade   bool
 	*proxyConfigOptions
 }
 
@@ -81,6 +83,7 @@ func newInstallOptions() *installOptions {
 		proxyAutoInject:    false,
 		singleNamespace:    false,
 		highAvailability:   false,
+		disableH2Upgrade:   false,
 		proxyConfigOptions: newProxyConfigOptions(),
 	}
 }
@@ -108,6 +111,7 @@ func newCmdInstall() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&options.proxyAutoInject, "proxy-auto-inject", options.proxyAutoInject, "Experimental: Enable proxy sidecar auto-injection webhook (default false)")
 	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Experimental: Configure the control plane to only operate in the installed namespace (default false)")
 	cmd.PersistentFlags().BoolVar(&options.highAvailability, "ha", options.highAvailability, "Experimental: Enable HA deployment config for the control plane")
+	cmd.PersistentFlags().BoolVar(&options.disableH2Upgrade, "disable-h2-upgrade", options.disableH2Upgrade, "Prevents the controller from instructing proxies to perform transparent HTTP/2 ugprading")
 	return cmd
 }
 
@@ -181,6 +185,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		ProxyBindTimeout:                 "1m",
 		SingleNamespace:                  options.singleNamespace,
 		EnableHA:                         options.highAvailability,
+		EnableH2Upgrade:                  !options.disableH2Upgrade,
 	}, nil
 }
 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -61,6 +61,7 @@ func TestRender(t *testing.T) {
 		ProxyResourceRequestCPU:          "RequestCPU",
 		ProxyResourceRequestMemory:       "RequestMemory",
 		ProxyBindTimeout:                 "1m",
+		EnableH2Upgrade:                  true,
 	}
 
 	singleNamespaceConfig := installConfig{
@@ -86,6 +87,7 @@ func TestRender(t *testing.T) {
 		TLSTrustAnchorVolumeSpecFileName: "TLSTrustAnchorVolumeSpecFileName",
 		TLSIdentityVolumeSpecFileName:    "TLSIdentityVolumeSpecFileName",
 		SingleNamespace:                  true,
+		EnableH2Upgrade:                  true,
 	}
 
 	haOptions := newInstallOptions()

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -172,6 +172,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -enable-tls=false
+        - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -175,6 +175,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -enable-tls=false
+        - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -175,6 +175,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -enable-tls=false
+        - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -175,6 +175,7 @@ spec:
         - -controller-namespace=Namespace
         - -single-namespace=false
         - -enable-tls=true
+        - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -177,6 +177,7 @@ spec:
         - -controller-namespace=Namespace
         - -single-namespace=true
         - -enable-tls=true
+        - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -199,6 +199,7 @@ spec:
         - "-controller-namespace={{.Namespace}}"
         - "-single-namespace={{.SingleNamespace}}"
         - "-enable-tls={{.EnableTLS}}"
+        - "-enable-h2-upgrade={{.EnableH2Upgrade}}"
         - "-log-level={{.ControllerLogLevel}}"
         livenessProbe:
           httpGet:

--- a/controller/api/proxy/server.go
+++ b/controller/api/proxy/server.go
@@ -14,9 +14,10 @@ import (
 )
 
 type server struct {
-	k8sAPI    *k8s.API
-	resolvers []streamingDestinationResolver
-	enableTLS bool
+	k8sAPI          *k8s.API
+	resolvers       []streamingDestinationResolver
+	enableH2Upgrade bool
+	enableTLS       bool
 }
 
 // The proxy-api service serves service discovery and other information to the
@@ -29,16 +30,17 @@ type server struct {
 //
 // Addresses for the given destination are fetched from the Kubernetes Endpoints
 // API.
-func NewServer(addr, k8sDNSZone string, controllerNamespace string, enableTLS bool, k8sAPI *k8s.API, done chan struct{}) (*grpc.Server, net.Listener, error) {
+func NewServer(addr, k8sDNSZone string, controllerNamespace string, enableTLS, enableH2Upgrade bool, k8sAPI *k8s.API, done chan struct{}) (*grpc.Server, net.Listener, error) {
 	resolvers, err := buildResolversList(k8sDNSZone, controllerNamespace, k8sAPI)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	srv := server{
-		k8sAPI:    k8sAPI,
-		resolvers: resolvers,
-		enableTLS: enableTLS,
+		k8sAPI:          k8sAPI,
+		resolvers:       resolvers,
+		enableH2Upgrade: enableH2Upgrade,
+		enableTLS:       enableTLS,
 	}
 
 	lis, err := net.Listen("tcp", addr)
@@ -91,7 +93,7 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 }
 
 func (s *server) streamResolutionUsingCorrectResolverFor(host string, port int, stream pb.Destination_GetServer) error {
-	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableTLS)
+	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableTLS, s.enableH2Upgrade)
 
 	for _, resolver := range s.resolvers {
 		resolverCanResolve, err := resolver.canResolve(host, port)

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -18,6 +18,7 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
+	enableH2Upgrade := flag.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
 	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
@@ -53,7 +54,7 @@ func main() {
 	done := make(chan struct{})
 	ready := make(chan struct{})
 
-	server, lis, err := proxy.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, k8sAPI, done)
+	server, lis, err := proxy.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, k8sAPI, done)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The proxy-api service _always_ suggests that two meshed pods communicate
via HTTP/2 (i.e. via transparent protocol upgrading, if necessary).
This can complicate debugging and diagnostics at times, so it's
important that we have a way to deploy linkerd without this auto-upgrade
behavior.

This change adds a `-disable-h2-upgrade` flag to the `linkerd install`
command that disables transparent upgrading for the whole cluster.