### PR TITLE
proxy: bump version to fix memory leak

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-2f20505}"
+PROXY_VERSION="${PROXY_VERSION:-08b2a23}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
- Update to trust-dns-resolver 0.10.1 (linkerd/linkerd2-proxy#169)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>