### PR TITLE
Fix panic when swagger has no paths

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -164,10 +164,12 @@ func renderOpenAPI(options *profileOptions, w io.Writer) error {
 	routes := make([]*sp.RouteSpec, 0)
 
 	paths := make([]string, 0)
-	for path := range swagger.Paths.Paths {
-		paths = append(paths, path)
+	if swagger.Paths != nil {
+		for path := range swagger.Paths.Paths {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
 	}
-	sort.Strings(paths)
 
 	for _, path := range paths {
 		item := swagger.Paths.Paths[path]


### PR DESCRIPTION
Fixes #2059 

Fix a panic in `linkerd profile --open-api` when the swagger spec has no Paths field.

Signed-off-by: Alex Leong <alex@buoyant.io>