### PR TITLE
Miscellaneous improvements to the Top Routes UX

### DIFF
--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -94,7 +94,8 @@ class BaseTable extends React.Component {
       );
     }
 
-    return _.isNil(col.tooltip) ? tableCell : <Tooltip key={col.key || col.dataIndex} placement="top" title={col.tooltip}>{tableCell}</Tooltip>;
+    return _.isNil(col.tooltip) ? tableCell :
+    <Tooltip key={col.key || col.dataIndex} placement="top" title={col.tooltip}>{tableCell}</Tooltip>;
   }
 
   render() {
@@ -118,14 +119,19 @@ class BaseTable extends React.Component {
               let key = !rowKey ? d.key : rowKey(d);
               return (
                 <TableRow key={key}>
-                  { _.map(tableColumns, c => (
-                    <TableCell
-                      className={classNames({[classes.denseTable]: padding === 'dense'})}
-                      key={`table-${key}-${c.key || c.dataIndex}`}
-                      numeric={c.isNumeric}>
-                      {c.render ? c.render(d) : _.get(d, c.dataIndex)}
-                    </TableCell>
-                  ))}
+                  { _.map(tableColumns, c => {
+                    let tableCell = (
+                      <TableCell
+                        className={classNames({[classes.denseTable]: padding === 'dense'})}
+                        key={`table-${key}-${c.key || c.dataIndex}`}
+                        numeric={c.isNumeric}>
+                        {c.render ? c.render(d) : _.get(d, c.dataIndex)}
+                      </TableCell>
+                    );
+
+                    return _.isNil(d.tooltip) ? tableCell :
+                    <Tooltip key={`table-${key}-${c.key || c.dataIndex}`} placement="right" title={d.tooltip}>{tableCell}</Tooltip>;
+                  })}
                 </TableRow>
               );
             })}

--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -117,24 +117,23 @@ class BaseTable extends React.Component {
             {
               _.map(sortedTableRows, d => {
               let key = !rowKey ? d.key : rowKey(d);
-              return (
+              let tableRow = (
                 <TableRow key={key}>
-                  { _.map(tableColumns, c => {
-                    let tableCell = (
-                      <TableCell
-                        className={classNames({[classes.denseTable]: padding === 'dense'})}
-                        key={`table-${key}-${c.key || c.dataIndex}`}
-                        numeric={c.isNumeric}>
-                        {c.render ? c.render(d) : _.get(d, c.dataIndex)}
-                      </TableCell>
-                    );
-
-                    return _.isNil(d.tooltip) ? tableCell :
-                    <Tooltip key={`table-${key}-${c.key || c.dataIndex}`} placement="right" title={d.tooltip}>{tableCell}</Tooltip>;
-                  })}
+                  { _.map(tableColumns, c => (
+                    <TableCell
+                      className={classNames({[classes.denseTable]: padding === 'dense'})}
+                      key={`table-${key}-${c.key || c.dataIndex}`}
+                      numeric={c.isNumeric}>
+                      {c.render ? c.render(d) : _.get(d, c.dataIndex)}
+                    </TableCell>
+                    )
+                  )}
                 </TableRow>
               );
-            })}
+              return _.isNil(d.tooltip) ? tableRow :
+              <Tooltip key={`table-row-${key}`} placement="left" title={d.tooltip}>{tableRow}</Tooltip>;
+              }
+            )}
           </TableBody>
         </Table>
       </Paper>

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -82,10 +82,12 @@ class TopRoutes extends React.Component {
   }
 
   componentDidMount() {
+    this._isMounted = true; // https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
     this.startServerPolling();
   }
 
   componentWillUnmount() {
+    this._isMounted = false;
     this.stopServerPolling();
   }
 
@@ -290,7 +292,7 @@ class TopRoutes extends React.Component {
           { this.renderRoutesQueryForm() }
           {  emptyQuery ? null :
           <QueryToCliCmd cmdName="routes" query={query} resource={query.resource_type + "/" + query.resource_name} /> }
-          { !this.state.requestInProgress ? null : <TopRoutesModule query={this.state.query} /> }
+          { !this.state.requestInProgress || !this._isMounted ? null : <TopRoutesModule query={this.state.query} /> }
         </Card>
       </div>
     );

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -25,9 +25,6 @@ const topRoutesQueryProps = {
   resource_name: PropTypes.string,
   resource_type: PropTypes.string,
   namespace: PropTypes.string,
-  from_name: PropTypes.string,
-  from_type: PropTypes.string,
-  from_namespace: PropTypes.string
 };
 const topRoutesQueryPropType = PropTypes.shape(topRoutesQueryProps);
 
@@ -57,9 +54,6 @@ class TopRoutes extends React.Component {
       resource_name: '',
       resource_type: '',
       namespace: '',
-      from_name: '',
-      from_type: '',
-      from_namespace: ''
     },
   }
 

--- a/web/app/js/components/TopRoutesModule.jsx
+++ b/web/app/js/components/TopRoutesModule.jsx
@@ -1,3 +1,5 @@
+import { DefaultRoute, processTopRoutesResults } from './util/MetricUtils.jsx';
+
 import ConfigureProfilesMsg from './ConfigureProfilesMsg.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import PropTypes from 'prop-types';
@@ -6,7 +8,6 @@ import Spinner from './util/Spinner.jsx';
 import TopRoutesTable from './TopRoutesTable.jsx';
 import _ from 'lodash';
 import { apiErrorPropType } from './util/ApiHelpers.jsx';
-import { processTopRoutesResults } from './util/MetricUtils.jsx';
 import withREST from './util/withREST.jsx';
 
 class TopRoutesBase extends React.Component {
@@ -41,7 +42,7 @@ class TopRoutesBase extends React.Component {
   render() {
     const {data, loading} = this.props;
     let metrics = processTopRoutesResults(_.get(data, '[0].routes.rows', []));
-    let allRoutesUnknown = _.every(metrics, m => m.route === "UNKNOWN");
+    let allRoutesUnknown = _.every(metrics, m => m.route === DefaultRoute);
     let showCallToAction = !loading &&  (_.isEmpty(metrics) || allRoutesUnknown);
 
     return (

--- a/web/app/js/components/TopRoutesTable.jsx
+++ b/web/app/js/components/TopRoutesTable.jsx
@@ -1,9 +1,9 @@
 import { metricToFormatter, numericSort } from './util/Utils.js';
 import BaseTable from './BaseTable.jsx';
+import { DefaultRoute } from './util/MetricUtils.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SuccessRateMiniChart from './util/SuccessRateMiniChart.jsx';
-import { DefaultRoute } from './util/MetricUtils.jsx';
 
 const routesColumns = [
   {

--- a/web/app/js/components/TopRoutesTable.jsx
+++ b/web/app/js/components/TopRoutesTable.jsx
@@ -3,12 +3,22 @@ import BaseTable from './BaseTable.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SuccessRateMiniChart from './util/SuccessRateMiniChart.jsx';
+import { DefaultRoute } from './util/MetricUtils.jsx';
 
 const routesColumns = [
   {
     title: "Route",
     dataIndex: "route",
-    sorter: (a, b) => (a.route).localeCompare(b.route)
+    sorter: (a, b) => {
+      if (a.route === DefaultRoute) {
+        return 1;
+      } else {
+        if (b.route === DefaultRoute) {
+          return -1;
+        }
+      }
+      return (a.route).localeCompare(b.route);
+    }
   },
   {
     title: "Authority",

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -156,9 +156,10 @@ const processStatTable = table => {
     .value();
 };
 
+export const DefaultRoute = "[default]";
 export const processTopRoutesResults = rows => {
   return _.map(rows, row => ({
-    route: row.route || "UNKNOWN",
+    route: row.route || DefaultRoute,
     authority: row.authority,
     totalRequests: getTotalRequests(row),
     requestRate: getRequestRate(row),

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -160,6 +160,7 @@ export const DefaultRoute = "[default]";
 export const processTopRoutesResults = rows => {
   return _.map(rows, row => ({
     route: row.route || DefaultRoute,
+    tooltip: !_.isEmpty(row.route) ? null : "Traffic does not match any configured routes",
     authority: row.authority,
     totalRequests: getTotalRequests(row),
     requestRate: getRequestRate(row),


### PR DESCRIPTION
- Renames UNKNOWN in the tables to (default) which is less scary (#1946)
- adds a tooltip explaining what (default) is
- adds url props to the Top Routes page, so that they query can be populated by a url
- fixes a js error that occurs when switching pages