### PR TITLE
Proxy: bump pinned version to 7add4fc

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-0fc35e2}"
+PROXY_VERSION="${PROXY_VERSION:-7add4fc}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
* Remove destination address from endpoint metric labels
(linkerd/linkerd2#187)
* Set proxy_id in calls to Get and GetProfile (linkerd/linkerd2#183)
* Add l5d-client-id on inbound requests if meshed TLS (linkerd/linkerd2#184)

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>