### PR TITLE
Re-add RBAC permission to access installed namespace in single ns mode

### DIFF
--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -20,6 +20,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["Namespace"]
+  verbs: ["list", "get", "watch"]
 
 ---
 kind: RoleBinding

--- a/cli/install/template.go
+++ b/cli/install/template.go
@@ -37,7 +37,12 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers"{{if not .SingleNamespace}}, "namespaces"{{end}}]
   verbs: ["list", "get", "watch"]
-{{- if not .SingleNamespace }}
+{{- if .SingleNamespace }}
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["{{.Namespace}}"]
+  verbs: ["list", "get", "watch"]
+{{- else }}
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]
   verbs: ["list", "get", "watch"]


### PR DESCRIPTION
In #1980 I pared-down the RBAC privileges for the controller running in single-namespace mode, and I removed the permission for the controller to read all namespaces in the cluster. It turns out the controller still needs to be able to read the namespace where it's installed, so I'm re-adding the RBAC permission to read namespaces in single-namespace mode, scoped to the namespace where the controller is installed.