### PR TITLE
Check RoleBindings for specified single namespace only

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -295,14 +295,14 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "can create Roles",
 					hintURL:     "https://linkerd.io/2/getting-started/#step-0-setup",
 					check: func() error {
-						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "Role")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "rbac.authorization.k8s.io", "v1beta1", "Role")
 					},
 				},
 				{
 					description: "can create RoleBindings",
 					hintURL:     "https://linkerd.io/2/getting-started/#step-0-setup",
 					check: func() error {
-						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
 					},
 				},
 			},


### PR DESCRIPTION
Previously, we were doing the creation checks for both Roles/RoleBindings and ClusterRoles/ClusterRoleBindings for all namespaces, but in `--single-namespace` mode, we only need to check that these can be created in the control plane namespace.

Fixes #2117