### PR TITLE
GetPodsFor() called for an ExternalName service shouldn't return any pods

### DIFF
--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -305,6 +305,9 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
 
 	case *apiv1.Service:
+		if typed.Spec.Type == apiv1.ServiceTypeExternalName {
+			return []*apiv1.Pod{}, nil
+		}
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
 

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -361,7 +361,7 @@ func TestGetPodsFor(t *testing.T) {
 
 		// all 3 of these are used to seed the k8s client
 		k8sResInput   string   // object used as input to GetPodFor()
-		k8sResResults []string // expected results from GetPodFor
+		k8sResResults []string // expected results from GetPodsFor
 		k8sResMisc    []string // additional k8s objects for seeding the k8s client
 	}
 
@@ -390,6 +390,57 @@ metadata:
     app: emoji-svc
 status:
   phase: Finished`,
+				},
+			},
+			// Retrieve pods associated to a ClusterIP service
+			getPodsForExpected{
+				err: nil,
+				k8sResInput: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  type: ClusterIP
+  selector:
+    app: emoji-svc`,
+				k8sResResults: []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emojivoto-meshed-finished
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+status:
+  phase: Running`,
+				},
+				k8sResMisc: []string{},
+			},
+			// ExternalName services shouldn't return any pods
+			getPodsForExpected{
+				err: nil,
+				k8sResInput: `
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  type: ExternalName
+  externalName: someapi.example.com`,
+				k8sResResults: []string{},
+				k8sResMisc: []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emojivoto-meshed-finished
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+status:
+  phase: Running`,
 				},
 			},
 			getPodsForExpected{


### PR DESCRIPTION
Fixes #2216

Running `linkerd routes`  for some resource was returning, besides the data for the resource, additional rows for each `ExternalName` service in the namespace:
```
$ bin/go-run cli routes deployment/voting --namespace emojivoto                                            
ROUTE                                  SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
[DEFAULT]                      external-name       0.00%   0.0rps           0ms           0ms           0ms
Results                             voting-svc     0.00%   0.0rps           0ms           0ms           0ms
Vote100                             voting-svc     0.00%   0.0rps           0ms           0ms           0ms
VoteBacon                           voting-svc   100.00%   0.1rps           1ms           1ms           1ms
VoteBalloon                         voting-svc     0.00%   0.0rps           0ms           0ms           0ms
...
```
Alongside the fix I added tests into `api_tests.go` making sure `ClusterIP` services do return pods while `ExternalName` services don't.
