### PR TITLE
Initial CNI plugin integration test

### DIFF
--- a/cni-plugin/integration_test/calico-etcd.yaml
+++ b/cni-plugin/integration_test/calico-etcd.yaml
@@ -1,0 +1,83 @@
+# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: calico-etcd
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-etcd
+      annotations:
+        # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+        # reserves resources for critical add-on pods so that they can be rescheduled after
+        # a failure.  This annotation works in tandem with the toleration below.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+        # This taint is set by all kubelets running `--cloud-provider=external`
+        # so we should tolerate it to schedule the Calico pods
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        # Allow this pod to run on the master.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+      # Only run this pod on the master.
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      containers:
+        - name: calico-etcd
+          image: quay.io/coreos/etcd:v3.3.9
+          env:
+            - name: CALICO_ETCD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command:
+          - /usr/local/bin/etcd
+          args:
+          - --name=calico
+          - --data-dir=/var/etcd/calico-data
+          - --advertise-client-urls=http://$(CALICO_ETCD_IP):6666
+          - --listen-client-urls=http://0.0.0.0:6666
+          - --listen-peer-urls=http://0.0.0.0:6667
+          - --auto-compaction-retention=1
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd
+      volumes:
+        - name: var-etcd
+          hostPath:
+            path: /var/etcd
+
+---
+
+# This manifest installs the Service which gets traffic to the Calico
+# etcd.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: calico-etcd
+  name: calico-etcd
+  namespace: kube-system
+spec:
+  # Select the calico-etcd pod running on the master.
+  selector:
+    k8s-app: calico-etcd
+  # This ClusterIP needs to be known in advance, since we cannot rely
+  # on DNS to get access to etcd.
+  clusterIP: 10.96.232.136
+  ports:
+    - port: 6666

--- a/cni-plugin/integration_test/calico.yaml
+++ b/cni-plugin/integration_test/calico.yaml
@@ -1,0 +1,492 @@
+# Calico Version v3.4.0
+# https://docs.projectcalico.org/v3.4/releases#v3.4.0
+# This manifest includes the following component versions:
+#   calico/node:v3.4.0
+#   calico/cni:v3.4.0
+#   calico/kube-controllers:v3.4.0
+
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # Configure this with the location of your etcd cluster.
+  etcd_endpoints: "http://10.96.232.136:6666"
+
+  # If you're using TLS enabled etcd uncomment the following.
+  # You must also populate the Secret below with these files.
+  etcd_ca: ""   # "/calico-secrets/etcd-ca"
+  etcd_cert: "" # "/calico-secrets/etcd-cert"
+  etcd_key: ""  # "/calico-secrets/etcd-key"
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # Configure the MTU to use
+  veth_mtu: "1440"
+
+  # The CNI network configuration to install on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "etcd_endpoints": "__ETCD_ENDPOINTS__",
+          "etcd_key_file": "__ETCD_KEY_FILE__",
+          "etcd_cert_file": "__ETCD_CERT_FILE__",
+          "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+
+---
+
+# The following contains k8s Secrets for use with a TLS enabled etcd cluster.
+# For information on populating Secrets, see http://kubernetes.io/docs/user-guide/secrets/
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: calico-etcd-secrets
+  namespace: kube-system
+data:
+  # Populate the following with etcd TLS configuration if desired, but leave blank if
+  # not using TLS for etcd.
+  # The keys below should be uncommented and the values populated with the base64
+  # encoded contents of each file that would be associated with the TLS data.
+  # Example command for encoding a file contents: cat <file> | base64 -w 0
+  # etcd-key: null
+  # etcd-cert: null
+  # etcd-ca: null
+
+---
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      initContainers:
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v3.4.0
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: calico/node:v3.4.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # Set noderef for node controller.
+            - name: CALICO_K8S_NODE_REF
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within `--cluster-cidr`.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+              host: localhost
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+            - mountPath: /calico-secrets
+              name: etcd-certs
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Mount in the etcd TLS secrets with mode 400.
+        # See https://kubernetes.io/docs/concepts/configuration/secret/
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets
+            defaultMode: 0400
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+
+---
+# This manifest deploys the Calico Kubernetes controllers.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  # The controllers can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      # The controllers must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      containers:
+        - name: calico-kube-controllers
+          image: calico/kube-controllers:v3.4.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Location of the CA certificate for etcd.
+            - name: ETCD_CA_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_ca
+            # Location of the client key for etcd.
+            - name: ETCD_KEY_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_key
+            # Location of the client certificate for etcd.
+            - name: ETCD_CERT_FILE
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_cert
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,namespace,serviceaccount,workloadendpoint,node
+          volumeMounts:
+            # Mount in the etcd TLS secrets.
+            - mountPath: /calico-secrets
+              name: etcd-certs
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+      volumes:
+        # Mount in the etcd TLS secrets with mode 400.
+        # See https://kubernetes.io/docs/concepts/configuration/secret/
+        - name: etcd-certs
+          secret:
+            secretName: calico-etcd-secrets
+            defaultMode: 0400
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+rules:
+  # Pods are monitored for changing labels.
+  # The node controller monitors Kubernetes nodes.
+  # Namespace and serviceaccount labels are used for policy.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - watch
+      - list
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+rules:
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+
+

--- a/cni-plugin/integration_test/iptables/Dockerfile-tester
+++ b/cni-plugin/integration_test/iptables/Dockerfile-tester
@@ -1,0 +1,4 @@
+FROM golang:1.10.3
+
+ADD iptables/ /go
+

--- a/cni-plugin/integration_test/iptables/cni_rules_test.go
+++ b/cni-plugin/integration_test/iptables/cni_rules_test.go
@@ -94,7 +94,7 @@ func expectSuccessfulGetRequestToRetry(t *testing.T, host string, port string) s
 	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
 
 	var result string = expectSuccessfulGetRequestToURLRetry(t, targetURL)
-  var count int = 0
+  var count int
 
   for result == attemptToRetry && count < retryLimit {
     fmt.Printf("Request failed. Retrying request. Attempt %d of %d\n", count+1, retryLimit)

--- a/cni-plugin/integration_test/iptables/cni_rules_test.go
+++ b/cni-plugin/integration_test/iptables/cni_rules_test.go
@@ -93,7 +93,7 @@ func expectCannotConnectGetRequestTo(t *testing.T, host string, port string) {
 func expectSuccessfulGetRequestToRetry(t *testing.T, host string, port string) string {
 	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
 
-	var result string = expectSuccessfulGetRequestToURLRetry(t, targetURL)
+	var result = expectSuccessfulGetRequestToURLRetry(t, targetURL)
   var count int
 
   for result == attemptToRetry && count < retryLimit {

--- a/cni-plugin/integration_test/iptables/cni_rules_test.go
+++ b/cni-plugin/integration_test/iptables/cni_rules_test.go
@@ -1,0 +1,145 @@
+package iptablestest
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+  "time"
+)
+
+const (
+	proxyContainerPort       = "8080"
+  attemptToRetry           = "attemptToRetry"
+  retryLimit               = 10
+)
+
+func TestMain(m *testing.M) {
+	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
+	flag.Parse()
+
+	if !*runTests {
+		fmt.Fprintln(os.Stderr, "integration tests not enabled: enable with -integration-tests")
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestPodWithNoRules(t *testing.T) {
+	t.Parallel()
+
+	podWithNoRulesIP := os.Getenv("POD_WITH_NO_RULES_IP")
+	svcName := "svc-pod-with-no-rules"
+
+	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
+		expectSuccessfulGetRequestTo(t, podWithNoRulesIP, proxyContainerPort)
+	})
+
+	t.Run("fails to connect to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
+		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8088")
+		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8888")
+		expectCannotConnectGetRequestTo(t, podWithNoRulesIP, "8988")
+	})
+
+	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
+		expectSuccessfulGetRequestTo(t, svcName, proxyContainerPort)
+	})
+
+	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
+		expectCannotConnectGetRequestTo(t, svcName, "8088")
+		expectCannotConnectGetRequestTo(t, svcName, "8888")
+		expectCannotConnectGetRequestTo(t, svcName, "8988")
+	})
+}
+
+func TestPodRedirectsAllPorts(t *testing.T) {
+	t.Parallel()
+	podRedirectsAllPortsIP := os.Getenv("POD_REDIRECTS_ALL_PORTS_IP")
+	svcName := "svc-pod-redirects-all-ports"
+
+	t.Run("succeeds connecting to pod directly through container's exposed port", func(t *testing.T) {
+		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, proxyContainerPort)
+	})
+
+	t.Run("succeeds connecting to pod directly through any port that isn't the container's exposed port", func(t *testing.T) {
+		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8088")
+		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8888")
+		expectSuccessfulGetRequestTo(t, podRedirectsAllPortsIP, "8988")
+	})
+
+	t.Run("succeeds connecting to pod via a service through container's exposed port", func(t *testing.T) {
+		expectSuccessfulGetRequestToRetry(t, svcName, proxyContainerPort)
+	})
+
+	t.Run("fails to connect to pod via a service through any port that isn't the container's exposed port", func(t *testing.T) {
+		expectCannotConnectGetRequestTo(t, svcName, "8088")
+		expectCannotConnectGetRequestTo(t, svcName, "8888")
+		expectCannotConnectGetRequestTo(t, svcName, "8988")
+	})
+}
+
+func expectCannotConnectGetRequestTo(t *testing.T, host string, port string) {
+	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
+	fmt.Printf("Expecting failed GET to %s\n", targetURL)
+	resp, err := http.Get(targetURL)
+	if err == nil {
+		t.Fatalf("Expected error when connecting to %s, got:\n%+v", targetURL, resp)
+	}
+}
+
+func expectSuccessfulGetRequestToRetry(t *testing.T, host string, port string) string {
+	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
+
+	var result string = expectSuccessfulGetRequestToURLRetry(t, targetURL)
+  var count int = 0
+
+  for result == attemptToRetry && count < retryLimit {
+    fmt.Printf("Request failed. Retrying request. Attempt %d of %d\n", count+1, retryLimit)
+    time.Sleep(2 * time.Second)
+    result =  expectSuccessfulGetRequestToURLRetry(t, targetURL)
+    count = count + 1
+  }
+  if result == attemptToRetry {
+    t.Fatalf("failed to send HTTP GET to %s:\n", targetURL)
+  }
+  return result
+}
+
+func expectSuccessfulGetRequestToURLRetry(t *testing.T, url string) string {
+	fmt.Printf("Expecting successful GET to %s\n", url)
+	resp, err := http.Get(url)
+	if err != nil {
+    fmt.Printf("fail to %s with %v", url, err)
+    return attemptToRetry
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed reading GET response from %s:\n%v", url, err)
+	}
+	response := string(body)
+	fmt.Printf("Response from %s: %s", url, response)
+	return response
+}
+
+func expectSuccessfulGetRequestTo(t *testing.T, host string, port string) string {
+	targetURL := fmt.Sprintf("http://%s:%s/", host, port)
+	return expectSuccessfulGetRequestToURL(t, targetURL)
+}
+
+func expectSuccessfulGetRequestToURL(t *testing.T, url string) string {
+	fmt.Printf("Expecting successful GET to %s\n", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("failed to send HTTP GET to %s:\n%v", url, err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed reading GET response from %s:\n%v", url, err)
+	}
+	response := string(body)
+	fmt.Printf("Response from %s: %s", url, response)
+	return response
+}

--- a/cni-plugin/integration_test/iptables/no-rules-iptablestest-lab.yaml
+++ b/cni-plugin/integration_test/iptables/no-rules-iptablestest-lab.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-with-no-rules
+  labels:
+    app: pod-with-no-rules
+spec:
+      containers:
+      - name: webserver
+        image: buoyantio/cni-iptables-tester:v1
+        env:
+         - name: PORT
+           value: "8080"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        ports:
+        - name: http
+          containerPort: 8080
+      - name: other-container
+        image: buoyantio/cni-iptables-tester:v1
+        env:
+         - name: PORT
+           value: "9090"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        ports:
+        - name: http
+          containerPort: 9090
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-pod-with-no-rules
+spec:
+  selector:
+    app: pod-with-no-rules
+  ports:
+  - name: http
+    port: 8080

--- a/cni-plugin/integration_test/iptables/redirect-all-iptablestest-lab.yaml
+++ b/cni-plugin/integration_test/iptables/redirect-all-iptablestest-lab.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-redirects-all-ports
+  labels:
+    app: pod-redirects-all-ports
+spec:
+      containers:
+      - name: other-container
+        image: buoyantio/cni-iptables-tester:v1
+        env:
+         - name: PORT
+           value: "9090"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        ports:
+        - name: http
+          containerPort: 9090
+      - name: proxy-stub
+        image: buoyantio/cni-iptables-tester:v1
+        env:
+         - name: PORT
+           value: "8080"
+         - name: AM_I_THE_PROXY
+           value: "yes"
+        command: ["go", "run", "/go/test_service/test_service.go"]
+        securityContext:
+          privileged: false
+          runAsUser: 2102
+        ports:
+        - name: http
+          containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-pod-redirects-all-ports
+spec:
+  selector:
+    app: pod-redirects-all-ports
+  ports:
+  - name: http
+    port: 8080

--- a/cni-plugin/integration_test/iptables/test_service/test_service.go
+++ b/cni-plugin/integration_test/iptables/test_service/test_service.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+var (
+	port            = os.Getenv("PORT")
+	_, amITheProxy  = os.LookupEnv("AM_I_THE_PROXY")
+	hostname, _     = os.Hostname()
+	defaultResponse = fmt.Sprintf("%s:%s", hostname, port)
+)
+
+func returnHostAndPortHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("Got request [%v] returning [%s]", r, response())
+	fmt.Fprintln(w, response())
+}
+
+func callOtherServiceHandler(w http.ResponseWriter, r *http.Request) {
+	url := r.FormValue("url")
+	log.Printf("Got request [%v] making HTTP call to [%s]", r, url)
+	downstreamResp, err := http.Get(url)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+	} else {
+		body, err := ioutil.ReadAll(downstreamResp.Body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+		} else {
+			response := fmt.Sprintf("me:[%s]downstream:[%s]", response(), strings.TrimSpace(string(body)))
+			fmt.Fprintln(w, response)
+		}
+	}
+}
+
+func response() string {
+	if amITheProxy {
+		return "proxy"
+	}
+
+	return defaultResponse
+}
+
+func main() {
+	fmt.Printf("Starting stub HTTP server on port [%s] will serve [%s] proxy [%t]", port, hostname, amITheProxy)
+
+	http.HandleFunc("/", returnHostAndPortHandler)
+	http.HandleFunc("/call", callOtherServiceHandler)
+	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cni-plugin/integration_test/run_all_tests.sh
+++ b/cni-plugin/integration_test/run_all_tests.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+NORMAL=$(tput sgr0)
+REVERSE=$(tput smso)
+WHITE=$(tput setaf 7)
+
+function header(){
+    local msg=$1
+    printf "\n${REVERSE}${msg}${NORMAL}\n"
+}
+
+function log(){
+    local msg=$1
+    printf "${WHITE}${msg}${NORMAL}\n"
+}
+
+# Helper function to find out when calico.conf/conflist file shows up
+doesCalicoExist() {
+  # find out if calico is in /etc/cni/net.d/ folder
+  simplematch=$(minikube ssh 'ls /etc/cni/net.d | grep calico.conf')
+  trimmedmatch=$(echo "$simplematch" | tr -d '[:space:]')
+  if [ "$trimmedmatch" != "" ]; then echo "0"; else echo "1"; fi
+}
+
+echo "Running this CNI integration test will destroy and recreate your existing minikube installation"
+read -p "Are you sure? (y/Y)" kill_minikube
+if [ "$kill_minikube" != "y" -a "$kill_minikube" != "Y" ]
+then
+  exit 1
+fi
+
+header "Killing Minikube"
+minikube stop
+minikube delete
+rm -rf ~/.minikube
+
+header "Creating Minikube"
+minikube start --kubernetes-version v1.10.8 --memory 8192 --cpus 4 --network-plugin=cni --extra-config=kubelet.network-plugin=cni
+
+header "Building deps and copying images to Minikube"
+./../../bin/update-go-deps-shas
+./../../bin/build-cli-bin
+./../../bin/mkube ./../../bin/docker-build
+header "Docker saving"
+
+header "Applying Calico"
+kubectl apply -f ./calico-etcd.yaml
+kubectl apply -f ./calico.yaml
+
+header "Waiting for Calico components to become ready"
+kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=calico-etcd --timeout=30s
+kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=calico-kube-controllers --timeout=30s
+kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=calico-node --timeout=30s
+
+header "Discover the calico conf file in /etc/cni/net.d"
+# adapted from https://superuser.com/questions/878640/unix-script-wait-until-a-file-exists
+calico_retry="10" # 10 seconds as default timeout
+echo "Find calico.conf/conflist retry countdown starts at $wait_seconds"
+sleepy_time="5"
+echo "Sleep time between Calico.conf/conflist retries set to $sleepy_time"
+
+doesExist=$(doesCalicoExist)
+until [ $calico_retry -eq 0 -o $doesExist = "0" ]
+do
+  log "Waiting for calico file to appear, $calico_retry retries left"
+  sleep $sleepy_time
+  doesExist=$(doesCalicoExist)
+  calico_retry=$((calico_retry-1))
+done
+
+if [ $((wait_seconds)) -eq 0 -a $doesExist = "1" ]
+then
+  log "could not find calico in /etc/cni/net.d"
+  exit 1
+else
+  log "found calico conf file in /etc/cni/net.d"
+fi
+
+header "Applying linkerd-cni plugin"
+./../../target/cli/darwin/linkerd install-cni --inbound-port 8080 --outbound-port 8080 --proxy-uid 2102 | kubectl apply -f -
+
+header "Waiting for linkerd-cni components to become ready"
+kubectl wait --for=condition=ready pod -n linkerd -l k8s-app=linkerd-cni --timeout=30s
+
+header "Running tests"
+./../../bin/mkube ./test_setup.sh

--- a/cni-plugin/integration_test/test_setup.sh
+++ b/cni-plugin/integration_test/test_setup.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# define some colors to use for output
+BLACK=$(tput setaf 0)
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+LIME_YELLOW=$(tput setaf 190)
+POWDER_BLUE=$(tput setaf 153)
+BLUE=$(tput setaf 4)
+MAGENTA=$(tput setaf 5)
+CYAN=$(tput setaf 6)
+WHITE=$(tput setaf 7)
+BRIGHT=$(tput bold)
+NORMAL=$(tput sgr0)
+BLINK=$(tput blink)
+REVERSE=$(tput smso)
+UNDERLINE=$(tput smul)
+
+function get_ip_for_pod(){
+    local pod_name=$1
+    until kubectl get pod ${pod_name} -o jsonpath='{.status.phase}' | grep Running > /dev/null ; do sleep 1 ; done
+
+    local pod_ip=`kubectl get pod ${pod_name} --template={{.status.podIP}}`
+    echo "${pod_ip}"
+}
+
+function wait_for_k8s_job_completion(){
+    local job_name=$1
+    until kubectl get jobs ${job_name} -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' | grep True ; do printf "." && sleep 1 ; done
+}
+
+function header(){
+    local msg=$1
+    printf "\n${REVERSE}${msg}${NORMAL}\n"
+}
+
+function log(){
+    local msg=$1
+    printf "${WHITE}${msg}${NORMAL}\n"
+}
+
+TESTER_JOB_NAME=cni-iptables-tester
+
+REDIRECTS_ALL_FILE=iptables/redirect-all-iptablestest-lab.yaml
+NO_RULES_FILE=iptables/no-rules-iptablestest-lab.yaml
+
+header "Deleting any existing objects from previous test runs..."
+kubectl delete -f ${REDIRECTS_ALL_FILE}
+kubectl delete -f ${NO_RULES_FILE}
+kubectl delete jobs/${TESTER_JOB_NAME}
+
+header "Building the image used in tests..."
+docker build . -f iptables/Dockerfile-tester --tag buoyantio/cni-iptables-tester:v1
+sleep 10
+
+header "Creating the test lab... redirects-all pod with linkerd injection and no-rules pod"
+cat ${REDIRECTS_ALL_FILE} | ./../../target/cli/darwin/linkerd inject --linkerd-cni-enabled - | kubectl apply -f -
+kubectl apply -f ${NO_RULES_FILE}
+
+POD_WITH_NO_RULES_IP=$(get_ip_for_pod "pod-with-no-rules")
+log "POD_WITH_NO_RULES_OP=${POD_WITH_NO_RULES_IP}"
+POD_REDIRECTS_ALL_PORTS_IP=$(get_ip_for_pod "pod-redirects-all-ports")
+log "POD_REDIRECTS_ALL_PORTS_IP=${POD_REDIRECTS_ALL_PORTS_IP}"
+
+header "Running tester..."
+cat <<EOF | kubectl create -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${TESTER_JOB_NAME}
+spec:
+  template:
+    metadata:
+      name: ${TESTER_JOB_NAME}
+    spec:
+      containers:
+      - name: tester
+        image: buoyantio/cni-iptables-tester:v1
+        env:
+          - name: POD_REDIRECTS_ALL_PORTS_IP
+            value: ${POD_REDIRECTS_ALL_PORTS_IP}
+          - name: POD_WITH_NO_RULES_IP
+            value: ${POD_WITH_NO_RULES_IP}
+        command: ["sh", "-c", "cd /go && (go test cni_rules_test.go -v -integration-tests; echo \"status:$?\")"]
+      restartPolicy: Never
+EOF
+
+wait_for_k8s_job_completion $TESTER_JOB_NAME
+
+header "Test output:"
+kubectl logs jobs/${TESTER_JOB_NAME}
+
+# Makes this script return status 0 if the test returned status 0
+kubectl logs jobs/${TESTER_JOB_NAME} 2>&1 | grep "status:0" > /dev/null


### PR DESCRIPTION
Signed-off-by: David Capino <david.capino@gmail.com>

The MR has a basic integration test that will exercise the CNI plugin in a minikube environment.
Ultimately we would like to have this integration test run through Travis, however I think we would need to create/destroy GKE clusters between tests runs because a CNI plugin fault can cripple a cluster.

The integration test spawns two test pods

* A pod that does not have the Linkerd-CNI plugin applied
* A pod that has the Linkerd-CNI plugin applied

The tests verify that the inbound iptables are written under the following conditions:

* Linkerd CNI plugin is installed
* A Linkerd proxy container is installed in the pod

Assumptions:

* The local host has minikube version: v0.33.1 installed

How to run the test:

* cd ./cni-plugin/integration_test
* ./run_all_tests.sh

Things to note:

* Just because the CNI daemon pod says it is ready, that does not mean it has actually written it's `.conf/conflist` files to the Node yet
* The order that CNI `.conf/.conflist` files are written matters
* The CNI plugin that assigns the ipAddress to the pod must exist on the Node before the linkerd-cni plugin is written to disk
* When the CNI plugins need to complete writing their `.conf/.conflist` files before trying to spawn the testing pods
* There is a delay between the time that a Service exists and when the kube-proxy actually updates the iptables for the Node. (This is why there are retries when trying to route to the Service name vs podIp)