### PR TITLE
Leave dashboard command running when open URL fails

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -109,16 +109,16 @@ func newCmdDashboard() *cobra.Command {
 
 				err = browser.OpenURL(webURL)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to open Linkerd URL %s in the default browser: %s", webURL, err)
-					os.Exit(1)
+					fmt.Fprintln(os.Stderr, "Failed to open Linkerd dashboard automatically")
+					fmt.Fprintf(os.Stderr, "Visit %s in your browser to view the dashboard\n", webURL)
 				}
 			case showGrafana:
 				fmt.Println("Opening Grafana dashboard in the default browser")
 
 				err = browser.OpenURL(grafanaURL)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "Failed to open Grafana URL %s in the default browser: %s", grafanaURL, err)
-					os.Exit(1)
+					fmt.Fprintln(os.Stderr, "Failed to open Grafana dashboard automatically")
+					fmt.Fprintf(os.Stderr, "Visit %s in your browser to view the dashboard\n", grafanaURL)
 				}
 			case showURL:
 				// no-op, we already printed the URLs


### PR DESCRIPTION
The `linkerd dashboard` command attempts to load the dashboard URL in the user's browser, and if it fails for any reason, the process exits. Instead, when opening the dashboard fails, we'll now leave the process running and instruct the user to manually load the dashboard. It looks like this:

```
Linkerd dashboard available at:
http://127.0.0.1:52513
Grafana dashboard available at:
http://127.0.0.1:52513/grafana
Opening Linkerd dashboard in the default browser
The file /Users/kl/workspace/go/src/github.com/linkerd/linkerd2/invalid does not exist.
Failed to open Linkerd dashboard automatically
Visit http://127.0.0.1:52513 in your browser to view the dashboard
```

This will allow users running on systems where we can't automatically open the dashboard to still use the command without needing to add the `--show url` flag.

Fixes #2014.
Fixes #2047.