### PR TITLE
proxy: update pinned version to 5b507a9

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-6df55c0}"
+PROXY_VERSION="${PROXY_VERSION:-5b507a9}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This picks up the following proxy commits:

* eaabc48 Update tower-grpc
* e9561de Update h2 to 0.1.16
* 28fd5e7 Add Route timeouts (linkerd/linkerd2-proxy#165)
* 5637372 Re-flag tcp_duration tests as flaky
* 20cbd18 Revise several log levels and messages (linkerd/linkerd2-proxy#177)
* ae16978 Remove flakiness from 'profiles' tests
* 49c29cd canonicalize: Only log errors at the WARN level when falling back (linkerd/linkerd2-proxy#174)
* 486dd13 Make outbound router honor `l5d-dst-override` header (linkerd/linkerd2-proxy#173)
* 7adc50d Make timeouts for canonicalization DNS queries tuneable (linkerd/linkerd2-proxy#175)
* 3188179 Try reducing CI flakiness by reducing RUST_TEST_THREADS to 1

Some of these changes will probably need changelog entries:

* Improve logging when rejecting malformed HTTP/2 pseudo-headers
  (carllerche/h2#347)
* Improve logging for gRPC errors (tower-rs/tower-grpc#111)
* Add Route timeouts (linkerd/linkerd2-proxy#165)
* Downgrade several of the noisiest log messages to TRACE
  (linkerd/linkerd2-proxy#177)
* Add an environment variable for configuring the DNS canonicalization
  timeout (linkerd/linkerd2-proxy#175)
* Make outbound router honor `l5d-dst-override` header
  (linkerd/linkerd2-proxy#173)

Perhaps all the logging related changes can be grouped into one
changelog entry, though...

Signed-off-by: Eliza Weisman <eliza@buoyant.io>