### PR TITLE
Fix issue where linkerd check would panic if there was a pod with a replicationcontroller ID in the control plane namespace 

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -802,7 +802,14 @@ func getPodStatuses(pods []v1.Pod) map[string][]v1.ContainerStatus {
 	for _, pod := range pods {
 		if pod.Status.Phase == v1.PodRunning {
 			parts := strings.Split(pod.Name, "-")
-			name := strings.Join(parts[1:len(parts)-2], "-")
+			var name string
+			// All control plane pods  should have a name that results in 3 substrings string.Split on '-'
+			if len(parts) == 3 {
+				name = strings.Join(parts[1:len(parts)-2], "-")
+			} else {
+				name = strings.Join(parts, "-")
+			}
+
 			if _, found := statuses[name]; !found {
 				statuses[name] = make([]v1.ContainerStatus, 0)
 			}


### PR DESCRIPTION
When running Linkerd check with a control plane namespace that may contain an additional pod with a replication controller ID for pod names instead of a replicaSet ID, the check command panics because of an "index out of bounds" error.

This PR adds a check to make sure that, when parsing pod names during the `checkControllerRunning` healthcheck, the check ensures that the pod name can be split into three substrings on '-'. This prevents the panic from occurring when the check encounters a replication controller ID pod name.

Fixes #2084 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>