### PR TITLE
Set proxy-injector resources at container level on install

### DIFF
--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -825,6 +825,12 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
+        {{- if .EnableHA }}
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+        {{- end }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:
@@ -835,12 +841,6 @@ spec:
       - name: proxy-spec
         configMap:
           name: linkerd-proxy-injector-sidecar-config
-      {{- if .EnableHA }}
-      resources:
-        requests:
-          cpu: 20m
-          memory: 50Mi
-      {{- end }}
 
 ---
 ### Proxy Injector Service Account ###


### PR DESCRIPTION
In the process of reviewing #1929, I realized that the project-injector deployment was setting its resource request at the pod level instead of the container level when the `--enable-ha` flag is specified. All of the other controller components set their resource requests at the container level, and it looks like our install command silently drops resource requests at the pod level. Am moving the proxy-injector resource requests to the container to fix.