### PR TITLE
Rename fast-build to build-cli-bin, fix shasum

### DIFF
--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -8,7 +8,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
-LINKERD_SKIP_CLI_CONTAINER=1 $bindir/docker-build
 current_platform=$(uname)
 host_platform="windows"
 if [ "${current_platform}" = 'Darwin' ]; then

--- a/bin/dep
+++ b/bin/dep
@@ -15,9 +15,11 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"
 
 os=linux
+dash_p="-p"
 exe=
 if [ "$(uname -s)" = "Darwin" ]; then
   os=darwin
+  dash_p="" # -p isn't needed on mac
 elif [ "$(uname -o)" = "Msys" ]; then
   os=windows
   exe=.exe
@@ -32,7 +34,7 @@ if [ ! -f "$depbin" ]; then
     cd "$tmp"
     curl -L --silent --fail -o depbin "$depurl"
     sha=$(curl -L --silent --fail "${depurl}.sha256" | awk '{ print $1 }')
-    (echo "$sha *depbin" | shasum -c -a 256 -p -s -) || {
+    (echo "$sha *depbin" | shasum -c -a 256 $dash_p -s -) || {
       echo "Actual digest of $(pwd)/depbin does not match expected digest."
       exit 1
     }

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -12,8 +12,10 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $bindir/docker-build-controller
 $bindir/docker-build-web
 $bindir/docker-build-proxy-init
-if [ -z "${LINKERD_SKIP_CLI_CONTAINER:-}" ]; then
+if [ -z "${LINKERD_LOCAL_BUILD_CLI:-}" ]; then
     $bindir/docker-build-cli-bin
+else
+    $bindir/build-cli-bin
 fi
 $bindir/docker-build-grafana
 $bindir/docker-build-proxy

--- a/bin/linkerd
+++ b/bin/linkerd
@@ -18,7 +18,7 @@ fi
 
 # build linkerd executable if it does not exist
 if [ ! -f $bin ]; then
-  $bindir/docker-build-cli-bin >/dev/null
+  $bindir/build-cli-bin >/dev/null
 fi
 
 exec $bin "$@"


### PR DESCRIPTION
`fast-build` was performing a full Docker build minus the cli, and then
building cli locally. Separately, shasum was called with a `-p flag,
breaking some builds on Darwin.

Instead, rename `fast-build` to `build-cli-bin`, and restrict it to only
building the cli locally, without any Docker dependencies. Also modify
`bin/linkerd` to call `build-cli-bin` rather than
`docker-build-cli-bin`.

To perform an equivalent of `fast-build`:
`LINKERD_LOCAL_BUILD_CLI=1 bin/docker-build`

`shasum` fix cribbed from #2071.

Relates to #1704

Signed-off-by: Andrew Seigner <siggy@buoyant.io>