### PR TITLE
Set default integration ns to l5d-integration

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -179,18 +179,17 @@ $ bin/test-run `pwd`/bin/linkerd
 That will create multiple namespaces in your Kubernetes cluster:
 
 ```bash
-$ kubectl get ns | grep linkerd
-NAME                  STATUS    AGE
-linkerd               Active    4m
-linkerd-egress-test   Active    4m
-linkerd-get-test      Active    3m
+$ kubectl get ns | grep l5d-integration
+l5d-integration                  Active    4m
+l5d-integration-egress-test      Active    2m
+l5d-integration-get-test         Active    1m
 ...
 ```
 
 To cleanup the namespaces after the test has finished, run:
 
 ```bash
-$ bin/test-cleanup linkerd
+$ bin/test-cleanup
 ```
 
 ## Writing tests

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -2,7 +2,7 @@
 
 set -eu
 
-linkerd_namespace=$1
+linkerd_namespace=${1:-l5d-integration}
 
 if [ -z "$linkerd_namespace" ]; then
     echo "usage: $(basename "$0") <namespace>" >&2

--- a/bin/test-run
+++ b/bin/test-run
@@ -48,7 +48,7 @@ check_if_k8s_reachable
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 test_directory="$bindir/../test"
 linkerd_version=$($linkerd_path version --client --short)
-linkerd_namespace=${2:-linkerd}
+linkerd_namespace=${2:-l5d-integration}
 
 printf "==================RUNNING ALL TESTS==================\\n"
 

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -34,7 +34,7 @@ func NewTestHelper() *TestHelper {
 	}
 
 	linkerd := flag.String("linkerd", "", "path to the linkerd binary to test")
-	namespace := flag.String("linkerd-namespace", "linkerd", "the namespace where linkerd is installed")
+	namespace := flag.String("linkerd-namespace", "l5d-integration", "the namespace where linkerd is installed")
 	tls := flag.Bool("enable-tls", false, "enable TLS in tests")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
 	verbose := flag.Bool("verbose", false, "turn on debug logging")


### PR DESCRIPTION
The default integration test namespace was `linkerd`.

Modify this default to `l5d-integration`, to minimize risk of
conflicting with an existing linkerd installation.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>