### PR TITLE
Reorganize install/inject config structs

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -256,24 +256,11 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 				Name:      PodNamespaceEnvVarName,
 				ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 			},
+			{Name: "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE", Value: fmt.Sprintf("%dms", defaultKeepaliveMs)},
+			{Name: "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE", Value: fmt.Sprintf("%dms", defaultKeepaliveMs)},
 		},
 		LivenessProbe:  &proxyProbe,
 		ReadinessProbe: &proxyProbe,
-	}
-
-	if options.inboundAcceptKeepaliveMs != 0 {
-		sidecar.Env = append(sidecar.Env,
-			v1.EnvVar{
-				Name:  "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE",
-				Value: fmt.Sprintf("%dms", options.inboundAcceptKeepaliveMs),
-			})
-	}
-	if options.outboundConnectKeepaliveMs != 0 {
-		sidecar.Env = append(sidecar.Env,
-			v1.EnvVar{
-				Name:  "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE",
-				Value: fmt.Sprintf("%dms", options.outboundConnectKeepaliveMs),
-			})
 	}
 
 	// Special case if the caller specifies that

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -73,6 +73,11 @@ type installConfig struct {
 	NoInitContainer                  bool
 }
 
+// installOptions holds values for command line flags that apply to the install
+// command. All fields in this struct should have corresponding flags added in
+// the newCmdInstall func later in this file. It also embeds proxyConfigOptions
+// in order to hold values for command line flags that apply to both inject and
+// install.
 type installOptions struct {
 	controllerReplicas uint
 	controllerLogLevel string
@@ -200,8 +205,8 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		OutboundPort:                     options.outboundPort,
 		IgnoreInboundPorts:               strings.Join(ignoreInboundPorts, ","),
 		IgnoreOutboundPorts:              strings.Join(ignoreOutboundPorts, ","),
-		InboundAcceptKeepaliveMs:         options.proxyConfigOptions.inboundAcceptKeepaliveMs,
-		OutboundConnectKeepaliveMs:       options.proxyConfigOptions.inboundAcceptKeepaliveMs,
+		InboundAcceptKeepaliveMs:         defaultKeepaliveMs,
+		OutboundConnectKeepaliveMs:       defaultKeepaliveMs,
 		ProxyAutoInjectEnabled:           options.proxyAutoInject,
 		ProxyInjectAnnotation:            k8s.ProxyInjectAnnotation,
 		ProxyInjectDisabled:              k8s.ProxyInjectDisabled,


### PR DESCRIPTION
This is a follow-up to #2193, which added configuration options for inbound/outbound keepalives to the `proxyConfigOptions` struct. It wasn't clear from the existing code, but the fields in that struct should map directly to command line flags. Since these configuration options don't have corresponding command line flags, I'm instead moving them to use a constant, and adding comments to explain how command line flags are configured. This also fixes an install issue that was incorrectly mapping the inbound keepalive to the outbound keepalive in the install template.