### PR TITLE
Group checkers by category

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -79,7 +79,7 @@ func configureAndRunChecks(options *checkOptions) error {
 	if err != nil {
 		return fmt.Errorf("Validation error when executing check command: %v", err)
 	}
-	checks := []healthcheck.Checks{
+	checks := []healthcheck.Category{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.KubernetesVersionChecks,
 	}

--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -12,7 +12,7 @@ import (
 func TestCheckStatus(t *testing.T) {
 	t.Run("Prints expected output", func(t *testing.T) {
 		hc := healthcheck.NewHealthChecker(
-			[]healthcheck.Checks{},
+			[]healthcheck.Category{},
 			&healthcheck.Options{},
 		)
 		hc.Add("category", "check1", func() error {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -97,7 +97,7 @@ func cliPublicAPIClient() pb.ApiClient {
 // checks fail, then CLI will print an error and exit. If the retryDeadline
 // param is specified, then the CLI will print a message to stderr and retry.
 func validatedPublicAPIClient(retryDeadline time.Time, apiChecks bool) pb.ApiClient {
-	checks := []healthcheck.Checks{
+	checks := []healthcheck.Category{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.LinkerdControlPlaneExistenceChecks,
 	}
@@ -123,11 +123,11 @@ func validatedPublicAPIClient(retryDeadline time.Time, apiChecks bool) pb.ApiCli
 		if result.Err != nil && !result.Warning {
 			var msg string
 			switch result.Category {
-			case healthcheck.KubernetesAPICategory:
+			case healthcheck.KubernetesAPIChecks:
 				msg = "Cannot connect to Kubernetes"
-			case healthcheck.LinkerdControlPlaneExistenceCategory:
+			case healthcheck.LinkerdControlPlaneExistenceChecks:
 				msg = "Cannot find Linkerd"
-			case healthcheck.LinkerdAPICategory:
+			case healthcheck.LinkerdAPIChecks:
 				msg = "Cannot connect to Linkerd"
 			}
 			fmt.Fprintf(os.Stderr, "%s: %s\n", msg, result.Err)


### PR DESCRIPTION
The `linkerd check` command organized the various checks via loosely
coupled category IDs, category names, and checkers themselves, all with
ordering defined by consumers of this code.

This change removes category IDs in favor of category names, groups all
checkers by category, and enforces ordering at the `HealthChecker`
level.

Part of #1471, depends on #2078.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>