### PR TITLE
Add newline separator above uninject reports

### DIFF
--- a/cli/cmd/testdata/inject_contour_uninject.report
+++ b/cli/cmd/testdata/inject_contour_uninject.report
@@ -1,2 +1,3 @@
+
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name_uninject.report
@@ -1,3 +1,4 @@
+
 deployment "controller" uninjected
 deployment "not-controller" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true_uninject.report
@@ -1,2 +1,3 @@
+
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp_uninject.report
@@ -1,2 +1,3 @@
+
 deployment "web" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_uninject.report
@@ -1,2 +1,3 @@
+
 deployment "web" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_istio_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_istio_uninject.report
@@ -1,2 +1,3 @@
+
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_list_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_list_uninject.report
@@ -1,3 +1,4 @@
+
 deployment "web" uninjected
 deployment "emoji" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_uninject.report
@@ -1,2 +1,3 @@
+
 pod "vote-bot" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests_uninject.report
@@ -1,2 +1,3 @@
+
 pod "vote-bot" uninjected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset_uninject.report
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset_uninject.report
@@ -1,2 +1,3 @@
+
 statefulset "web" uninjected
 

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -43,7 +43,7 @@ sub-folders, or coming from stdin.`,
 
   # Download a resource and uninject it through stdin.
   curl http://url.to/yml | linkerd uninject - | kubectl apply -f -
-  
+
   # Uninject all the resources inside a folder and its sub-folders.
   linkerd uninject <folder> | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -102,6 +102,9 @@ func (rt resourceTransformerUninjectSilent) transform(bytes []byte, options *inj
 }
 
 func (resourceTransformerUninject) generateReport(uninjectReports []injectReport, output io.Writer) {
+	// leading newline to separate from yaml output on stdout
+	output.Write([]byte("\n"))
+
 	for _, r := range uninjectReports {
 		if r.sidecar {
 			output.Write([]byte(fmt.Sprintf("%s \"%s\" uninjected\n", r.kind, r.name)))


### PR DESCRIPTION
This is a follow-up to #2089. I noticed in reviewing that branch that our inject reports contain a newline separate at the top to separate them from the YAML output, but our uninject reports did not. I'm adding a newline in this branch so that they're consistent.