### PR TITLE
Send non-zero status code when proxy-init command fails

### DIFF
--- a/proxy-init/main.go
+++ b/proxy-init/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	if err := cmd.NewRootCmd().Execute(); err != nil{
+	if err := cmd.NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/proxy-init/main.go
+++ b/proxy-init/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/linkerd/linkerd2/proxy-init/cmd"
+import (
+	"os"
+
+	"github.com/linkerd/linkerd2/proxy-init/cmd"
+)
 
 func main() {
-	cmd.NewRootCmd().Execute()
+	if err := cmd.NewRootCmd().Execute(); err != nil{
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
When the proxy-init script fails for whatever reason, it exits and failed to trigger an initContainer restart because it always sent a zero exit code for the command.

This PR mimics the behavior of the Linkerd CLI by capturing the error returned by the proxy-init root command and return `os.Exit(1)` if an error exists.

Before:
```bash
➜  linkerd2 git:(dad/init-container-exit-code) ✗ kubectl get pods -n linkerd
NAME                                  READY     STATUS    RESTARTS   AGE
linkerd-controller-7bb4d68fdf-zg9wr   4/4       Running   0          48s
linkerd-grafana-67c97b848d-tvpmx      2/2       Running   0          47s
linkerd-prometheus-d4cb6cfd9-rcst8    2/2       Running   0          48s
linkerd-web-947fcbfc5-nhb6p           2/2       Running   0          48s
```
proxy-init logs
```bash
➜  linkerd2 git:(dad/init-container-exit-code) ✗ kubectl -n linkerd logs linkerd-controller-7bb4d68fdf-zg9wr linkerd-init
2019/01/10 22:03:44 Tracing this script execution as [1547157824]
2019/01/10 22:03:44 State of iptables rules before run:
2019/01/10 22:03:44 > iptables -t nat -vnL
2019/01/10 22:03:44 < iptables v1.4.21: can't initialize iptables table `nat': Permission denied (you must be root)
Perhaps iptables or your kernel needs to be upgraded.

2019/01/10 22:03:44 Aborting firewall configuration
Error: exit status 3
Usage:
  proxy-init [flags]

Flags:
  -h, --help                                help for proxy-init
      --inbound-ports-to-ignore intSlice    Inbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.
  -p, --incoming-proxy-port int             Port to redirect incoming traffic (default -1)
      --outbound-ports-to-ignore intSlice   Outbound ports to ignore and not redirect to proxy. This has higher precedence than any other parameters.
  -o, --outgoing-proxy-port int             Port to redirect outgoing traffic (default -1)
  -r, --ports-to-redirect intSlice          Port to redirect to proxy, if no port is specified then ALL ports are redirected
  -u, --proxy-uid int                       User ID that the proxy is running under. Any traffic coming from this user will be ignored to avoid infinite redirection loops. (default -1)
      --simulate                            Don't execute any command, just print what would be executed
```


After:
```bash
➜  linkerd2 git:(dad/init-container-exit-code) ✗ kubectl get pods -n linkerd
NAME                                  READY     STATUS                  RESTARTS   AGE
linkerd-controller-687ff55c99-8p925   0/4       Init:CrashLoopBackOff   2          48s
linkerd-grafana-6695687585-c9znq      2/2       Running                 0          46s
linkerd-prometheus-7c76cbc64-ffj46    1/2       Running                 0          46s
linkerd-web-76b4c6fd7c-9pqg9          2/2       Running                 0          47s
```

fixes #2056
 
Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>