### PR TITLE
Bump pinned proxy version

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-0a085f9}"
+PROXY_VERSION="${PROXY_VERSION:-2f20505}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
Picking up the following changes:

```
2f20505 add Route retries to Service Profiles
6649630 Improve load balancer configuration (#167)
5b00bcf Update to latest tower and tower-grpc
efe5299 Makefile: Add missing fetch for test-flakey (#163)
9c0a949 Add clean target (#161)
792c04b Replace tower-h2 tap service with hyper
```

This branch successfully passed integration tests.

```
kl ~/workspace/linkerd2 (kl/bump-proxy) $ bin/test-run `pwd`/bin/linkerd kltest
Checking the linkerd binary...[ok]
Checking if there is a Kubernetes cluster available...[ok]
==================RUNNING ALL TESTS==================
Testing Linkerd version [dev-07cbfe27-kl] namespace [kltest]
Running test [install_test.go] 
=== RUN   TestVersionPreInstall
--- PASS: TestVersionPreInstall (0.09s)
=== RUN   TestCheckPreInstall
--- PASS: TestCheckPreInstall (0.13s)
=== RUN   TestInstall
--- PASS: TestInstall (45.13s)
=== RUN   TestVersionPostInstall
--- PASS: TestVersionPostInstall (0.10s)
=== RUN   TestCheckPostInstall
--- PASS: TestCheckPostInstall (0.38s)
=== RUN   TestDashboard
--- PASS: TestDashboard (0.60s)
=== RUN   TestInject
--- PASS: TestInject (19.65s)
=== RUN   TestCheckProxy
--- PASS: TestCheckProxy (0.39s)
PASS
ok  	command-line-arguments	66.594s
Running test [install_test.go] -enable-tls
=== RUN   TestVersionPreInstall
--- PASS: TestVersionPreInstall (0.10s)
=== RUN   TestCheckPreInstall
--- PASS: TestCheckPreInstall (0.13s)
=== RUN   TestInstall
--- PASS: TestInstall (50.35s)
=== RUN   TestVersionPostInstall
--- PASS: TestVersionPostInstall (0.09s)
=== RUN   TestCheckPostInstall
--- PASS: TestCheckPostInstall (0.18s)
=== RUN   TestDashboard
--- PASS: TestDashboard (0.64s)
=== RUN   TestInject
--- PASS: TestInject (20.11s)
=== RUN   TestCheckProxy
--- PASS: TestCheckProxy (0.27s)
PASS
ok  	command-line-arguments	71.965s
Running test [egress_test.go] 
=== RUN   TestEgressHttp
=== RUN   TestEgressHttp/Can_use_egress_to_send_GET_request_to_http_(egress-test-http-get-svc)
=== RUN   TestEgressHttp/Can_use_egress_to_send_POST_request_to_http_(egress-test-http-post-svc)
=== RUN   TestEgressHttp/Can_use_egress_to_send_GET_request_to_https_(egress-test-https-get-svc)
=== RUN   TestEgressHttp/Can_use_egress_to_send_POST_request_to_https_(egress-test-https-post-svc)
=== RUN   TestEgressHttp/Can_use_egress_to_send_GET_request_to_https_(egress-test-not-www-get-svc)
--- PASS: TestEgressHttp (23.76s)
    --- PASS: TestEgressHttp/Can_use_egress_to_send_GET_request_to_http_(egress-test-http-get-svc) (0.40s)
    --- PASS: TestEgressHttp/Can_use_egress_to_send_POST_request_to_http_(egress-test-http-post-svc) (0.27s)
    --- PASS: TestEgressHttp/Can_use_egress_to_send_GET_request_to_https_(egress-test-https-get-svc) (0.68s)
    --- PASS: TestEgressHttp/Can_use_egress_to_send_POST_request_to_https_(egress-test-https-post-svc) (0.45s)
    --- PASS: TestEgressHttp/Can_use_egress_to_send_GET_request_to_https_(egress-test-not-www-get-svc) (0.45s)
PASS
ok  	command-line-arguments	23.857s
Running test [get_test.go] 
=== RUN   TestCliGet
=== RUN   TestCliGet/get_pods_from_--all-namespaces
=== RUN   TestCliGet/get_pods_from_the_linkerd_namespace
--- PASS: TestCliGet (27.82s)
    --- PASS: TestCliGet/get_pods_from_--all-namespaces (0.22s)
    --- PASS: TestCliGet/get_pods_from_the_linkerd_namespace (0.18s)
PASS
ok  	command-line-arguments	27.963s
Running test [tap_test.go] 
=== RUN   TestCliTap
=== RUN   TestCliTap/tap_a_deployment
=== RUN   TestCliTap/tap_a_service_call
=== RUN   TestCliTap/tap_a_pod
=== RUN   TestCliTap/filter_tap_events_by_method
=== RUN   TestCliTap/filter_tap_events_by_authority
--- PASS: TestCliTap (47.07s)
    --- PASS: TestCliTap/tap_a_deployment (4.08s)
    --- PASS: TestCliTap/tap_a_service_call (4.18s)
    --- PASS: TestCliTap/tap_a_pod (3.81s)
    --- PASS: TestCliTap/filter_tap_events_by_method (4.19s)
    --- PASS: TestCliTap/filter_tap_events_by_authority (3.80s)
PASS
ok  	command-line-arguments	47.193s
Running test [stat_test.go] 
=== RUN   TestCliStatForLinkerdNamespace
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_po_-n_kltest_--from_deploy/linkerd-controller
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest_--to_po/linkerd-prometheus-766977646c-5ct9m
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_svc_-n_kltest_--from_deploy/linkerd-controller
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest_--to_svc/linkerd-prometheus
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_ns_kltest
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_po_-n_kltest_--to_au/linkerd-prometheus.kltest.svc.cluster.local:9090
=== RUN   TestCliStatForLinkerdNamespace/linkerd_stat_au_-n_kltest_--to_po/linkerd-prometheus-766977646c-5ct9m
--- PASS: TestCliStatForLinkerdNamespace (2.18s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest (0.31s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_po_-n_kltest_--from_deploy/linkerd-controller (0.17s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest_--to_po/linkerd-prometheus-766977646c-5ct9m (0.46s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_svc_-n_kltest_--from_deploy/linkerd-controller (0.21s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_deploy_-n_kltest_--to_svc/linkerd-prometheus (0.27s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_ns_kltest (0.24s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_po_-n_kltest_--to_au/linkerd-prometheus.kltest.svc.cluster.local:9090 (0.23s)
    --- PASS: TestCliStatForLinkerdNamespace/linkerd_stat_au_-n_kltest_--to_po/linkerd-prometheus-766977646c-5ct9m (0.22s)
PASS
ok  	command-line-arguments	2.329s

=== PASS: all tests passed
```