### PR TITLE
Add SpeedMeasurePlugin to measure the speed of webpack builds

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -53,6 +53,7 @@
     "react-test-renderer": "16.5.2",
     "sinon": "7.0.0",
     "sinon-stub-promise": "4.0.0",
+    "speed-measure-webpack-plugin": "^1.2.5",
     "style-loader": "0.21.0",
     "url-loader": "1.0.1",
     "webpack": "4.20.2",

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -3,10 +3,14 @@
 const path = require('path');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
-// uncomment here and in plugins to analyze bundle size
+// analyze plugin speeds
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const smp = new SpeedMeasurePlugin();
+
+// uncomment here and in plugins to analyze webpack bundle size
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-module.exports = {
+module.exports = smp.wrap({
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './js/index.js',
   output: {
@@ -66,4 +70,4 @@ module.exports = {
       'paths': true
     })
   ]
-}
+});

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -8149,6 +8149,13 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
+speed-measure-webpack-plugin@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.2.5.tgz#8179936eb8c5e891f7481bd5075a9ea9a0f74823"
+  integrity sha512-S/guYjC4Izn5wY2d0+M4zowED/F77Lxh9yjkTZ+XAr244pr9c1MYNcXcRe9lx2hmAj0GPbOrBXgOF2YIp/CZ8A==
+  dependencies:
+    chalk "^2.0.1"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
This way we at least know which parts of our build are being slow!
I'll then look into speeding up the slower parts.

Output:
```
 SMP  ⏱
General output time took 23.74 secs

 SMP  ⏱  Plugins
LodashModuleReplacementPlugin took 1.001 secs

 SMP  ⏱  Loaders
modules with no loaders took 19.27 secs
  module count = 969
babel-loader, and
eslint-loader took 18.18 secs
  module count = 56
css-loader took 1.48 secs
  module count = 2
file-loader took 1.005 secs
  module count = 1
style-loader, and
css-loader took 0.014 secs
  module count = 2
```