### PR TITLE
Bump lodash dependency to fix security warning

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,7 +12,7 @@
     "d3-format": "^1.3.2",
     "d3-selection": "^1.3.2",
     "date-fns": "^1.30.1",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "path": "0.12.7",
     "prop-types": "15.6.1",
     "react": "16.5.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -5727,11 +5727,6 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
 lodash@4.17.11, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"


### PR DESCRIPTION
This fixes the following vulnerability:

![image](https://user-images.githubusercontent.com/9226/52505829-91f51d80-2ba1-11e9-83cf-90b90e42c924.png)
