### PR TITLE
Replacing lodash filter with native filter to avoid additional import

### DIFF
--- a/web/app/js/components/util/withREST.jsx
+++ b/web/app/js/components/util/withREST.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _filter from 'lodash/filter';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _merge from 'lodash/merge';
@@ -48,9 +47,8 @@ const withREST = (WrappedComponent, componentPromises, options={}) => {
     }
 
     componentDidUpdate(prevProps) {
-      const changed = _filter(
-        localOptions.resetProps,
-        prop => _get(prevProps, prop) !== _get(this.props, prop),
+      const changed = localOptions.resetProps.filter(
+        prop => _get(prevProps, prop) !== _get(this.props, prop)
       );
 
       if (_isEmpty(changed)) { return; }


### PR DESCRIPTION
Fixes #2034 

@rmars and I set out to replace all instances of lodash filter with native filter in order to prevent the additional import. However, there was only one use of _filter that could be easily replaced, since our other uses depend on lodash's ability to handle empty variables, and the ability to filter both objects and arrays (JS's native filter is only for arrays). Switching to native filter in those cases would have required us to manually check the value of the variable, set it to an empty array and/or convert it from an object to an array.