### PR TITLE
Reduce webpack bundle size: remove react prop types in production builds

### DIFF
--- a/web/app/.babelrc
+++ b/web/app/.babelrc
@@ -1,5 +1,8 @@
 {
-  "presets": [
-    "env", "react-app"
-  ]
+  "env": {
+    "production": {
+      "plugins": ["transform-react-remove-prop-types"]
+    }
+  },
+  "presets": ["react-app"]
 }

--- a/web/app/js/components/NetworkGraph.jsx
+++ b/web/app/js/components/NetworkGraph.jsx
@@ -1,6 +1,6 @@
 import 'whatwg-fetch';
-import { attr, call, select, selectAll } from 'd3-selection';
 import { forceCenter, forceLink, forceManyBody, forceSimulation } from 'd3-force';
+import { select, selectAll } from 'd3-selection';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _get from 'lodash/get';
@@ -17,8 +17,6 @@ import withREST from './util/withREST.jsx';
 const d3 = Object.assign(
   {},
   {
-    attr,
-    call,
     drag,
     forceCenter,
     forceLink,

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@material-ui/core": "3.6.1",
     "@material-ui/icons": "3.0.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "classnames": "2.2.6",
     "d3-drag": "^1.2.3",
     "d3-force": "^2.0.0",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@material-ui/core": "3.6.1",
     "@material-ui/icons": "3.0.1",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "classnames": "2.2.6",
     "d3-drag": "^1.2.3",
     "d3-force": "^2.0.0",
@@ -30,6 +29,7 @@
     "babel-jest": "23.6.0",
     "babel-loader": "7.1.4",
     "babel-plugin-import": "1.7.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "babel-preset-env": "1.7.0",
     "babel-preset-react-app": "3.1.1",
     "babel-runtime": "^6.26.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -1317,6 +1317,11 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.21:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.21.tgz#0087938f4348cb751b3e5055a6b38f3c61b5231b"
+  integrity sha512-+gQBtcnEhYFbMPFGr8YL7SHD4BpHifFDGEc+ES0+1iDwC9psist2+eumcLoHjBMumL7N/HI/G64XR5aQC8Nr5Q==
+
 babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"


### PR DESCRIPTION
Use https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types to slim down the production build.

```
Before:
Assets:
  index_bundle.js (859 KiB)

After:
Assets:
  index_bundle.js (820 KiB)
```

Combined with #2035, our prod bundle size is down to 799 KiB!