### PR TITLE
Update QueryToCliCmd to include non-default controller namespaces

### DIFF
--- a/web/app/js/components/QueryToCliCmd.jsx
+++ b/web/app/js/components/QueryToCliCmd.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import { displayOrder } from './util/CliQueryUtils.js';
+import { withContext } from './util/AppContext.jsx';
 
 const toCliParam = {
   "namespace": "--namespace",
@@ -25,9 +26,10 @@ const toCliParam = {
   prints a given linkerd api query in an equivalent CLI format, such that it
   could be pasted into a terminal
 */
-export default class QueryToCliCmd extends React.Component {
+class QueryToCliCmd extends React.Component {
   static propTypes = {
     cmdName: PropTypes.string.isRequired,
+    controllerNamespace: PropTypes.string.isRequired,
     query: PropTypes.shape({}).isRequired,
     resource: PropTypes.string.isRequired
   }
@@ -37,7 +39,7 @@ export default class QueryToCliCmd extends React.Component {
   }
 
   render = () => {
-    let { cmdName, query, resource } = this.props;
+    let { cmdName, query, resource, controllerNamespace } = this.props;
 
     return (
       _.isEmpty(resource) ? null :
@@ -51,8 +53,11 @@ export default class QueryToCliCmd extends React.Component {
           { _.map(displayOrder(cmdName, query), item => {
             return !toCliParam[item] ? null : this.renderCliItem(toCliParam[item], query[item]);
           })}
+          { controllerNamespace === "linkerd" ? null : ` --linkerd-namespace ${controllerNamespace}`}
         </code>
       </CardContent>
     );
   }
 }
+
+export default withContext(QueryToCliCmd);

--- a/web/app/js/components/QueryToCliCmd.test.jsx
+++ b/web/app/js/components/QueryToCliCmd.test.jsx
@@ -22,6 +22,25 @@ describe('QueryToCliCmd', () => {
     expect(component).toIncludeText("linkerd routes deploy/controller --namespace linkerd");
   });
 
+  it('shows the linkerd namespace if the controller is not in the default namespace', () => {
+    let query = {
+      "resource": "deploy/controller",
+      "namespace": "linkerd"
+    }
+
+    let component = mount(
+      <QueryToCliCmd
+        cmdName="routes"
+        query={query}
+        resource={query.resource}
+        controllerNamespace={"my-linkerd-ns"}
+        />
+    );
+
+    expect(component).toIncludeText("Current Routes query");
+    expect(component).toIncludeText("linkerd routes deploy/controller --namespace linkerd --linkerd-namespace my-linkerd-ns");
+  });
+
   it('does not render flags for items that are not populated in the query', () => {
     let query = {
       "resource": "deploy/controller",


### PR DESCRIPTION
Previously, the module assumed all `linkerd`s were in the linkerd namespace. Include the `--linkerd-namespace` flag in the query if linkerd is not in the default ns.