### PR TITLE
Fix Unicode and color output for Windows

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -95,7 +95,7 @@ sub-folders, or coming from stdin.`,
 				return err
 			}
 
-			exitCode := uninjectAndInject(in, os.Stderr, os.Stdout, options)
+			exitCode := uninjectAndInject(in, stderr, stdout, options)
 			os.Exit(exitCode)
 			return nil
 		},

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
 	"github.com/wercker/stern/stern"
@@ -26,6 +27,7 @@ type logCmdConfig struct {
 type logsOptions struct {
 	container             string
 	controlPlaneComponent string
+	noColor               bool
 	sinceSeconds          time.Duration
 	tail                  int64
 	timestamps            bool
@@ -35,6 +37,7 @@ func newLogsOptions() *logsOptions {
 	return &logsOptions{
 		container:             "",
 		controlPlaneComponent: "",
+		noColor:               false,
 		sinceSeconds:          48 * time.Hour,
 		tail:                  -1,
 		timestamps:            false,
@@ -162,6 +165,8 @@ func newCmdLogs() *cobra.Command {
   linkerd logs --control-plane-component controller --container linkerd-proxy --timestamps
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			color.NoColor = options.noColor
+
 			opts, err := newLogCmdConfig(options, kubeconfigPath, kubeContext)
 
 			if err != nil {
@@ -174,6 +179,7 @@ func newCmdLogs() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&options.container, "container", "c", options.container, "Tail logs from the specified container. Options are 'public-api', 'proxy-api', 'tap', 'destination', 'prometheus', 'grafana' or 'linkerd-proxy'")
 	cmd.PersistentFlags().StringVar(&options.controlPlaneComponent, "control-plane-component", options.controlPlaneComponent, "Tail logs from the specified control plane component. Default value (empty string) causes this command to tail logs from all resources marked with the 'linkerd.io/control-plane-component' label selector")
+	cmd.PersistentFlags().BoolVarP(&options.noColor, "no-color", "n", options.noColor, "Disable colorized output") // needed until at least https://github.com/wercker/stern/issues/69 is resolved
 	cmd.PersistentFlags().DurationVarP(&options.sinceSeconds, "since", "s", options.sinceSeconds, "Duration of how far back logs should be retrieved")
 	cmd.PersistentFlags().Int64Var(&options.tail, "tail", options.tail, "Last number of log lines to show for a given container. -1 does not show previous log lines")
 	cmd.PersistentFlags().BoolVarP(&options.timestamps, "timestamps", "t", options.timestamps, "Print timestamps for each given log line")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,17 +22,22 @@ const (
 	lineWidth        = 80
 )
 
-var okStatus = color.New(color.FgGreen, color.Bold).SprintFunc()("\u2714")    // ✔
-var warnStatus = color.New(color.FgYellow, color.Bold).SprintFunc()("\u26A0") // ⚠
-var failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u2718")    // ✘
-
-var controlPlaneNamespace string
-var apiAddr string // An empty value means "use the Kubernetes configuration"
-var kubeconfigPath string
-var kubeContext string
-var verbose bool
-
 var (
+	// special handling for Windows, on all other platforms these resolve to
+	// os.Stdout and os.Stderr, thanks to https://github.com/mattn/go-colorable
+	stdout = color.Output
+	stderr = color.Error
+
+	okStatus   = color.New(color.FgGreen, color.Bold).SprintFunc()("\u221A")  // √
+	warnStatus = color.New(color.FgYellow, color.Bold).SprintFunc()("\u203C") // ‼
+	failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u00D7")    // ×
+
+	controlPlaneNamespace string
+	apiAddr               string // An empty value means "use the Kubernetes configuration"
+	kubeconfigPath        string
+	kubeContext           string
+	verbose               bool
+
 	// These regexs are not as strict as they could be, but are a quick and dirty
 	// sanity check against illegal characters.
 	alphaNumDash              = regexp.MustCompile("^[a-zA-Z0-9-]+$")

--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -1,6 +1,6 @@
 category
 --------
-✔ check1
-✘ check2
+√ check1
+× check2
     This should contain instructions for fail
     See http://linkerd.io/hint-url for hints

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
@@ -1,16 +1,16 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "redis" injected
 
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "redis" injected
 

--- a/cli/cmd/testdata/inject_contour.report
+++ b/cli/cmd/testdata/inject_contour.report
@@ -1,6 +1,6 @@
 
-⚠ known 3rd party sidecar detected in deployment/contour
-⚠ no supported objects found
+‼ known 3rd party sidecar detected in deployment/contour
+‼ no supported objects found
 
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-⚠ known 3rd party sidecar detected in deployment/contour
-⚠ no supported objects found
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+‼ known 3rd party sidecar detected in deployment/contour
+‼ no supported objects found
+√ pod specs do not include UDP ports
 
 deployment "contour" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "web1" injected
 deployment "web2" injected

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "controller" injected
 deployment "not-controller" injected

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report
@@ -1,6 +1,6 @@
 
-⚠ "hostNetwork: true" detected in deployment/web
-⚠ no supported objects found
+‼ "hostNetwork: true" detected in deployment/web
+‼ no supported objects found
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
@@ -1,8 +1,8 @@
 
-⚠ "hostNetwork: true" detected in deployment/web
-✔ pods do not have a 3rd party proxy or initContainer already injected
-⚠ no supported objects found
-✔ pod specs do not include UDP ports
+‼ "hostNetwork: true" detected in deployment/web
+√ pods do not have a 3rd party proxy or initContainer already injected
+‼ no supported objects found
+√ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
@@ -1,5 +1,5 @@
 
-⚠ deployment/web uses "protocol: UDP"
+‼ deployment/web uses "protocol: UDP"
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-⚠ deployment/web uses "protocol: UDP"
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+‼ deployment/web uses "protocol: UDP"
 
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report
@@ -1,6 +1,6 @@
 
-⚠ known 3rd party sidecar detected in deployment/web
-⚠ no supported objects found
+‼ known 3rd party sidecar detected in deployment/web
+‼ no supported objects found
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-⚠ known 3rd party sidecar detected in deployment/web
-⚠ no supported objects found
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+‼ known 3rd party sidecar detected in deployment/web
+‼ no supported objects found
+√ pod specs do not include UDP ports
 
 deployment "web" skipped
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "web" injected
 deployment "emoji" injected

--- a/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 statefulset "web" injected
 

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
@@ -1,8 +1,8 @@
 
-✔ pods do not use host networking
-✔ pods do not have a 3rd party proxy or initContainer already injected
-✔ at least one resource injected
-✔ pod specs do not include UDP ports
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ at least one resource injected
+√ pod specs do not include UDP ports
 
 deployment "get-test-deploy-injected-1" injected
 deployment "get-test-deploy-injected-2" injected

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -1,37 +1,37 @@
 kubernetes-api
 --------------
-✔ can initialize the client
-✔ can query the Kubernetes API
+√ can initialize the client
+√ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✔ is running the minimum Kubernetes API version
+√ is running the minimum Kubernetes API version
 
 linkerd-existence
 -----------------
-✔ control plane namespace exists
-✔ controller pod is running
-✔ can initialize the client
-✔ can query the control plane API
+√ control plane namespace exists
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-api
 -----------
-✔ control plane pods are ready
-✔ can query the control plane API
-✔ [kubernetes] control plane can talk to Kubernetes
-✔ [prometheus] control plane can talk to Prometheus
+√ control plane pods are ready
+√ can query the control plane API
+√ [kubernetes] control plane can talk to Kubernetes
+√ [prometheus] control plane can talk to Prometheus
 
 linkerd-service-profile
 -----------------------
-✔ no invalid service profiles
+√ no invalid service profiles
 
 linkerd-version
 ---------------
-✔ can determine the latest version
-✔ cli is up-to-date
+√ can determine the latest version
+√ cli is up-to-date
 
 control-plane-version
 ---------------------
-✔ control plane is up-to-date
+√ control plane is up-to-date
 
-Status check results are ✔
+Status check results are √

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -1,30 +1,30 @@
 kubernetes-api
 --------------
-✔ can initialize the client
-✔ can query the Kubernetes API
+√ can initialize the client
+√ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✔ is running the minimum Kubernetes API version
+√ is running the minimum Kubernetes API version
 
 pre-kubernetes-cluster-setup
 ----------------------------
-✔ control plane namespace does not already exist
-✔ can create Namespaces
-✔ can create ClusterRoles
-✔ can create ClusterRoleBindings
-✔ can create CustomResourceDefinitions
+√ control plane namespace does not already exist
+√ can create Namespaces
+√ can create ClusterRoles
+√ can create ClusterRoleBindings
+√ can create CustomResourceDefinitions
 
 pre-kubernetes-setup
 --------------------
-✔ can create ServiceAccounts
-✔ can create Services
-✔ can create Deployments
-✔ can create ConfigMaps
+√ can create ServiceAccounts
+√ can create Services
+√ can create Deployments
+√ can create ConfigMaps
 
 linkerd-version
 ---------------
-✔ can determine the latest version
-✔ cli is up-to-date
+√ can determine the latest version
+√ cli is up-to-date
 
-Status check results are ✔
+Status check results are √

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -1,40 +1,40 @@
 kubernetes-api
 --------------
-✔ can initialize the client
-✔ can query the Kubernetes API
+√ can initialize the client
+√ can query the Kubernetes API
 
 kubernetes-version
 ------------------
-✔ is running the minimum Kubernetes API version
+√ is running the minimum Kubernetes API version
 
 linkerd-existence
 -----------------
-✔ control plane namespace exists
-✔ controller pod is running
-✔ can initialize the client
-✔ can query the control plane API
+√ control plane namespace exists
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-api
 -----------
-✔ control plane pods are ready
-✔ can query the control plane API
-✔ [kubernetes] control plane can talk to Kubernetes
-✔ [prometheus] control plane can talk to Prometheus
+√ control plane pods are ready
+√ can query the control plane API
+√ [kubernetes] control plane can talk to Kubernetes
+√ [prometheus] control plane can talk to Prometheus
 
 linkerd-service-profile
 -----------------------
-✔ no invalid service profiles
+√ no invalid service profiles
 
 linkerd-version
 ---------------
-✔ can determine the latest version
-✔ cli is up-to-date
+√ can determine the latest version
+√ cli is up-to-date
 
 linkerd-data-plane
 ------------------
-✔ data plane namespace exists
-✔ data plane proxies are ready
-✔ data plane proxy metrics are present in Prometheus
-✔ data plane is up-to-date
+√ data plane namespace exists
+√ data plane proxies are ready
+√ data plane proxy metrics are present in Prometheus
+√ data plane is up-to-date
 
-Status check results are ✔
+Status check results are √


### PR DESCRIPTION
The default font in Windows console did not support the Unicode
characters recently added to check and inject commands. Also the color
library the linkerd cli depends on was not being used in a
cross-platform way.

Replace the existing Unicode characters used in `check` and `inject`
with characters available in most fonts, including Windows console.
Similarly replace the spinner used in `check` with one that uses
characters available in most fonts.

Modify `check` and `inject` to use `color.Output` and `color.Error`,
which wrap `os.Stdout` and `os.Stderr`, and perform special
tranformations when on Windows.

Add a `--no-color` option to `linkerd logs`. While stern uses the same
color library that `check`/`inject` use, it is not yet using the
`color.Output` API for Windows support. That issue is tracked at:
https://github.com/wercker/stern/issues/69

Relates to https://github.com/linkerd/linkerd2/pull/2087

Signed-off-by: Andrew Seigner <siggy@buoyant.io>