### PR TITLE
Add display chips to the resource detail page to provide more detail

### DIFF
--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -167,7 +167,7 @@ class NamespaceLanding extends React.Component {
       let hr = (
         <Grid container justify="space-between" alignItems="center">
           <Grid item><Typography variant="subtitle1">{ns.name}</Typography></Grid>
-          {!ns.added ? null : <Grid item><SimpleChip /></Grid> }
+          {!ns.added ? null : <Grid item><SimpleChip label="meshed" type="good" /></Grid> }
         </Grid>
       );
       return {

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -68,8 +68,8 @@ export class ResourceDetailBase extends React.Component {
       resourceMetrics: [],
       podMetrics: [], // metrics for all pods whose owner is this resource
       neighborMetrics: {
-        upstream: {},
-        downstream: {}
+        upstream: [],
+        downstream: []
       },
       unmeshedSources: {},
       resourceIsMeshed: true,
@@ -200,14 +200,23 @@ export class ResourceDetailBase extends React.Component {
       return <Spinner />;
     }
 
-    let { resourceName, resourceType, namespace } = this.state;
+    let {
+      resourceName,
+      resourceType,
+      namespace,
+      resourceMetrics,
+      unmeshedSources,
+      resourceIsMeshed,
+      neighborMetrics
+    } = this.state;
+
     let query = {
       resourceName,
       resourceType,
       namespace
     };
 
-    let unmeshed = _filter(this.state.unmeshedSources, d => d.type === this.state.resourceType)
+    let unmeshed = _filter(unmeshedSources, d => d.type === resourceType)
       .map(d => _merge({}, emptyMetric, d, {
         unmeshed: true,
         pods: {
@@ -216,30 +225,31 @@ export class ResourceDetailBase extends React.Component {
         }
       }));
 
-    let upstreams = this.state.neighborMetrics.upstream.concat(unmeshed);
+    let upstreams = neighborMetrics.upstream.concat(unmeshed);
 
+    console.log(resourceMetrics[0]);
     return (
       <div>
         {
-          this.state.resourceIsMeshed ? null :
+          resourceIsMeshed ? null :
           <React.Fragment>
             <AddResources
-              resourceName={this.state.resourceName}
-              resourceType={this.state.resourceType} />
+              resourceName={resourceName}
+              resourceType={resourceType} />
           </React.Fragment>
         }
 
         <Octopus
-          resource={this.state.resourceMetrics[0]}
-          neighbors={this.state.neighborMetrics}
-          unmeshedSources={Object.values(this.state.unmeshedSources)}
+          resource={resourceMetrics[0]}
+          neighbors={neighborMetrics}
+          unmeshedSources={Object.values(unmeshedSources)}
           api={this.api} />
 
         <TopRoutesTabs
           query={query}
           pathPrefix={this.props.pathPrefix}
           updateNeighborsFromTapData={this.updateNeighborsFromTapData}
-          disableTop={!this.state.resourceIsMeshed} />
+          disableTop={!resourceIsMeshed} />
 
 
         { _isEmpty(upstreams) ? null : (

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -22,7 +22,7 @@ import { processNeighborData } from './util/TapUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
 
 // if there has been no traffic for some time, show a warning
-const showNoTrafficMsgDelay = 1000;
+const showNoTrafficMsgDelayMs = 6000;
 
 const getResourceFromUrl = (match, pathPrefix) => {
   let resource = {
@@ -238,7 +238,7 @@ export class ResourceDetailBase extends React.Component {
 
     let upstreams = neighborMetrics.upstream.concat(unmeshed);
 
-    let showNoTrafficMsg = resourceIsMeshed && (Date.now() - lastMetricReceivedTime > showNoTrafficMsgDelay);
+    let showNoTrafficMsg = resourceIsMeshed && (Date.now() - lastMetricReceivedTime > showNoTrafficMsgDelayMs);
 
     return (
       <div>

--- a/web/app/js/components/util/Chip.jsx
+++ b/web/app/js/components/util/Chip.jsx
@@ -3,25 +3,36 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = () => ({
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    flexWrap: 'wrap',
+const styles = theme => ({
+  good: {
+    color: theme.status.dark.good,
+    border: '1px solid ' + theme.status.dark.good
   },
+  warning: {
+    color: theme.status.dark.warning,
+    border: '1px solid ' + theme.status.dark.warning,
+  },
+  bad: {
+    color: theme.status.dark.danger,
+    border: '1px solid ' + theme.status.dark.danger,
+  }
 });
 
 function SimpleChip(props) {
-  const { classes } = props;
+  const { classes, label, type } = props;
+
   return (
-    <div className={classes.root}>
-      <Chip className={classes.chip} color="primary" label="meshed" variant="outlined" />
-    </div>
+    <Chip
+      className={classes[type]}
+      label={label}
+      variant="outlined" />
   );
 }
 
 SimpleChip.propTypes = {
-  classes: PropTypes.shape({}).isRequired
+  classes: PropTypes.shape({}).isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired
 };
 
-export default withStyles(styles)(SimpleChip);
+export default withStyles(styles, { withTheme: true })(SimpleChip);


### PR DESCRIPTION
Trying this out: having "meshed" and "no traffic" badges on the resource detail pages to display a little more info to the user.

This branch also contains some  code cleanup in ResourceDetail.jsx

![screen shot 2019-01-09 at 1 19 39 pm](https://user-images.githubusercontent.com/549258/50996793-c1980380-14d7-11e9-942c-a99561da347c.png)
![screen shot 2019-01-09 at 1 18 18 pm](https://user-images.githubusercontent.com/549258/50996794-c1980380-14d7-11e9-9d33-30ff5cc76936.png)
