### PR TITLE
Fix lodash error on namespace landing page

### DIFF
--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     "react",
-    "promise"
+    "promise",
+    "lodash"
   ],
   "parser": "babel-eslint",
   "parserOptions": {
@@ -34,6 +35,9 @@
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-quotes": 2,
     "keyword-spacing": 2,
+    "lodash/matches-shorthand": [2, "never"],
+    "lodash/matches-prop-shorthand": [2, "never"],
+    "lodash/prop-shorthand": [2, "never"],
     "no-console": [1, { "allow": ["warn", "error"] }], // minor offense
     "no-restricted-imports": [2, "lodash"],
     "no-trailing-spaces": 2,

--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -94,7 +94,7 @@ class NamespaceLanding extends React.Component {
         // by default, show the first non-linkerd meshed namesapce
         // if no other meshed namespaces are found, show the linkerd namespace
         let defaultOpenNs = _find(namespaces, ns => ns.added && ns.name !== this.props.controllerNamespace);
-        defaultOpenNs = defaultOpenNs || _find(namespaces, ['name', this.props.controllerNamespace]);
+        defaultOpenNs = defaultOpenNs || _find(namespaces, ns => ns.name === this.props.controllerNamespace);
 
         this.setState({
           namespaces,

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -40,6 +40,7 @@
     "eslint-loader": "2.0.0",
     "eslint-plugin-import": "2.12.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
+    "eslint-plugin-lodash": "5.1.0",
     "eslint-plugin-promise": "3.6.0",
     "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -3137,6 +3137,13 @@ eslint-plugin-jsx-a11y@6.0.3:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
+eslint-plugin-lodash@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-5.1.0.tgz#f7dc6c14f104cacb169a18d17c27d9c015a53924"
+  integrity sha512-mMKmf1OMLS8VExtaHCcrwBmsYIiOVYEibnAFDzXrbJdtFGOcLEw37tryN/WGYKBiJy6nAIGC43i5Wh3KA9lO2g==
+  dependencies:
+    lodash "4.17.11"
+
 eslint-plugin-promise@3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
@@ -5597,7 +5604,7 @@ lodash@4.17.10:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.17.11, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
This is a follow-up to #2028. As part of that branch, we stopped including the lodash "shorthands" feature set as part of our webpack bundle, which means we can no longer use the `_.property`, `_.matches` and `_.matchesProperty` shorthands. Fortunately we were only doing this in one place, and there are eslint rules to prevent us from using them going forward. This branch fixes the invalid shorthand and adds the new eslint rules.