### PR TITLE
Rename path_regex to pathRegex

### DIFF
--- a/controller/api/proxy/profile_watcher_test.go
+++ b/controller/api/proxy/profile_watcher_test.go
@@ -27,11 +27,11 @@ spec:
   routes:
   - condition:
       pathRegex: "/x/y/z"
-    response_classes:
+    responseClasses:
     - condition:
         status:
           min: 500
-      is_failure: true`,
+      isFailure: true`,
 			},
 			service: profileId{namespace: "linkerd", name: "foobar.ns.svc.cluster.local"},
 			expectedProfiles: []*sp.ServiceProfileSpec{

--- a/controller/api/proxy/profile_watcher_test.go
+++ b/controller/api/proxy/profile_watcher_test.go
@@ -26,7 +26,7 @@ metadata:
 spec:
   routes:
   - condition:
-      path_regex: "/x/y/z"
+      pathRegex: "/x/y/z"
     response_classes:
     - condition:
         status:

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -32,7 +32,7 @@ type ServiceProfileSpec struct {
 type RouteSpec struct {
 	Name            string           `json:"name"`
 	Condition       *RequestMatch    `json:"condition"`
-	ResponseClasses []*ResponseClass `json:"response_classes,omitempty"`
+	ResponseClasses []*ResponseClass `json:"responseClasses,omitempty"`
 }
 
 type RequestMatch struct {
@@ -45,7 +45,7 @@ type RequestMatch struct {
 
 type ResponseClass struct {
 	Condition *ResponseMatch `json:"condition"`
-	IsFailure bool           `json:"is_failure,omitempty"`
+	IsFailure bool           `json:"isFailure,omitempty"`
 }
 
 type ResponseMatch struct {

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -39,7 +39,7 @@ type RequestMatch struct {
 	All       []*RequestMatch `json:"all,omitempty"`
 	Not       *RequestMatch   `json:"not,omitempty"`
 	Any       []*RequestMatch `json:"any,omitempty"`
-	PathRegex string          `json:"path_regex,omitempty"`
+	PathRegex string          `json:"pathRegex,omitempty"`
 	Method    string          `json:"method,omitempty"`
 }
 

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -18,7 +18,7 @@ spec:
     # matches more than one route, the first match wins.
     condition:
       # The simplest condition is a path regular expression.
-      path_regex: '/authors/\d+'
+      pathRegex: '/authors/\d+'
 
       # This is a condition that checks the request method.
       method: POST
@@ -26,18 +26,18 @@ spec:
       # If more than one condition field is set, all of them must be satisfied.
       # This is equivalent to using the 'all' condition:
       # all:
-      # - path_regex: '/authors/\d+'
+      # - pathRegex: '/authors/\d+'
       # - method: POST
 
       # Conditions can be combined using 'all', 'any', and 'not'.
       # any:
       # - all:
       #   - method: POST
-      #   - path_regex: '/authors/\d+'
+      #   - pathRegex: '/authors/\d+'
       # - all:
       #   - not:
       #       method: DELETE
-      #   - path_regex: /info.txt
+      #   - pathRegex: /info.txt
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -41,7 +41,7 @@ spec:
 
     # A route may optionally define a list of response classes which describe
     # how responses from this route will be classified.
-    response_classes:
+    responseClasses:
 
     # Each response class must define a condition.  All responses from this
     # route that match the condition will be classified as this response class.
@@ -66,5 +66,5 @@ spec:
 
       # The response class defines whether responses should be counted as
       # successes or failures.
-      is_failure: true
+      isFailure: true
 `


### PR DESCRIPTION
Rename snake case fields to camel case in service profile spec.  This improves the way they are rendered when the `kubectl describe` command is used.