### PR TITLE
Don't show the tap icon for requests from sources that are not meshed

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -25,3 +25,7 @@ a:focus, a:hover, a:visited, a:link, a:active {
 .breadcrumb-link a {
   color: white;
 }
+
+i.tapGrayed {
+  color: lightgray;
+}

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -18,7 +18,6 @@ import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
 import _merge from 'lodash/merge';
 import _reduce from 'lodash/reduce';
-import { processNeighborData } from './util/TapUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
 
 // if there has been no traffic for some time, show a warning
@@ -202,11 +201,8 @@ export class ResourceDetailBase extends React.Component {
     });
   }
 
-  updateNeighborsFromTapData = (source, sourceLabels) => {
-    // store this outside of state, as updating the state upon every websocket event received
-    // is very costly and causes the page to freeze up
-    this.unmeshedSources = processNeighborData(source, sourceLabels, this.unmeshedSources, this.state.resource.type);
-    return this.unmeshedSources;
+  updateUnmeshedSources = obj => {
+    this.unmeshedSources = obj;
   }
 
   banner = () => {
@@ -289,7 +285,7 @@ export class ResourceDetailBase extends React.Component {
         <TopRoutesTabs
           query={query}
           pathPrefix={this.props.pathPrefix}
-          updateNeighborsFromTapData={this.updateNeighborsFromTapData}
+          updateUnmeshedSources={this.updateUnmeshedSources}
           disableTop={!resourceIsMeshed} />
 
         { _isEmpty(upstreams) ? null : (

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -206,6 +206,7 @@ export class ResourceDetailBase extends React.Component {
     // store this outside of state, as updating the state upon every websocket event received
     // is very costly and causes the page to freeze up
     this.unmeshedSources = processNeighborData(source, sourceLabels, this.unmeshedSources, this.state.resource.type);
+    return this.unmeshedSources;
   }
 
   banner = () => {

--- a/web/app/js/components/TapLink.jsx
+++ b/web/app/js/components/TapLink.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, path}) => {
+const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, path, disabled}) => {
   let params = {
     autostart: "true",
     namespace,
@@ -12,7 +12,7 @@ const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, pa
   };
   let queryStr = Object.entries(params).map(([k, v]) => `${k}=${v}`).join("&");
 
-  if (resource === "") {
+  if (disabled) {
     return <i className="fas fa-microscope tapGrayed" />;
   }
 
@@ -24,6 +24,7 @@ const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, pa
 };
 
 TapLink.propTypes = {
+  disabled: PropTypes.bool.isRequired,
   namespace: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   PrefixedLink: PropTypes.func.isRequired,

--- a/web/app/js/components/TapLink.jsx
+++ b/web/app/js/components/TapLink.jsx
@@ -24,7 +24,7 @@ const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, pa
 };
 
 TapLink.propTypes = {
-  disabled: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   namespace: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   PrefixedLink: PropTypes.func.isRequired,
@@ -32,5 +32,9 @@ TapLink.propTypes = {
   toNamespace: PropTypes.string.isRequired,
   toResource: PropTypes.string.isRequired,
 };
+
+TapLink.defaultProps = {
+  disabled: false
+}
 
 export default TapLink;

--- a/web/app/js/components/TapLink.jsx
+++ b/web/app/js/components/TapLink.jsx
@@ -12,6 +12,10 @@ const TapLink = ({PrefixedLink, namespace, resource, toNamespace, toResource, pa
   };
   let queryStr = Object.entries(params).map(([k, v]) => `${k}=${v}`).join("&");
 
+  if (resource === "") {
+    return <i className="fas fa-microscope tapGrayed" />;
+  }
+
   return (
     <PrefixedLink to={`/tap?${queryStr}`}>
       <i className="fas fa-microscope" />

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -9,6 +9,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _each from 'lodash/each';
 import _get from 'lodash/get';
 import _has from 'lodash/has';
+import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
 import _isNil from 'lodash/isNil';
 import _noop from 'lodash/noop';
@@ -244,7 +245,7 @@ class TopModule extends React.Component {
       if (isPod) {
         topResults[eventKey].meshed = !_has(this.unmeshedSources, "pod/" + d.base.source.pod);
       } else {
-        topResults[eventKey].meshed = !_has(this.unmeshedSources, d.base.source.owner);
+        topResults[eventKey].meshed = !_isEmpty(d.base.source.owner) && !_has(this.unmeshedSources, d.base.source.owner);
       }
     }
 

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -266,7 +266,7 @@ class TopModule extends React.Component {
     // is very costly and causes the page to freeze up
     let resourceType = _isNil(this.props.query.resource) ? "" : this.props.query.resource.split("/")[0];
     this.unmeshedSources = processNeighborData(source, sourceLabels, this.unmeshedSources, resourceType);
-    if (this.props.updateUnmeshedSources) {this.props.updateUnmeshedSources(this.unmeshedSources);}
+    this.props.updateUnmeshedSources(this.unmeshedSources);
   }
 
   indexTapResult = data => {

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -8,6 +8,7 @@ import TopEventTable from './TopEventTable.jsx';
 import _cloneDeep from 'lodash/cloneDeep';
 import _each from 'lodash/each';
 import _get from 'lodash/get';
+import _has from 'lodash/has';
 import _isEqual from 'lodash/isEqual';
 import _isNil from 'lodash/isNil';
 import _noop from 'lodash/noop';
@@ -173,6 +174,7 @@ class TopModule extends React.Component {
       last: d.responseEnd.latency,
       success: !d.success ? 0 : 1,
       failure: !d.success ? 1 : 0,
+      meshed: true,
       successRate: !d.success ? new Percentage(0, 1) : new Percentage(1, 1),
       direction: d.base.proxyDirection,
       source: d.requestInit.source,
@@ -237,7 +239,8 @@ class TopModule extends React.Component {
     }
 
     if (d.base.proxyDirection === "INBOUND") {
-      this.props.updateNeighbors(d.requestInit.source, _get(d, "requestInit.sourceMeta.labels"), null);
+      let unmeshedSources = this.props.updateNeighbors(d.requestInit.source, _get(d, "requestInit.sourceMeta.labels"), null);
+      topResults[eventKey].meshed = !_has(unmeshedSources, d.base.source.owner);
     }
 
     return topResults;

--- a/web/app/js/components/TopRoutesTabs.jsx
+++ b/web/app/js/components/TopRoutesTabs.jsx
@@ -30,7 +30,7 @@ class TopRoutesTabs extends React.Component {
   };
 
   renderTopComponent() {
-    let { disableTop, query, pathPrefix, updateNeighborsFromTapData } = this.props;
+    let { disableTop, query, pathPrefix, updateUnmeshedSources } = this.props;
     if (disableTop) {
       return null;
     }
@@ -46,7 +46,7 @@ class TopRoutesTabs extends React.Component {
           pathPrefix={pathPrefix}
           query={topQuery}
           startTap={true}
-          updateNeighbors={updateNeighborsFromTapData}
+          updateUnmeshedSources={updateUnmeshedSources}
           maxRowsToDisplay={10} />
         <QueryToCliCmd cmdName="top" query={topQuery} resource={topQuery.resource} />
       </React.Fragment>
@@ -105,13 +105,13 @@ TopRoutesTabs.propTypes = {
   pathPrefix: PropTypes.string.isRequired,
   query: PropTypes.shape({}),
   theme: PropTypes.shape({}).isRequired,
-  updateNeighborsFromTapData: PropTypes.func
+  updateUnmeshedSources: PropTypes.func
 };
 
 TopRoutesTabs.defaultProps = {
   disableTop: false,
   query: {},
-  updateNeighborsFromTapData: _noop
+  updateUnmeshedSources: _noop
 };
 
 export default withStyles(styles, { withTheme: true })(TopRoutesTabs);

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -352,16 +352,19 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
 
 export const tapLink = (d, resourceType, PrefixedLink) => {
   let namespace = d.sourceLabels.namespace;
-  let resource = "";
+  let resource;
 
   if (!d.meshed) {
-    return null;
+    namespace = "";
+    resource = "";
   } else if (_has(d.sourceLabels, resourceType)) {
     resource = `${resourceType}/${d.sourceLabels[resourceType]}`;
   } else if (_has(d.sourceLabels, "pod")) {
     resource = `pod/${d.sourceLabels.pod}`;
   } else {
-    return null; // can't tap a resource by IP from the web UI
+    // can't tap a resource by IP from the web UI
+    namespace = "";
+    resource = "";
   }
 
   let toNamespace = "";

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -351,20 +351,19 @@ export const srcDstColumn = (d, resourceType, ResourceLink) => {
 };
 
 export const tapLink = (d, resourceType, PrefixedLink) => {
+  let disabled = false;
   let namespace = d.sourceLabels.namespace;
-  let resource;
+  let resource = "";
 
   if (!d.meshed) {
-    namespace = "";
-    resource = "";
+    disabled = true;
   } else if (_has(d.sourceLabels, resourceType)) {
     resource = `${resourceType}/${d.sourceLabels[resourceType]}`;
   } else if (_has(d.sourceLabels, "pod")) {
     resource = `pod/${d.sourceLabels.pod}`;
   } else {
     // can't tap a resource by IP from the web UI
-    namespace = "";
-    resource = "";
+    disabled = true;
   }
 
   let toNamespace = "";
@@ -385,6 +384,7 @@ export const tapLink = (d, resourceType, PrefixedLink) => {
       toNamespace={toNamespace}
       toResource={toResource}
       path={d.path}
-      PrefixedLink={PrefixedLink} />
+      PrefixedLink={PrefixedLink}
+      disabled={disabled} />
   );
 };

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -354,7 +354,9 @@ export const tapLink = (d, resourceType, PrefixedLink) => {
   let namespace = d.sourceLabels.namespace;
   let resource = "";
 
-  if (_has(d.sourceLabels, resourceType)) {
+  if (!d.meshed) {
+    return null;
+  } else if (_has(d.sourceLabels, resourceType)) {
     resource = `${resourceType}/${d.sourceLabels[resourceType]}`;
   } else if (_has(d.sourceLabels, "pod")) {
     resource = `pod/${d.sourceLabels.pod}`;


### PR DESCRIPTION
Fixes #1723

For testing, I injected all the emojivoto deployments but vote-bot. You can see the requests coming from vote-bot are not tappable anymore:

![image](https://user-images.githubusercontent.com/554287/51622118-f0649f80-1f03-11e9-804d-27a5e39cc63b.png)
