### PR TITLE
Added `linkerd uninject` command

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -13,16 +11,11 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
-	appsV1 "k8s.io/api/apps/v1"
-	batchV1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	k8sMeta "k8s.io/apimachinery/pkg/api/meta"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (
@@ -75,7 +68,8 @@ func newCmdInject() *cobra.Command {
 		Short: "Add the Linkerd proxy to a Kubernetes config",
 		Long: `Add the Linkerd proxy to a Kubernetes config.
 
-You can inject resources contained in a single file, inside a folder and its sub-folders, or coming from stdin.`,
+You can inject resources contained in a single file, inside a folder and its
+sub-folders, or coming from stdin.`,
 		Example: `  # Inject all the deployments in the default namespace.
   kubectl get deploy -o yaml | linkerd inject - | kubectl apply -f -
 
@@ -107,32 +101,6 @@ You can inject resources contained in a single file, inside a folder and its sub
 
 	addProxyConfigFlags(cmd, options.proxyConfigOptions)
 	return cmd
-}
-
-// Returns the integer representation of os.Exit code; 0 on success and 1 on failure.
-// TODO: move to separate file
-func transformInput(inputs []io.Reader, errWriter, outWriter io.Writer, options *injectOptions, rt resourceTransformer) int {
-	postInjectBuf := &bytes.Buffer{}
-	reportBuf := &bytes.Buffer{}
-
-	for _, input := range inputs {
-		err := ProcessYAML(input, postInjectBuf, reportBuf, options, rt)
-		if err != nil {
-			// TODO: have a more generic error (shared with uninject)
-			fmt.Fprintf(errWriter, "Error injecting linkerd proxy: %v\n", err)
-			return 1
-		}
-		_, err = io.Copy(outWriter, postInjectBuf)
-
-		// print error report after yaml output, for better visibility
-		io.Copy(errWriter, reportBuf)
-
-		if err != nil {
-			fmt.Fprintf(errWriter, "Error printing YAML: %v\n", err)
-			return 1
-		}
-	}
-	return 0
 }
 
 /* Given a ObjectMeta, update ObjectMeta in place with the new labels and
@@ -360,205 +328,6 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	t.InitContainers = append(t.InitContainers, initContainer)
 
 	return true
-}
-
-// ProcessYAML takes an input stream of YAML, outputting injected/uninjected YAML to out.
-// TODO: move to separate file
-func ProcessYAML(in io.Reader, out io.Writer, report io.Writer, options *injectOptions, rt resourceTransformer) error {
-	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
-
-	injectReports := []injectReport{}
-
-	// Iterate over all YAML objects in the input
-	for {
-		// Read a single YAML object
-		bytes, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		result, irs, err := rt.transform(bytes, options)
-		if err != nil {
-			return err
-		}
-
-		out.Write(result)
-		out.Write([]byte("---\n"))
-
-		injectReports = append(injectReports, irs...)
-	}
-
-	rt.generateReport(injectReports, report)
-
-	return nil
-}
-
-// TODO: shared with uninject, so better move it to some common file
-func processList(b []byte, options *injectOptions, rt resourceTransformer) ([]byte, []injectReport, error) {
-	var sourceList v1.List
-	if err := yaml.Unmarshal(b, &sourceList); err != nil {
-		return nil, nil, err
-	}
-
-	injectReports := []injectReport{}
-	items := []runtime.RawExtension{}
-
-	for _, item := range sourceList.Items {
-		result, reports, err := rt.transform(item.Raw, options)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// At this point, we have yaml. The kubernetes internal representation is
-		// json. Because we're building a list from RawExtensions, the yaml needs
-		// to be converted to json.
-		injected, err := yaml.YAMLToJSON(result)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		items = append(items, runtime.RawExtension{Raw: injected})
-		injectReports = append(injectReports, reports...)
-	}
-
-	sourceList.Items = items
-	result, err := yaml.Marshal(sourceList)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return result, injectReports, nil
-}
-
-// TODO: move to separate file
-func (conf *resourceConfig) parse(bytes []byte, options *injectOptions, rt resourceTransformer) ([]byte, []injectReport, error) {
-	// The Kubernetes API is versioned and each version has an API modeled
-	// with its own distinct Go types. If we tell `yaml.Unmarshal()` which
-	// version we support then it will provide a representation of that
-	// object using the given type if possible. However, it only allows us
-	// to supply one object (of one type), so first we have to determine
-	// what kind of object `bytes` represents so we can pass an object of
-	// the correct type to `yaml.Unmarshal()`.
-	// ---------------------------------------
-	// Note: bytes is expected to be YAML and will only modify it when a
-	// supported type is found. Otherwise, it is returned unmodified.
-
-	// Unmarshal the object enough to read the Kind field
-	if err := yaml.Unmarshal(bytes, &conf.meta); err != nil {
-		return nil, nil, err
-	}
-
-	// retrieve the `metadata/name` field for reporting later
-	if err := yaml.Unmarshal(bytes, &conf.om); err != nil {
-		return nil, nil, err
-	}
-
-	conf.k8sLabels = map[string]string{}
-
-	// When injecting the linkerd proxy into a linkerd controller pod. The linkerd proxy's
-	// LINKERD2_PROXY_CONTROL_URL variable must be set to localhost for the following reasons:
-	//	1. According to https://github.com/kubernetes/minikube/issues/1568, minikube has an issue
-	//     where pods are unable to connect to themselves through their associated service IP.
-	//     Setting the LINKERD2_PROXY_CONTROL_URL to localhost allows the proxy to bypass kube DNS
-	//     name resolution as a workaround to this issue.
-	//  2. We avoid the TLS overhead in encrypting and decrypting intra-pod traffic i.e. traffic
-	//     between containers in the same pod.
-	//  3. Using a Service IP instead of localhost would mean intra-pod traffic would be load-balanced
-	//     across all controller pod replicas. This is undesirable as we would want all traffic between
-	//	   containers to be self contained.
-	//  4. We skip recording telemetry for intra-pod traffic within the control plane.
-	switch conf.meta.Kind {
-	case "Deployment":
-		var deployment v1beta1.Deployment
-		if err := yaml.Unmarshal(bytes, &deployment); err != nil {
-			return nil, nil, err
-		}
-
-		if deployment.Name == ControlPlanePodName && deployment.Namespace == controlPlaneNamespace {
-			conf.dnsNameOverride = LocalhostDNSNameOverride
-		}
-
-		conf.obj = &deployment
-		conf.k8sLabels[k8s.ProxyDeploymentLabel] = deployment.Name
-		conf.podSpec = &deployment.Spec.Template.Spec
-		conf.objectMeta = &deployment.Spec.Template.ObjectMeta
-
-	case "ReplicationController":
-		var rc v1.ReplicationController
-		if err := yaml.Unmarshal(bytes, &rc); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &rc
-		conf.k8sLabels[k8s.ProxyReplicationControllerLabel] = rc.Name
-		conf.podSpec = &rc.Spec.Template.Spec
-		conf.objectMeta = &rc.Spec.Template.ObjectMeta
-
-	case "ReplicaSet":
-		var rs v1beta1.ReplicaSet
-		if err := yaml.Unmarshal(bytes, &rs); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &rs
-		conf.k8sLabels[k8s.ProxyReplicaSetLabel] = rs.Name
-		conf.podSpec = &rs.Spec.Template.Spec
-		conf.objectMeta = &rs.Spec.Template.ObjectMeta
-
-	case "Job":
-		var job batchV1.Job
-		if err := yaml.Unmarshal(bytes, &job); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &job
-		conf.k8sLabels[k8s.ProxyJobLabel] = job.Name
-		conf.podSpec = &job.Spec.Template.Spec
-		conf.objectMeta = &job.Spec.Template.ObjectMeta
-
-	case "DaemonSet":
-		var ds v1beta1.DaemonSet
-		if err := yaml.Unmarshal(bytes, &ds); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &ds
-		conf.k8sLabels[k8s.ProxyDaemonSetLabel] = ds.Name
-		conf.podSpec = &ds.Spec.Template.Spec
-		conf.objectMeta = &ds.Spec.Template.ObjectMeta
-
-	case "StatefulSet":
-		var statefulset appsV1.StatefulSet
-		if err := yaml.Unmarshal(bytes, &statefulset); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &statefulset
-		conf.k8sLabels[k8s.ProxyStatefulSetLabel] = statefulset.Name
-		conf.podSpec = &statefulset.Spec.Template.Spec
-		conf.objectMeta = &statefulset.Spec.Template.ObjectMeta
-
-	case "Pod":
-		var pod v1.Pod
-		if err := yaml.Unmarshal(bytes, &pod); err != nil {
-			return nil, nil, err
-		}
-
-		conf.obj = &pod
-		conf.podSpec = &pod.Spec
-		conf.objectMeta = &pod.ObjectMeta
-
-	case "List":
-		// Lists are a little different than the other types. There's no immediate
-		// pod template. Because of this, we do a recursive call for each element
-		// in the list (instead of just marshaling the injected pod template).
-		return processList(bytes, options, rt)
-	}
-
-	return nil, nil, nil
 }
 
 func (rt resourceTransformerInject) transform(bytes []byte, options *injectOptions) ([]byte, []injectReport, error) {

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -1,12 +1,22 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/ghodss/yaml"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	appsV1 "k8s.io/api/apps/v1"
+	batchV1 "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 type resourceTransformer interface {
@@ -30,6 +40,226 @@ type resourceConfig struct {
 	objectMeta      *metaV1.ObjectMeta
 	dnsNameOverride string
 	k8sLabels       map[string]string
+}
+
+// Returns the integer representation of os.Exit code; 0 on success and 1 on failure.
+func transformInput(inputs []io.Reader, errWriter, outWriter io.Writer, options *injectOptions, rt resourceTransformer) int {
+	postInjectBuf := &bytes.Buffer{}
+	reportBuf := &bytes.Buffer{}
+
+	for _, input := range inputs {
+		err := ProcessYAML(input, postInjectBuf, reportBuf, options, rt)
+		if err != nil {
+			fmt.Fprintf(errWriter, "Error transforming resources: %v\n", err)
+			return 1
+		}
+		_, err = io.Copy(outWriter, postInjectBuf)
+
+		// print error report after yaml output, for better visibility
+		io.Copy(errWriter, reportBuf)
+
+		if err != nil {
+			fmt.Fprintf(errWriter, "Error printing YAML: %v\n", err)
+			return 1
+		}
+	}
+	return 0
+}
+
+// ProcessYAML takes an input stream of YAML, outputting injected/uninjected YAML to out.
+func ProcessYAML(in io.Reader, out io.Writer, report io.Writer, options *injectOptions, rt resourceTransformer) error {
+	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
+
+	injectReports := []injectReport{}
+
+	// Iterate over all YAML objects in the input
+	for {
+		// Read a single YAML object
+		bytes, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		result, irs, err := rt.transform(bytes, options)
+		if err != nil {
+			return err
+		}
+
+		out.Write(result)
+		out.Write([]byte("---\n"))
+
+		injectReports = append(injectReports, irs...)
+	}
+
+	rt.generateReport(injectReports, report)
+
+	return nil
+}
+
+func processList(b []byte, options *injectOptions, rt resourceTransformer) ([]byte, []injectReport, error) {
+	var sourceList v1.List
+	if err := yaml.Unmarshal(b, &sourceList); err != nil {
+		return nil, nil, err
+	}
+
+	injectReports := []injectReport{}
+	items := []runtime.RawExtension{}
+
+	for _, item := range sourceList.Items {
+		result, reports, err := rt.transform(item.Raw, options)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// At this point, we have yaml. The kubernetes internal representation is
+		// json. Because we're building a list from RawExtensions, the yaml needs
+		// to be converted to json.
+		injected, err := yaml.YAMLToJSON(result)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		items = append(items, runtime.RawExtension{Raw: injected})
+		injectReports = append(injectReports, reports...)
+	}
+
+	sourceList.Items = items
+	result, err := yaml.Marshal(sourceList)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, injectReports, nil
+}
+
+func (conf *resourceConfig) parse(bytes []byte, options *injectOptions, rt resourceTransformer) ([]byte, []injectReport, error) {
+	// The Kubernetes API is versioned and each version has an API modeled
+	// with its own distinct Go types. If we tell `yaml.Unmarshal()` which
+	// version we support then it will provide a representation of that
+	// object using the given type if possible. However, it only allows us
+	// to supply one object (of one type), so first we have to determine
+	// what kind of object `bytes` represents so we can pass an object of
+	// the correct type to `yaml.Unmarshal()`.
+	// ---------------------------------------
+	// Note: bytes is expected to be YAML and will only modify it when a
+	// supported type is found. Otherwise, it is returned unmodified.
+
+	// Unmarshal the object enough to read the Kind field
+	if err := yaml.Unmarshal(bytes, &conf.meta); err != nil {
+		return nil, nil, err
+	}
+
+	// retrieve the `metadata/name` field for reporting later
+	if err := yaml.Unmarshal(bytes, &conf.om); err != nil {
+		return nil, nil, err
+	}
+
+	conf.k8sLabels = map[string]string{}
+
+	// When injecting the linkerd proxy into a linkerd controller pod. The linkerd proxy's
+	// LINKERD2_PROXY_CONTROL_URL variable must be set to localhost for the following reasons:
+	//	1. According to https://github.com/kubernetes/minikube/issues/1568, minikube has an issue
+	//     where pods are unable to connect to themselves through their associated service IP.
+	//     Setting the LINKERD2_PROXY_CONTROL_URL to localhost allows the proxy to bypass kube DNS
+	//     name resolution as a workaround to this issue.
+	//  2. We avoid the TLS overhead in encrypting and decrypting intra-pod traffic i.e. traffic
+	//     between containers in the same pod.
+	//  3. Using a Service IP instead of localhost would mean intra-pod traffic would be load-balanced
+	//     across all controller pod replicas. This is undesirable as we would want all traffic between
+	//	   containers to be self contained.
+	//  4. We skip recording telemetry for intra-pod traffic within the control plane.
+	switch conf.meta.Kind {
+	case "Deployment":
+		var deployment v1beta1.Deployment
+		if err := yaml.Unmarshal(bytes, &deployment); err != nil {
+			return nil, nil, err
+		}
+
+		if deployment.Name == ControlPlanePodName && deployment.Namespace == controlPlaneNamespace {
+			conf.dnsNameOverride = LocalhostDNSNameOverride
+		}
+
+		conf.obj = &deployment
+		conf.k8sLabels[k8s.ProxyDeploymentLabel] = deployment.Name
+		conf.podSpec = &deployment.Spec.Template.Spec
+		conf.objectMeta = &deployment.Spec.Template.ObjectMeta
+
+	case "ReplicationController":
+		var rc v1.ReplicationController
+		if err := yaml.Unmarshal(bytes, &rc); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &rc
+		conf.k8sLabels[k8s.ProxyReplicationControllerLabel] = rc.Name
+		conf.podSpec = &rc.Spec.Template.Spec
+		conf.objectMeta = &rc.Spec.Template.ObjectMeta
+
+	case "ReplicaSet":
+		var rs v1beta1.ReplicaSet
+		if err := yaml.Unmarshal(bytes, &rs); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &rs
+		conf.k8sLabels[k8s.ProxyReplicaSetLabel] = rs.Name
+		conf.podSpec = &rs.Spec.Template.Spec
+		conf.objectMeta = &rs.Spec.Template.ObjectMeta
+
+	case "Job":
+		var job batchV1.Job
+		if err := yaml.Unmarshal(bytes, &job); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &job
+		conf.k8sLabels[k8s.ProxyJobLabel] = job.Name
+		conf.podSpec = &job.Spec.Template.Spec
+		conf.objectMeta = &job.Spec.Template.ObjectMeta
+
+	case "DaemonSet":
+		var ds v1beta1.DaemonSet
+		if err := yaml.Unmarshal(bytes, &ds); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &ds
+		conf.k8sLabels[k8s.ProxyDaemonSetLabel] = ds.Name
+		conf.podSpec = &ds.Spec.Template.Spec
+		conf.objectMeta = &ds.Spec.Template.ObjectMeta
+
+	case "StatefulSet":
+		var statefulset appsV1.StatefulSet
+		if err := yaml.Unmarshal(bytes, &statefulset); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &statefulset
+		conf.k8sLabels[k8s.ProxyStatefulSetLabel] = statefulset.Name
+		conf.podSpec = &statefulset.Spec.Template.Spec
+		conf.objectMeta = &statefulset.Spec.Template.ObjectMeta
+
+	case "Pod":
+		var pod v1.Pod
+		if err := yaml.Unmarshal(bytes, &pod); err != nil {
+			return nil, nil, err
+		}
+
+		conf.obj = &pod
+		conf.podSpec = &pod.Spec
+		conf.objectMeta = &pod.ObjectMeta
+
+	case "List":
+		// Lists are a little different than the other types. There's no immediate
+		// pod template. Because of this, we do a recursive call for each element
+		// in the list (instead of just marshaling the injected pod template).
+		return processList(bytes, options, rt)
+	}
+
+	return nil, nil, nil
 }
 
 // Read all the resource files found in path into a slice of readers.

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -28,7 +28,7 @@ type resourceConfig struct {
 	meta            metaV1.TypeMeta
 	podSpec         *v1.PodSpec
 	objectMeta      *metaV1.ObjectMeta
-	DNSNameOverride string
+	dnsNameOverride string
 	k8sLabels       map[string]string
 }
 

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type resourceTransformer func(bytes []byte, options *injectOptions) ([]byte, []injectReport, error)
+
+type injectReport struct {
+	name                string
+	hostNetwork         bool
+	sidecar             bool
+	udp                 bool // true if any port in any container has `protocol: UDP`
+	unsupportedResource bool
+}
+
+type resourceConfig struct {
+	obj             interface{}
+	om              objMeta
+	meta            metaV1.TypeMeta
+	podSpec         *v1.PodSpec
+	objectMeta      *metaV1.ObjectMeta
+	DNSNameOverride string
+	k8sLabels       map[string]string
+}
+
+// Read all the resource files found in path into a slice of readers.
+// path can be either a file, directory or stdin.
+func read(path string) ([]io.Reader, error) {
+	var (
+		in  []io.Reader
+		err error
+	)
+	if path == "-" {
+		in = append(in, os.Stdin)
+	} else {
+		in, err = walk(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return in, nil
+}
+
+// walk walks the file tree rooted at path. path may be a file or a directory.
+// Creates a reader for each file found.
+func walk(path string) ([]io.Reader, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !stat.IsDir() {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+
+		return []io.Reader{file}, nil
+	}
+
+	var in []io.Reader
+	werr := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		in = append(in, file)
+		return nil
+	})
+
+	if werr != nil {
+		return nil, werr
+	}
+
+	return in, nil
+}
+
+func generateReport(injectReports []injectReport, output io.Writer) {
+
+	injected := []string{}
+	hostNetwork := []string{}
+	sidecar := []string{}
+	udp := []string{}
+
+	for _, r := range injectReports {
+		if !r.hostNetwork && !r.sidecar && !r.unsupportedResource {
+			injected = append(injected, r.name)
+		}
+
+		if r.hostNetwork {
+			hostNetwork = append(hostNetwork, r.name)
+		}
+
+		if r.sidecar {
+			sidecar = append(sidecar, r.name)
+		}
+
+		if r.udp {
+			udp = append(udp, r.name)
+		}
+	}
+
+	//
+	// Warnings
+	//
+
+	// leading newline to separate from yaml output on stdout
+	output.Write([]byte("\n"))
+
+	hostNetworkPrefix := fmt.Sprintf("%s%s", hostNetworkDesc, getFiller(hostNetworkDesc))
+	if len(hostNetwork) == 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", hostNetworkPrefix, okStatus)))
+	} else {
+		output.Write([]byte(fmt.Sprintf("%s%s -- \"hostNetwork: true\" detected in %s\n", hostNetworkPrefix, warnStatus, strings.Join(hostNetwork, ", "))))
+	}
+
+	sidecarPrefix := fmt.Sprintf("%s%s", sidecarDesc, getFiller(sidecarDesc))
+	if len(sidecar) == 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", sidecarPrefix, okStatus)))
+	} else {
+		output.Write([]byte(fmt.Sprintf("%s%s -- known sidecar detected in %s\n", sidecarPrefix, warnStatus, strings.Join(sidecar, ", "))))
+	}
+
+	unsupportedPrefix := fmt.Sprintf("%s%s", unsupportedDesc, getFiller(unsupportedDesc))
+	if len(injected) > 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", unsupportedPrefix, okStatus)))
+	} else {
+		output.Write([]byte(fmt.Sprintf("%s%s -- no supported objects found\n", unsupportedPrefix, warnStatus)))
+	}
+
+	udpPrefix := fmt.Sprintf("%s%s", udpDesc, getFiller(udpDesc))
+	if len(udp) == 0 {
+		output.Write([]byte(fmt.Sprintf("%s%s\n", udpPrefix, okStatus)))
+	} else {
+		verb := "uses"
+		if len(udp) > 1 {
+			verb = "use"
+		}
+		output.Write([]byte(fmt.Sprintf("%s%s -- %s %s \"protocol: UDP\"\n", udpPrefix, warnStatus, strings.Join(udp, ", "), verb)))
+	}
+
+	//
+	// Summary
+	//
+
+	// TODO: make message more generic (shared with uninject)
+	summary := fmt.Sprintf("Summary: %d of %d YAML document(s) injected", len(injected), len(injectReports))
+	output.Write([]byte(fmt.Sprintf("\n%s\n", summary)))
+
+	for _, i := range injected {
+		output.Write([]byte(fmt.Sprintf("  %s\n", i)))
+	}
+
+	// trailing newline to separate from kubectl output if piping
+	output.Write([]byte("\n"))
+}
+
+func getFiller(text string) string {
+	filler := ""
+	for i := 0; i < lineWidth-len(text)-len(okStatus)-len("\n"); i++ {
+		filler = filler + "."
+	}
+
+	return filler
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -76,13 +76,13 @@ func init() {
 	RootCmd.AddCommand(newCmdDashboard())
 	RootCmd.AddCommand(newCmdGet())
 	RootCmd.AddCommand(newCmdInject())
-	RootCmd.AddCommand(newCmdUninject())
 	RootCmd.AddCommand(newCmdInstall())
 	RootCmd.AddCommand(newCmdProfile())
 	RootCmd.AddCommand(newCmdRoutes())
 	RootCmd.AddCommand(newCmdStat())
 	RootCmd.AddCommand(newCmdTap())
 	RootCmd.AddCommand(newCmdTop())
+	RootCmd.AddCommand(newCmdUninject())
 	RootCmd.AddCommand(newCmdVersion())
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -76,6 +76,7 @@ func init() {
 	RootCmd.AddCommand(newCmdDashboard())
 	RootCmd.AddCommand(newCmdGet())
 	RootCmd.AddCommand(newCmdInject())
+	RootCmd.AddCommand(newCmdUninject())
 	RootCmd.AddCommand(newCmdInstall())
 	RootCmd.AddCommand(newCmdProfile())
 	RootCmd.AddCommand(newCmdRoutes())

--- a/cli/cmd/testdata/inject_contour.input.yml
+++ b/cli/cmd/testdata/inject_contour.input.yml
@@ -1,55 +1,69 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  creationTimestamp: null
   labels:
     app: contour
   name: contour
   namespace: heptio-contour
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: contour
-  replicas: 2
+  strategy: {}
   template:
     metadata:
+      annotations:
+        prometheus.io/format: prometheus
+        prometheus.io/path: /stats
+        prometheus.io/port: "9001"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
       labels:
         app: contour
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
-        prometheus.io/path: "/stats"
-        prometheus.io/format: "prometheus"
     spec:
       containers:
-      - image: gcr.io/heptio-images/contour:master
+      - args:
+        - serve
+        - --incluster
+        command:
+        - contour
+        image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
         name: contour
-        command: ["contour"]
-        args: ["serve", "--incluster"]
-      - image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+        resources: {}
+      - args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
+        command:
+        - envoy
+        image: docker.io/envoyproxy/envoy-alpine:v1.6.0
         name: envoy
         ports:
         - containerPort: 8080
           name: http
         - containerPort: 8443
           name: https
-        command: ["envoy"]
-        args:
-        - --config-path /config/contour.yaml
-        - --service-cluster cluster0
-        - --service-node node0
-        - --log-level info
-        - --v2-config-only
+        resources: {}
         volumeMounts:
-        - name: contour-config
-          mountPath: /config
+        - mountPath: /config
+          name: contour-config
       initContainers:
-      - image: gcr.io/heptio-images/contour:master
+      - args:
+        - bootstrap
+        - /config/contour.yaml
+        command:
+        - contour
+        image: gcr.io/heptio-images/contour:master
         imagePullPolicy: Always
         name: envoy-initconfig
-        command: ["contour"]
-        args: ["bootstrap", "/config/contour.yaml"]
+        resources: {}
         volumeMounts:
-        - name: contour-config
-          mountPath: /config
+        - mountPath: /config
+          name: contour-config
+status: {}
 ---

--- a/cli/cmd/testdata/inject_contour_uninject.report
+++ b/cli/cmd/testdata/inject_contour_uninject.report
@@ -1,0 +1,3 @@
+
+Summary: 0 of 1 YAML document(s) uninjected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name_uninject.report
@@ -1,0 +1,5 @@
+
+Summary: 2 of 2 YAML document(s) uninjected
+  deployment/controller
+  deployment/not-controller
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true_uninject.report
@@ -1,0 +1,3 @@
+
+Summary: 0 of 1 YAML document(s) uninjected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp_uninject.report
@@ -1,0 +1,4 @@
+
+Summary: 1 of 1 YAML document(s) uninjected
+  deployment/web
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_uninject.report
@@ -1,0 +1,4 @@
+
+Summary: 1 of 1 YAML document(s) uninjected
+  deployment/web
+

--- a/cli/cmd/testdata/inject_emojivoto_istio.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_istio.input.yml
@@ -35,8 +35,10 @@ spec:
         resources: {}
       - image: gcr.io/istio-release/proxyv2:1.0.2
         name: istio-proxy
+        resources: {}
       initContainers:
       - image: gcr.io/istio-release/proxy_init:1.0.2
         name: istio-init
+        resources: {}
 status: {}
 ---

--- a/cli/cmd/testdata/inject_emojivoto_istio_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_istio_uninject.report
@@ -1,0 +1,3 @@
+
+Summary: 0 of 1 YAML document(s) uninjected
+

--- a/cli/cmd/testdata/inject_emojivoto_list.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.input.yml
@@ -1,70 +1,70 @@
 ---
 apiVersion: v1
 items:
-  - apiVersion: apps/v1beta1
-    kind: Deployment
-    metadata:
-      creationTimestamp: null
-      name: web
-      namespace: emojivoto
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: web
+    namespace: emojivoto
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: web-svc
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
           app: web-svc
-      strategy: {}
-      template:
-        metadata:
-          creationTimestamp: null
-          labels:
-            app: web-svc
-        spec:
-          containers:
-          - env:
-            - name: WEB_PORT
-              value: "80"
-            - name: EMOJISVC_HOST
-              value: emoji-svc.emojivoto:8080
-            - name: VOTINGSVC_HOST
-              value: voting-svc.emojivoto:8080
-            - name: INDEX_BUNDLE
-              value: dist/index_bundle.js
-            image: buoyantio/emojivoto-web:v3
-            name: web-svc
-            ports:
-            - containerPort: 80
-              name: http
-            resources: {}
-    status: {}
-  - apiVersion: apps/v1beta1
-    kind: Deployment
-    metadata:
-      creationTimestamp: null
-      name: emoji
-      namespace: emojivoto
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
+      spec:
+        containers:
+        - env:
+          - name: WEB_PORT
+            value: "80"
+          - name: EMOJISVC_HOST
+            value: emoji-svc.emojivoto:8080
+          - name: VOTINGSVC_HOST
+            value: voting-svc.emojivoto:8080
+          - name: INDEX_BUNDLE
+            value: dist/index_bundle.js
+          image: buoyantio/emojivoto-web:v3
+          name: web-svc
+          ports:
+          - containerPort: 80
+            name: http
+          resources: {}
+  status: {}
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    creationTimestamp: null
+    name: emoji
+    namespace: emojivoto
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: emoji-svc
+    strategy: {}
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
           app: emoji-svc
-      strategy: {}
-      template:
-        metadata:
-          creationTimestamp: null
-          labels:
-            app: emoji-svc
-        spec:
-          containers:
-          - env:
-            - name: GRPC_PORT
-              value: "8080"
-            image: buoyantio/emojivoto-emoji-svc:v3
-            name: emoji-svc
-            ports:
-            - containerPort: 8080
-              name: grpc
-              protocol: TCP
-            resources: {}
-    status: {}
+      spec:
+        containers:
+        - env:
+          - name: GRPC_PORT
+            value: "8080"
+          image: buoyantio/emojivoto-emoji-svc:v3
+          name: emoji-svc
+          ports:
+          - containerPort: 8080
+            name: grpc
+            protocol: TCP
+          resources: {}
+  status: {}
 kind: List
 metadata: {}

--- a/cli/cmd/testdata/inject_emojivoto_list_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_list_uninject.report
@@ -1,0 +1,5 @@
+
+Summary: 2 of 2 YAML document(s) uninjected
+  deployment/web
+  deployment/emoji
+

--- a/cli/cmd/testdata/inject_emojivoto_pod.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.input.yml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  creationTimestamp: null
   labels:
     app: vote-bot
   name: vote-bot
@@ -14,3 +15,5 @@ spec:
       value: web-svc.emojivoto:80
     image: buoyantio/emojivoto-web:v3
     name: vote-bot
+    resources: {}
+status: {}

--- a/cli/cmd/testdata/inject_emojivoto_pod_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_uninject.report
@@ -1,0 +1,4 @@
+
+Summary: 1 of 1 YAML document(s) uninjected
+  pod/vote-bot
+

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
+  creationTimestamp: null
   labels:
     app: vote-bot
   name: vote-bot
@@ -14,3 +15,5 @@ spec:
       value: web-svc.emojivoto:80
     image: buoyantio/emojivoto-web:v3
     name: vote-bot
+    resources: {}
+status: {}

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests_uninject.report
@@ -1,0 +1,4 @@
+
+Summary: 1 of 1 YAML document(s) uninjected
+  pod/vote-bot
+

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.input.yml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: web-svc
-  strategy: {}
+  serviceName: ""
   template:
     metadata:
       creationTimestamp: null
@@ -33,4 +33,6 @@ spec:
         - containerPort: 80
           name: http
         resources: {}
-status: {}
+  updateStrategy: {}
+status:
+  replicas: 0

--- a/cli/cmd/testdata/inject_emojivoto_statefulset_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset_uninject.report
@@ -1,0 +1,4 @@
+
+Summary: 1 of 1 YAML document(s) uninjected
+  statefulset/web
+

--- a/cli/cmd/testdata/inject_gettest_deployment.bad.golden
+++ b/cli/cmd/testdata/inject_gettest_deployment.bad.golden
@@ -1,1 +1,1 @@
-Error injecting linkerd proxy: error converting YAML to JSON: yaml: line 14: did not find expected key
+Error transforming resources: error converting YAML to JSON: yaml: line 14: did not find expected key

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -30,7 +30,8 @@ func newCmdUninject() *cobra.Command {
 		Short: "Remove the Linkerd proxy from a Kubernetes config",
 		Long: `Remove the Linkerd proxy from a Kubernetes config.
 
-You can uninject resources contained in a single file, inside a folder and its sub-folders, or coming from stdin.`,
+You can uninject resources contained in a single file, inside a folder and its
+sub-folders, or coming from stdin.`,
 		Example: `  # Uninject all the deployments in the default namespace.
   kubectl get deploy -o yaml | linkerd uninject - | kubectl apply -f -
 

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -112,6 +112,14 @@ func uninjectPodSpec(t *v1.PodSpec) {
 		}
 	}
 	t.Containers = containers
+
+	volumes := []v1.Volume{}
+	for _, volume := range t.Volumes {
+		if volume.Name != "linkerd-trust-anchors" && volume.Name != "linkerd-secrets" {
+			volumes = append(volumes, volume)
+		}
+	}
+	t.Volumes = volumes
 }
 
 func uninjectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string) {

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newCmdUninject() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninject",
+		Short: "Remove the Linkerd proxy from a Kubernetes config",
+		Long: `Remove the Linkerd proxy from a Kubernetes config.
+
+You can use a config file from stdin by using the '-' argument
+with 'linkerd uninject'. e.g. curl http://url.to/yml | linkerd uninject -
+Also works with a folder containing resource files and other
+sub-folder. e.g. linkerd uninject <folder> | kubectl apply -f -
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			in, err := read(args[0])
+			if err != nil {
+				return err
+			}
+
+			exitCode := transformInput(in, os.Stderr, os.Stdout, nil, uninjectResource)
+			os.Exit(exitCode)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func uninjectResource(bytes []byte, options *injectOptions) ([]byte, []injectReport, error) {
+	conf := &resourceConfig{}
+	output, reports, err := conf.parse(bytes, options, uninjectResource)
+	if output != nil || err != nil {
+		return output, reports, err
+	}
+
+	report := injectReport{
+		name: fmt.Sprintf("%s/%s", strings.ToLower(conf.meta.Kind), conf.om.Name),
+	}
+
+	// If we don't uninject anything into the pod template then output the
+	// original serialization of the original object. Otherwise, output the
+	// serialization of the modified object.
+	output = bytes
+	if conf.podSpec != nil {
+		uninjectPodSpec(conf.podSpec)
+		uninjectObjectMeta(conf.objectMeta, conf.k8sLabels)
+		var err error
+		output, err = yaml.Marshal(conf.obj)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		report.unsupportedResource = true
+	}
+
+	return output, []injectReport{report}, nil
+}
+
+// Given a PodSpec, update the PodSpec in place with the sidecar
+// and init-container uninjected
+func uninjectPodSpec(t *v1.PodSpec) {
+	initContainers := []v1.Container{}
+	for _, container := range t.InitContainers {
+		if container.Name != k8s.InitContainerName {
+			initContainers = append(initContainers, container)
+		}
+	}
+	t.InitContainers = initContainers
+
+	containers := []v1.Container{}
+	for _, container := range t.Containers {
+		if container.Name != k8s.ProxyContainerName {
+			containers = append(containers, container)
+		}
+	}
+	t.Containers = containers
+}
+
+func uninjectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string) {
+	newAnnotations := make(map[string]string)
+	for key, val := range t.Annotations {
+		if key != k8s.CreatedByAnnotation && key != k8s.ProxyVersionAnnotation {
+			newAnnotations[key] = val
+		}
+	}
+	t.Annotations = newAnnotations
+
+	labels := make(map[string]string)
+	ldLabels := []string{k8s.ControllerNSLabel}
+	for key := range k8sLabels {
+		ldLabels = append(ldLabels, key)
+	}
+	for key, val := range t.Labels {
+		keep := true
+		for _, label := range ldLabels {
+			if key == label {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			labels[key] = val
+		}
+	}
+	t.Labels = labels
+}

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -14,7 +14,7 @@ import (
 
 func newCmdUninject() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "uninject",
+		Use:   "uninject [flags] CONFIG-FILE",
 		Short: "Remove the Linkerd proxy from a Kubernetes config",
 		Long: `Remove the Linkerd proxy from a Kubernetes config.
 
@@ -24,6 +24,11 @@ Also works with a folder containing resource files and other
 sub-folder. e.g. linkerd uninject <folder> | kubectl apply -f -
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) < 1 {
+				return fmt.Errorf("please specify a kubernetes resource file")
+			}
+
 			in, err := read(args[0])
 			if err != nil {
 				return err

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -113,7 +113,7 @@ func TestUninjectYAML(t *testing.T) {
 	}
 }
 
-// stripDashes removes the YAML dashes (---) found at the beginning and endind of the
+// stripDashes removes the YAML dashes (---) found at the beginning and ending of the
 // input and golden files respectively.
 func stripDashes(str string) string {
 	return strings.Trim(str, "-\n")

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestUninjectYAML does the reverse of TestInjectYAML.
+// We use as input the same "golden" file and as expected output the same "input" file as in the inject tests.
+func TestUninjectYAML(t *testing.T) {
+
+	testCases := []struct {
+		inputFileName     string
+		goldenFileName    string
+		reportFileName    string
+		testInjectOptions *injectOptions
+	}{
+		{
+			inputFileName:  "inject_emojivoto_deployment.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment.input.yml",
+			reportFileName: "inject_emojivoto_deployment_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_list.golden.yml",
+			goldenFileName: "inject_emojivoto_list.input.yml",
+			reportFileName: "inject_emojivoto_list_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_deployment_hostNetwork_true.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment_hostNetwork_true.input.yml",
+			reportFileName: "inject_emojivoto_deployment_hostNetwork_true_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_deployment_controller_name.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment_controller_name.input.yml",
+			reportFileName: "inject_emojivoto_deployment_controller_name_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_statefulset.golden.yml",
+			goldenFileName: "inject_emojivoto_statefulset.input.yml",
+			reportFileName: "inject_emojivoto_statefulset_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_pod.golden.yml",
+			goldenFileName: "inject_emojivoto_pod.input.yml",
+			reportFileName: "inject_emojivoto_pod_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_pod_with_requests.golden.yml",
+			goldenFileName: "inject_emojivoto_pod_with_requests.input.yml",
+			reportFileName: "inject_emojivoto_pod_with_requests_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_deployment_tls.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment.input.yml",
+			reportFileName: "inject_emojivoto_deployment_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_pod_tls.golden.yml",
+			goldenFileName: "inject_emojivoto_pod.input.yml",
+			reportFileName: "inject_emojivoto_pod_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_deployment_udp.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment_udp.input.yml",
+			reportFileName: "inject_emojivoto_deployment_udp_uninject.report",
+		},
+		{
+			inputFileName:  "inject_emojivoto_istio.input.yml",
+			goldenFileName: "inject_emojivoto_istio.input.yml",
+			reportFileName: "inject_emojivoto_istio_uninject.report",
+		},
+		{
+			inputFileName:  "inject_contour.input.yml",
+			goldenFileName: "inject_contour.input.yml",
+			reportFileName: "inject_contour_uninject.report",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, tc.inputFileName), func(t *testing.T) {
+			file, err := os.Open("testdata/" + tc.inputFileName)
+			if err != nil {
+				t.Errorf("error opening test input file: %v\n", err)
+			}
+
+			read := bufio.NewReader(file)
+
+			output := new(bytes.Buffer)
+			report := new(bytes.Buffer)
+
+			err = UninjectYAML(read, output, report, nil)
+			if err != nil {
+				t.Errorf("Unexpected error uninjecting YAML: %v\n", err)
+			}
+
+			actualOutput := stripDashes(output.String())
+			expectedOutput := stripDashes(readOptionalTestFile(t, tc.goldenFileName))
+			if expectedOutput != actualOutput {
+				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedOutput, actualOutput)
+			}
+
+			actualReport := report.String()
+			expectedReport := readOptionalTestFile(t, tc.reportFileName)
+			if expectedReport != actualReport {
+				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedReport, actualReport)
+			}
+		})
+	}
+}
+
+// stripDashes removes the YAML dashes (---) found at the beginning and endind of the
+// input and golden files respectively.
+func stripDashes(str string) string {
+	return strings.Trim(str, "-\n")
+}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -136,6 +136,10 @@ const (
 	MountPathBase = "/var/linkerd-io"
 )
 
+// InjectedLabels contains the list of label keys subjected to be injected by Linkerd into resource definitions
+var InjectedLabels = []string{ControllerNSLabel, ProxyDeploymentLabel, ProxyReplicationControllerLabel,
+	ProxyReplicaSetLabel, ProxyJobLabel, ProxyDaemonSetLabel, ProxyStatefulSetLabel}
+
 var (
 	// MountPathTLSTrustAnchor is the path at which the trust anchor file is
 	// mounted


### PR DESCRIPTION
uninject.go iterates through the resources annotations, labels,
initContainers and Containers, removing what we know was injected by
linkerd.

The biggest part of this commit is the refactoring of inject.go, to make
it more generic and reusable by uninject. Some common parts were moved
into inject_util.go but others common parts remained in inject.go to
ease review and will then later get moved (marked with a comment).

The entry-point function `transformInput` (formerly called
`runInjectCmd`) receives as a parameter the function holding the logic
specific for injection (`injectResource`) or uninjection
(`uninjectResource`).

`injectResource` was split into the `parse` (reused by uninject) and
`injectResource` methods on the new `resourceConfig` receiver. That
receiver holds all the info required for the injection/uninjection.

The idea is that in a following PR this functionality will get reused by
`linkerd inject` to uninject as as preliminary step to injection, as a
solution to #1970.

This was tested successfully on emojivoto with:

```
1) inject:
kubectl get -n emojivoto deployment -o yaml | bin/linkerd inject - |
kubectl apply -f -
2) uninject:
kubectl get -n emojivoto deployment -o yaml | bin/linkerd uninject - |
kubectl apply -f -
```