### PR TITLE
Fix reporting of injected resources

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	k8sMeta "k8s.io/apimachinery/pkg/api/meta"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
@@ -574,8 +574,9 @@ func injectResource(bytes []byte, options *injectOptions) ([]byte, []injectRepor
 		return injectList(bytes, options)
 	}
 
-	report := injectReport{}
-	report.name = fmt.Sprintf("%s/%s", strings.ToLower(meta.Kind), om.Name)
+	report := injectReport{
+		name: fmt.Sprintf("%s/%s", strings.ToLower(meta.Kind), om.Name),
+	}
 
 	// If we don't inject anything into the pod template then output the
 	// original serialization of the original object. Otherwise, output the

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -105,6 +105,106 @@ items:
             runAsUser: 0
           terminationMessagePolicy: FallbackToLogsOnError
   status: {}
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: emoji
+    namespace: emojivoto
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: emoji-svc
+    strategy: {}
+    template:
+      metadata:
+        annotations:
+          linkerd.io/created-by: linkerd/cli undefined
+          linkerd.io/proxy-version: testinjectversion
+        creationTimestamp: null
+        labels:
+          app: emoji-svc
+          linkerd.io/control-plane-ns: linkerd
+          linkerd.io/proxy-deployment: emoji
+      spec:
+        containers:
+        - env:
+          - name: GRPC_PORT
+            value: "8080"
+          image: buoyantio/emojivoto-emoji-svc:v3
+          name: emoji-svc
+          ports:
+          - containerPort: 8080
+            name: grpc
+            protocol: TCP
+          resources: {}
+        - env:
+          - name: LINKERD2_PROXY_LOG
+            value: warn,linkerd2_proxy=info
+          - name: LINKERD2_PROXY_BIND_TIMEOUT
+            value: 10s
+          - name: LINKERD2_PROXY_CONTROL_URL
+            value: tcp://linkerd-proxy-api.linkerd.svc.cluster.local:8086
+          - name: LINKERD2_PROXY_CONTROL_LISTENER
+            value: tcp://0.0.0.0:4190
+          - name: LINKERD2_PROXY_METRICS_LISTENER
+            value: tcp://0.0.0.0:4191
+          - name: LINKERD2_PROXY_OUTBOUND_LISTENER
+            value: tcp://127.0.0.1:4140
+          - name: LINKERD2_PROXY_INBOUND_LISTENER
+            value: tcp://0.0.0.0:4143
+          - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+            value: .
+          - name: LINKERD2_PROXY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: gcr.io/linkerd-io/proxy:testinjectversion
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 4191
+            initialDelaySeconds: 10
+          name: linkerd-proxy
+          ports:
+          - containerPort: 4143
+            name: linkerd-proxy
+          - containerPort: 4191
+            name: linkerd-metrics
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 4191
+            initialDelaySeconds: 10
+          resources: {}
+          securityContext:
+            runAsUser: 2102
+          terminationMessagePolicy: FallbackToLogsOnError
+        initContainers:
+        - args:
+          - --incoming-proxy-port
+          - "4143"
+          - --outgoing-proxy-port
+          - "4140"
+          - --proxy-uid
+          - "2102"
+          - --inbound-ports-to-ignore
+          - 4190,4191
+          image: gcr.io/linkerd-io/proxy-init:testinjectversion
+          imagePullPolicy: IfNotPresent
+          name: linkerd-init
+          resources: {}
+          securityContext:
+            capabilities:
+              add:
+              - NET_ADMIN
+            privileged: false
+            runAsNonRoot: false
+            runAsUser: 0
+          terminationMessagePolicy: FallbackToLogsOnError
+  status: {}
 kind: List
 metadata: {}
 ---

--- a/cli/cmd/testdata/inject_emojivoto_list.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.input.yml
@@ -36,5 +36,35 @@ items:
               name: http
             resources: {}
     status: {}
+  - apiVersion: apps/v1beta1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      name: emoji
+      namespace: emojivoto
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: emoji-svc
+      strategy: {}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: emoji-svc
+        spec:
+          containers:
+          - env:
+            - name: GRPC_PORT
+              value: "8080"
+            image: buoyantio/emojivoto-emoji-svc:v3
+            name: emoji-svc
+            ports:
+            - containerPort: 8080
+              name: grpc
+              protocol: TCP
+            resources: {}
+    status: {}
 kind: List
 metadata: {}

--- a/cli/cmd/testdata/inject_emojivoto_list.report
+++ b/cli/cmd/testdata/inject_emojivoto_list.report
@@ -4,6 +4,7 @@ sidecar: pods do not have a proxy or initContainer already injected........[ok]
 supported: at least one resource injected..................................[ok]
 udp: pod specs do not include UDP ports....................................[ok]
 
-Summary: 1 of 1 YAML document(s) injected
+Summary: 2 of 2 YAML document(s) injected
   deployment/web
+  deployment/emoji
 


### PR DESCRIPTION
When reporting resources provided as a list, it was picking just one
item from the list and ignoring the rest.

Fixes #1676

Signed-off-by: Alejandro Pedraza <alejandro.pedraza@gmail.com>