### PR TITLE
proxy: bump pinned version to fix a h2 bug

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-08b2a23}"
+PROXY_VERSION="${PROXY_VERSION:-6df55c0}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
- Update h2 to 0.1.15 (linkerd/linkerd2-proxy#172)

carllerche/h2#338 fixes a deadlock in stream reference counts that could
potentially impact the proxy. linkerd/linkerd2-proxy@6df55c0 updates our 
`h2` dependency to a version which includes this change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>