### PR TITLE
Fix panic when routes is called in single-namespace mode

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -29,6 +29,7 @@ type (
 		k8sAPI              *k8s.API
 		controllerNamespace string
 		ignoredNamespaces   []string
+		singleNamespace     bool
 	}
 )
 
@@ -51,6 +52,7 @@ func newGrpcServer(
 	k8sAPI *k8s.API,
 	controllerNamespace string,
 	ignoredNamespaces []string,
+	singleNamespace bool,
 ) *grpcServer {
 	return &grpcServer{
 		prometheusAPI:       promAPI,
@@ -58,6 +60,7 @@ func newGrpcServer(
 		k8sAPI:              k8sAPI,
 		controllerNamespace: controllerNamespace,
 		ignoredNamespaces:   ignoredNamespaces,
+		singleNamespace:     singleNamespace,
 	}
 }
 

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -172,6 +172,7 @@ spec:
 				k8sAPI,
 				"linkerd",
 				[]string{},
+				false,
 			)
 
 			k8sAPI.Sync()
@@ -253,6 +254,7 @@ metadata:
 				k8sAPI,
 				"linkerd",
 				[]string{},
+				false,
 			)
 
 			k8sAPI.Sync()

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -247,6 +247,7 @@ func NewServer(
 	k8sAPI *k8s.API,
 	controllerNamespace string,
 	ignoredNamespaces []string,
+	singleNamespace bool,
 ) *http.Server {
 	baseHandler := &handler{
 		grpcServer: newGrpcServer(
@@ -255,6 +256,7 @@ func NewServer(
 			k8sAPI,
 			controllerNamespace,
 			ignoredNamespaces,
+			singleNamespace,
 		),
 	}
 

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -776,6 +776,7 @@ status:
 				k8sAPI,
 				"linkerd",
 				[]string{},
+				false,
 			)
 
 			_, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)
@@ -800,6 +801,7 @@ status:
 			k8sAPI,
 			"linkerd",
 			[]string{},
+			false,
 		)
 
 		invalidRequests := []statSumExpected{

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -281,6 +281,7 @@ func newMockGrpcServer(exp expectedStatRPC) (*mockProm, *grpcServer, error) {
 		k8sAPI,
 		"linkerd",
 		[]string{},
+		false,
 	)
 
 	k8sAPI.Sync()

--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -42,6 +42,10 @@ type resourceTable struct {
 func (s *grpcServer) TopRoutes(ctx context.Context, req *pb.TopRoutesRequest) (*pb.TopRoutesResponse, error) {
 	log.Debugf("TopRoutes request: %+v", req)
 
+	if s.singleNamespace {
+		return topRoutesError(req, "Routes are not available in single-namespace mode"), nil
+	}
+
 	errRsp := validateRequest(req)
 	if errRsp != nil {
 		return errRsp, nil

--- a/controller/cmd/proxy-api/main.go
+++ b/controller/cmd/proxy-api/main.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/linkerd/linkerd2/controller/api/proxy"
+	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
@@ -32,33 +33,27 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	var k8sAPI *k8s.API
+	var spClient *spclient.Clientset
+	restrictToNamespace := ""
+	resources := []k8s.APIResource{k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc}
+
 	if *singleNamespace {
-		k8sAPI = k8s.NewAPI(
-			k8sClient,
-			nil,
-			*controllerNamespace,
-			k8s.Endpoint,
-			k8s.Pod,
-			k8s.RS,
-			k8s.Svc,
-		)
+		restrictToNamespace = *controllerNamespace
 	} else {
-		spClient, err := k8s.NewSpClientSet(*kubeConfigPath)
+		spClient, err = k8s.NewSpClientSet(*kubeConfigPath)
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		k8sAPI = k8s.NewAPI(
-			k8sClient,
-			spClient,
-			"",
-			k8s.Endpoint,
-			k8s.Pod,
-			k8s.RS,
-			k8s.Svc,
-			k8s.SP,
-		)
+
+		resources = append(resources, k8s.SP)
 	}
+
+	k8sAPI := k8s.NewAPI(
+		k8sClient,
+		spClient,
+		restrictToNamespace,
+		resources...,
+	)
 
 	done := make(chan struct{})
 


### PR DESCRIPTION
Fixes #2119 

When Linkerd is installed in single-namespace mode, the public-api container panics when it attempts to access watch service profiles.

In single-namespace mode, we no longer watch service profiles and return an informative error when the TopRoutes API is called.

Signed-off-by: Alex Leong <alex@buoyant.io>