### PR TITLE
Update check and inject output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -46,12 +46,11 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
-  digest = "1:87a8cd3894b69f36d93f71074b921d6446483cc9465b36415991ecc02851ec08"
+  digest = "1:453c7a777da3e9aa031a0d9b8e0c882af15afb18e6c3651de7610fcb628dbd4b"
   name = "github.com/briandowns/spinner"
   packages = ["."]
   pruneopts = ""
-  revision = "dd69c579ff204842e8962816987f838e2c2c18d8"
-  version = "1.4"
+  revision = "195c31b675a7d5ac6859ea5371d6f3bc775f003d"
 
 [[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
@@ -973,6 +972,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/briandowns/spinner",
+    "github.com/fatih/color",
     "github.com/ghodss/yaml",
     "github.com/go-openapi/spec",
     "github.com/golang/protobuf/jsonpb",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -46,6 +46,14 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:87a8cd3894b69f36d93f71074b921d6446483cc9465b36415991ecc02851ec08"
+  name = "github.com/briandowns/spinner"
+  packages = ["."]
+  pruneopts = ""
+  revision = "dd69c579ff204842e8962816987f838e2c2c18d8"
+  version = "1.4"
+
+[[projects]]
   digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -70,6 +78,14 @@
   ]
   pruneopts = ""
   revision = "449fdfce4d962303d702fec724ef0ad181c92528"
+
+[[projects]]
+  digest = "1:e988ed0ca0d81f4d28772760c02ee95084961311291bdfefc1b04617c178b722"
+  name = "github.com/fatih/color"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
@@ -288,6 +304,22 @@
   ]
   pruneopts = ""
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
+
+[[projects]]
+  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  pruneopts = ""
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  digest = "1:3140e04675a6a91d2a20ea9d10bdadf6072085502e6def6768361260aee4b967"
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
@@ -940,6 +972,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/briandowns/spinner",
     "github.com/ghodss/yaml",
     "github.com/go-openapi/spec",
     "github.com/golang/protobuf/jsonpb",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@ required = [
 
 [[constraint]]
   name = "github.com/briandowns/spinner"
-  version = "1.4"
+  revision = "195c31b675a7d5ac6859ea5371d6f3bc775f003d"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -33,6 +33,10 @@ required = [
   version = "kubernetes-1.11.1"
 
 [[constraint]]
+  name = "github.com/briandowns/spinner"
+  version = "1.4"
+
+[[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "v1.0.3"
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:18d4ad09 as golang
+FROM gcr.io/linkerd-io/go-deps:844900ed as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY controller/k8s controller/k8s

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -7,14 +7,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/spf13/cobra"
-)
-
-const (
-	retryStatus   = "[retry]"
-	failStatus    = "[FAIL]"
-	warningStatus = "[warning]"
 )
 
 type checkOptions struct {
@@ -82,6 +77,7 @@ func configureAndRunChecks(options *checkOptions) error {
 	checks := []healthcheck.CategoryID{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.KubernetesVersionChecks,
+		healthcheck.LinkerdVersionChecks,
 	}
 
 	if options.preInstallOnly {
@@ -91,30 +87,19 @@ func configureAndRunChecks(options *checkOptions) error {
 			checks = append(checks, healthcheck.LinkerdPreInstallClusterChecks)
 		}
 		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
-	} else if options.dataPlaneOnly {
-		checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
-		checks = append(checks, healthcheck.LinkerdAPIChecks)
-		if !options.singleNamespace {
-			checks = append(checks, healthcheck.LinkerdServiceProfileChecks)
-		}
-		if options.namespace != "" {
-			checks = append(checks, healthcheck.LinkerdDataPlaneExistenceChecks)
-		}
-		checks = append(checks, healthcheck.LinkerdDataPlaneChecks)
 	} else {
 		checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
 		checks = append(checks, healthcheck.LinkerdAPIChecks)
+
 		if !options.singleNamespace {
 			checks = append(checks, healthcheck.LinkerdServiceProfileChecks)
 		}
-	}
 
-	checks = append(checks, healthcheck.LinkerdVersionChecks)
-	if !(options.preInstallOnly || options.dataPlaneOnly) {
-		checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
-	}
-	if options.dataPlaneOnly {
-		checks = append(checks, healthcheck.LinkerdDataPlaneVersionChecks)
+		if options.dataPlaneOnly {
+			checks = append(checks, healthcheck.LinkerdDataPlaneChecks)
+		} else {
+			checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
+		}
 	}
 
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
@@ -150,30 +135,49 @@ func (o *checkOptions) validate() error {
 }
 
 func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
+	var lastCategory healthcheck.CategoryID
+	spin := spinner.New(spinner.CharSets[0], 100*time.Millisecond)
+	spin.Writer = w
+
 	prettyPrintResults := func(result *healthcheck.CheckResult) {
-		checkLabel := fmt.Sprintf("%s: %s", result.Category, result.Description)
-
-		filler := ""
-		lineBreak := "\n"
-		for i := 0; i < lineWidth-len(checkLabel)-len(okStatus)-len(lineBreak); i++ {
-			filler = filler + "."
-		}
-
-		if result.Retry {
-			fmt.Fprintf(w, "%s%s%s -- %s%s", checkLabel, filler, retryStatus, result.Err, lineBreak)
-			return
-		}
-
-		if result.Err != nil {
-			status := failStatus
-			if result.Warning {
-				status = warningStatus
+		if lastCategory != result.Category {
+			if lastCategory != "" {
+				fmt.Fprintln(w, "")
 			}
-			fmt.Fprintf(w, "%s%s%s -- %s%s", checkLabel, filler, status, result.Err, lineBreak)
+
+			underline := ""
+			for i := 0; i < len(result.Category); i++ {
+				underline = underline + "-"
+			}
+
+			fmt.Fprintln(w, result.Category)
+			fmt.Fprintln(w, underline)
+
+			lastCategory = result.Category
+		}
+
+		spin.Stop()
+		if result.Retry {
+			spin.Suffix = fmt.Sprintf("  %s -- %s", result.Description, result.Err)
+			spin.Color("bgBlack", "bold", "fgRed")
 			return
 		}
 
-		fmt.Fprintf(w, "%s%s%s%s", checkLabel, filler, okStatus, lineBreak)
+		status := okStatus
+		if result.Err != nil {
+			status = failStatus
+			if result.Warning {
+				status = warnStatus
+			}
+		}
+
+		fmt.Fprintln(w, status, result.Description)
+		if result.Err != nil {
+			fmt.Fprintf(w, "    %s\n", result.Err)
+			if result.HintURL != "" {
+				fmt.Fprintf(w, "    See %s for hints\n", result.HintURL)
+			}
+		}
 	}
 
 	return hc.RunChecks(prettyPrintResults)

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -145,13 +146,8 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 				fmt.Fprintln(w)
 			}
 
-			underline := ""
-			for i := 0; i < len(result.Category); i++ {
-				underline = underline + "-"
-			}
-
 			fmt.Fprintln(w, result.Category)
-			fmt.Fprintln(w, underline)
+			fmt.Fprintln(w, strings.Repeat("-", len(result.Category)))
 
 			lastCategory = result.Category
 		}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -136,13 +136,13 @@ func (o *checkOptions) validate() error {
 
 func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 	var lastCategory healthcheck.CategoryID
-	spin := spinner.New(spinner.CharSets[0], 100*time.Millisecond)
+	spin := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
 	spin.Writer = w
 
 	prettyPrintResults := func(result *healthcheck.CheckResult) {
 		if lastCategory != result.Category {
 			if lastCategory != "" {
-				fmt.Fprintln(w, "")
+				fmt.Fprintln(w)
 			}
 
 			underline := ""
@@ -158,8 +158,8 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 
 		spin.Stop()
 		if result.Retry {
-			spin.Suffix = fmt.Sprintf("  %s -- %s", result.Description, result.Err)
-			spin.Color("bgBlack", "bold", "fgRed")
+			spin.Suffix = fmt.Sprintf(" %s -- %s", result.Description, result.Err)
+			spin.Color("bold")
 			return
 		}
 
@@ -171,7 +171,7 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 			}
 		}
 
-		fmt.Fprintln(w, status, result.Description)
+		fmt.Fprintf(w, "%s %s\n", status, result.Description)
 		if result.Err != nil {
 			fmt.Fprintf(w, "    %s\n", result.Err)
 			if result.HintURL != "" {

--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -15,10 +15,10 @@ func TestCheckStatus(t *testing.T) {
 			[]healthcheck.CategoryID{},
 			&healthcheck.Options{},
 		)
-		hc.Add("category", "check1", func() error {
+		hc.Add("category", "check1", "", func() error {
 			return nil
 		})
-		hc.Add("category", "check2", func() error {
+		hc.Add("category", "check2", "http://linkerd.io/hint-url", func() error {
 			return fmt.Errorf("This should contain instructions for fail")
 		})
 

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -11,6 +11,46 @@ import (
 	"testing"
 )
 
+type injectYAML struct {
+	inputFileName     string
+	goldenFileName    string
+	reportFileName    string
+	testInjectOptions *injectOptions
+}
+
+func testInjectYAML(t *testing.T, tc injectYAML) {
+	file, err := os.Open("testdata/" + tc.inputFileName)
+	if err != nil {
+		t.Errorf("error opening test input file: %v\n", err)
+	}
+
+	read := bufio.NewReader(file)
+
+	output := new(bytes.Buffer)
+	report := new(bytes.Buffer)
+
+	err = InjectYAML(read, output, report, tc.testInjectOptions)
+	if err != nil {
+		t.Errorf("Unexpected error injecting YAML: %v\n", err)
+	}
+
+	actualOutput := output.String()
+	expectedOutput := readOptionalTestFile(t, tc.goldenFileName)
+	if expectedOutput != actualOutput {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedOutput, actualOutput)
+	}
+
+	actualReport := report.String()
+	reportFileName := tc.reportFileName
+	if verbose {
+		reportFileName += ".verbose"
+	}
+	expectedReport := readOptionalTestFile(t, reportFileName)
+	if expectedReport != actualReport {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedReport, actualReport)
+	}
+}
+
 func TestInjectYAML(t *testing.T) {
 	defaultOptions := newInjectOptions()
 	defaultOptions.linkerdVersion = "testinjectversion"
@@ -24,12 +64,7 @@ func TestInjectYAML(t *testing.T) {
 	proxyRequestOptions.proxyCPURequest = "110m"
 	proxyRequestOptions.proxyMemoryRequest = "100Mi"
 
-	testCases := []struct {
-		inputFileName     string
-		goldenFileName    string
-		reportFileName    string
-		testInjectOptions *injectOptions
-	}{
+	testCases := []injectYAML{
 		{
 			inputFileName:     "inject_emojivoto_deployment.input.yml",
 			goldenFileName:    "inject_emojivoto_deployment.golden.yml",
@@ -117,46 +152,61 @@ func TestInjectYAML(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
+		verbose = true
+		t.Run(fmt.Sprintf("%d: %s --verbose", i, tc.inputFileName), func(t *testing.T) {
+			testInjectYAML(t, tc)
+		})
+		verbose = false
 		t.Run(fmt.Sprintf("%d: %s", i, tc.inputFileName), func(t *testing.T) {
-			file, err := os.Open("testdata/" + tc.inputFileName)
-			if err != nil {
-				t.Errorf("error opening test input file: %v\n", err)
-			}
-
-			read := bufio.NewReader(file)
-
-			output := new(bytes.Buffer)
-			report := new(bytes.Buffer)
-
-			err = InjectYAML(read, output, report, tc.testInjectOptions)
-			if err != nil {
-				t.Errorf("Unexpected error injecting YAML: %v\n", err)
-			}
-
-			actualOutput := output.String()
-			expectedOutput := readOptionalTestFile(t, tc.goldenFileName)
-			if expectedOutput != actualOutput {
-				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedOutput, actualOutput)
-			}
-
-			actualReport := report.String()
-			expectedReport := readOptionalTestFile(t, tc.reportFileName)
-			if expectedReport != actualReport {
-				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedReport, actualReport)
-			}
+			testInjectYAML(t, tc)
 		})
 	}
 }
 
-func TestRunInjectCmd(t *testing.T) {
+type injectCmd struct {
+	inputFileName        string
+	stdErrGoldenFileName string
+	stdOutGoldenFileName string
+	exitCode             int
+}
+
+func testInjectCmd(t *testing.T, tc injectCmd) {
 	testInjectOptions := newInjectOptions()
 	testInjectOptions.linkerdVersion = "testinjectversion"
-	testCases := []struct {
-		inputFileName        string
-		stdErrGoldenFileName string
-		stdOutGoldenFileName string
-		exitCode             int
-	}{
+
+	errBuffer := &bytes.Buffer{}
+	outBuffer := &bytes.Buffer{}
+
+	in, err := os.Open(fmt.Sprintf("testdata/%s", tc.inputFileName))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, testInjectOptions)
+	if exitCode != tc.exitCode {
+		t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
+	}
+
+	actualStdOutResult := outBuffer.String()
+	expectedStdOutResult := readOptionalTestFile(t, tc.stdOutGoldenFileName)
+	if expectedStdOutResult != actualStdOutResult {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedStdOutResult, actualStdOutResult)
+	}
+
+	actualStdErrResult := errBuffer.String()
+
+	stdErrGoldenFileName := tc.stdErrGoldenFileName
+	if verbose {
+		stdErrGoldenFileName += ".verbose"
+	}
+
+	expectedStdErrResult := readOptionalTestFile(t, stdErrGoldenFileName)
+	if expectedStdErrResult != actualStdErrResult {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedStdErrResult, actualStdErrResult)
+	}
+}
+func TestRunInjectCmd(t *testing.T) {
+	testCases := []injectCmd{
 		{
 			inputFileName:        "inject_gettest_deployment.bad.input.yml",
 			stdErrGoldenFileName: "inject_gettest_deployment.bad.golden",
@@ -171,32 +221,77 @@ func TestRunInjectCmd(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("%d: %s", i, tc.inputFileName), func(t *testing.T) {
-			errBuffer := &bytes.Buffer{}
-			outBuffer := &bytes.Buffer{}
-
-			in, err := os.Open(fmt.Sprintf("testdata/%s", tc.inputFileName))
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-
-			exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, testInjectOptions)
-			if exitCode != tc.exitCode {
-				t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
-			}
-
-			actualStdOutResult := outBuffer.String()
-			expectedStdOutResult := readOptionalTestFile(t, tc.stdOutGoldenFileName)
-			if expectedStdOutResult != actualStdOutResult {
-				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedStdOutResult, actualStdOutResult)
-			}
-
-			actualStdErrResult := errBuffer.String()
-			expectedStdErrResult := readOptionalTestFile(t, tc.stdErrGoldenFileName)
-			if expectedStdErrResult != actualStdErrResult {
-				t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expectedStdErrResult, actualStdErrResult)
-			}
+		verbose = true
+		t.Run(fmt.Sprintf("%d: %s --verbose", i, tc.inputFileName), func(t *testing.T) {
+			testInjectCmd(t, tc)
 		})
+		verbose = false
+		t.Run(fmt.Sprintf("%d: %s", i, tc.inputFileName), func(t *testing.T) {
+			testInjectCmd(t, tc)
+		})
+	}
+}
+
+type injectFilePath struct {
+	resource     string
+	resourceFile string
+	expectedFile string
+	stdErrFile   string
+}
+
+func testInjectFilePath(t *testing.T, tc injectFilePath) {
+	in, err := read(tc.resourceFile)
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	errBuf := &bytes.Buffer{}
+	actual := &bytes.Buffer{}
+	if exitCode := runInjectCmd(in, errBuf, actual, newInjectOptions()); exitCode != 0 {
+		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
+	}
+
+	expected := readOptionalTestFile(t, tc.expectedFile)
+	if expected != actual.String() {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
+	}
+
+	stdErrFile := tc.stdErrFile
+	if verbose {
+		stdErrFile += ".verbose"
+	}
+
+	stdErr := readOptionalTestFile(t, stdErrFile)
+	if stdErr != errBuf.String() {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", stdErr, errBuf.String())
+	}
+}
+
+func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder string) {
+	in, err := read(resourceFolder)
+	if err != nil {
+		t.Fatal("Unexpected error: ", err)
+	}
+
+	errBuf := &bytes.Buffer{}
+	actual := &bytes.Buffer{}
+	if exitCode := runInjectCmd(in, errBuf, actual, newInjectOptions()); exitCode != 0 {
+		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
+	}
+
+	expected := readOptionalTestFile(t, filepath.Join(expectedFolder, "injected_nginx_redis.yaml"))
+	if expected != actual.String() {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
+	}
+
+	stdErrFileName := filepath.Join(expectedFolder, "injected_nginx_redis.stderr")
+	if verbose {
+		stdErrFileName += ".verbose"
+	}
+
+	stdErr := readOptionalTestFile(t, stdErrFileName)
+	if stdErr != errBuf.String() {
+		t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", stdErr, errBuf.String())
 	}
 }
 
@@ -204,16 +299,10 @@ func TestInjectFilePath(t *testing.T) {
 	var (
 		resourceFolder = filepath.Join("testdata", "inject-filepath", "resources")
 		expectedFolder = filepath.Join("inject-filepath", "expected")
-		options        = newInjectOptions()
 	)
 
 	t.Run("read from files", func(t *testing.T) {
-		testCases := []struct {
-			resource     string
-			resourceFile string
-			expectedFile string
-			stdErrFile   string
-		}{
+		testCases := []injectFilePath{
 			{
 				resource:     "nginx",
 				resourceFile: filepath.Join(resourceFolder, "nginx.yaml"),
@@ -229,52 +318,24 @@ func TestInjectFilePath(t *testing.T) {
 		}
 
 		for i, testCase := range testCases {
+			verbose = true
 			t.Run(fmt.Sprintf("%d %s", i, testCase.resource), func(t *testing.T) {
-				in, err := read(testCase.resourceFile)
-				if err != nil {
-					t.Fatal("Unexpected error: ", err)
-				}
-
-				errBuf := &bytes.Buffer{}
-				actual := &bytes.Buffer{}
-				if exitCode := runInjectCmd(in, errBuf, actual, options); exitCode != 0 {
-					t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
-				}
-
-				expected := readOptionalTestFile(t, testCase.expectedFile)
-				if expected != actual.String() {
-					t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
-				}
-
-				stdErr := readOptionalTestFile(t, testCase.stdErrFile)
-				if stdErr != errBuf.String() {
-					t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", stdErr, errBuf.String())
-				}
+				testInjectFilePath(t, testCase)
+			})
+			verbose = false
+			t.Run(fmt.Sprintf("%d %s", i, testCase.resource), func(t *testing.T) {
+				testInjectFilePath(t, testCase)
 			})
 		}
 	})
 
-	t.Run("read from folder", func(t *testing.T) {
-		in, err := read(resourceFolder)
-		if err != nil {
-			t.Fatal("Unexpected error: ", err)
-		}
-
-		errBuf := &bytes.Buffer{}
-		actual := &bytes.Buffer{}
-		if exitCode := runInjectCmd(in, errBuf, actual, options); exitCode != 0 {
-			t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
-		}
-
-		expected := readOptionalTestFile(t, filepath.Join(expectedFolder, "injected_nginx_redis.yaml"))
-		if expected != actual.String() {
-			t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", expected, actual.String())
-		}
-
-		stdErr := readOptionalTestFile(t, filepath.Join(expectedFolder, "injected_nginx_redis.stderr"))
-		if stdErr != errBuf.String() {
-			t.Errorf("Result mismatch.\nExpected: %s\nActual: %s", stdErr, errBuf.String())
-		}
+	verbose = true
+	t.Run("read from folder --verbose", func(t *testing.T) {
+		testReadFromFolder(t, resourceFolder, expectedFolder)
+	})
+	verbose = false
+	t.Run("read from folder --verbose", func(t *testing.T) {
+		testReadFromFolder(t, resourceFolder, expectedFolder)
 	})
 }
 

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -328,12 +328,3 @@ func walk(path string) ([]io.Reader, error) {
 
 	return in, nil
 }
-
-func getFiller(text string) string {
-	filler := ""
-	for i := 0; i < lineWidth-len(text)-len(okStatus)-len("\n"); i++ {
-		filler = filler + "."
-	}
-
-	return filler
-}

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -25,6 +25,7 @@ type resourceTransformer interface {
 }
 
 type injectReport struct {
+	kind                string
 	name                string
 	hostNetwork         bool
 	sidecar             bool
@@ -40,6 +41,10 @@ type resourceConfig struct {
 	objectMeta      *metaV1.ObjectMeta
 	dnsNameOverride string
 	k8sLabels       map[string]string
+}
+
+func (i injectReport) resName() string {
+	return fmt.Sprintf("%s/%s", i.kind, i.name)
 }
 
 // Returns the integer representation of os.Exit code; 0 on success and 1 on failure.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -20,8 +20,9 @@ const (
 	defaultNamespace = "linkerd"
 
 	lineWidth  = 80
-	okStatus   = "[ok]"
-	warnStatus = "[warn]"
+	okStatus   = "✅"
+	warnStatus = "⚠️ "
+	failStatus = "❌"
 )
 
 var controlPlaneNamespace string

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/version"
@@ -18,12 +19,12 @@ import (
 
 const (
 	defaultNamespace = "linkerd"
-
-	lineWidth  = 80
-	okStatus   = "✅"
-	warnStatus = "⚠️ "
-	failStatus = "❌"
+	lineWidth        = 80
 )
+
+var okStatus = color.New(color.FgGreen, color.Bold).SprintFunc()("\u2714")    // ✔
+var warnStatus = color.New(color.FgYellow, color.Bold).SprintFunc()("\u26A0") // ⚠
+var failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u2718")    // ✘
 
 var controlPlaneNamespace string
 var apiAddr string // An empty value means "use the Kubernetes configuration"

--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -1,6 +1,6 @@
 category
 --------
-✅ check1
-❌ check2
+✔ check1
+✘ check2
     This should contain instructions for fail
     See http://linkerd.io/hint-url for hints

--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -1,2 +1,6 @@
-category: check1...........................................................[ok]
-category: check2...........................................................[FAIL] -- This should contain instructions for fail
+category
+--------
+✅ check1
+❌ check2
+    This should contain instructions for fail
+    See http://linkerd.io/hint-url for hints

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/nginx
+deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "nginx" injected
+

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
@@ -1,18 +1,6 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/redis
+deployment "redis" injected
 
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/nginx
+deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
@@ -1,16 +1,16 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "redis" injected
 
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
@@ -1,0 +1,16 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "redis" injected
+
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "nginx" injected
+

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/redis
+deployment "redis" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "redis" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "redis" injected
+

--- a/cli/cmd/testdata/inject_contour.report
+++ b/cli/cmd/testdata/inject_contour.report
@@ -1,6 +1,6 @@
 
-⚠️  known sidecar detected in deployment/contour
-⚠️  no supported objects found
+⚠ known sidecar detected in deployment/contour
+⚠ no supported objects found
 
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -1,6 +1,8 @@
 
+✅ pods do not use host networking
 ⚠️  known sidecar detected in deployment/contour
 ⚠️  no supported objects found
+✅ pod specs do not include UDP ports
 
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-⚠️  known sidecar detected in deployment/contour
-⚠️  no supported objects found
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+⚠ known sidecar detected in deployment/contour
+⚠ no supported objects found
+✔ pod specs do not include UDP ports
 
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report
@@ -1,6 +1,6 @@
 
-⚠️  known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
-⚠️  no supported objects found
+⚠ known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
+⚠ no supported objects found
 
 deployment "web1" skipped
 deployment "web2" skipped

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-⚠️  known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
-⚠️  no supported objects found
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+⚠ known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
+⚠ no supported objects found
+✔ pod specs do not include UDP ports
 
 deployment "web1" skipped
 deployment "web2" skipped

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
@@ -1,6 +1,8 @@
 
+✅ pods do not use host networking
 ⚠️  known sidecar detected in deployment/web1, deployment/web2, deployment/web3, deployment/web4
 ⚠️  no supported objects found
+✅ pod specs do not include UDP ports
 
 deployment "web1" skipped
 deployment "web2" skipped

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/web
+deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "web" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
@@ -1,10 +1,4 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 2 of 2 YAML document(s) injected
-  deployment/controller
-  deployment/not-controller
+deployment "controller" injected
+deployment "not-controller" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "controller" injected
 deployment "not-controller" injected

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
@@ -1,0 +1,9 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "controller" injected
+deployment "not-controller" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  deployment/web
+deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "web" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report
@@ -1,6 +1,6 @@
 
-⚠️  "hostNetwork: true" detected in deployment/web
-⚠️  no supported objects found
+⚠ "hostNetwork: true" detected in deployment/web
+⚠ no supported objects found
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
@@ -1,8 +1,8 @@
 
-⚠️  "hostNetwork: true" detected in deployment/web
-✅ pods do not have a proxy or initContainer already injected
-⚠️  no supported objects found
-✅ pod specs do not include UDP ports
+⚠ "hostNetwork: true" detected in deployment/web
+✔ pods do not have a proxy or initContainer already injected
+⚠ no supported objects found
+✔ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
@@ -1,6 +1,8 @@
 
 ⚠️  "hostNetwork: true" detected in deployment/web
+✅ pods do not have a proxy or initContainer already injected
 ⚠️  no supported objects found
+✅ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
@@ -1,5 +1,5 @@
 
-⚠️  deployment/web uses "protocol: UDP"
+⚠ deployment/web uses "protocol: UDP"
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
@@ -1,9 +1,5 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[warn] -- deployment/web uses "protocol: UDP"
+⚠️  deployment/web uses "protocol: UDP"
 
-Summary: 1 of 1 YAML document(s) injected
-  deployment/web
+deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+⚠️  deployment/web uses "protocol: UDP"
+
+deployment "web" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-⚠️  deployment/web uses "protocol: UDP"
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+⚠ deployment/web uses "protocol: UDP"
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report
@@ -1,6 +1,6 @@
 
-⚠️  known sidecar detected in deployment/web
-⚠️  no supported objects found
+⚠ known sidecar detected in deployment/web
+⚠ no supported objects found
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-⚠️  known sidecar detected in deployment/web
-⚠️  no supported objects found
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+⚠ known sidecar detected in deployment/web
+⚠ no supported objects found
+✔ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
@@ -1,6 +1,8 @@
 
+✅ pods do not use host networking
 ⚠️  known sidecar detected in deployment/web
 ⚠️  no supported objects found
+✅ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report
+++ b/cli/cmd/testdata/inject_emojivoto_list.report
@@ -1,10 +1,4 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 2 of 2 YAML document(s) injected
-  deployment/web
-  deployment/emoji
+deployment "web" injected
+deployment "emoji" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "web" injected
 deployment "emoji" injected

--- a/cli/cmd/testdata/inject_emojivoto_list.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list.report.verbose
@@ -1,0 +1,9 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "web" injected
+deployment "emoji" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_pod.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  pod/vote-bot
+pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+pod "vote-bot" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  pod/vote-bot
+pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+pod "vote-bot" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report
@@ -1,9 +1,3 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 1 of 1 YAML document(s) injected
-  statefulset/web
+statefulset "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 statefulset "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
@@ -1,0 +1,8 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+statefulset "web" injected
+

--- a/cli/cmd/testdata/inject_gettest_deployment.bad.golden.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.bad.golden.verbose
@@ -1,0 +1,1 @@
+Error transforming resources: error converting YAML to JSON: yaml: line 14: did not find expected key

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
@@ -1,10 +1,4 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 2 of 2 YAML document(s) injected
-  deployment/get-test-deploy-injected-1
-  deployment/get-test-deploy-injected-2
+deployment "get-test-deploy-injected-1" injected
+deployment "get-test-deploy-injected-2" injected
 

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
@@ -1,8 +1,8 @@
 
-✅ pods do not use host networking
-✅ pods do not have a proxy or initContainer already injected
-✅ at least one resource injected
-✅ pod specs do not include UDP ports
+✔ pods do not use host networking
+✔ pods do not have a proxy or initContainer already injected
+✔ at least one resource injected
+✔ pod specs do not include UDP ports
 
 deployment "get-test-deploy-injected-1" injected
 deployment "get-test-deploy-injected-2" injected

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
@@ -1,0 +1,9 @@
+
+✅ pods do not use host networking
+✅ pods do not have a proxy or initContainer already injected
+✅ at least one resource injected
+✅ pod specs do not include UDP ports
+
+deployment "get-test-deploy-injected-1" injected
+deployment "get-test-deploy-injected-2" injected
+

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:18d4ad09 as golang
+FROM gcr.io/linkerd-io/go-deps:844900ed as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -149,9 +149,9 @@ func TestHealthChecker(t *testing.T) {
 			"cat2 desc2",
 			"cat3 desc3: error",
 			"cat4 desc4",
-			"cat4[rpc1] rpc desc1",
+			"cat4 [rpc1] rpc desc1",
 			"cat5 desc5",
-			"cat5[rpc2] rpc desc2: rpc error",
+			"cat5 [rpc2] rpc desc2: rpc error",
 		}
 
 		hc.RunChecks(observer)

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:18d4ad09 as golang
+FROM gcr.io/linkerd-io/go-deps:844900ed as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -1,17 +1,37 @@
-kubernetes-api: can initialize the client..................................[ok]
-kubernetes-api: can query the Kubernetes API...............................[ok]
-kubernetes-version: is running the minimum Kubernetes API version..........[ok]
-linkerd-existence: control plane namespace exists..........................[ok]
-linkerd-existence: controller pod is running...............................[ok]
-linkerd-existence: can initialize the client...............................[ok]
-linkerd-existence: can query the control plane API.........................[ok]
-linkerd-api: control plane pods are ready..................................[ok]
-linkerd-api: can query the control plane API...............................[ok]
-linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
-linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
-linkerd-service-profile: no invalid service profiles.......................[ok]
-linkerd-version: can determine the latest version..........................[ok]
-linkerd-version: cli is up-to-date.........................................[ok]
-linkerd-control-plane-version: control plane is up-to-date.................[ok]
+kubernetes-api
+--------------
+✅ can initialize the client
+✅ can query the Kubernetes API
 
-Status check results are [ok]
+kubernetes-version
+------------------
+✅ is running the minimum Kubernetes API version
+
+linkerd-existence
+-----------------
+✅ control plane namespace exists
+✅ controller pod is running
+✅ can initialize the client
+✅ can query the control plane API
+
+linkerd-api
+-----------
+✅ control plane pods are ready
+✅ can query the control plane API
+✅ [kubernetes] control plane can talk to Kubernetes
+✅ [prometheus] control plane can talk to Prometheus
+
+linkerd-service-profile
+-----------------------
+✅ no invalid service profiles
+
+linkerd-version
+---------------
+✅ can determine the latest version
+✅ cli is up-to-date
+
+control-plane-version
+---------------------
+✅ control plane is up-to-date
+
+Status check results are ✅

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -1,37 +1,37 @@
 kubernetes-api
 --------------
-✅ can initialize the client
-✅ can query the Kubernetes API
+✔ can initialize the client
+✔ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✅ is running the minimum Kubernetes API version
+✔ is running the minimum Kubernetes API version
 
 linkerd-existence
 -----------------
-✅ control plane namespace exists
-✅ controller pod is running
-✅ can initialize the client
-✅ can query the control plane API
+✔ control plane namespace exists
+✔ controller pod is running
+✔ can initialize the client
+✔ can query the control plane API
 
 linkerd-api
 -----------
-✅ control plane pods are ready
-✅ can query the control plane API
-✅ [kubernetes] control plane can talk to Kubernetes
-✅ [prometheus] control plane can talk to Prometheus
+✔ control plane pods are ready
+✔ can query the control plane API
+✔ [kubernetes] control plane can talk to Kubernetes
+✔ [prometheus] control plane can talk to Prometheus
 
 linkerd-service-profile
 -----------------------
-✅ no invalid service profiles
+✔ no invalid service profiles
 
 linkerd-version
 ---------------
-✅ can determine the latest version
-✅ cli is up-to-date
+✔ can determine the latest version
+✔ cli is up-to-date
 
 control-plane-version
 ---------------------
-✅ control plane is up-to-date
+✔ control plane is up-to-date
 
-Status check results are ✅
+Status check results are ✔

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -1,16 +1,30 @@
-kubernetes-api: can initialize the client..................................[ok]
-kubernetes-api: can query the Kubernetes API...............................[ok]
-kubernetes-version: is running the minimum Kubernetes API version..........[ok]
-kubernetes-cluster-setup: control plane namespace does not already exist...[ok]
-kubernetes-cluster-setup: can create Namespaces............................[ok]
-kubernetes-cluster-setup: can create ClusterRoles..........................[ok]
-kubernetes-cluster-setup: can create ClusterRoleBindings...................[ok]
-kubernetes-cluster-setup: can create CustomResourceDefinitions.............[ok]
-kubernetes-setup: can create ServiceAccounts...............................[ok]
-kubernetes-setup: can create Services......................................[ok]
-kubernetes-setup: can create Deployments...................................[ok]
-kubernetes-setup: can create ConfigMaps....................................[ok]
-linkerd-version: can determine the latest version..........................[ok]
-linkerd-version: cli is up-to-date.........................................[ok]
+kubernetes-api
+--------------
+✅ can initialize the client
+✅ can query the Kubernetes API
 
-Status check results are [ok]
+kubernetes-version
+------------------
+✅ is running the minimum Kubernetes API version
+
+pre-kubernetes-cluster-setup
+----------------------------
+✅ control plane namespace does not already exist
+✅ can create Namespaces
+✅ can create ClusterRoles
+✅ can create ClusterRoleBindings
+✅ can create CustomResourceDefinitions
+
+pre-kubernetes-setup
+--------------------
+✅ can create ServiceAccounts
+✅ can create Services
+✅ can create Deployments
+✅ can create ConfigMaps
+
+linkerd-version
+---------------
+✅ can determine the latest version
+✅ cli is up-to-date
+
+Status check results are ✅

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -1,30 +1,30 @@
 kubernetes-api
 --------------
-✅ can initialize the client
-✅ can query the Kubernetes API
+✔ can initialize the client
+✔ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✅ is running the minimum Kubernetes API version
+✔ is running the minimum Kubernetes API version
 
 pre-kubernetes-cluster-setup
 ----------------------------
-✅ control plane namespace does not already exist
-✅ can create Namespaces
-✅ can create ClusterRoles
-✅ can create ClusterRoleBindings
-✅ can create CustomResourceDefinitions
+✔ control plane namespace does not already exist
+✔ can create Namespaces
+✔ can create ClusterRoles
+✔ can create ClusterRoleBindings
+✔ can create CustomResourceDefinitions
 
 pre-kubernetes-setup
 --------------------
-✅ can create ServiceAccounts
-✅ can create Services
-✅ can create Deployments
-✅ can create ConfigMaps
+✔ can create ServiceAccounts
+✔ can create Services
+✔ can create Deployments
+✔ can create ConfigMaps
 
 linkerd-version
 ---------------
-✅ can determine the latest version
-✅ cli is up-to-date
+✔ can determine the latest version
+✔ cli is up-to-date
 
-Status check results are ✅
+Status check results are ✔

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -1,40 +1,40 @@
 kubernetes-api
 --------------
-✅ can initialize the client
-✅ can query the Kubernetes API
+✔ can initialize the client
+✔ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✅ is running the minimum Kubernetes API version
+✔ is running the minimum Kubernetes API version
 
 linkerd-existence
 -----------------
-✅ control plane namespace exists
-✅ controller pod is running
-✅ can initialize the client
-✅ can query the control plane API
+✔ control plane namespace exists
+✔ controller pod is running
+✔ can initialize the client
+✔ can query the control plane API
 
 linkerd-api
 -----------
-✅ control plane pods are ready
-✅ can query the control plane API
-✅ [kubernetes] control plane can talk to Kubernetes
-✅ [prometheus] control plane can talk to Prometheus
+✔ control plane pods are ready
+✔ can query the control plane API
+✔ [kubernetes] control plane can talk to Kubernetes
+✔ [prometheus] control plane can talk to Prometheus
 
 linkerd-service-profile
 -----------------------
-✅ no invalid service profiles
+✔ no invalid service profiles
 
 linkerd-version
 ---------------
-✅ can determine the latest version
-✅ cli is up-to-date
+✔ can determine the latest version
+✔ cli is up-to-date
 
 linkerd-data-plane
 ------------------
-✅ data plane namespace exists
-✅ data plane proxies are ready
-✅ data plane proxy metrics are present in Prometheus
-✅ data plane is up-to-date
+✔ data plane namespace exists
+✔ data plane proxies are ready
+✔ data plane proxy metrics are present in Prometheus
+✔ data plane is up-to-date
 
-Status check results are ✅
+Status check results are ✔

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -1,20 +1,40 @@
-kubernetes-api: can initialize the client..................................[ok]
-kubernetes-api: can query the Kubernetes API...............................[ok]
-kubernetes-version: is running the minimum Kubernetes API version..........[ok]
-linkerd-existence: control plane namespace exists..........................[ok]
-linkerd-existence: controller pod is running...............................[ok]
-linkerd-existence: can initialize the client...............................[ok]
-linkerd-existence: can query the control plane API.........................[ok]
-linkerd-api: control plane pods are ready..................................[ok]
-linkerd-api: can query the control plane API...............................[ok]
-linkerd-api[kubernetes]: control plane can talk to Kubernetes..............[ok]
-linkerd-api[prometheus]: control plane can talk to Prometheus..............[ok]
-linkerd-service-profile: no invalid service profiles.......................[ok]
-linkerd-data-plane-existence: data plane namespace exists..................[ok]
-linkerd-data-plane: data plane proxies are ready...........................[ok]
-linkerd-data-plane: data plane proxy metrics are present in Prometheus.....[ok]
-linkerd-version: can determine the latest version..........................[ok]
-linkerd-version: cli is up-to-date.........................................[ok]
-linkerd-data-plane-version: data plane is up-to-date.......................[ok]
+kubernetes-api
+--------------
+✅ can initialize the client
+✅ can query the Kubernetes API
 
-Status check results are [ok]
+kubernetes-version
+------------------
+✅ is running the minimum Kubernetes API version
+
+linkerd-existence
+-----------------
+✅ control plane namespace exists
+✅ controller pod is running
+✅ can initialize the client
+✅ can query the control plane API
+
+linkerd-api
+-----------
+✅ control plane pods are ready
+✅ can query the control plane API
+✅ [kubernetes] control plane can talk to Kubernetes
+✅ [prometheus] control plane can talk to Prometheus
+
+linkerd-service-profile
+-----------------------
+✅ no invalid service profiles
+
+linkerd-version
+---------------
+✅ can determine the latest version
+✅ cli is up-to-date
+
+linkerd-data-plane
+------------------
+✅ data plane namespace exists
+✅ data plane proxies are ready
+✅ data plane proxy metrics are present in Prometheus
+✅ data plane is up-to-date
+
+Status check results are ✅

--- a/test/testdata/inject.report.golden
+++ b/test/testdata/inject.report.golden
@@ -1,10 +1,6 @@
 
-hostNetwork: pods do not use host networking...............................[ok]
-sidecar: pods do not have a proxy or initContainer already injected........[ok]
-supported: at least one resource injected..................................[ok]
-udp: pod specs do not include UDP ports....................................[ok]
-
-Summary: 2 of 4 YAML document(s) injected
-  deployment/smoke-test-terminus
-  deployment/smoke-test-gateway
+deployment "smoke-test-terminus" injected
+service "smoke-test-terminus-svc" skipped
+deployment "smoke-test-gateway" injected
+service "smoke-test-gateway-svc" skipped
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:18d4ad09 as golang
+FROM gcr.io/linkerd-io/go-deps:844900ed as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
The outputs of the `check` and `inject` commands did not vary much
between successful and failed executions, and were a bit verbose and
challenging to parse.

Reorganize output of `check` and `inject` commands, to provide more
output when errors occur, and less output when successful.

Specific changes:

`linkerd check`
- visually group checks by category
- introduce `hintURL`'s, to provide doc links when checks fail
- add spinners when retrying, remove addtional retry lines
- colored emojis to indicate success/warning/failure

`linkerd inject`
- modify default output to mirror `kubectl apply`
- only output non-successful inject reports
- support `--verbose` flag to output all inject reports

Fixes #1471, #1653, #1656, #1739

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

# Example outputs

Note the unicode symbols are rendered with color in the terminal:

![screen shot 2019-01-15 at 3 35 08 pm](https://user-images.githubusercontent.com/236915/51216984-2e960980-18db-11e9-88db-3da870f8766f.png)

```
✔
✘
⚠
```

## `linkerd check` with retries

![check-spinner4](https://user-images.githubusercontent.com/236915/51217231-225e7c00-18dc-11e9-9c15-72a436e377c0.gif)

## `linkerd check --pre`

```
$ bin/linkerd check --pre --expected-version=$(bin/root-tag)
kubernetes-api
--------------
✔ can initialize the client
✔ can query the Kubernetes API

kubernetes-version
------------------
✔ is running the minimum Kubernetes API version

pre-kubernetes-cluster-setup
----------------------------
✘ control plane namespace does not already exist
    The "linkerd" namespace already exists
✔ can create Namespaces
✔ can create ClusterRoles
✔ can create ClusterRoleBindings
✔ can create CustomResourceDefinitions

pre-kubernetes-setup
--------------------
✔ can create ServiceAccounts
✔ can create Services
✔ can create Deployments
✔ can create ConfigMaps

linkerd-version
---------------
✔ can determine the latest version
✔ cli is up-to-date

Status check results are ✘
```

## `linkerd check`
```
$ bin/linkerd check --expected-version=$(bin/root-tag)
kubernetes-api
--------------
✔ can initialize the client
✔ can query the Kubernetes API

kubernetes-version
------------------
✔ is running the minimum Kubernetes API version

linkerd-existence
-----------------
✔ control plane namespace exists
✔ controller pod is running
✔ can initialize the client
✔ can query the control plane API

linkerd-api
-----------
✔ control plane pods are ready
✔ can query the control plane API
✔ [kubernetes] control plane can talk to Kubernetes
✔ [prometheus] control plane can talk to Prometheus

linkerd-service-profile
-----------------------
✔ no invalid service profiles

linkerd-version
---------------
✔ can determine the latest version
✔ cli is up-to-date

control-plane-version
---------------------
⚠ control plane is up-to-date
    is running version 19.1.1 but the latest dev version is 75971c4b-siggy

Status check results are ✔
```

## `linkerd check --pre` with errors

```
$ bin/linkerd check --pre --expected-version=$(bin/root-tag)
kubernetes-api
--------------
✔ can initialize the client
✔ can query the Kubernetes API

kubernetes-version
------------------
✔ is running the minimum Kubernetes API version

pre-kubernetes-cluster-setup
----------------------------
✘ control plane namespace does not already exist
    The "linkerd" namespace already exists
✔ can create Namespaces
✘ can create ClusterRoles
    Missing permissions to create ClusterRoles
    See https://linkerd.io/2/getting-started/#step-0-setup for hints
✔ can create ClusterRoleBindings
✔ can create CustomResourceDefinitions

pre-kubernetes-setup
--------------------
✔ can create ServiceAccounts
✔ can create Services
✔ can create Deployments
✔ can create ConfigMaps

linkerd-version
---------------
✔ can determine the latest version
✔ cli is up-to-date

Status check results are ✘
```

## `linkerd check --proxy`

```
$ bin/linkerd check --expected-version=$(bin/root-tag) --proxy
kubernetes-api
--------------
✔ can initialize the client
✔ can query the Kubernetes API

kubernetes-version
------------------
✔ is running the minimum Kubernetes API version

linkerd-existence
-----------------
✔ control plane namespace exists
✔ controller pod is running
✔ can initialize the client
✔ can query the control plane API

linkerd-api
-----------
✔ control plane pods are ready
✔ can query the control plane API
✔ [kubernetes] control plane can talk to Kubernetes
✔ [prometheus] control plane can talk to Prometheus

linkerd-service-profile
-----------------------
✔ no invalid service profiles

linkerd-version
---------------
✔ can determine the latest version
✔ cli is up-to-date

linkerd-data-plane
------------------
✔ data plane namespace exists
✔ data plane proxies are ready
✔ data plane proxy metrics are present in Prometheus
⚠ data plane is up-to-date
    linkerd/linkerd-prometheus-568f746f6b-pvs6w is running version edge-19.1.1 but the latest version is dev-75971c4b-siggy

Status check results are ✔
```

## `linkerd inject`

```
$ curl -s https://run.linkerd.io/emojivoto.yml | bin/linkerd inject - | kubectl apply -f -

namespace "emojivoto" skipped
deployment "emoji" injected
service "emoji-svc" skipped
deployment "voting" injected
service "voting-svc" skipped
deployment "web" injected
service "web-svc" skipped
deployment "vote-bot" injected

namespace "emojivoto" created
deployment.apps "emoji" created
service "emoji-svc" created
deployment.apps "voting" created
service "voting-svc" created
deployment.apps "web" created
service "web-svc" created
deployment.apps "vote-bot" created
```

## `linkerd inject --verbose`

```
$ curl -s https://run.linkerd.io/emojivoto.yml | bin/linkerd inject --verbose - | kubectl apply -f -

✔ pods do not use host networking
✔ pods do not have a proxy or initContainer already injected
✔ at least one resource injected
✔ pod specs do not include UDP ports

namespace "emojivoto" skipped
deployment "emoji" injected
service "emoji-svc" skipped
deployment "voting" injected
service "voting-svc" skipped
deployment "web" injected
service "web-svc" skipped
deployment "vote-bot" injected

namespace "emojivoto" created
deployment.apps "emoji" created
service "emoji-svc" created
deployment.apps "voting" created
service "voting-svc" created
deployment.apps "web" created
service "web-svc" created
deployment.apps "vote-bot" created
```