### PR TITLE
Fix update neighbors function not being passed in to top module

### DIFF
--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -235,7 +235,7 @@ export class ResourceDetailBase extends React.Component {
         <TopRoutesTabs
           query={query}
           pathPrefix={this.props.pathPrefix}
-          updateNeighbors={this.updateNeighborsFromTapData}
+          updateNeighborsFromTapData={this.updateNeighborsFromTapData}
           disableTop={!this.state.resourceIsMeshed} />
 
 


### PR DESCRIPTION
I realized that at some point we stopped showing unmeshed upstreams in the octopus graph.
Turns out we were passing in the wrong prop name for the update function.

Before:
![screen shot 2018-12-19 at 3 10 58 pm](https://user-images.githubusercontent.com/549258/50253814-7428ea80-03a0-11e9-9fac-4d5c905ec40a.png)
![screen shot 2018-12-19 at 3 09 06 pm](https://user-images.githubusercontent.com/549258/50253815-7428ea80-03a0-11e9-8f80-b8b66418164f.png)


After:
![screen shot 2018-12-19 at 3 07 02 pm](https://user-images.githubusercontent.com/549258/50253819-7ab76200-03a0-11e9-816f-f5471069f22e.png)
![screen shot 2018-12-19 at 3 08 48 pm](https://user-images.githubusercontent.com/549258/50253818-7ab76200-03a0-11e9-895c-81748887d7fd.png)
