### PR TITLE
If GOPATH env var not set, use build.Default.GOPATH

### DIFF
--- a/cli/static/templates.go
+++ b/cli/static/templates.go
@@ -3,11 +3,20 @@
 package static
 
 import (
+	"go/build"
 	"net/http"
 	"os"
 	"path"
 )
 
 // Templates that will be rendered by `linkerd install`. This is only used on
-// dev builds so we can assume $GOPATH is set properly.
-var Templates http.FileSystem = http.Dir(path.Join(os.Getenv("GOPATH"), "src/github.com/linkerd/linkerd2/chart"))
+// dev builds so we can assume GOPATH is set properly (either explicitly through
+// an env var, or defaulting to $HOME/go)
+var Templates http.FileSystem = http.Dir(path.Join(getGOPATH(), "src/github.com/linkerd/linkerd2/chart"))
+
+func getGOPATH() string {
+	if goPath := os.Getenv("GOPATH"); goPath != "" {
+		return goPath
+	}
+	return build.Default.GOPATH
+}


### PR DESCRIPTION
Follow-up to #2189 

When the env var GOPATH is not set, go defaults to `$HOME/go`:
```
$ echo $GOPATH

$ go env
GOARCH="amd64"
GOBIN=""
GOCACHE="/home/alpeb/.cache/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/home/alpeb/go"
...
```
That was the case in my machine, which `linkerd install` didn't like. So I updated the part where GOPATH is used to take that into account.