### PR TITLE
Remove namespace definition from --single-namespace installs

### DIFF
--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -1,9 +1,3 @@
-### Namespace ###
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: Namespace
-
 ### Service Account Controller ###
 ---
 kind: ServiceAccount

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -1,7 +1,8 @@
 package install
 
 // Template provides the base template for the `linkerd install` command.
-const Template = `### Namespace ###
+const Template = `{{ if not .SingleNamespace -}}
+### Namespace ###
 kind: Namespace
 apiVersion: v1
 metadata:
@@ -11,6 +12,7 @@ metadata:
     {{.ProxyAutoInjectLabel}}: disabled
   {{- end }}
 
+{{ end -}}
 ### Service Account Controller ###
 ---
 kind: ServiceAccount


### PR DESCRIPTION
Users installing linkerd in single-namespace mode likely don't have cluster-wide permissions to create namespaces, so in this branch I'm removing the namespace definition from the `linkerd install --single-namespace` output, and I'm updating `linkerd check --single-namespace` to require that the namespace already exist, and not require that the user has permissions to create namespaces.

Fixes #1889.