### PR TITLE
Add go linting to CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
         - ./bin/protoc-go.sh
         - go test -race -v ./...
         - go vet ./...
+        - ./bin/lint
 
     - language: node_js
       node_js:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,6 +445,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:053024e8981dab276218a180e58f97034d06e8c4dd2e24c9365ad489104e1d90"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = ""
+  revision = "8f45f776aaf18cebc8d65861cc70c33c60471952"
+
+[[projects]]
+  branch = "master"
   digest = "1:e8c91565d4707bd93aa70e096884ce533acc5deb2bbb500bb064f49de70acda0"
   name = "golang.org/x/net"
   packages = [
@@ -525,6 +536,9 @@
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
   ]
@@ -963,6 +977,7 @@
     "github.com/sergi/go-diff/diffmatchpatch",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
+    "golang.org/x/lint/golint",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,6 @@
 required = [
   "github.com/golang/protobuf/protoc-gen-go",
+  "golang.org/x/lint/golint",
   "k8s.io/code-generator/cmd/client-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",
   "k8s.io/code-generator/cmd/defaulter-gen",

--- a/TEST.md
+++ b/TEST.md
@@ -37,6 +37,12 @@ To analyze the Go code without running tests, run:
 go vet ./...
 ```
 
+To lint the Go code using golint, run:
+
+```bash
+bin/lint
+```
+
 ## Javascript
 
 Javascript dependencies are managed via [yarn](https://yarnpkg.com/) and

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+cd "$(pwd -P)"
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+cd "$rootdir"
+
+# install golint from vendor
+go install ./vendor/golang.org/x/lint/golint
+
+# use `go list` to exclude packages in vendor, ignore uncommented warnings
+out=$(go list ./... | xargs golint | grep -v 'should have comment') || true
+
+if [ -n "$out" ]; then
+  echo "$out"
+  exit 1
+fi
+
+echo "all clean!"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:cd57a76a as golang
+FROM gcr.io/linkerd-io/go-deps:4b31aa9b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:cd57a76a as golang
+FROM gcr.io/linkerd-io/go-deps:4b31aa9b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/proxy/server.go
+++ b/controller/api/proxy/server.go
@@ -20,7 +20,9 @@ type server struct {
 	enableTLS       bool
 }
 
-// The proxy-api service serves service discovery and other information to the
+// NewServer returns a new instance of the proxy-api server.
+//
+// The proxy-api server serves service discovery and other information to the
 // proxy.  This implementation supports the "k8s" destination scheme and expects
 // destination paths to be of the form:
 // <service>.<namespace>.svc.cluster.local:<port>

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -122,7 +122,6 @@ type PodCounts struct {
 	FailedPods  uint64
 }
 
-// satisfies v1.API
 func (m *MockProm) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
 	m.rwLock.Lock()
 	defer m.rwLock.Unlock()

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -48,8 +48,8 @@ var (
 	}
 )
 
-// Parameters that are used to build requests for metrics data.  This includes
-// requests to StatSummary and TopRoutes
+// StatsBaseRequestParams contains parameters that are used to build requests
+// for metrics data.  This includes requests to StatSummary and TopRoutes
 type StatsBaseRequestParams struct {
 	TimeWindow    string
 	Namespace     string

--- a/controller/ca/ca.go
+++ b/controller/ca/ca.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// CA provides a certificate authority for TLS-enabled installs.
 // Issuing certificates concurrently is not supported.
 type CA struct {
 	// validity is the duration for which issued certificates are valid. This
@@ -104,7 +105,7 @@ func NewCA() (*CA, error) {
 	return &ca, nil
 }
 
-// TrustAnchorDER returns the PEM-encoded X.509 certificate of the trust anchor
+// TrustAnchorPEM returns the PEM-encoded X.509 certificate of the trust anchor
 // (root CA).
 func (ca *CA) TrustAnchorPEM() string {
 	return ca.rootPEM

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -62,7 +62,7 @@ type Range struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MyResourceList is a list of MyResource resources
+// ServiceProfileList is a list of ServiceProfile resources
 type ServiceProfileList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -6,6 +6,7 @@ import (
 	httpPb "github.com/linkerd/linkerd2-proxy-api/go/http_types"
 )
 
+// ParseScheme converts a scheme string to protobuf
 // TODO: validate scheme
 func ParseScheme(scheme string) *httpPb.Scheme {
 	value, ok := httpPb.Scheme_Registered_value[strings.ToUpper(scheme)]
@@ -23,6 +24,7 @@ func ParseScheme(scheme string) *httpPb.Scheme {
 	}
 }
 
+// ParseMethod converts a method string to protobuf
 // TODO: validate method
 func ParseMethod(method string) *httpPb.HttpMethod {
 	value, ok := httpPb.HttpMethod_Registered_value[strings.ToUpper(method)]

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:cd57a76a as golang
+FROM gcr.io/linkerd-io/go-deps:4b31aa9b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:cd57a76a as golang
+FROM gcr.io/linkerd-io/go-deps:4b31aa9b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
This branch starts running [golint](https://github.com/golang/lint) on every CI build. I'm expecting this PR to fail CI with 8 lint warning, which I'll clean up in a subsequent commit. This is a follow-up to #1982.