### PR TITLE
Add --routes flag to linkerd top

### DIFF
--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -30,6 +30,7 @@ type topOptions struct {
 	authority   string
 	path        string
 	hideSources bool
+	routes      bool
 }
 
 type topRequest struct {
@@ -49,9 +50,25 @@ func (id topRequestID) String() string {
 	return fmt.Sprintf("%s->%s(%d)", id.src, id.dst, id.stream)
 }
 
+type tableColumn struct {
+	header string
+	width  int
+	// Columns with key=true will be treated as the primary key for the table.
+	// In other words, if two rows have equal values for the key=true columns
+	// then those rows will be merged.
+	key bool
+	// If true, render this column.
+	display bool
+	// If true, set the width to the widest value in this column.
+	flexible   bool
+	rightAlign bool
+	value      func(tableRow) string
+}
+
 type tableRow struct {
-	by          string
+	path        string
 	method      string
+	route       string
 	source      string
 	destination string
 	count       int
@@ -62,11 +79,145 @@ type tableRow struct {
 	failures    int
 }
 
-const headerHeight = 3
+func (r tableRow) merge(other tableRow) tableRow {
+	r.count += other.count
+	if other.best.Nanoseconds() < r.best.Nanoseconds() {
+		r.best = other.best
+	}
+	if other.worst.Nanoseconds() > r.worst.Nanoseconds() {
+		r.worst = other.worst
+	}
+	r.last = other.last
+	r.successes += other.successes
+	r.failures += other.failures
+	return r
+}
+
+const (
+	headerHeight  = 3
+	columnSpacing = 2
+)
 
 var (
-	columnNames  = []string{"Source", "Destination", "Method", "Path", "Count", "Best", "Worst", "Last", "Success Rate"}
-	columnWidths = []int{23, 23, 10, 37, 6, 6, 6, 6, 3}
+	sourceColumn = tableColumn{
+		header:   "Source",
+		width:    23,
+		key:      true,
+		display:  true,
+		flexible: true,
+		value: func(r tableRow) string {
+			return r.source
+		},
+	}
+
+	destinationColumn = tableColumn{
+		header:   "Destination",
+		width:    23,
+		key:      true,
+		display:  true,
+		flexible: true,
+		value: func(r tableRow) string {
+			return r.destination
+		},
+	}
+
+	methodColumn = tableColumn{
+		header:   "Method",
+		width:    10,
+		key:      true,
+		display:  true,
+		flexible: false,
+		value: func(r tableRow) string {
+			return r.method
+		},
+	}
+
+	pathColumn = tableColumn{
+		header:   "Path",
+		width:    37,
+		key:      true,
+		display:  true,
+		flexible: true,
+		value: func(r tableRow) string {
+			return r.path
+		},
+	}
+
+	routeColumn = tableColumn{
+		header:   "Route",
+		width:    47,
+		key:      false,
+		display:  false,
+		flexible: true,
+		value: func(r tableRow) string {
+			return r.route
+		},
+	}
+
+	countColumn = tableColumn{
+		header:     "Count",
+		width:      6,
+		key:        false,
+		display:    true,
+		flexible:   false,
+		rightAlign: true,
+		value: func(r tableRow) string {
+			return strconv.Itoa(r.count)
+		},
+	}
+
+	bestColumn = tableColumn{
+		header:     "Best",
+		width:      6,
+		key:        false,
+		display:    true,
+		flexible:   false,
+		rightAlign: true,
+		value: func(r tableRow) string {
+			return formatDuration(r.best)
+		},
+	}
+
+	worstColumn = tableColumn{
+		header:     "Worst",
+		width:      6,
+		key:        false,
+		display:    true,
+		flexible:   false,
+		rightAlign: true,
+		value: func(r tableRow) string {
+			return formatDuration(r.worst)
+		},
+	}
+
+	lastColumn = tableColumn{
+		header:     "Last",
+		width:      6,
+		key:        false,
+		display:    true,
+		flexible:   false,
+		rightAlign: true,
+		value: func(r tableRow) string {
+			return formatDuration(r.last)
+		},
+	}
+
+	successRateColumn = tableColumn{
+		header:     "Success Rate",
+		width:      12,
+		key:        false,
+		display:    true,
+		flexible:   false,
+		rightAlign: true,
+		value: func(r tableRow) string {
+			return fmt.Sprintf("%.2f%%", 100.0*float32(r.successes)/float32(r.successes+r.failures))
+		},
+	}
+
+	columns = []*tableColumn{
+		&sourceColumn, &destinationColumn, &methodColumn, &pathColumn, &routeColumn,
+		&countColumn, &bestColumn, &worstColumn, &lastColumn, &successRateColumn,
+	}
 )
 
 func newTopOptions() *topOptions {
@@ -80,6 +231,7 @@ func newTopOptions() *topOptions {
 		authority:   "",
 		path:        "",
 		hideSources: false,
+		routes:      false,
 	}
 }
 
@@ -127,6 +279,20 @@ func newCmdTop() *cobra.Command {
 				Path:        options.path,
 			}
 
+			if options.hideSources {
+				sourceColumn.key = false
+				sourceColumn.display = false
+			}
+
+			if options.routes {
+				methodColumn.key = false
+				methodColumn.display = false
+				pathColumn.key = false
+				pathColumn.display = false
+				routeColumn.key = true
+				routeColumn.display = true
+			}
+
 			req, err := util.BuildTapByResourceRequest(requestParams)
 			if err != nil {
 				return err
@@ -153,6 +319,7 @@ func newCmdTop() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&options.path, "path", options.path,
 		"Display requests with paths that start with this prefix")
 	cmd.PersistentFlags().BoolVar(&options.hideSources, "hide-sources", options.hideSources, "Hide the source column")
+	cmd.PersistentFlags().BoolVar(&options.routes, "routes", options.routes, "Display data per route instead of per path")
 
 	return cmd
 }
@@ -175,7 +342,7 @@ func getTrafficByResourceFromAPI(w io.Writer, client pb.ApiClient, req *pb.TapBy
 	go recvEvents(rsp, requestCh, done)
 	go pollInput(done)
 
-	renderTable(requestCh, done, !options.hideSources)
+	renderTable(requestCh, done)
 
 	return nil
 }
@@ -239,7 +406,7 @@ func pollInput(done chan<- struct{}) {
 	}
 }
 
-func renderTable(requestCh <-chan topRequest, done <-chan struct{}, withSource bool) {
+func renderTable(requestCh <-chan topRequest, done <-chan struct{}) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	var table []tableRow
 
@@ -248,18 +415,23 @@ func renderTable(requestCh <-chan topRequest, done <-chan struct{}, withSource b
 		case <-done:
 			return
 		case req := <-requestCh:
-			tableInsert(&table, req, withSource)
+			tableInsert(&table, req)
 		case <-ticker.C:
 			termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-			renderHeaders(withSource)
-			renderTableBody(&table, withSource)
+			adjustColumnWidths(&table)
+			renderHeaders()
+			renderTableBody(&table)
 			termbox.Flush()
 		}
 	}
 }
 
-func tableInsert(table *[]tableRow, req topRequest, withSource bool) {
-	by := req.reqInit.GetPath()
+func newRow(req topRequest) (tableRow, error) {
+	path := req.reqInit.GetPath()
+	route := req.event.GetRouteMeta().GetLabels()["route"]
+	if route == "" {
+		route = defaultRoute
+	}
 	method := req.reqInit.GetMethod().GetRegistered().String()
 	source := stripPort(addr.PublicAddressToString(req.event.GetSource()))
 	if pod := req.event.SourceMeta.Labels["pod"]; pod != "" {
@@ -272,9 +444,10 @@ func tableInsert(table *[]tableRow, req topRequest, withSource bool) {
 
 	latency, err := ptypes.Duration(req.rspEnd.GetSinceRequestInit())
 	if err != nil {
-		log.Errorf("error parsing duration %v: %s", req.rspEnd.GetSinceRequestInit(), err)
-		return
+		return tableRow{}, fmt.Errorf("error parsing duration %v: %s", req.rspEnd.GetSinceRequestInit(), err)
 	}
+	// TODO: Once tap events have a classification field, we should use that field
+	// instead of determining success here.
 	success := req.rspInit.GetHttpStatus() < 500
 	if success {
 		switch eos := req.rspEnd.GetEos().GetEnd().(type) {
@@ -286,47 +459,57 @@ func tableInsert(table *[]tableRow, req topRequest, withSource bool) {
 		}
 	}
 
-	found := false
-	for i, row := range *table {
-		if row.by == by && row.method == method && row.destination == destination && (row.source == source || !withSource) {
-			(*table)[i].count++
-			if latency.Nanoseconds() < row.best.Nanoseconds() {
-				(*table)[i].best = latency
-			}
-			if latency.Nanoseconds() > row.worst.Nanoseconds() {
-				(*table)[i].worst = latency
-			}
-			(*table)[i].last = latency
-			if success {
-				(*table)[i].successes++
-			} else {
-				(*table)[i].failures++
-			}
-			found = true
-		}
+	successes := 0
+	failures := 0
+	if success {
+		successes++
+	} else {
+		failures++
 	}
 
+	return tableRow{
+		path:        path,
+		method:      method,
+		route:       route,
+		source:      source,
+		destination: destination,
+		best:        latency,
+		worst:       latency,
+		last:        latency,
+		count:       1,
+		successes:   successes,
+		failures:    failures,
+	}, nil
+}
+
+func tableInsert(table *[]tableRow, req topRequest) {
+	insert, err := newRow(req)
+	if err != nil {
+		log.Error(err.Error())
+		return
+	}
+
+	found := false
+	// Search for a matching row
+	for i, row := range *table {
+		match := true
+		// If the rows have equal values in all of the key columns, merge them.
+		for _, col := range columns {
+			if col.key {
+				if col.value(row) != col.value(insert) {
+					match = false
+					break
+				}
+			}
+		}
+		if match {
+			found = true
+			(*table)[i] = row.merge(insert)
+			break
+		}
+	}
 	if !found {
-		successes := 0
-		failures := 0
-		if success {
-			successes++
-		} else {
-			failures++
-		}
-		row := tableRow{
-			by:          by,
-			method:      method,
-			source:      source,
-			destination: destination,
-			count:       1,
-			best:        latency,
-			worst:       latency,
-			last:        latency,
-			successes:   successes,
-			failures:    failures,
-		}
-		*table = append(*table, row)
+		*table = append(*table, insert)
 	}
 }
 
@@ -334,17 +517,19 @@ func stripPort(address string) string {
 	return strings.Split(address, ":")[0]
 }
 
-func renderHeaders(withSource bool) {
+func renderHeaders() {
 	tbprint(0, 0, "(press q to quit)")
 	x := 0
-	for i, header := range columnNames {
-		if i == 0 && !withSource {
+	for _, col := range columns {
+		if !col.display {
 			continue
 		}
-		width := columnWidths[i]
-		padded := fmt.Sprintf("%-"+strconv.Itoa(width)+"s ", header)
-		tbprintBold(x, 2, padded)
-		x += width + 1
+		padding := 0
+		if col.rightAlign {
+			padding = col.width - runewidth.StringWidth(col.header)
+		}
+		tbprintBold(x+padding, headerHeight-1, col.header)
+		x += col.width + columnSpacing
 	}
 }
 
@@ -355,39 +540,41 @@ func max(i, j int) int {
 	return j
 }
 
-func renderTableBody(table *[]tableRow, withSource bool) {
+func adjustColumnWidths(table *[]tableRow) {
+	for i, col := range columns {
+		if !col.flexible {
+			continue
+		}
+		columns[i].width = runewidth.StringWidth(col.header)
+		for _, row := range *table {
+			cellWidth := runewidth.StringWidth(col.value(row))
+			if cellWidth > columns[i].width {
+				columns[i].width = cellWidth
+			}
+		}
+	}
+}
+
+func renderTableBody(table *[]tableRow) {
 	sort.SliceStable(*table, func(i, j int) bool {
 		return (*table)[i].count > (*table)[j].count
 	})
-	adjustedColumnWidths := columnWidths
-	for _, row := range *table {
-		adjustedColumnWidths[0] = max(adjustedColumnWidths[0], runewidth.StringWidth(row.source))
-		adjustedColumnWidths[1] = max(adjustedColumnWidths[1], runewidth.StringWidth(row.destination))
-		adjustedColumnWidths[3] = max(adjustedColumnWidths[3], runewidth.StringWidth(row.by))
 
-	}
 	for i, row := range *table {
 		x := 0
-		if withSource {
-			tbprint(x, i+headerHeight, row.source)
-			x += adjustedColumnWidths[0] + 1
+
+		for _, col := range columns {
+			if !col.display {
+				continue
+			}
+			value := col.value(row)
+			padding := 0
+			if col.rightAlign {
+				padding = col.width - runewidth.StringWidth(value)
+			}
+			tbprint(x+padding, i+headerHeight, value)
+			x += col.width + columnSpacing
 		}
-		tbprint(x, i+headerHeight, row.destination)
-		x += adjustedColumnWidths[1] + 1
-		tbprint(x, i+headerHeight, row.method)
-		x += adjustedColumnWidths[2] + 1
-		tbprint(x, i+headerHeight, row.by)
-		x += adjustedColumnWidths[3] + 1
-		tbprint(x, i+headerHeight, strconv.Itoa(row.count))
-		x += adjustedColumnWidths[4] + 1
-		tbprint(x, i+headerHeight, formatDuration(row.best))
-		x += adjustedColumnWidths[5] + 1
-		tbprint(x, i+headerHeight, formatDuration(row.worst))
-		x += adjustedColumnWidths[6] + 1
-		tbprint(x, i+headerHeight, formatDuration(row.last))
-		x += adjustedColumnWidths[7] + 1
-		successRate := fmt.Sprintf("%.2f%%", 100.0*float32(row.successes)/float32(row.successes+row.failures))
-		tbprint(x, i+headerHeight, successRate)
 	}
 }
 


### PR DESCRIPTION
Add a `--routes` flag to the `top` command which show requests by route instead of by path.  

This also includes an overhaul of the live table rendering code to be more flexible and better accommodate the various combinations of columns that may be visible or hidden.

Signed-off-by: Alex Leong <alex@buoyant.io>