### PR TITLE
Start reducing webpack bundle size, fix minor bugs

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -24,21 +24,6 @@ a {
   }
 }
 
-/* Colored dot for indicating statuses */
-div.status-table-dot {
-  width: calc(2 * var(--base-width));
-  height: calc(2 * var(--base-width));
-  min-width: calc(2 * var(--base-width));
-  border-radius: 50%;
-}
-
-div.success-rate-dot {
-  width: calc(1 * var(--base-width));
-  height: calc(1 * var(--base-width));
-  min-width: calc(1 * var(--base-width));
-  border-radius: 50%;
-}
-
 .breadcrumb-link a {
   color: white;
 }
@@ -47,10 +32,9 @@ div.success-rate-dot {
   max-width: 250px;
   padding: 24px;
   font-size: 12px;
-
-  & .new-version-text {
-    margin-bottom: 12px;
-  }
+}
+.version .new-version-text {
+  margin-bottom: 12px;
 }
 
 div.octopus-graph-container {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,35 +1,32 @@
-import {
-  AppBar,
-  Collapse,
-  Divider,
-  Drawer,
-  IconButton,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  MenuItem,
-  MenuList,
-  Toolbar,
-  Typography
-} from '@material-ui/core';
 import { githubIcon, linkerdWordLogo, slackIcon } from './util/SvgWrappers.jsx';
-
+import AppBar from '@material-ui/core/AppBar';
 import BreadcrumbHeader from './BreadcrumbHeader.jsx';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import CloudQueueIcon from '@material-ui/icons/CloudQueue';
+import Collapse from '@material-ui/core/Collapse';
+import Divider from '@material-ui/core/Divider';
+import Drawer from '@material-ui/core/Drawer';
 import EmailIcon from '@material-ui/icons/Email';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import HomeIcon from '@material-ui/icons/Home';
 import Icon from '@material-ui/core/Icon';
+import IconButton from '@material-ui/core/IconButton';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
 import { Link } from 'react-router-dom';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
 import MenuIcon from '@material-ui/icons/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
 import NavigationResources from './NavigationResources.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
 import Version from './Version.jsx';
 import classNames from 'classnames';
 import { withContext } from './util/AppContext.jsx';

--- a/web/app/js/components/NavigationResource.jsx
+++ b/web/app/js/components/NavigationResource.jsx
@@ -1,13 +1,10 @@
-import {
-  Collapse,
-  ListItemIcon,
-  ListItemText,
-  MenuItem,
-  MenuList,
-} from '@material-ui/core';
-
+import Collapse from '@material-ui/core/Collapse';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import { Link } from 'react-router-dom';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/web/app/js/components/NavigationResources.jsx
+++ b/web/app/js/components/NavigationResources.jsx
@@ -1,14 +1,11 @@
-import {
-  Collapse,
-  ListItemIcon,
-  ListItemText,
-  MenuItem,
-  MenuList,
-} from '@material-ui/core';
 import { metricsPropType, processMultiResourceRollup } from './util/MetricUtils.jsx';
-
+import Collapse from '@material-ui/core/Collapse';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import MenuList from '@material-ui/core/MenuList';
 import NavigationResource from './NavigationResource.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -17,7 +14,6 @@ import _ from 'lodash';
 import { withContext } from './util/AppContext.jsx';
 import withREST from './util/withREST.jsx';
 import { withStyles } from '@material-ui/core/styles';
-
 
 const styles = () => ({
   navMenuItem: {

--- a/web/app/js/components/QueryToCliCmd.jsx
+++ b/web/app/js/components/QueryToCliCmd.jsx
@@ -1,10 +1,7 @@
-import {
-  CardContent,
-  Typography
-} from '@material-ui/core';
-
+import CardContent from '@material-ui/core/CardContent';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Typography from '@material-ui/core/Typography';
 import _ from 'lodash';
 import { displayOrder } from './util/CliQueryUtils.js';
 import { withContext } from './util/AppContext.jsx';

--- a/web/app/js/components/QueryToCliCmd.test.jsx
+++ b/web/app/js/components/QueryToCliCmd.test.jsx
@@ -15,7 +15,7 @@ describe('QueryToCliCmd', () => {
         cmdName="routes"
         query={query}
         resource={query.resource}
-        />
+        controllerNamespace="linkerd" />
     );
 
     expect(component).toIncludeText("Current Routes query");
@@ -33,8 +33,7 @@ describe('QueryToCliCmd', () => {
         cmdName="routes"
         query={query}
         resource={query.resource}
-        controllerNamespace={"my-linkerd-ns"}
-        />
+        controllerNamespace="my-linkerd-ns" />
     );
 
     expect(component).toIncludeText("Current Routes query");
@@ -54,7 +53,8 @@ describe('QueryToCliCmd', () => {
       <QueryToCliCmd
         cmdName="tap"
         query={query}
-        resource={query.resource} />
+        resource={query.resource}
+        controllerNamespace="linkerd" />
     );
 
     expect(component).toIncludeText("Current Tap query");
@@ -76,7 +76,7 @@ describe('QueryToCliCmd', () => {
         cmdName="tap"
         query={query}
         resource={query.resource}
-        />
+        controllerNamespace="linkerd" />
     );
 
     expect(component).toIncludeText("Current Tap query");
@@ -94,7 +94,7 @@ describe('QueryToCliCmd', () => {
         cmdName="top"
         query={query}
         resource={query.resource}
-        />
+        controllerNamespace="linkerd" />
     );
 
     expect(component).toIncludeText("Current Top query");
@@ -114,7 +114,7 @@ describe('QueryToCliCmd', () => {
           cmdName="tap"
           query={query}
           resource={query.resource}
-          />
+          controllerNamespace="linkerd" />
       );
 
       expect(component).toIncludeText("Current Tap query");

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -39,12 +39,12 @@ const getPodClassification = pod => {
 };
 
 const componentsToDeployNames = {
-  "Grafana" : "grafana",
-  "Prometheus": "prometheus",
-  "Proxy API": "controller",
-  "Public API": "controller",
-  "Tap": "controller",
-  "Web UI": "web"
+  "Grafana" : "linkerd-grafana",
+  "Prometheus": "linkerd-prometheus",
+  "Proxy API": "linkerd-controller",
+  "Public API": "linkerd-controller",
+  "Tap": "linkerd-controller",
+  "Web UI": "linkerd-web"
 };
 
 class ServiceMesh extends React.Component {

--- a/web/app/js/components/StatusTable.jsx
+++ b/web/app/js/components/StatusTable.jsx
@@ -7,7 +7,14 @@ import classNames from 'classnames';
 import { statusClassNames } from './util/theme.js';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => statusClassNames(theme);
+const styles = theme => _.merge({}, statusClassNames(theme), {
+  statusTableDot: {
+    width: 2 * theme.spacing.unit,
+    height: 2 * theme.spacing.unit,
+    minWidth: 2 * theme.spacing.unit,
+    borderRadius: "50%"
+  }
+});
 
 const columnConfig = {
   "Pod Status": {
@@ -45,7 +52,7 @@ const StatusDot = ({status, multilineDots, columnName, classes}) => (
     )}>
     <div
       className={classNames(
-        "status-table-dot",
+        classes.statusTableDot,
         classes[status.value],
         { "dot-multiline": multilineDots }
       )}

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -1,19 +1,3 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  FormControl,
-  FormHelperText,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
-  Typography
-} from '@material-ui/core';
 import { UrlQueryParamTypes, addUrlProps } from 'react-url-query';
 import {
   defaultMaxRps,
@@ -22,11 +6,24 @@ import {
   tapQueryPropType,
   tapQueryProps
 } from './util/TapUtils.jsx';
-
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import Grid from '@material-ui/core/Grid';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
 import PropTypes from 'prop-types';
 import QueryToCliCmd from './QueryToCliCmd.jsx';
 import React from 'react';
+import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
 import _ from 'lodash';
 import { withStyles } from '@material-ui/core/styles';
 

--- a/web/app/js/components/util/SuccessRateDot.jsx
+++ b/web/app/js/components/util/SuccessRateDot.jsx
@@ -1,18 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import _merge from 'lodash/merge';
 import classNames from 'classnames';
 import { getSuccessRateClassification } from './MetricUtils.jsx';
 import { statusClassNames } from './theme.js';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => statusClassNames(theme);
+const styles = theme => _merge({}, statusClassNames(theme), {
+  successRateDot: {
+    width: theme.spacing.unit,
+    height: theme.spacing.unit,
+    minWidth: theme.spacing.unit,
+    borderRadius: "50%"
+  }
+});
 
 class SuccessRateDot extends React.Component {
   render() {
     const { sr, classes } = this.props;
 
     return (
-      <div className={classNames("success-rate-dot", classes[getSuccessRateClassification(sr)])} />
+      <div className={classNames(classes.successRateDot, classes[getSuccessRateClassification(sr)])} />
     );
   }
 }

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "d3": "4.11.0",
     "lodash": "4.17.10",
     "moment": "2.22.2",
+    "moment-locales-webpack-plugin": "^1.0.7",
     "path": "0.12.7",
     "prop-types": "15.6.1",
     "react": "16.5.0",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -57,6 +57,7 @@
     "style-loader": "0.21.0",
     "url-loader": "1.0.1",
     "webpack": "4.20.2",
+    "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "3.0.7",
     "webpack-dev-server": "3.1.9"
   },

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -1,6 +1,7 @@
 /* global require, module, __dirname */
 
 const path = require('path');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -70,5 +71,6 @@ module.exports = {
         ]
       }
     ]
-  }
+  },
+  plugins: [new BundleAnalyzerPlugin()]
 }

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -1,8 +1,10 @@
 /* global require, module, __dirname */
 
 const path = require('path');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
+
+// uncomment here and in plugins to analyze bundle size
+// const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -74,7 +76,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new BundleAnalyzerPlugin(),
+    // new BundleAnalyzerPlugin(), // uncomment to analyze bundle size
     new MomentLocalesPlugin()
   ]
 }

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 
 module.exports = {
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
@@ -72,5 +73,8 @@ module.exports = {
       }
     ]
   },
-  plugins: [new BundleAnalyzerPlugin()]
+  plugins: [
+    new BundleAnalyzerPlugin(),
+    new MomentLocalesPlugin()
+  ]
 }

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -5951,6 +5951,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -6331,6 +6336,13 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment-locales-webpack-plugin@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.0.7.tgz#ce2931b8a25100dae0868adbd9e93972dcb33359"
+  integrity sha512-KjYpaAhmuzGFZl6534FlZoK7QtW3vqlxd+A17W9DlgHJ5yhXANy7AZJl7iYtZpWjAfMTAWiVrQ7YDZdkFO6uRw==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment@2.22.2:
   version "2.22.2"

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -417,7 +417,7 @@ acorn@^3.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
+acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2, acorn@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -1581,6 +1581,16 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bfj@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.1.tgz#05a3b7784fbd72cfa3c22e56002ef99336516c48"
+  integrity sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==
+  dependencies:
+    bluebird "^3.5.1"
+    check-types "^7.3.0"
+    hoopy "^0.1.2"
+    tryer "^1.0.0"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1951,6 +1961,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-types@^7.3.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
+  integrity sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -2179,7 +2194,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.11.0:
+commander@2, commander@^2.11.0, commander@^2.18.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -3221,6 +3236,11 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125"
@@ -3243,6 +3263,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+ejs@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
+  integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.79"
@@ -3727,7 +3752,7 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
-express@^4.16.2:
+express@^4.16.2, express@^4.16.3:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
@@ -3926,6 +3951,11 @@ fileset@^2.0.2:
   dependencies:
     glob "^7.0.3"
     minimatch "^3.0.3"
+
+filesize@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
+  integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
 
 fill-range@^2.1.0:
   version "2.2.4"
@@ -4255,6 +4285,14 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gzip-size@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
+  integrity sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^3.0.0"
+
 handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
@@ -4404,6 +4442,11 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+hoopy@^0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
+  integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -6724,6 +6767,11 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 opn@^5.1.0:
   version "5.4.0"
@@ -9264,6 +9312,11 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+tryer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+  integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -9596,6 +9649,24 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz#dbc7fff8f52058b6714a20fddf309d0790e3e0a0"
+  integrity sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==
+  dependencies:
+    acorn "^5.7.3"
+    bfj "^6.1.1"
+    chalk "^2.4.1"
+    commander "^2.18.0"
+    ejs "^2.6.1"
+    express "^4.16.3"
+    filesize "^3.6.1"
+    gzip-size "^5.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    opener "^1.5.1"
+    ws "^6.0.0"
+
 webpack-cli@3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.0.7.tgz#d4171aa6a52f28d3a40048db3d0764e1c601c029"
@@ -9830,6 +9901,13 @@ ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
+  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
- Adds bundle analyzer so we can see the composition of our bundle.
- Stop importing all the locales of moment.js
- Use named imports for all places we use material-ui components
- Fix a bug where, due to the controller components being relabled `linkerd-`, the service mesh page wasn't showing the correct statuses.
- Fixes some eslint warnings on tests

Next up will be fixing our lodash imports, and moving away from postcss

Running `NODE_ENV=production webpack -p --progress`:
bundle size (before):
index_bundle.js (1.42 MiB)

bundle size (after):
index_bundle.js (1.2 MiB)