### PR TITLE
Pin the `area/test` label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,7 @@ exemptLabels:
   - area/security
   - area/tls
   - area/docs
+  - area/test
   - good first issue
   - benchmarking
   - help wanted


### PR DESCRIPTION
The `area/test` issue label contains a lot of tickets decribing areas of
the codebase that need more tests, or flaky test behaviours. These
issues are often fairly low-priority, so they usually aren't closed
right away, but rarely become invalid. In my opinion, it's good for
these issues to remain open so that those test deficiencies are clearly
documented.

This branch adds the `area/test` label to the list of labels ignored by
stalebot, so that they aren't closed after being left inactive.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>