### PR TITLE
Controller: wait for caches to sync before opening listeners

### DIFF
--- a/controller/api/proxy/endpoints_watcher_test.go
+++ b/controller/api/proxy/endpoints_watcher_test.go
@@ -267,7 +267,7 @@ spec:
 
 			watcher := newEndpointsWatcher(k8sAPI)
 
-			k8sAPI.Sync(nil)
+			k8sAPI.Sync()
 
 			listener, cancelFn := newCollectUpdateListener()
 			defer cancelFn()

--- a/controller/api/proxy/profile_watcher_test.go
+++ b/controller/api/proxy/profile_watcher_test.go
@@ -73,7 +73,7 @@ spec:
 
 			watcher := newProfileWatcher(k8sAPI)
 
-			k8sAPI.Sync(nil)
+			k8sAPI.Sync()
 
 			listener, cancelFn := newCollectProfileListener()
 			defer cancelFn()

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -174,7 +174,7 @@ spec:
 				[]string{},
 			)
 
-			k8sAPI.Sync(nil)
+			k8sAPI.Sync()
 
 			rsp, err := fakeGrpcServer.ListPods(context.TODO(), &pb.ListPodsRequest{})
 			if err != exp.err {
@@ -255,7 +255,7 @@ metadata:
 				[]string{},
 			)
 
-			k8sAPI.Sync(nil)
+			k8sAPI.Sync()
 
 			rsp, err := fakeGrpcServer.ListServices(context.TODO(), &pb.ListServicesRequest{})
 			if err != exp.err {

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -242,7 +242,7 @@ func newMockGrpcServer(exp expectedStatRpc) (*MockProm, *grpcServer, error) {
 		[]string{},
 	)
 
-	k8sAPI.Sync(nil)
+	k8sAPI.Sync()
 
 	return mockProm, fakeGrpcServer, nil
 }

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -67,11 +67,9 @@ func NewCertificateController(controllerNamespace string, k8sAPI *k8s.API, proxy
 	return c, nil
 }
 
-func (c *CertificateController) Run(readyCh <-chan struct{}, stopCh <-chan struct{}) {
+func (c *CertificateController) Run(stopCh <-chan struct{}) {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
-
-	<-readyCh
 
 	log.Info("starting certificate controller")
 	defer log.Info("shutting down certificate controller")

--- a/controller/ca/controller_test.go
+++ b/controller/ca/controller_test.go
@@ -79,12 +79,10 @@ func new(fixtures ...string) (*CertificateController, chan bool, chan struct{}, 
 		return err
 	}
 
-	controller.k8sAPI.Sync(nil)
+	controller.k8sAPI.Sync()
 
 	stopCh := make(chan struct{})
-	ready := make(chan struct{})
-	close(ready)
-	go controller.Run(ready, stopCh)
+	go controller.Run(stopCh)
 
 	return controller, synced, stopCh, nil
 }

--- a/controller/cmd/ca/main.go
+++ b/controller/cmd/ca/main.go
@@ -47,16 +47,15 @@ func main() {
 	}
 
 	stopCh := make(chan struct{})
-	ready := make(chan struct{})
 
-	go k8sAPI.Sync(ready)
+	k8sAPI.Sync() // blocks until caches are synced
 
 	go func() {
 		log.Info("starting CA")
-		controller.Run(ready, stopCh)
+		controller.Run(stopCh)
 	}()
 
-	go admin.StartServer(*metricsAddr, ready)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -52,21 +52,20 @@ func main() {
 	)
 
 	done := make(chan struct{})
-	ready := make(chan struct{})
 
 	server, lis, err := proxy.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, k8sAPI, done)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	go k8sAPI.Sync(ready)
+	k8sAPI.Sync() // blocks until caches are synced
 
 	go func() {
 		log.Infof("starting gRPC server on %s", *addr)
 		server.Serve(lis)
 	}()
 
-	go admin.StartServer(*metricsAddr, ready)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -80,7 +80,7 @@ func main() {
 			log.Fatal(err)
 		}
 	}()
-	go admin.StartServer(*metricsAddr, nil)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 	log.Info("shutting down webhook server")

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -70,16 +70,14 @@ func main() {
 		strings.Split(*ignoredNamespaces, ","),
 	)
 
-	ready := make(chan struct{})
-
-	go k8sAPI.Sync(ready)
+	k8sAPI.Sync() // blocks until caches are synced
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)
 		server.ListenAndServe()
 	}()
 
-	go admin.StartServer(*metricsAddr, ready)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -49,16 +49,14 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	ready := make(chan struct{})
-
-	go k8sAPI.Sync(ready)
+	k8sAPI.Sync() // blocks until caches are synced
 
 	go func() {
 		log.Println("starting gRPC server on", *addr)
 		server.Serve(lis)
 	}()
 
-	go admin.StartServer(*metricsAddr, ready)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -126,9 +126,7 @@ func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, namespa
 }
 
 // Sync waits for all informers to be synced.
-// For servers, call this asynchronously.
-// For testing, call this synchronously.
-func (api *API) Sync(readyCh chan<- struct{}) {
+func (api *API) Sync() {
 	api.sharedInformers.Start(nil)
 	api.spSharedInformers.Start(nil)
 
@@ -140,10 +138,6 @@ func (api *API) Sync(readyCh chan<- struct{}) {
 		log.Fatal("failed to sync caches")
 	}
 	log.Infof("caches synced")
-
-	if readyCh != nil {
-		close(readyCh)
-	}
 }
 
 func (api *API) Deploy() appinformers.DeploymentInformer {

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -35,7 +35,7 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 		return nil, nil, fmt.Errorf("NewFakeAPI returned an error: %s", err)
 	}
 
-	api.Sync(nil)
+	api.Sync()
 
 	return api, k8sResults, nil
 }

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -197,7 +197,7 @@ status:
 			go func() { server.Serve(listener) }()
 			defer server.GracefulStop()
 
-			k8sAPI.Sync(nil)
+			k8sAPI.Sync()
 
 			client, conn, err := NewClient(listener.Addr().String())
 			if err != nil {

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -11,23 +10,13 @@ import (
 
 type handler struct {
 	promHandler http.Handler
-	ready       bool
-	sync.RWMutex
 }
 
-func StartServer(addr string, readyCh <-chan struct{}) {
+func StartServer(addr string) {
 	log.Infof("starting admin server on %s", addr)
 
 	h := &handler{
 		promHandler: promhttp.Handler(),
-		ready:       readyCh == nil,
-	}
-
-	if readyCh != nil {
-		go func() {
-			<-readyCh
-			h.setReady(true)
-		}()
 	}
 
 	s := &http.Server{
@@ -58,21 +47,5 @@ func (h *handler) servePing(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *handler) serveReady(w http.ResponseWriter, req *http.Request) {
-	if h.getReady() {
-		w.Write([]byte("ok\n"))
-	} else {
-		http.Error(w, "unready", http.StatusServiceUnavailable)
-	}
-}
-
-func (h *handler) getReady() bool {
-	h.RLock()
-	defer h.RUnlock()
-	return h.ready
-}
-
-func (h *handler) setReady(ready bool) {
-	h.Lock()
-	defer h.Unlock()
-	h.ready = ready
+	w.Write([]byte("ok\n"))
 }

--- a/web/main.go
+++ b/web/main.go
@@ -47,7 +47,7 @@ func main() {
 		server.ListenAndServe()
 	}()
 
-	go admin.StartServer(*metricsAddr, nil)
+	go admin.StartServer(*metricsAddr)
 
 	<-stop
 


### PR DESCRIPTION
This branch updates our controller components to block their main thread until caches have fully synced with Kubernetes, before opening up their listeners. This will make them unable to serve any requests until caches are fully synced, and it should hopefully prevent issues like the one described in #1659.