### PR TITLE
Introduce version consistency checks

### DIFF
--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -11,8 +11,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         app: nginx
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -79,7 +79,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -11,8 +11,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         app: redis
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -79,7 +79,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -106,8 +106,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         app: nginx
@@ -142,7 +142,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -174,7 +174,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -11,8 +11,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         app: redis
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -79,7 +79,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
@@ -119,7 +119,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
@@ -225,7 +225,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
@@ -331,7 +331,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
@@ -119,7 +119,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -15,7 +15,7 @@ items:
     template:
       metadata:
         annotations:
-          linkerd.io/created-by: linkerd/cli undefined
+          linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: testinjectversion
         creationTimestamp: null
         labels:
@@ -120,7 +120,7 @@ items:
     template:
       metadata:
         annotations:
-          linkerd.io/created-by: linkerd/cli undefined
+          linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: testinjectversion
         creationTimestamp: null
         labels:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: testinjectversion
   creationTimestamp: null
   labels:

--- a/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: testinjectversion
   creationTimestamp: null
   labels:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: testinjectversion
   creationTimestamp: null
   labels:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:
@@ -116,7 +116,7 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -86,7 +86,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -105,7 +105,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -120,7 +120,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
@@ -132,8 +132,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: controller
@@ -147,7 +147,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -176,7 +176,7 @@ spec:
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -202,7 +202,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -244,7 +244,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -276,7 +276,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -297,7 +297,7 @@ metadata:
   name: serviceprofiles.linkerd.io
   namespace: linkerd
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -396,7 +396,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -414,7 +414,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
@@ -426,8 +426,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: web
@@ -442,7 +442,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/web:undefined
+        image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -484,7 +484,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -516,7 +516,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -539,7 +539,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -554,7 +554,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
@@ -566,8 +566,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: prometheus
@@ -629,7 +629,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -661,7 +661,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -690,7 +690,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   prometheus.yml: |-
     global:
@@ -788,7 +788,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -803,7 +803,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
@@ -815,8 +815,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: grafana
@@ -827,7 +827,7 @@ spec:
       - env:
         - name: GF_PATHS_DATA
           value: /data
-        image: gcr.io/linkerd-io/grafana:undefined
+        image: gcr.io/linkerd-io/grafana:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -872,7 +872,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -904,7 +904,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -940,7 +940,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -86,7 +86,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -105,7 +105,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -120,7 +120,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
@@ -132,8 +132,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: controller
@@ -147,7 +147,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -179,7 +179,7 @@ spec:
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -208,7 +208,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -253,7 +253,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -288,7 +288,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -309,7 +309,7 @@ metadata:
   name: serviceprofiles.linkerd.io
   namespace: linkerd
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -408,7 +408,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -426,7 +426,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
@@ -438,8 +438,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: web
@@ -454,7 +454,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/web:undefined
+        image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -499,7 +499,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -534,7 +534,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -557,7 +557,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -572,7 +572,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
@@ -584,8 +584,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: prometheus
@@ -650,7 +650,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -685,7 +685,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -714,7 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   prometheus.yml: |-
     global:
@@ -812,7 +812,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -827,7 +827,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
@@ -839,8 +839,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: grafana
@@ -851,7 +851,7 @@ spec:
       - env:
         - name: GF_PATHS_DATA
           value: /data
-        image: gcr.io/linkerd-io/grafana:undefined
+        image: gcr.io/linkerd-io/grafana:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -899,7 +899,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -934,7 +934,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -970,7 +970,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -86,7 +86,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -105,7 +105,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -120,7 +120,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
@@ -132,8 +132,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: controller
@@ -147,7 +147,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -179,7 +179,7 @@ spec:
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -208,7 +208,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:undefined
+        image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -253,7 +253,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -288,7 +288,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -309,7 +309,7 @@ metadata:
   name: serviceprofiles.linkerd.io
   namespace: linkerd
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -408,7 +408,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -426,7 +426,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
@@ -438,8 +438,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: web
@@ -454,7 +454,7 @@ spec:
         - -controller-namespace=linkerd
         - -single-namespace=false
         - -log-level=info
-        image: gcr.io/linkerd-io/web:undefined
+        image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -499,7 +499,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -534,7 +534,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -557,7 +557,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -572,7 +572,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
@@ -584,8 +584,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: prometheus
@@ -650,7 +650,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -685,7 +685,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -714,7 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   prometheus.yml: |-
     global:
@@ -812,7 +812,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   type: ClusterIP
   selector:
@@ -827,7 +827,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
@@ -839,8 +839,8 @@ spec:
   template:
     metadata:
       annotations:
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: grafana
@@ -851,7 +851,7 @@ spec:
       - env:
         - name: GF_PATHS_DATA
           value: /data
-        image: gcr.io/linkerd-io/grafana:undefined
+        image: gcr.io/linkerd-io/grafana:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -899,7 +899,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -934,7 +934,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -970,7 +970,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
   annotations:
-    linkerd.io/created-by: linkerd/cli undefined
+    linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -135,8 +135,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: controller
@@ -247,7 +247,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -279,7 +279,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -430,8 +430,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: web
@@ -488,7 +488,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -520,7 +520,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -571,8 +571,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: prometheus
@@ -634,7 +634,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -666,7 +666,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -821,8 +821,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: grafana
@@ -878,7 +878,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -910,7 +910,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -1062,8 +1062,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: ca
@@ -1117,7 +1117,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1149,7 +1149,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -1184,8 +1184,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: proxy-injector
@@ -1246,7 +1246,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1278,7 +1278,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -132,8 +132,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: controller
@@ -244,7 +244,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -276,7 +276,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -338,8 +338,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: web
@@ -396,7 +396,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -428,7 +428,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -479,8 +479,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: prometheus
@@ -542,7 +542,7 @@ spec:
               fieldPath: metadata.namespace
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -574,7 +574,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -731,8 +731,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: grafana
@@ -788,7 +788,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -820,7 +820,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -971,8 +971,8 @@ spec:
     metadata:
       annotations:
         CreatedByAnnotation: CliVersion
-        linkerd.io/created-by: linkerd/cli undefined
-        linkerd.io/proxy-version: undefined
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/proxy-version: dev-undefined
       creationTimestamp: null
       labels:
         ControllerComponentLabel: ca
@@ -1025,7 +1025,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/linkerd-io/proxy:undefined
+        image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1057,7 +1057,7 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:undefined
+        image: gcr.io/linkerd-io/proxy-init:dev-undefined
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -1,39 +1,80 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/version"
 )
 
-func TestGetServerVersion(t *testing.T) {
-	t.Run("Returns existing version from server", func(t *testing.T) {
-		expectedServerVersion := "1.2.3"
-		mockClient := &public.MockAPIClient{}
-		mockClient.VersionInfoToReturn = &pb.VersionInfo{
-			ReleaseVersion: expectedServerVersion,
-		}
+func mkMockClient(version string, err error) func() (pb.ApiClient, error) {
+	return func() (pb.ApiClient, error) {
+		return &public.MockAPIClient{
+			ErrorToReturn: err,
+			VersionInfoToReturn: &pb.VersionInfo{
+				ReleaseVersion: version,
+			},
+		}, nil
+	}
+}
 
-		version := getServerVersion(mockClient)
+func TestConfigureAndRunVersion(t *testing.T) {
+	testCases := []struct {
+		options  *versionOptions
+		mkClient func() (pb.ApiClient, error)
+		out      string
+		err      string
+	}{
+		{
+			newVersionOptions(),
+			mkMockClient("server-version", nil),
+			fmt.Sprintf("Client version: %s\nServer version: %s\n", version.Version, "server-version"),
+			"",
+		},
+		{
+			&versionOptions{false, true},
+			mkMockClient("", nil),
+			fmt.Sprintf("Client version: %s\n", version.Version),
+			"",
+		},
+		{
+			&versionOptions{true, true},
+			mkMockClient("", nil),
+			fmt.Sprintf("%s\n", version.Version),
+			"",
+		},
+		{
+			&versionOptions{true, false},
+			mkMockClient("server-version", nil),
+			fmt.Sprintf("%s\n%s\n", version.Version, "server-version"),
+			"",
+		},
+		{
+			newVersionOptions(),
+			mkMockClient("", errors.New("bad client")),
+			fmt.Sprintf("Client version: %s\nServer version: %s\n", version.Version, defaultVersionString),
+			"",
+		},
+	}
 
-		if version != expectedServerVersion {
-			t.Fatalf("Expected server version to be [%s], was [%s]",
-				expectedServerVersion, version)
-		}
-	})
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test %d TestConfigureAndRunVersion()", i), func(t *testing.T) {
+			wout := bytes.NewBufferString("")
+			werr := bytes.NewBufferString("")
 
-	t.Run("Returns unavailable when cannot get server version", func(t *testing.T) {
-		expectedServerVersion := "unavailable"
-		mockClient := &public.MockAPIClient{}
-		mockClient.ErrorToReturn = errors.New("expected")
+			configureAndRunVersion(tc.options, wout, werr, tc.mkClient)
 
-		version := getServerVersion(mockClient)
+			if tc.out != wout.String() {
+				t.Fatalf("Expected output: \"%s\", got: \"%s\"", tc.out, wout)
+			}
 
-		if version != expectedServerVersion {
-			t.Fatalf("Expected server version to be [%s], was [%s]",
-				expectedServerVersion, version)
-		}
-	})
+			if tc.err != werr.String() {
+				t.Fatalf("Expected output: \"%s\", got: \"%s\"", tc.err, werr)
+			}
+		})
+	}
 }

--- a/pkg/healthcheck/version.go
+++ b/pkg/healthcheck/version.go
@@ -1,0 +1,21 @@
+package healthcheck
+
+import (
+	"context"
+	"time"
+
+	pb "github.com/linkerd/linkerd2/controller/gen/public"
+)
+
+// GetServerVersion returns the Linkerd Public API server version
+func GetServerVersion(apiClient pb.ApiClient) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rsp, err := apiClient.Version(ctx, &pb.Empty{})
+	if err != nil {
+		return "", err
+	}
+
+	return rsp.GetReleaseVersion(), nil
+}

--- a/pkg/healthcheck/version_test.go
+++ b/pkg/healthcheck/version_test.go
@@ -1,0 +1,47 @@
+package healthcheck
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/linkerd/linkerd2/controller/api/public"
+	pb "github.com/linkerd/linkerd2/controller/gen/public"
+)
+
+func createMockPublicAPI(version string) *public.MockAPIClient {
+	return &public.MockAPIClient{
+		VersionInfoToReturn: &pb.VersionInfo{
+			ReleaseVersion: version,
+		},
+	}
+}
+
+func TestGetServerVersion(t *testing.T) {
+	t.Run("Returns existing version from server", func(t *testing.T) {
+		expectedServerVersion := "1.2.3"
+		mockClient := &public.MockAPIClient{}
+		mockClient.VersionInfoToReturn = &pb.VersionInfo{
+			ReleaseVersion: expectedServerVersion,
+		}
+
+		version, err := GetServerVersion(mockClient)
+		if err != nil {
+			t.Fatalf("GetServerVersion returned unexpected error: %s", err)
+		}
+
+		if version != expectedServerVersion {
+			t.Fatalf("Expected server version to be [%s], was [%s]",
+				expectedServerVersion, version)
+		}
+	})
+
+	t.Run("Returns an error when cannot get server version", func(t *testing.T) {
+		mockClient := &public.MockAPIClient{}
+		mockClient.ErrorToReturn = errors.New("expected")
+
+		_, err := GetServerVersion(mockClient)
+		if err != mockClient.ErrorToReturn {
+			t.Fatalf("GetServerVersion returned unexpected error: %s", err)
+		}
+	})
+}

--- a/pkg/version/channels.go
+++ b/pkg/version/channels.go
@@ -12,7 +12,7 @@ import (
 
 // Channels provides an interface to interact with a set of release channels.
 // This module is also responsible for online retrieval of the latest release
-// versions. It depends only on channelVersion in the version package.
+// versions.
 type Channels struct {
 	array []channelVersion
 }

--- a/pkg/version/channels.go
+++ b/pkg/version/channels.go
@@ -1,0 +1,115 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// Channels provides an interface to interact with a set of release channels.
+// This module is also responsible for online retrieval of the latest release
+// versions. It depends only on channelVersion in the version package.
+type Channels struct {
+	array []channelVersion
+}
+
+const (
+	versionCheckURL = "https://versioncheck.linkerd.io/version.json?version=%s&uuid=%s&source=%s"
+)
+
+// NewChannels is used primarily for testing, it returns a Channels struct that
+// mimic a GetLatestVersions response.
+func NewChannels(channel string) (Channels, error) {
+	cv, err := parseChannelVersion(channel)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	return Channels{
+		array: []channelVersion{cv},
+	}, nil
+}
+
+// Match validates whether the given version string:
+// 1) is a well-formed channel-version string, for example: "edge-19.1.2"
+// 2) references a known channel
+// 3) matches the version in the known channel
+func (c Channels) Match(actualVersion string) error {
+	if actualVersion == "" {
+		return errors.New("actual version is empty")
+	}
+
+	actual, err := parseChannelVersion(actualVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse actual version: %s", err)
+	}
+
+	for _, cv := range c.array {
+		if cv.channel == actual.channel {
+			return Match(cv.String(), actualVersion)
+		}
+	}
+
+	return fmt.Errorf("unsupported version channel: %s", actualVersion)
+}
+
+// GetLatestVersions performs an online request to check for the latest Linkerd
+// release channels.
+func GetLatestVersions(uuid string, source string) (Channels, error) {
+	url := fmt.Sprintf(versionCheckURL, Version, uuid, source)
+	return getLatestVersions(http.DefaultClient, url, uuid, source)
+}
+
+func getLatestVersions(client *http.Client, url string, uuid string, source string) (Channels, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rsp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return Channels{}, err
+	}
+	defer rsp.Body.Close()
+
+	if rsp.StatusCode != 200 {
+		return Channels{}, fmt.Errorf("unexpected versioncheck response: %s", rsp.Status)
+	}
+
+	bytes, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	var versionRsp map[string]string
+	err = json.Unmarshal(bytes, &versionRsp)
+	if err != nil {
+		return Channels{}, err
+	}
+
+	channels := Channels{}
+	for _, v := range versionRsp {
+		cv, err := parseChannelVersion(v)
+		if err != nil {
+			return Channels{}, fmt.Errorf("unexpected versioncheck response: %s", err)
+		}
+
+		// TODO: introduce this sanity check once all keys in the response match
+		// their respective channels.
+		// Right now we have: `"version": "stable-2.1.0"`
+		// if c != cv.channel {
+		// 	return Channels{}, fmt.Errorf("unexpected versioncheck response: channel in %s does not match %s", cv, c)
+		// }
+
+		channels.array = append(channels.array, cv)
+	}
+
+	return channels, nil
+}

--- a/pkg/version/channels.go
+++ b/pkg/version/channels.go
@@ -95,18 +95,15 @@ func getLatestVersions(client *http.Client, url string, uuid string, source stri
 	}
 
 	channels := Channels{}
-	for _, v := range versionRsp {
+	for c, v := range versionRsp {
 		cv, err := parseChannelVersion(v)
 		if err != nil {
 			return Channels{}, fmt.Errorf("unexpected versioncheck response: %s", err)
 		}
 
-		// TODO: introduce this sanity check once all keys in the response match
-		// their respective channels.
-		// Right now we have: `"version": "stable-2.1.0"`
-		// if c != cv.channel {
-		// 	return Channels{}, fmt.Errorf("unexpected versioncheck response: channel in %s does not match %s", cv, c)
-		// }
+		if c != cv.channel {
+			return Channels{}, fmt.Errorf("unexpected versioncheck response: channel in %s does not match %s", cv, c)
+		}
 
 		channels.array = append(channels.array, cv)
 	}

--- a/pkg/version/channels_test.go
+++ b/pkg/version/channels_test.go
@@ -1,0 +1,149 @@
+package version
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetLatestVersions(t *testing.T) {
+	testCases := []struct {
+		resp   interface{}
+		err    error
+		latest Channels
+	}{
+		{
+			map[string]string{
+				"foo":     "foo-1.2.3",
+				"stable":  "stable-2.1.0",
+				"version": "stable-2.1.0",
+			},
+			nil,
+			Channels{
+				[]channelVersion{
+					{"foo", "1.2.3"},
+					{"stable", "2.1.0"},
+					{"version", "2.1.0"},
+				},
+			},
+		},
+		{
+			map[string]string{
+				"foo":    "foo-1.2.3",
+				"stable": "badchannelversion",
+			},
+			fmt.Errorf("unexpected versioncheck response: unsupported version format: badchannelversion"),
+			Channels{},
+		},
+		{
+			"bad response",
+			fmt.Errorf("json: cannot unmarshal string into Go value of type map[string]string"),
+			Channels{},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test %d GetLatestVersions(%s, %s)", i, tc.err, tc.latest), func(t *testing.T) {
+			j, err := json.Marshal(tc.resp)
+			if err != nil {
+				t.Fatalf("JSON marshal failed with: %s", err)
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					w.Write(j)
+				}),
+			)
+			defer ts.Close()
+
+			latest, err := getLatestVersions(ts.Client(), ts.URL, "uuid", "source")
+			if (err == nil && tc.err != nil) ||
+				(err != nil && tc.err == nil) ||
+				((err != nil && tc.err != nil) && (err.Error() != tc.err.Error())) {
+				t.Fatalf("Expected \"%s\", got \"%s\"", tc.err, err)
+			}
+
+			if !channelsEqual(latest, tc.latest) {
+				t.Fatalf("Expected latest versions \"%s\", got \"%s\"", tc.latest, latest)
+			}
+		})
+	}
+}
+
+func channelsEqual(c1, c2 Channels) bool {
+	if len(c1.array) != len(c2.array) {
+		return false
+	}
+
+	for _, cv1 := range c1.array {
+		found := false
+		for _, cv2 := range c2.array {
+			if cv1 == cv2 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestChannelsMatch(t *testing.T) {
+	testCases := []struct {
+		actualVersion string
+		channels      Channels
+		err           error
+	}{
+		{
+			"version-3.2.1-test",
+			Channels{
+				[]channelVersion{
+					{"stable", "2.1.0"},
+					{"foo", "1.2.3"},
+					{"version", "3.2.1-test"},
+				},
+			},
+			nil,
+		},
+		{
+			"edge-older",
+			Channels{
+				[]channelVersion{
+					{"stable", "2.1.0"},
+					{"foo", "1.2.3"},
+					{"edge", "latest"},
+				},
+			},
+			errors.New("is running version older but the latest edge version is latest"),
+		},
+		{
+			"unsupported-version-channel",
+			Channels{
+				[]channelVersion{
+					{"stable", "2.1.0"},
+					{"foo", "1.2.3"},
+					{"bar", "3.2.1"},
+				},
+			},
+			fmt.Errorf("unsupported version channel: %s", "unsupported-version-channel"),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test %d ChannelsMatch(%s, %s)", i, tc.actualVersion, tc.err), func(t *testing.T) {
+
+			err := tc.channels.Match(tc.actualVersion)
+			if (err == nil && tc.err != nil) ||
+				(err != nil && tc.err == nil) ||
+				((err != nil && tc.err != nil) && (err.Error() != tc.err.Error())) {
+				t.Fatalf("Expected \"%s\", got \"%s\"", tc.err, err)
+			}
+		})
+	}
+}

--- a/pkg/version/channels_test.go
+++ b/pkg/version/channels_test.go
@@ -17,18 +17,27 @@ func TestGetLatestVersions(t *testing.T) {
 	}{
 		{
 			map[string]string{
-				"foo":     "foo-1.2.3",
-				"stable":  "stable-2.1.0",
-				"version": "stable-2.1.0",
+				"foo":    "foo-1.2.3",
+				"stable": "stable-2.1.0",
+				"edge":   "edge-2.1.0",
 			},
 			nil,
 			Channels{
 				[]channelVersion{
 					{"foo", "1.2.3"},
 					{"stable", "2.1.0"},
-					{"version", "2.1.0"},
+					{"edge", "2.1.0"},
 				},
 			},
+		},
+		{
+			map[string]string{
+				"foo":        "foo-1.2.3",
+				"stable":     "stable-2.1.0",
+				"badchannel": "edge-2.1.0",
+			},
+			fmt.Errorf("unexpected versioncheck response: channel in edge-2.1.0 does not match badchannel"),
+			Channels{},
 		},
 		{
 			map[string]string{

--- a/pkg/version/channelversion.go
+++ b/pkg/version/channelversion.go
@@ -1,0 +1,29 @@
+package version
+
+import (
+	"fmt"
+	"strings"
+)
+
+// channelVersion is a low-level struct for handling release channels in a
+// structured way. It has no dependencies on the rest of the version package.
+type channelVersion struct {
+	channel string
+	version string
+}
+
+// String returns a string representation of a channelVersion, for example:
+// { "channel": "version"} => "channel-version"
+func (cv channelVersion) String() string {
+	return fmt.Sprintf("%s-%s", cv.channel, cv.version)
+}
+
+func parseChannelVersion(cv string) (channelVersion, error) {
+	if parts := strings.SplitN(cv, "-", 2); len(parts) == 2 {
+		return channelVersion{
+			channel: parts[0],
+			version: parts[1],
+		}, nil
+	}
+	return channelVersion{}, fmt.Errorf("unsupported version format: %s", cv)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,8 +6,6 @@ import (
 	"os"
 )
 
-// This module depends only on channelVersion in the version package.
-
 // Version is updated automatically as part of the build process, and is the
 // ground source of truth for the current process's build version.
 //

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,26 +1,23 @@
 package version
 
 import (
-	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
-	"strings"
-	"time"
-
-	pb "github.com/linkerd/linkerd2/controller/gen/public"
 )
 
-// Version is updated automatically as part of the build process
+// This module depends only on channelVersion in the version package.
+
+// Version is updated automatically as part of the build process, and is the
+// ground source of truth for the current process's build version.
 //
 // DO NOT EDIT
 var Version = undefinedVersion
 
 const (
-	undefinedVersion = "undefined"
-	versionCheckURL  = "https://versioncheck.linkerd.io/version.json?version=%s&uuid=%s&source=%s"
+	// undefinedVersion should take the form `channel-version` to conform to
+	// channelVersion functions.
+	undefinedVersion = "dev-undefined"
 )
 
 func init() {
@@ -37,114 +34,31 @@ func init() {
 	}
 }
 
-// CheckClientVersion validates whether the Linkerd Public API client's version
-// matches an expected version.
-func CheckClientVersion(expectedVersion string) error {
-	if Version != expectedVersion {
-		return versionMismatchError(expectedVersion, Version)
+// Match compares two versions and returns success if they match, or an error
+// with a contextual message if they do not.
+func Match(expectedVersion, actualVersion string) error {
+	if expectedVersion == "" {
+		return errors.New("expected version is empty")
+	} else if actualVersion == "" {
+		return errors.New("actual version is empty")
+	} else if actualVersion == expectedVersion {
+		return nil
 	}
 
-	return nil
-}
-
-// GetServerVersion returns the Linkerd Public API server version
-func GetServerVersion(apiClient pb.ApiClient) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	rsp, err := apiClient.Version(ctx, &pb.Empty{})
+	actual, err := parseChannelVersion(actualVersion)
 	if err != nil {
-		return "", err
+		return fmt.Errorf("failed to parse actual version: %s", err)
 	}
-
-	return rsp.GetReleaseVersion(), nil
-}
-
-// CheckServerVersion validates whether the Linkerd Public API server's version
-// matches an expected version.
-func CheckServerVersion(apiClient pb.ApiClient, expectedVersion string) error {
-	releaseVersion, err := GetServerVersion(apiClient)
+	expected, err := parseChannelVersion(expectedVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse expected version: %s", err)
 	}
 
-	if releaseVersion != expectedVersion {
-		return versionMismatchError(expectedVersion, releaseVersion)
+	if actual.channel != expected.channel {
+		return fmt.Errorf("mismatched channels: running %s but retrieved %s",
+			actual, expected)
 	}
 
-	return nil
-}
-
-// GetLatestVersion performs an online request to check for the latest Linkerd
-// version.
-func GetLatestVersion(uuid string, source string) (string, error) {
-	url := fmt.Sprintf(versionCheckURL, Version, uuid, source)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	rsp, err := http.DefaultClient.Do(req.WithContext(ctx))
-	if err != nil {
-		return "", err
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode != 200 {
-		return "", fmt.Errorf("Unexpected versioncheck response: %s", rsp.Status)
-	}
-
-	bytes, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var versionRsp map[string]string
-	err = json.Unmarshal(bytes, &versionRsp)
-	if err != nil {
-		return "", err
-	}
-
-	channel := parseChannel(Version)
-	if channel == "" {
-		return "", fmt.Errorf("Unsupported version format: %s", Version)
-	}
-
-	version, ok := versionRsp[channel]
-	if !ok {
-		return "", fmt.Errorf("Unsupported version channel: %s", channel)
-	}
-
-	return version, nil
-}
-
-func parseVersion(version string) string {
-	if parts := strings.SplitN(version, "-", 2); len(parts) == 2 {
-		return parts[1]
-	}
-	return version
-}
-
-func parseChannel(version string) string {
-	if parts := strings.SplitN(version, "-", 2); len(parts) == 2 {
-		return parts[0]
-	}
-	return ""
-}
-
-func versionMismatchError(expectedVersion, actualVersion string) error {
-	channel := parseChannel(expectedVersion)
-	expectedVersionStr := parseVersion(expectedVersion)
-	actualVersionStr := parseVersion(actualVersion)
-
-	if channel != "" {
-		return fmt.Errorf("is running version %s but the latest %s version is %s",
-			actualVersionStr, channel, expectedVersionStr)
-	}
-
-	return fmt.Errorf("is running version %s but the latest version is %s",
-		actualVersionStr, expectedVersionStr)
+	return fmt.Errorf("is running version %s but the latest %s version is %s",
+		actual.version, actual.channel, expected.version)
 }

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -33,5 +33,6 @@ linkerd-version
 control-plane-version
 ---------------------
 √ control plane is up-to-date
+√ control plane and cli versions match
 
 Status check results are √

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -36,5 +36,6 @@ linkerd-data-plane
 √ data plane proxies are ready
 √ data plane proxy metrics are present in Prometheus
 √ data plane is up-to-date
+√ data plane and cli versions match
 
 Status check results are √


### PR DESCRIPTION
Version checks were not validating that the cli version matched the
control plane or data plane versions.

Add checks via the `linkerd check` command to validate the cli is
running the same version as the control and data plane.

Also add types around `channel-version` string parsing and matching. A
consequence being that during development `version.Version` changes from
`undefined` to `dev-undefined`.

Depends on linkerd/website#101

Fixes #2076

Signed-off-by: Andrew Seigner <siggy@buoyant.io>