### PR TITLE
Show routes with the same name from different services

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -198,6 +198,7 @@ func renderStatStats(rows []*pb.StatTable_PodGroup_Row, options *statOptions) st
 const padding = 3
 
 type rowStats struct {
+	route       string
 	dst         string
 	requestRate float64
 	successRate float64


### PR DESCRIPTION
If the `linkerd routes` command gets two routes with the same name, it will only display one of them, even if the routes are from different services.  This is particularly obvious with the default `[UNKNOWN]` route.

We now display all routes, even if they have the same name.

Signed-off-by: Alex Leong <alex@buoyant.io>