### PR TITLE
Add cli command to install linkerd service profiles

### DIFF
--- a/cli/cmd/install-sp.go
+++ b/cli/cmd/install-sp.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"text/template"
+
+	"github.com/linkerd/linkerd2/cli/installsp"
+	"github.com/spf13/cobra"
+)
+
+type installSPConfig struct {
+	Namespace string
+}
+
+func newCmdInstallSP() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install-sp [flags]",
+		Short: "Output Kubernetes configs to install Linkerd Service Profiles",
+		Long: `Output Kubernetes configs to install Linkerd Service Profiles.",
+
+This command installs Service Profiles into the Linkerd control plane. A
+cluster-wide Linkerd control-plane is a prerequisite. To confirm Service Profile
+support, verify "kubectl api-versions" outputs "linkerd.io/v1alpha1".`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return renderSP(os.Stdout, controlPlaneNamespace)
+		},
+	}
+
+	return cmd
+}
+
+func renderSP(w io.Writer, namespace string) error {
+	template, err := template.New("linkerd").Parse(installsp.Template)
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	err = template.Execute(buf, map[string]string{"Namespace": namespace})
+	if err != nil {
+		return err
+	}
+
+	w.Write(buf.Bytes())
+	w.Write([]byte("---\n"))
+
+	return nil
+}

--- a/cli/cmd/install-sp_test.go
+++ b/cli/cmd/install-sp_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+func TestRenderSP(t *testing.T) {
+	testCases := []struct {
+		controlPlaneNamespace string
+		goldenFileName        string
+	}{
+		{controlPlaneNamespace, "testdata/install-sp_default.golden"},
+		{"NAMESPACE", "testdata/install-sp_output.golden"},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
+			var buf bytes.Buffer
+			err := renderSP(&buf, tc.controlPlaneNamespace)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			content := buf.String()
+
+			goldenFileBytes, err := ioutil.ReadFile(tc.goldenFileName)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			expectedContent := string(goldenFileBytes)
+			diffCompare(t, content, expectedContent)
+		})
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -84,6 +84,7 @@ func init() {
 	RootCmd.AddCommand(newCmdGet())
 	RootCmd.AddCommand(newCmdInject())
 	RootCmd.AddCommand(newCmdInstall())
+	RootCmd.AddCommand(newCmdInstallSP())
 	RootCmd.AddCommand(newCmdLogs())
 	RootCmd.AddCommand(newCmdProfile())
 	RootCmd.AddCommand(newCmdRoutes())

--- a/cli/cmd/testdata/install-sp_default.golden
+++ b/cli/cmd/testdata/install-sp_default.golden
@@ -1,11 +1,9 @@
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-controller-api.linkerd.svc.cluster.local
   namespace: linkerd
 spec:
-  retryBudget: null
   routes:
   - name: POST /api/v1/StatSummary
     condition:
@@ -43,11 +41,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-proxy-api.linkerd.svc.cluster.local
   namespace: linkerd
 spec:
-  retryBudget: null
   routes:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
@@ -61,11 +57,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-prometheus.linkerd.svc.cluster.local
   namespace: linkerd
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/v1/query
     condition:
@@ -83,11 +77,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-grafana.linkerd.svc.cluster.local
   namespace: linkerd
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/annotations
     condition:

--- a/cli/cmd/testdata/install-sp_default.golden
+++ b/cli/cmd/testdata/install-sp_default.golden
@@ -1,0 +1,132 @@
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-controller-api.linkerd.svc.cluster.local
+  namespace: linkerd
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /api/v1/StatSummary
+    condition:
+      method: POST
+      pathRegex: /api/v1/StatSummary
+  - name: POST /api/v1/TopRoutes
+    condition:
+      method: POST
+      pathRegex: /api/v1/TopRoutes
+  - name: POST /api/v1/ListPods
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListPods
+  - name: POST /api/v1/ListServices
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListServices
+  - name: POST /api/v1/Tap
+    condition:
+      method: POST
+      pathRegex: /api/v1/Tap
+  - name: POST /api/v1/TapByResource
+    condition:
+      method: POST
+      pathRegex: /api/v1/TapByResource
+  - name: POST /api/v1/Version
+    condition:
+      method: POST
+      pathRegex: /api/v1/Version
+  - name: POST /api/v1/SelfCheck
+    condition:
+      method: POST
+      pathRegex: /api/v1/SelfCheck
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-proxy-api.linkerd.svc.cluster.local
+  namespace: linkerd
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /io.linkerd.proxy.destination.Destination/Get
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+  - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-prometheus.linkerd.svc.cluster.local
+  namespace: linkerd
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/v1/query
+    condition:
+      method: GET
+      pathRegex: /api/v1/query
+  - name: GET /api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/v1/query_range
+  - name: GET /api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/v1/series
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-grafana.linkerd.svc.cluster.local
+  namespace: linkerd
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/annotations
+    condition:
+      method: GET
+      pathRegex: /api/annotations
+  - name: GET /api/dashboards/tags
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/tags
+  - name: GET /api/dashboards/uid/{uid}
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/datasources/proxy/1/api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/series
+  - name: GET /api/datasources/proxy/1/api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/query_range
+  - name: GET /api/search
+    condition:
+      method: GET
+      pathRegex: /api/search
+  - name: GET /d/{uid}/{dashboard-name}
+    condition:
+      method: GET
+      pathRegex: /d/[^/]*/.*
+  - name: GET /public/build/{style}.css
+    condition:
+      method: GET
+      pathRegex: /public/build/.*\.css
+  - name: GET /public/fonts/{font}
+    condition:
+      method: GET
+      pathRegex: /public/fonts/.*
+  - name: GET /public/img/{img}
+    condition:
+      method: GET
+      pathRegex: /public/img/.*
+---

--- a/cli/cmd/testdata/install-sp_default.golden
+++ b/cli/cmd/testdata/install-sp_default.golden
@@ -48,11 +48,11 @@ spec:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/Get
   - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/GetProfile
 ---
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile

--- a/cli/cmd/testdata/install-sp_output.golden
+++ b/cli/cmd/testdata/install-sp_output.golden
@@ -1,0 +1,132 @@
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-controller-api.NAMESPACE.svc.cluster.local
+  namespace: NAMESPACE
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /api/v1/StatSummary
+    condition:
+      method: POST
+      pathRegex: /api/v1/StatSummary
+  - name: POST /api/v1/TopRoutes
+    condition:
+      method: POST
+      pathRegex: /api/v1/TopRoutes
+  - name: POST /api/v1/ListPods
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListPods
+  - name: POST /api/v1/ListServices
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListServices
+  - name: POST /api/v1/Tap
+    condition:
+      method: POST
+      pathRegex: /api/v1/Tap
+  - name: POST /api/v1/TapByResource
+    condition:
+      method: POST
+      pathRegex: /api/v1/TapByResource
+  - name: POST /api/v1/Version
+    condition:
+      method: POST
+      pathRegex: /api/v1/Version
+  - name: POST /api/v1/SelfCheck
+    condition:
+      method: POST
+      pathRegex: /api/v1/SelfCheck
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-proxy-api.NAMESPACE.svc.cluster.local
+  namespace: NAMESPACE
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /io.linkerd.proxy.destination.Destination/Get
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+  - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-prometheus.NAMESPACE.svc.cluster.local
+  namespace: NAMESPACE
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/v1/query
+    condition:
+      method: GET
+      pathRegex: /api/v1/query
+  - name: GET /api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/v1/query_range
+  - name: GET /api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/v1/series
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-grafana.NAMESPACE.svc.cluster.local
+  namespace: NAMESPACE
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/annotations
+    condition:
+      method: GET
+      pathRegex: /api/annotations
+  - name: GET /api/dashboards/tags
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/tags
+  - name: GET /api/dashboards/uid/{uid}
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/datasources/proxy/1/api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/series
+  - name: GET /api/datasources/proxy/1/api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/query_range
+  - name: GET /api/search
+    condition:
+      method: GET
+      pathRegex: /api/search
+  - name: GET /d/{uid}/{dashboard-name}
+    condition:
+      method: GET
+      pathRegex: /d/[^/]*/.*
+  - name: GET /public/build/{style}.css
+    condition:
+      method: GET
+      pathRegex: /public/build/.*\.css
+  - name: GET /public/fonts/{font}
+    condition:
+      method: GET
+      pathRegex: /public/fonts/.*
+  - name: GET /public/img/{img}
+    condition:
+      method: GET
+      pathRegex: /public/img/.*
+---

--- a/cli/cmd/testdata/install-sp_output.golden
+++ b/cli/cmd/testdata/install-sp_output.golden
@@ -48,11 +48,11 @@ spec:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/Get
   - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/GetProfile
 ---
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile

--- a/cli/cmd/testdata/install-sp_output.golden
+++ b/cli/cmd/testdata/install-sp_output.golden
@@ -1,11 +1,9 @@
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-controller-api.NAMESPACE.svc.cluster.local
   namespace: NAMESPACE
 spec:
-  retryBudget: null
   routes:
   - name: POST /api/v1/StatSummary
     condition:
@@ -43,11 +41,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-proxy-api.NAMESPACE.svc.cluster.local
   namespace: NAMESPACE
 spec:
-  retryBudget: null
   routes:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
@@ -61,11 +57,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-prometheus.NAMESPACE.svc.cluster.local
   namespace: NAMESPACE
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/v1/query
     condition:
@@ -83,11 +77,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-grafana.NAMESPACE.svc.cluster.local
   namespace: NAMESPACE
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/annotations
     condition:

--- a/cli/installsp/template.go
+++ b/cli/installsp/template.go
@@ -4,11 +4,9 @@ package installsp
 const Template = `apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-controller-api.{{.Namespace}}.svc.cluster.local
   namespace: {{.Namespace}}
 spec:
-  retryBudget: null
   routes:
   - name: POST /api/v1/StatSummary
     condition:
@@ -46,11 +44,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-proxy-api.{{.Namespace}}.svc.cluster.local
   namespace: {{.Namespace}}
 spec:
-  retryBudget: null
   routes:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
@@ -64,11 +60,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-prometheus.{{.Namespace}}.svc.cluster.local
   namespace: {{.Namespace}}
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/v1/query
     condition:
@@ -86,11 +80,9 @@ spec:
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
-  creationTimestamp: null
   name: linkerd-grafana.{{.Namespace}}.svc.cluster.local
   namespace: {{.Namespace}}
 spec:
-  retryBudget: null
   routes:
   - name: GET /api/annotations
     condition:

--- a/cli/installsp/template.go
+++ b/cli/installsp/template.go
@@ -51,11 +51,11 @@ spec:
   - name: POST /io.linkerd.proxy.destination.Destination/Get
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/Get
   - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
     condition:
       method: POST
-      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+      pathRegex: /io\.linkerd\.proxy\.destination\.Destination/GetProfile
 ---
 apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile

--- a/cli/installsp/template.go
+++ b/cli/installsp/template.go
@@ -1,0 +1,135 @@
+package installsp
+
+// Template provides the base template for the `linkerd install-sp` command.
+const Template = `apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-controller-api.{{.Namespace}}.svc.cluster.local
+  namespace: {{.Namespace}}
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /api/v1/StatSummary
+    condition:
+      method: POST
+      pathRegex: /api/v1/StatSummary
+  - name: POST /api/v1/TopRoutes
+    condition:
+      method: POST
+      pathRegex: /api/v1/TopRoutes
+  - name: POST /api/v1/ListPods
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListPods
+  - name: POST /api/v1/ListServices
+    condition:
+      method: POST
+      pathRegex: /api/v1/ListServices
+  - name: POST /api/v1/Tap
+    condition:
+      method: POST
+      pathRegex: /api/v1/Tap
+  - name: POST /api/v1/TapByResource
+    condition:
+      method: POST
+      pathRegex: /api/v1/TapByResource
+  - name: POST /api/v1/Version
+    condition:
+      method: POST
+      pathRegex: /api/v1/Version
+  - name: POST /api/v1/SelfCheck
+    condition:
+      method: POST
+      pathRegex: /api/v1/SelfCheck
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-proxy-api.{{.Namespace}}.svc.cluster.local
+  namespace: {{.Namespace}}
+spec:
+  retryBudget: null
+  routes:
+  - name: POST /io.linkerd.proxy.destination.Destination/Get
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/Get
+  - name: POST /io.linkerd.proxy.destination.Destination/GetProfile
+    condition:
+      method: POST
+      pathRegex: /io.linkerd.proxy.destination.Destination/GetProfile
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-prometheus.{{.Namespace}}.svc.cluster.local
+  namespace: {{.Namespace}}
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/v1/query
+    condition:
+      method: GET
+      pathRegex: /api/v1/query
+  - name: GET /api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/v1/query_range
+  - name: GET /api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/v1/series
+---
+apiVersion: linkerd.io/v1alpha1
+kind: ServiceProfile
+metadata:
+  creationTimestamp: null
+  name: linkerd-grafana.{{.Namespace}}.svc.cluster.local
+  namespace: {{.Namespace}}
+spec:
+  retryBudget: null
+  routes:
+  - name: GET /api/annotations
+    condition:
+      method: GET
+      pathRegex: /api/annotations
+  - name: GET /api/dashboards/tags
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/tags
+  - name: GET /api/dashboards/uid/{uid}
+    condition:
+      method: GET
+      pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/datasources/proxy/1/api/v1/series
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/series
+  - name: GET /api/datasources/proxy/1/api/v1/query_range
+    condition:
+      method: GET
+      pathRegex: /api/datasources/proxy/1/api/v1/query_range
+  - name: GET /api/search
+    condition:
+      method: GET
+      pathRegex: /api/search
+  - name: GET /d/{uid}/{dashboard-name}
+    condition:
+      method: GET
+      pathRegex: /d/[^/]*/.*
+  - name: GET /public/build/{style}.css
+    condition:
+      method: GET
+      pathRegex: /public/build/.*\.css
+  - name: GET /public/fonts/{font}
+    condition:
+      method: GET
+      pathRegex: /public/fonts/.*
+  - name: GET /public/img/{img}
+    condition:
+      method: GET
+      pathRegex: /public/img/.*
+`


### PR DESCRIPTION
This introduces a `linkerd install-sp` command to install service
profiles into the linkerd control plane. It installs one service profile
for each of controller-api, proxy-api, prometheus, and grafana.

Fixes #1901

Signed-off-by: Andrew Seigner <siggy@buoyant.io>