### PR TITLE
GetProfiles should always respond immediately

### DIFF
--- a/controller/api/proxy/profile_listener.go
+++ b/controller/api/proxy/profile_listener.go
@@ -40,12 +40,14 @@ func (l *profileListener) Stop() {
 }
 
 func (l *profileListener) Update(profile *sp.ServiceProfile) {
-	if profile != nil {
-		destinationProfile, err := profiles.ToServiceProfile(&profile.Spec)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		l.stream.Send(destinationProfile)
+	if profile == nil {
+		l.stream.Send(&profiles.DefaultServiceProfile)
+		return
 	}
+	destinationProfile, err := profiles.ToServiceProfile(&profile.Spec)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	l.stream.Send(destinationProfile)
 }

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -20,14 +20,21 @@ type profileTemplateConfig struct {
 	ClusterZone           string
 }
 
-// DefaultRetryBudget is used for routes which do not specify one.
-var DefaultRetryBudget = pb.RetryBudget{
-	MinRetriesPerSecond: 10,
-	RetryRatio:          0.2,
-	Ttl: &duration.Duration{
-		Seconds: 10,
-	},
-}
+var (
+	// DefaultRetryBudget is used for routes which do not specify one.
+	DefaultRetryBudget = pb.RetryBudget{
+		MinRetriesPerSecond: 10,
+		RetryRatio:          0.2,
+		Ttl: &duration.Duration{
+			Seconds: 10,
+		},
+	}
+	// DefaultServiceProfile is used for services with no service profile.
+	DefaultServiceProfile = pb.DestinationProfile{
+		Routes:      []*pb.Route{},
+		RetryBudget: &DefaultRetryBudget,
+	}
+)
 
 // ToServiceProfile returns a Proxy API DestinationProfile, given a
 // ServiceProfile.


### PR DESCRIPTION
When `GetProfiles` is called for a destination that does not have a service profile, the proxy-api service does not return any messages until a service profile is created for that service.  This can be interpreted as hanging, and can make it difficult to calculate response latency metrics.

Change the behavior of the API to always return a service profile message immediately.  If the service does not have a service profile, the default service profile is returned.

Signed-off-by: Alex Leong <alex@buoyant.io>