### PR TITLE
Add a less scary message to the user when retries are still in progress

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -15,6 +15,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/version"
+	log "github.com/sirupsen/logrus"
 	authorizationapi "k8s.io/api/authorization/v1beta1"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -608,6 +609,9 @@ func (hc *HealthChecker) runCheck(categoryID CategoryID, c *checker, observer ch
 
 		if err != nil && time.Now().Before(c.retryDeadline) {
 			checkResult.Retry = true
+			checkResult.Err = errors.New("waiting for check to complete")
+			log.Debugf("Retrying on error: %s", err.Error())
+
 			observer(checkResult)
 			time.Sleep(retryWindow)
 			continue

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -278,7 +278,7 @@ func TestHealthChecker(t *testing.T) {
 
 		expectedResults := []string{
 			"cat1 desc1 retry=false",
-			"cat7 desc7 retry=true: retry",
+			"cat7 desc7 retry=true: waiting for check to complete",
 			"cat7 desc7 retry=false",
 		}
 


### PR DESCRIPTION
When a failing check is being retried, we show the current err to the user. This can sometimes be unnecessarily alarming, as in the case of the control plane starting up.

If a failing check is in the process of being retried, wait to show the final error message until the retries have completed.

Fixes #2082