### PR TITLE
CNI: Removed unnecessary tolerations; added created-by annotation.

### DIFF
--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/linkerd/linkerd2/cli/install"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -25,6 +26,8 @@ type installCNIPluginConfig struct {
 	ProxyUID            int64
 	DestCNINetDir       string
 	DestCNIBinDir       string
+	CreatedByAnnotation string
+	CliVersion          string
 }
 
 type cniPluginOptions struct {
@@ -150,6 +153,8 @@ func validateAndBuildCNIConfig(options *cniPluginOptions) (*installCNIPluginConf
 		ProxyUID:            options.proxyUID,
 		DestCNINetDir:       options.destCNINetDir,
 		DestCNIBinDir:       options.destCNIBinDir,
+		CreatedByAnnotation: k8s.CreatedByAnnotation,
+		CliVersion:          k8s.CreatedByAnnotationValue(),
 	}, nil
 }
 

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -99,6 +99,8 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -85,6 +85,8 @@ metadata:
   namespace: linkerd
   labels:
     k8s-app: linkerd-cni
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   selector:
     matchLabels:
@@ -97,25 +99,10 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      tolerations:
-      # Make sure linkerd-cni gets scheduled on all nodes.
-      - effect: NoSchedule
-        operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: linkerd-cni
       terminationGracePeriodSeconds: 5
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -85,6 +85,8 @@ metadata:
   namespace: other
   labels:
     k8s-app: linkerd-cni
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   selector:
     matchLabels:
@@ -97,25 +99,10 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      tolerations:
-      # Make sure linkerd-cni gets scheduled on all nodes.
-      - effect: NoSchedule
-        operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: linkerd-cni
       terminationGracePeriodSeconds: 5
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -99,6 +99,8 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -85,6 +85,8 @@ metadata:
   namespace: other
   labels:
     k8s-app: linkerd-cni
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   selector:
     matchLabels:
@@ -97,25 +99,10 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      tolerations:
-      # Make sure linkerd-cni gets scheduled on all nodes.
-      - effect: NoSchedule
-        operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: linkerd-cni
       terminationGracePeriodSeconds: 5
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -99,6 +99,8 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/cli/install/cni-template.go
+++ b/cli/install/cni-template.go
@@ -106,6 +106,8 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     k8s-app: linkerd-cni
+  annotations:
+    {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   selector:
     matchLabels:
@@ -118,25 +120,10 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
-      tolerations:
-      # Make sure linkerd-cni gets scheduled on all nodes.
-      - effect: NoSchedule
-        operator: Exists
-      # Mark the pod as a critical add-on for rescheduling.
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: linkerd-cni
       terminationGracePeriodSeconds: 5
       containers:

--- a/cli/install/cni-template.go
+++ b/cli/install/cni-template.go
@@ -120,6 +120,8 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+      annotations:
+        {{.CreatedByAnnotation}}: {{.CliVersion}}
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
Signed-off-by: Cody Vandermyn <cody.vandermyn@nordstrom.com>

In our cluster, we have some nodes that are tainted with `NoSchedule` and this means that only "master"-level pods will be installed on those nodes (pods that tolerate `NoSchedule`). The linkerd-cni plugin only needs to be installed and executed on nodes that will have "user" pods on them so the output .yaml does not need any special tolerations. Installing the linkerd-cni plugin on nodes that will never have "user" pods scheduled on them by default is unnecessary.

I also removed the `scheduler.alpha.kubernetes.io/critical-pod: ''` based on this documentation which mentions that the annotation is only effective if the pod is in the `kube-system` namespace: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/