### PR TITLE
proxy: bump version for TLS skipped ports fix

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-0065c13}"
+PROXY_VERSION="${PROXY_VERSION:-0a085f9}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
* 761a08e Make TLS accept logic compatible with disabled protocol
  detection (linkerd/linkerd2-proxy#158)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>