### PR TITLE
Disable serivce profiles in single-namespace mode

### DIFF
--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -23,7 +23,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
@@ -371,6 +371,7 @@ spec:
         - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
+        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -23,7 +23,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
@@ -383,6 +383,7 @@ spec:
         - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
+        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -23,7 +23,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
@@ -383,6 +383,7 @@ spec:
         - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
+        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -25,7 +25,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
@@ -375,6 +375,7 @@ spec:
         - -api-addr=linkerd-controller-api.Namespace.svc.cluster.local:8085
         - -uuid=UUID
         - -controller-namespace=Namespace
+        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: WebImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -18,10 +18,7 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: ["linkerd.io"]
-  resources: ["serviceprofiles"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 
 ---
@@ -291,26 +288,6 @@ spec:
       serviceAccountName: linkerd-controller
 status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: serviceprofiles.linkerd.io
-  namespace: Namespace
-  annotations:
-    CreatedByAnnotation: CliVersion
-spec:
-  group: linkerd.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: serviceprofiles
-    singular: serviceprofile
-    kind: ServiceProfile
-    shortNames:
-    - sp
-
-### Service Account Web ###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -371,6 +348,7 @@ spec:
         - -api-addr=linkerd-controller-api.Namespace.svc.cluster.local:8085
         - -uuid=UUID
         - -controller-namespace=Namespace
+        - -single-namespace=true
         - -log-level=ControllerLogLevel
         image: WebImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -35,11 +35,13 @@ rules:
   resources: ["deployments", "replicasets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services", "namespaces", "replicationcontrollers"]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers"{{if not .SingleNamespace}}, "namespaces"{{end}}]
   verbs: ["list", "get", "watch"]
+{{- if not .SingleNamespace }}
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
   verbs: ["list", "get", "watch"]
+{{- end }}
 
 ---
 kind: {{if not .SingleNamespace}}Cluster{{end}}RoleBinding
@@ -255,6 +257,7 @@ spec:
         securityContext:
           runAsUser: {{.ControllerUID}}
 
+{{- if not .SingleNamespace }}
 ### Service Profile CRD ###
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -274,6 +277,7 @@ spec:
     kind: ServiceProfile
     shortNames:
     - sp
+{{- end }}
 
 ### Service Account Web ###
 ---
@@ -338,6 +342,7 @@ spec:
         - "-api-addr=linkerd-controller-api.{{.Namespace}}.svc.cluster.local:8085"
         - "-uuid={{.UUID}}"
         - "-controller-namespace={{.Namespace}}"
+        - "-single-namespace={{.SingleNamespace}}"
         - "-log-level={{.ControllerLogLevel}}"
         livenessProbe:
           httpGet:

--- a/controller/api/proxy/server_test.go
+++ b/controller/api/proxy/server_test.go
@@ -51,7 +51,7 @@ func TestBuildResolver(t *testing.T) {
 	t.Run("Doesn't build a resolver if Kubernetes DNS zone isnt valid", func(t *testing.T) {
 		invalidK8sDNSZones := []string{"1", "-a", "a-", "-"}
 		for _, dsnZone := range invalidK8sDNSZones {
-			resolver, err := buildResolver(dsnZone, "linkerd", k8sAPI)
+			resolver, err := buildResolver(dsnZone, "linkerd", k8sAPI, false)
 			if err == nil {
 				t.Fatalf("Expecting error when k8s zone is [%s], got nothing. Resolver: %v", dsnZone, resolver)
 			}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -280,13 +280,15 @@ func (hc *HealthChecker) addLinkerdPreInstallChecks() {
 		},
 	})
 
-	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdPreInstallCategory,
-		description: "can create CustomResourceDefinitions",
-		check: func() error {
-			return hc.checkCanCreate(hc.ControlPlaneNamespace, "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
-		},
-	})
+	if !hc.SingleNamespace {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdPreInstallCategory,
+			description: "can create CustomResourceDefinitions",
+			check: func() error {
+				return hc.checkCanCreate(hc.ControlPlaneNamespace, "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
+			},
+		})
+	}
 }
 
 func (hc *HealthChecker) addLinkerdAPIChecks() {
@@ -340,14 +342,16 @@ func (hc *HealthChecker) addLinkerdAPIChecks() {
 		},
 	})
 
-	hc.checkers = append(hc.checkers, &checker{
-		category:    LinkerdAPICategory,
-		description: "no invalid service profiles",
-		warning:     true,
-		check: func() error {
-			return hc.validateServiceProfiles()
-		},
-	})
+	if !hc.SingleNamespace {
+		hc.checkers = append(hc.checkers, &checker{
+			category:    LinkerdAPICategory,
+			description: "no invalid service profiles",
+			warning:     true,
+			check: func() error {
+				return hc.validateServiceProfiles()
+			},
+		})
+	}
 }
 
 func (hc *HealthChecker) addLinkerdDataPlaneChecks() {

--- a/web/app/js/components/ConfigureProfilesMsg.jsx
+++ b/web/app/js/components/ConfigureProfilesMsg.jsx
@@ -140,7 +140,9 @@ class ConfigureProfilesMsg extends React.Component {
   render() {
     const { showAsIcon } = this.props;
 
-    if (showAsIcon) {
+    if (this.props.singleNamespace === "true") {
+      return null;
+    } else if (showAsIcon) {
       return this.renderDownloadProfileForm();
     } else {
       return (
@@ -161,7 +163,8 @@ ConfigureProfilesMsg.propTypes = {
     prefixedUrl: PropTypes.func.isRequired,
   }).isRequired,
   classes: PropTypes.shape({}).isRequired,
-  showAsIcon: PropTypes.bool
+  showAsIcon: PropTypes.bool,
+  singleNamespace: PropTypes.string.isRequired,
 };
 
 ConfigureProfilesMsg.defaultProps = {

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -48,6 +48,7 @@ class TopRoutes extends React.Component {
     }).isRequired,
     classes: PropTypes.shape({}).isRequired,
     query: topRoutesQueryPropType,
+    singleNamespace: PropTypes.string.isRequired,
   }
   static defaultProps = {
     query: {
@@ -204,7 +205,8 @@ class TopRoutes extends React.Component {
           </Grid>
         </Grid>
         <Divider light className={classes.root} />
-        <Typography variant="caption">You can also create a new profile <ConfigureProfilesMsg showAsIcon={true} /></Typography>
+        {this.props.singleNamespace === "true" ? null :
+        <Typography variant="caption">You can also create a new profile <ConfigureProfilesMsg showAsIcon={true} /></Typography>}
       </CardContent>
     );
   }

--- a/web/main.go
+++ b/web/main.go
@@ -26,6 +26,7 @@ func main() {
 	reload := flag.Bool("reload", true, "reloading set to true or false")
 	webpackDevServer := flag.String("webpack-dev-server", "", "use webpack to serve static assets; frontend will use this instead of static-dir")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	flags.ConfigureAndParse()
 
 	_, _, err := net.SplitHostPort(*kubernetesApiHost) // Verify kubernetesApiHost is of the form host:port.
@@ -40,7 +41,7 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	server := srv.NewServer(*addr, *templateDir, *staticDir, *uuid, *controllerNamespace, *webpackDevServer, *reload, client)
+	server := srv.NewServer(*addr, *templateDir, *staticDir, *uuid, *controllerNamespace, *singleNamespace, *webpackDevServer, *reload, client)
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -24,6 +24,7 @@ type (
 		apiClient           pb.ApiClient
 		uuid                string
 		controllerNamespace string
+		singleNamespace     bool
 	}
 )
 
@@ -37,6 +38,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httpro
 	params := appParams{
 		UUID:                h.uuid,
 		ControllerNamespace: h.controllerNamespace,
+		SingleNamespace:     h.singleNamespace,
 		PathPrefix:          pathPfx,
 	}
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -40,6 +40,7 @@ type (
 		Data                pb.VersionInfo
 		UUID                string
 		ControllerNamespace string
+		SingleNamespace     bool
 		Error               bool
 		ErrorMessage        string
 		PathPrefix          string
@@ -51,7 +52,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
-func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackDevServer string, reload bool, apiClient pb.ApiClient) *http.Server {
+func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace string, singleNamespace bool, webpackDevServer string, reload bool, apiClient pb.ApiClient) *http.Server {
 	server := &Server{
 		templateDir:     templateDir,
 		staticDir:       staticDir,
@@ -72,6 +73,7 @@ func NewServer(addr, templateDir, staticDir, uuid, controllerNamespace, webpackD
 		serveFile:           server.serveFile,
 		uuid:                uuid,
 		controllerNamespace: controllerNamespace,
+		singleNamespace:     singleNamespace,
 	}
 
 	httpServer := &http.Server{

--- a/web/templates/app.tmpl.html
+++ b/web/templates/app.tmpl.html
@@ -3,6 +3,7 @@
     data-release-version="{{.Data.ReleaseVersion}}"
     data-go-version="{{.Data.GoVersion}}"
     data-controller-namespace="{{.ControllerNamespace}}"
+    data-single-namespace="{{.SingleNamespace}}"
     data-uuid="{{.UUID}}">
     {{ if .Error }}
       <p>Failed to call public API: {{ .ErrorMessage }}</p>


### PR DESCRIPTION
Service profiles are backed by a CRD, which requires cluster-wide permissions to create. Since users running in single-namespace mode don't have cluster-wide permissions, I'm disabling service profiles when linkerd is installed with the `--single-namespace` flag. This branch conditionally removes the CRD from the install YAML, adjusts RBAC permissions accordingly, modifies pre-flight permission checks to stop checking for permission to create CRDs, updates the destination service to not watch sp resources and to close `GetProfile` streams, and updates the web UI to not prompt users to create service profiles.

Fixes #1847.
Fixes #1890.