### PR TITLE
Fail CI on unlinted js code

### DIFF
--- a/web/app/js/components/TapLink.jsx
+++ b/web/app/js/components/TapLink.jsx
@@ -35,6 +35,6 @@ TapLink.propTypes = {
 
 TapLink.defaultProps = {
   disabled: false
-}
+};
 
 export default TapLink;

--- a/web/app/webpack.config.js
+++ b/web/app/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = {
           {
             loader: 'eslint-loader',
             options: {
-              fix: true,
+              fix: process.env.NODE_ENV === 'development',
               emitWarning: process.env.NODE_ENV === 'development'
             }
           }


### PR DESCRIPTION
I noticed that #2131 was able to merge even though it contained a missing `;` which should have failed lint checks. I think the problem is that if `fix` is enabled, running `bin/web build` fixes the issue and then the lint checks pass on the fixed but uncommitted code.

We should avoid autofixing in environments that aren't `development` to avoid merging unfixed code to master.

This CI should fail until I've fixed the `;`