### PR TITLE
Introduce golangci-lint tooling, fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ web/app/yarn-error.log
 .protoc
 .gorun
 .dep*
+.golangci*
 **.gogen*
 **/*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
         # this or we should error if it dirties the repo.
         - ./bin/protoc-go.sh
         - go test -race -v ./...
-        - go vet ./...
         - ./bin/lint
 
     - language: node_js

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -675,17 +675,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:053024e8981dab276218a180e58f97034d06e8c4dd2e24c9365ad489104e1d90"
-  name = "golang.org/x/lint"
-  packages = [
-    ".",
-    "golint",
-  ]
-  pruneopts = ""
-  revision = "8f45f776aaf18cebc8d65861cc70c33c60471952"
-
-[[projects]]
-  branch = "master"
   digest = "1:e8c91565d4707bd93aa70e096884ce533acc5deb2bbb500bb064f49de70acda0"
   name = "golang.org/x/net"
   packages = [
@@ -772,9 +761,6 @@
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
-    "go/gcexportdata",
-    "go/internal/gcimporter",
-    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
   ]
@@ -1274,7 +1260,6 @@
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/wercker/stern/stern",
-    "golang.org/x/lint/golint",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,5 @@
 required = [
   "github.com/golang/protobuf/protoc-gen-go",
-  "golang.org/x/lint/golint",
   "k8s.io/code-generator/cmd/client-gen",
   "k8s.io/code-generator/cmd/deepcopy-gen",
   "k8s.io/code-generator/cmd/defaulter-gen",

--- a/TEST.md
+++ b/TEST.md
@@ -31,13 +31,7 @@ bin/dep ensure
 go test -race ./...
 ```
 
-To analyze the Go code without running tests, run:
-
-```bash
-go vet ./...
-```
-
-To lint the Go code using golint, run:
+To analyze and lint the Go code using golangci-lint, run:
 
 ```bash
 bin/lint

--- a/bin/lint
+++ b/bin/lint
@@ -2,6 +2,8 @@
 
 set -eu
 
+lintversion=1.14.0
+
 cd "$(pwd -P)"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -9,15 +11,23 @@ rootdir="$( cd $bindir/.. && pwd )"
 
 cd "$rootdir"
 
-# install golint from vendor
-go install ./vendor/golang.org/x/lint/golint
-
-# use `go list` to exclude packages in vendor
-out=$(go list ./... | xargs golint) || true
-
-if [ -n "$out" ]; then
-  echo "$out"
-  exit 1
+os=linux
+exe=
+if [ "$(uname -s)" = "Darwin" ]; then
+  os=darwin
+elif [ "$(uname -o)" = "Msys" ]; then
+  os=windows
+  exe=.exe
 fi
 
-echo "all clean!"
+lintbin="${rootdir}/.golangci-lint-${lintversion}${exe}"
+
+if [ ! -f "$lintbin" ]; then
+  curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v$lintversion/install.sh | sh -s -- -b . v$lintversion
+  mv ./golangci-lint${exe} $lintbin
+fi
+
+$lintbin run \
+  --enable gofmt,golint \
+  --disable deadcode,errcheck,gosimple,staticcheck,structcheck,unused,varcheck \
+  "$@"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:9c6adbc7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -83,7 +83,7 @@ requests.`,
 			output := renderEndpoints(endpoints, options)
 			_, err = fmt.Print(output)
 
-			return nil
+			return err
 		},
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -337,7 +337,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 			Image:                    options.taggedProxyInitImage(),
 			ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
 			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-			Args: initArgs,
+			Args:                     initArgs,
 			SecurityContext: &v1.SecurityContext{
 				Capabilities: &v1.Capabilities{
 					Add: []v1.Capability{v1.Capability("NET_ADMIN")},

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:9c6adbc7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:9c6adbc7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/proxy/endpoint_listener_test.go
+++ b/controller/api/proxy/endpoint_listener_test.go
@@ -51,12 +51,12 @@ var (
 	}
 
 	add = []*updateAddress{
-		&updateAddress{address: addedAddress1, pod: pod1},
-		&updateAddress{address: addedAddress2, pod: pod2},
+		{address: addedAddress1, pod: pod1},
+		{address: addedAddress2, pod: pod2},
 	}
 
 	remove = []*updateAddress{
-		&updateAddress{address: removedAddress1},
+		{address: removedAddress1},
 	}
 )
 
@@ -181,7 +181,7 @@ func TestEndpointListener(t *testing.T) {
 		}
 
 		add := []*updateAddress{
-			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
+			{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 
@@ -238,7 +238,7 @@ func TestEndpointListener(t *testing.T) {
 		)
 
 		add := []*updateAddress{
-			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
+			{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 
@@ -286,7 +286,7 @@ func TestEndpointListener(t *testing.T) {
 		)
 
 		add := []*updateAddress{
-			&updateAddress{address: addedAddress1, pod: podForAddedAddress1},
+			{address: addedAddress1, pod: podForAddedAddress1},
 		}
 		listener.Update(add, nil)
 

--- a/controller/api/proxy/endpoints_watcher_test.go
+++ b/controller/api/proxy/endpoints_watcher_test.go
@@ -99,7 +99,7 @@ status:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name1"}: map[uint32]*servicePort{
-					8989: &servicePort{
+					8989: {
 						addresses: []*updateAddress{
 							makeUpdateAddress("172.17.0.12", 8989, "ns", "name1-1"),
 							makeUpdateAddress("172.17.0.19", 8989, "ns", "name1-2"),
@@ -112,22 +112,22 @@ status:
 								Namespace: "ns",
 							},
 							Subsets: []v1.EndpointSubset{
-								v1.EndpointSubset{
+								{
 									Addresses: []v1.EndpointAddress{
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.12",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
 										},
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.19",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
 										},
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.20",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
 										},
 									},
-									Ports: []v1.EndpointPort{v1.EndpointPort{Port: 8989}},
+									Ports: []v1.EndpointPort{{Port: 8989}},
 								},
 							},
 						},
@@ -199,7 +199,7 @@ status:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name1"}: map[uint32]*servicePort{
-					8989: &servicePort{
+					8989: {
 						addresses: []*updateAddress{
 							makeUpdateAddress("10.233.66.239", 8990, "ns", "name1-f748fb6b4-hpwpw"),
 							makeUpdateAddress("10.233.88.244", 8990, "ns", "name1-f748fb6b4-6vcmw"),
@@ -211,18 +211,18 @@ status:
 								Namespace: "ns",
 							},
 							Subsets: []v1.EndpointSubset{
-								v1.EndpointSubset{
+								{
 									Addresses: []v1.EndpointAddress{
-										v1.EndpointAddress{
+										{
 											IP:        "10.233.66.239",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-hpwpw"},
 										},
-										v1.EndpointAddress{
+										{
 											IP:        "10.233.88.244",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-6vcmw"},
 										},
 									},
-									Ports: []v1.EndpointPort{v1.EndpointPort{Port: 8990, Protocol: "TCP"}},
+									Ports: []v1.EndpointPort{{Port: 8990, Protocol: "TCP"}},
 								},
 							},
 						},
@@ -281,7 +281,7 @@ status:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "world"}: map[uint32]*servicePort{
-					7778: &servicePort{
+					7778: {
 						addresses: []*updateAddress{
 							makeUpdateAddress("10.1.30.135", 7779, "ns", "world-575bf846b4-tp4hw"),
 						},
@@ -292,14 +292,14 @@ status:
 								Namespace: "ns",
 							},
 							Subsets: []v1.EndpointSubset{
-								v1.EndpointSubset{
+								{
 									Addresses: []v1.EndpointAddress{
-										v1.EndpointAddress{
+										{
 											IP:        "10.1.30.135",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
 										},
 									},
-									Ports: []v1.EndpointPort{v1.EndpointPort{Name: "app", Port: 7779, Protocol: "TCP"}},
+									Ports: []v1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
 								},
 							},
 						},
@@ -363,7 +363,7 @@ status:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name1"}: map[uint32]*servicePort{
-					8989: &servicePort{
+					8989: {
 						addresses: []*updateAddress{
 							makeUpdateAddress("172.17.0.25", 8989, "ns", "name1-3"),
 						},
@@ -374,22 +374,22 @@ status:
 								Namespace: "ns",
 							},
 							Subsets: []v1.EndpointSubset{
-								v1.EndpointSubset{
+								{
 									Addresses: []v1.EndpointAddress{
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.23",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
 										},
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.24",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
 										},
-										v1.EndpointAddress{
+										{
 											IP:        "172.17.0.25",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
 										},
 									},
-									Ports: []v1.EndpointPort{v1.EndpointPort{Port: 8989}},
+									Ports: []v1.EndpointPort{{Port: 8989}},
 								},
 							},
 						},
@@ -417,7 +417,7 @@ spec:
 			expectedNoEndpointsServiceExists: true,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name2"}: map[uint32]*servicePort{
-					7979: &servicePort{
+					7979: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 7979},
 						endpoints:  &v1.Endpoints{},
 					},
@@ -443,7 +443,7 @@ spec:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name3"}: map[uint32]*servicePort{
-					6969: &servicePort{
+					6969: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 6969},
 						endpoints:  &v1.Endpoints{},
 					},
@@ -460,7 +460,7 @@ spec:
 			expectedNoEndpointsServiceExists: false,
 			expectedState: servicePorts{
 				serviceID{namespace: "ns", name: "name4"}: map[uint32]*servicePort{
-					5959: &servicePort{
+					5959: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 5959},
 						endpoints:  &v1.Endpoints{},
 					},

--- a/controller/api/proxy/k8s_resolver.go
+++ b/controller/api/proxy/k8s_resolver.go
@@ -171,7 +171,7 @@ func (k *k8sResolver) localKubernetesServiceIDFromDNSName(host string) (*service
 	// doesn't require Kubernetes to do this, but some hosting providers like
 	// GKE do it, and so we need to support it for transparency.
 	if !matched {
-		hostLabels, matched = maybeStripSuffixLabels(hostLabels, []string{"cluster", "local"})
+		hostLabels, _ = maybeStripSuffixLabels(hostLabels, []string{"cluster", "local"})
 	}
 	// TODO:
 	// ```

--- a/controller/api/proxy/k8s_resolver_test.go
+++ b/controller/api/proxy/k8s_resolver_test.go
@@ -70,7 +70,7 @@ func TestGetState(t *testing.T) {
 		{
 			servicePorts: servicePorts{
 				serviceID{namespace: "ns", name: "name"}: map[uint32]*servicePort{
-					8888: &servicePort{
+					8888: {
 						addresses: []*updateAddress{
 							makeUpdateAddress("10.1.30.135", 7779, "ns", "world-575bf846b4-tp4hw"),
 						},
@@ -80,14 +80,14 @@ func TestGetState(t *testing.T) {
 								Namespace: "ns",
 							},
 							Subsets: []v1.EndpointSubset{
-								v1.EndpointSubset{
+								{
 									Addresses: []v1.EndpointAddress{
-										v1.EndpointAddress{
+										{
 											IP:        "10.1.30.135",
 											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
 										},
 									},
-									Ports: []v1.EndpointPort{v1.EndpointPort{Name: "app", Port: 7779, Protocol: "TCP"}},
+									Ports: []v1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
 								},
 							},
 						},

--- a/controller/api/proxy/profile_listener_test.go
+++ b/controller/api/proxy/profile_listener_test.go
@@ -15,10 +15,10 @@ import (
 var (
 	getButNotPrivate = &sp.RequestMatch{
 		All: []*sp.RequestMatch{
-			&sp.RequestMatch{
+			{
 				Method: "GET",
 			},
-			&sp.RequestMatch{
+			{
 				Not: &sp.RequestMatch{
 					PathRegex: "/private/.*",
 				},
@@ -30,7 +30,7 @@ var (
 		Match: &pb.RequestMatch_All{
 			All: &pb.RequestMatch_Seq{
 				Matches: []*pb.RequestMatch{
-					&pb.RequestMatch{
+					{
 						Match: &pb.RequestMatch_Method{
 							Method: &httpPb.HttpMethod{
 								Type: &httpPb.HttpMethod_Registered_{
@@ -39,7 +39,7 @@ var (
 							},
 						},
 					},
-					&pb.RequestMatch{
+					{
 						Match: &pb.RequestMatch_Not{
 							Not: &pb.RequestMatch{
 								Match: &pb.RequestMatch_Path{
@@ -86,7 +86,7 @@ var (
 	fiveXXfourTwenty = &sp.ResponseMatch{
 		Any: []*sp.ResponseMatch{
 			fiveXX,
-			&sp.ResponseMatch{
+			{
 				Status: &sp.Range{
 					Min: 420,
 					Max: 420,
@@ -100,7 +100,7 @@ var (
 			Any: &pb.ResponseMatch_Seq{
 				Matches: []*pb.ResponseMatch{
 					pbFiveXX,
-					&pb.ResponseMatch{
+					{
 						Match: &pb.ResponseMatch_Status{
 							Status: &pb.HttpStatusRange{
 								Min: 420,
@@ -117,7 +117,7 @@ var (
 		Name:      "route1",
 		Condition: getButNotPrivate,
 		ResponseClasses: []*sp.ResponseClass{
-			&sp.ResponseClass{
+			{
 				Condition: fiveXX,
 				IsFailure: true,
 			},
@@ -130,7 +130,7 @@ var (
 		},
 		Condition: pbGetButNotPrivate,
 		ResponseClasses: []*pb.ResponseClass{
-			&pb.ResponseClass{
+			{
 				Condition: pbFiveXX,
 				IsFailure: true,
 			},
@@ -144,7 +144,7 @@ var (
 		Name:      "route2",
 		Condition: login,
 		ResponseClasses: []*sp.ResponseClass{
-			&sp.ResponseClass{
+			{
 				Condition: fiveXXfourTwenty,
 				IsFailure: true,
 			},
@@ -157,7 +157,7 @@ var (
 		},
 		Condition: pbLogin,
 		ResponseClasses: []*pb.ResponseClass{
-			&pb.ResponseClass{
+			{
 				Condition: pbFiveXXfourTwenty,
 				IsFailure: true,
 			},
@@ -192,7 +192,7 @@ var (
 	multipleRequestMatches = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Name: "multipleRequestMatches",
 					Condition: &sp.RequestMatch{
 						Method:    "GET",
@@ -205,12 +205,12 @@ var (
 
 	pbRequestMatchAll = &pb.DestinationProfile{
 		Routes: []*pb.Route{
-			&pb.Route{
+			{
 				Condition: &pb.RequestMatch{
 					Match: &pb.RequestMatch_All{
 						All: &pb.RequestMatch_Seq{
 							Matches: []*pb.RequestMatch{
-								&pb.RequestMatch{
+								{
 									Match: &pb.RequestMatch_Method{
 										Method: &httpPb.HttpMethod{
 											Type: &httpPb.HttpMethod_Registered_{
@@ -219,7 +219,7 @@ var (
 										},
 									},
 								},
-								&pb.RequestMatch{
+								{
 									Match: &pb.RequestMatch_Path{
 										Path: &pb.PathMatch{
 											Regex: "/my/path",
@@ -245,7 +245,7 @@ var (
 	notEnoughRequestMatches = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Condition: &sp.RequestMatch{},
 				},
 			},
@@ -255,13 +255,13 @@ var (
 	multipleResponseMatches = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Name: "multipleResponseMatches",
 					Condition: &sp.RequestMatch{
 						Method: "GET",
 					},
 					ResponseClasses: []*sp.ResponseClass{
-						&sp.ResponseClass{
+						{
 							Condition: &sp.ResponseMatch{
 								Status: &sp.Range{
 									Min: 400,
@@ -282,7 +282,7 @@ var (
 
 	pbResponseMatchAll = &pb.DestinationProfile{
 		Routes: []*pb.Route{
-			&pb.Route{
+			{
 				Condition: &pb.RequestMatch{
 					Match: &pb.RequestMatch_Method{
 						Method: &httpPb.HttpMethod{
@@ -296,12 +296,12 @@ var (
 					"route": "multipleResponseMatches",
 				},
 				ResponseClasses: []*pb.ResponseClass{
-					&pb.ResponseClass{
+					{
 						Condition: &pb.ResponseMatch{
 							Match: &pb.ResponseMatch_All{
 								All: &pb.ResponseMatch_Seq{
 									Matches: []*pb.ResponseMatch{
-										&pb.ResponseMatch{
+										{
 											Match: &pb.ResponseMatch_Status{
 												Status: &pb.HttpStatusRange{
 													Min: 400,
@@ -309,7 +309,7 @@ var (
 												},
 											},
 										},
-										&pb.ResponseMatch{
+										{
 											Match: &pb.ResponseMatch_Not{
 												Not: &pb.ResponseMatch{
 													Match: &pb.ResponseMatch_Status{
@@ -337,12 +337,12 @@ var (
 	oneSidedStatusRange = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Condition: &sp.RequestMatch{
 						Method: "GET",
 					},
 					ResponseClasses: []*sp.ResponseClass{
-						&sp.ResponseClass{
+						{
 							Condition: &sp.ResponseMatch{
 								Status: &sp.Range{
 									Min: 200,
@@ -358,12 +358,12 @@ var (
 	invalidStatusRange = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Condition: &sp.RequestMatch{
 						Method: "GET",
 					},
 					ResponseClasses: []*sp.ResponseClass{
-						&sp.ResponseClass{
+						{
 							Condition: &sp.ResponseMatch{
 								Status: &sp.Range{
 									Min: 201,
@@ -380,12 +380,12 @@ var (
 	notEnoughResponseMatches = &sp.ServiceProfile{
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Condition: &sp.RequestMatch{
 						Method: "GET",
 					},
 					ResponseClasses: []*sp.ResponseClass{
-						&sp.ResponseClass{
+						{
 							Condition: &sp.ResponseMatch{},
 						},
 					},

--- a/controller/api/proxy/profile_watcher_test.go
+++ b/controller/api/proxy/profile_watcher_test.go
@@ -35,14 +35,14 @@ spec:
 			},
 			service: profileID{namespace: "linkerd", name: "foobar.ns.svc.cluster.local"},
 			expectedProfiles: []*sp.ServiceProfileSpec{
-				&sp.ServiceProfileSpec{
+				{
 					Routes: []*sp.RouteSpec{
-						&sp.RouteSpec{
+						{
 							Condition: &sp.RequestMatch{
 								PathRegex: "/x/y/z",
 							},
 							ResponseClasses: []*sp.ResponseClass{
-								&sp.ResponseClass{
+								{
 									Condition: &sp.ResponseMatch{
 										Status: &sp.Range{
 											Min: 500,

--- a/controller/api/public/client_test.go
+++ b/controller/api/public/client_test.go
@@ -99,7 +99,7 @@ func TestFromByteStreamToProtocolBuffers(t *testing.T) {
 			Response: &pb.StatSummaryResponse_Ok_{
 				Ok: &pb.StatSummaryResponse_Ok{
 					StatTables: []*pb.StatTable{
-						&pb.StatTable{
+						{
 							Table: &pb.StatTable_PodGroup_{
 								PodGroup: &pb.StatTable_PodGroup{
 									Rows: rows,

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -84,7 +84,7 @@ func listPodResponsesEqual(a *pb.ListPodsResponse, b *pb.ListPodsResponse) bool 
 func TestListPods(t *testing.T) {
 	t.Run("Queries to the ListPods endpoint", func(t *testing.T) {
 		expectations := []listPodsExpected{
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -155,7 +155,7 @@ spec:
 				req: &pb.ListPodsRequest{},
 				res: &pb.ListPodsResponse{
 					Pods: []*pb.Pod{
-						&pb.Pod{
+						{
 							Name:            "emojivoto/emojivoto-meshed",
 							Added:           true,
 							SinceLastReport: &duration.Duration{},
@@ -163,7 +163,7 @@ spec:
 							PodIP:           "1.2.3.4",
 							Owner:           &pb.Pod_Deployment{Deployment: "emojivoto/meshed-deployment"},
 						},
-						&pb.Pod{
+						{
 							Name:   "emojivoto/emojivoto-not-meshed",
 							Status: "Pending",
 							PodIP:  "4.3.2.1",
@@ -172,7 +172,7 @@ spec:
 					},
 				},
 			},
-			listPodsExpected{
+			{
 				err: fmt.Errorf("cannot set both namespace and resource in the request. These are mutually exclusive"),
 				promRes: model.Vector{
 					&model.Sample{
@@ -191,7 +191,7 @@ spec:
 				},
 				res: nil,
 			},
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -210,7 +210,7 @@ spec:
 				res:              &pb.ListPodsResponse{},
 				promReqNamespace: "testnamespace",
 			},
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -231,7 +231,7 @@ spec:
 				promReqNamespace: "testnamespace",
 			},
 			// non-matching owner type -> no pod in the result
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -267,7 +267,7 @@ status:
 				res: &pb.ListPodsResponse{},
 			},
 			// matching owner type -> pod is part of the result
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -302,7 +302,7 @@ status:
 				},
 				res: &pb.ListPodsResponse{
 					Pods: []*pb.Pod{
-						&pb.Pod{
+						{
 							Name:            "emojivoto/emojivoto-meshed",
 							Added:           true,
 							SinceLastReport: &duration.Duration{},
@@ -314,7 +314,7 @@ status:
 				},
 			},
 			// matching label in request -> pod is in the response
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -346,7 +346,7 @@ status:
 				},
 				res: &pb.ListPodsResponse{
 					Pods: []*pb.Pod{
-						&pb.Pod{
+						{
 							Name:            "emojivoto/emojivoto-meshed",
 							Added:           true,
 							SinceLastReport: &duration.Duration{},
@@ -358,7 +358,7 @@ status:
 				},
 			},
 			// NOT matching label in request -> pod is NOT in the response
-			listPodsExpected{
+			{
 				err: nil,
 				promRes: model.Vector{
 					&model.Sample{
@@ -465,7 +465,7 @@ func listServiceResponsesEqual(a pb.ListServicesResponse, b pb.ListServicesRespo
 func TestListServices(t *testing.T) {
 	t.Run("Successfully queryies for services", func(t *testing.T) {
 		expectations := []listServicesExpected{
-			listServicesExpected{
+			{
 				err: nil,
 				k8sRes: []string{`
 apiVersion: v1
@@ -483,11 +483,11 @@ metadata:
 				},
 				res: pb.ListServicesResponse{
 					Services: []*pb.Service{
-						&pb.Service{
+						{
 							Name:      "service-foo",
 							Namespace: "emojivoto",
 						},
-						&pb.Service{
+						{
 							Name:      "service-bar",
 							Namespace: "default",
 						},
@@ -535,7 +535,7 @@ type endpointsExpected struct {
 func TestEndpoints(t *testing.T) {
 	t.Run("Queries to the Endpoints endpoint", func(t *testing.T) {
 		expectations := []endpointsExpected{
-			endpointsExpected{
+			{
 				err: nil,
 				req: &discovery.EndpointsParams{},
 				res: &discovery.EndpointsResponse{},

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -53,7 +53,7 @@ func genEmptyResponse() pb.StatSummaryResponse {
 		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
 			Ok: &pb.StatSummaryResponse_Ok{
 				StatTables: []*pb.StatTable{
-					&pb.StatTable{
+					{
 						Table: &pb.StatTable_PodGroup_{
 							PodGroup: &pb.StatTable_PodGroup{},
 						},
@@ -135,7 +135,7 @@ func (s byStatResult) Less(i, j int) bool {
 func TestStatSummary(t *testing.T) {
 	t.Run("Successfully performs a query based on resource type", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -211,7 +211,7 @@ status:
 
 	t.Run("Successfully performs a query based on resource type DaemonSet", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -287,7 +287,7 @@ status:
 
 	t.Run("Successfully performs a query based on resource type StatefulSet", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -382,7 +382,7 @@ status:
 
 	t.Run("Queries prometheus for a specific resource if name is specified", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -429,7 +429,7 @@ status:
 
 	t.Run("Queries prometheus for outbound metrics if from resource is specified, ignores resource name", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -479,7 +479,7 @@ status:
 
 	t.Run("Queries prometheus for outbound metrics if --to resource is specified", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -535,7 +535,7 @@ status:
 
 	t.Run("Queries prometheus for outbound metrics if --to resource is specified and --to-namespace is different from the resource namespace", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -591,7 +591,7 @@ status:
 
 	t.Run("Queries prometheus for outbound metrics if --from resource is specified", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -658,7 +658,7 @@ status:
 
 	t.Run("Queries prometheus for outbound metrics if --from resource is specified and --from-namespace is different from the resource namespace", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -725,7 +725,7 @@ status:
 
 	t.Run("Successfully queries for resource type 'all'", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -793,32 +793,32 @@ status:
 					Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
 						Ok: &pb.StatSummaryResponse_Ok{
 							StatTables: []*pb.StatTable{
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{},
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{},
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{},
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
-												&pb.StatTable_PodGroup_Row{
+												{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
 														Type:      pkgK8s.Authority,
@@ -837,11 +837,11 @@ status:
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
-												&pb.StatTable_PodGroup_Row{
+												{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
 														Type:      pkgK8s.Deployment,
@@ -863,11 +863,11 @@ status:
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
-												&pb.StatTable_PodGroup_Row{
+												{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
 														Type:      pkgK8s.Pod,
@@ -881,11 +881,11 @@ status:
 										},
 									},
 								},
-								&pb.StatTable{
+								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
-												&pb.StatTable_PodGroup_Row{
+												{
 													Resource: &pb.Resource{
 														Namespace: "emojivoto",
 														Type:      pkgK8s.Service,
@@ -916,7 +916,7 @@ status:
 		}
 
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: badtype"),
 				},
@@ -928,7 +928,7 @@ status:
 					},
 				},
 			},
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: deployments"),
 				},
@@ -940,7 +940,7 @@ status:
 					},
 				},
 			},
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: errors.New("rpc error: code = Unimplemented desc = unimplemented resource type: po"),
 				},
@@ -992,10 +992,10 @@ status:
 		)
 
 		invalidRequests := []statSumExpected{
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{},
 			},
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
@@ -1004,7 +1004,7 @@ status:
 					},
 				},
 			},
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
@@ -1018,7 +1018,7 @@ status:
 					},
 				},
 			},
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
@@ -1043,7 +1043,7 @@ status:
 		}
 
 		validRequests := []statSumExpected{
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
@@ -1057,7 +1057,7 @@ status:
 					},
 				},
 			},
-			statSumExpected{
+			{
 				req: pb.StatSummaryRequest{
 					Selector: &pb.ResourceSelection{
 						Resource: &pb.Resource{
@@ -1085,7 +1085,7 @@ status:
 	t.Run("Return empty stats summary response", func(t *testing.T) {
 		t.Run("when pod phase is succeeded or failed", func(t *testing.T) {
 			expectations := []statSumExpected{
-				statSumExpected{
+				{
 					expectedStatRPC: expectedStatRPC{
 						err: nil,
 						k8sConfigs: []string{`
@@ -1136,7 +1136,7 @@ status:
 
 		t.Run("for succeeded or failed replicas of a deployment", func(t *testing.T) {
 			expectations := []statSumExpected{
-				statSumExpected{
+				{
 					expectedStatRPC: expectedStatRPC{
 						err: nil,
 						k8sConfigs: []string{`
@@ -1223,7 +1223,7 @@ status:
 
 	t.Run("Queries prometheus for authority stats", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -1267,7 +1267,7 @@ status:
 
 	t.Run("Queries prometheus for authority stats when --from deployment is used", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -1318,7 +1318,7 @@ status:
 
 	t.Run("Queries prometheus for a named authority", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
@@ -1363,7 +1363,7 @@ status:
 
 	t.Run("Stats returned are nil when SkipStats is true", func(t *testing.T) {
 		expectations := []statSumExpected{
-			statSumExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -201,7 +201,7 @@ func GenStatSummaryResponse(resName, resType string, resNs []string, counts *Pod
 		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
 			Ok: &pb.StatSummaryResponse_Ok{
 				StatTables: []*pb.StatTable{
-					&pb.StatTable{
+					{
 						Table: &pb.StatTable_PodGroup_{
 							PodGroup: &pb.StatTable_PodGroup{
 								Rows: rows,
@@ -258,7 +258,7 @@ func GenTopRoutesResponse(routes []string, counts []uint64, outbound bool, autho
 		Response: &pb.TopRoutesResponse_Ok_{
 			Ok: &pb.TopRoutesResponse_Ok{
 				Routes: []*pb.RouteTable{
-					&pb.RouteTable{
+					{
 						Rows:     rows,
 						Resource: "deploy/foobar",
 					},
@@ -284,9 +284,9 @@ func GenEndpointsResponse(identities []string) discovery.EndpointsResponse {
 		ip, _ := addr.ParsePublicIPV4("1.2.3.4")
 		resp.ServicePorts[identity] = &discovery.ServicePort{
 			PortEndpoints: map[uint32]*discovery.PodAddresses{
-				8080: &discovery.PodAddresses{
+				8080: {
 					PodAddresses: []*discovery.PodAddress{
-						&discovery.PodAddress{
+						{
 							Addr: &pb.TcpAddress{
 								Ip:   ip,
 								Port: 8080,

--- a/controller/api/public/top_routes_test.go
+++ b/controller/api/public/top_routes_test.go
@@ -222,7 +222,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),
@@ -258,7 +258,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),
@@ -294,7 +294,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),
@@ -327,7 +327,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),
@@ -360,7 +360,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),
@@ -399,7 +399,7 @@ func TestTopRoutes(t *testing.T) {
 		routes := []string{"/a"}
 		counts := []uint64{123}
 		expectations := []topRoutesExpected{
-			topRoutesExpected{
+			{
 				expectedStatRPC: expectedStatRPC{
 					err:              nil,
 					mockPromResponse: routesMetric([]string{"/a"}),

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -200,7 +200,7 @@ func TestBuildResource(t *testing.T) {
 	t.Run("Returns expected errors on invalid input", func(t *testing.T) {
 		msg := "cannot find Kubernetes canonical name from friendly name [invalid]"
 		expectations := []resourceExp{
-			resourceExp{
+			{
 				namespace: "",
 				args:      []string{"invalid"},
 			},
@@ -219,7 +219,7 @@ func TestBuildResource(t *testing.T) {
 
 	t.Run("Correctly parses Kubernetes resources from the command line", func(t *testing.T) {
 		expectations := []resourceExp{
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"deployments"},
 				resource: pb.Resource{
@@ -228,7 +228,7 @@ func TestBuildResource(t *testing.T) {
 					Name:      "",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "",
 				args:      []string{"deploy/foo"},
 				resource: pb.Resource{
@@ -237,7 +237,7 @@ func TestBuildResource(t *testing.T) {
 					Name:      "foo",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"po"},
 				resource: pb.Resource{
@@ -246,7 +246,7 @@ func TestBuildResource(t *testing.T) {
 					Name:      "",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"ns"},
 				resource: pb.Resource{
@@ -255,7 +255,7 @@ func TestBuildResource(t *testing.T) {
 					Name:      "",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"ns/foo-ns2"},
 				resource: pb.Resource{
@@ -289,11 +289,11 @@ func TestBuildResources(t *testing.T) {
 	t.Run("Rejects duped resources", func(t *testing.T) {
 		msg := "cannot supply duplicate resources"
 		expectations := []resourceExp{
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"foo", "foo"},
 			},
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"all", "all"},
 			},
@@ -313,15 +313,15 @@ func TestBuildResources(t *testing.T) {
 	t.Run("Ensures 'all' can't be supplied alongside other resources", func(t *testing.T) {
 		msg := "'all' can't be supplied alongside other resources"
 		expectations := []resourceExp{
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"po", "foo", "all"},
 			},
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"foo", "all"},
 			},
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"all", "foo"},
 			},
@@ -340,7 +340,7 @@ func TestBuildResources(t *testing.T) {
 
 	t.Run("Correctly parses Kubernetes resources from the command line", func(t *testing.T) {
 		expectations := []resourceExp{
-			resourceExp{
+			{
 				namespace: "test-ns",
 				args:      []string{"deployments"},
 				resource: pb.Resource{
@@ -349,7 +349,7 @@ func TestBuildResources(t *testing.T) {
 					Name:      "",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "",
 				args:      []string{"deploy/foo"},
 				resource: pb.Resource{
@@ -358,7 +358,7 @@ func TestBuildResources(t *testing.T) {
 					Name:      "foo",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"po", "foo"},
 				resource: pb.Resource{
@@ -367,7 +367,7 @@ func TestBuildResources(t *testing.T) {
 					Name:      "foo",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"ns", "foo-ns2"},
 				resource: pb.Resource{
@@ -376,7 +376,7 @@ func TestBuildResources(t *testing.T) {
 					Name:      "foo-ns2",
 				},
 			},
-			resourceExp{
+			{
 				namespace: "foo-ns",
 				args:      []string{"ns/foo-ns2"},
 				resource: pb.Resource{
@@ -410,13 +410,13 @@ func TestK8sPodToPublicPod(t *testing.T) {
 
 	t.Run("Returns expected pods", func(t *testing.T) {
 		expectations := []podExp{
-			podExp{
+			{
 				k8sPod: v1.Pod{},
 				publicPod: pb.Pod{
 					Name: "/",
 				},
 			},
-			podExp{
+			{
 				k8sPod: v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "ns",
@@ -429,7 +429,7 @@ func TestK8sPodToPublicPod(t *testing.T) {
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name:  k8s.ProxyContainerName,
 								Image: "linkerd-proxy:test-version",
 							},
@@ -439,7 +439,7 @@ func TestK8sPodToPublicPod(t *testing.T) {
 						PodIP: "pod-ip",
 						Phase: "status",
 						ContainerStatuses: []v1.ContainerStatus{
-							v1.ContainerStatus{
+							{
 								Name:  k8s.ProxyContainerName,
 								Ready: true,
 							},

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -58,7 +58,7 @@ func TestGetObjects(t *testing.T) {
 
 	t.Run("Returns expected objects based on input", func(t *testing.T) {
 		expectations := []getObjectsExpected{
-			getObjectsExpected{
+			{
 				err:           status.Errorf(codes.Unimplemented, "unimplemented resource type: bar"),
 				namespace:     "foo",
 				resType:       "bar",
@@ -66,7 +66,7 @@ func TestGetObjects(t *testing.T) {
 				k8sResResults: []string{},
 				k8sResMisc:    []string{},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "my-ns",
 				resType:   k8s.Pod,
@@ -85,7 +85,7 @@ status:
 				},
 				k8sResMisc: []string{},
 			},
-			getObjectsExpected{
+			{
 				err:           errors.New("pod \"my-pod\" not found"),
 				namespace:     "not-my-ns",
 				resType:       k8s.Pod,
@@ -99,7 +99,7 @@ metadata:
   namespace: my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "",
 				resType:   k8s.ReplicationController,
@@ -113,7 +113,7 @@ metadata:
 				},
 				k8sResMisc: []string{},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "my-ns",
 				resType:   k8s.Deployment,
@@ -133,7 +133,7 @@ metadata:
   namespace: not-my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "",
 				resType:   k8s.DaemonSet,
@@ -146,7 +146,7 @@ metadata:
   namespace: my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "my-ns",
 				resType:   k8s.DaemonSet,
@@ -166,7 +166,7 @@ metadata:
   namespace: not-my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "",
 				resType:   k8s.StatefulSet,
@@ -179,7 +179,7 @@ metadata:
   namespace: my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "my-ns",
 				resType:   k8s.StatefulSet,
@@ -199,7 +199,7 @@ metadata:
   namespace: not-my-ns`,
 				},
 			},
-			getObjectsExpected{
+			{
 				err:       nil,
 				namespace: "",
 				resType:   k8s.Namespace,
@@ -273,7 +273,7 @@ metadata:
 	t.Run("If objects are pods", func(t *testing.T) {
 		t.Run("Return running or pending pods", func(t *testing.T) {
 			expectations := []getObjectsExpected{
-				getObjectsExpected{
+				{
 					err:       nil,
 					namespace: "my-ns",
 					resType:   k8s.Pod,
@@ -291,7 +291,7 @@ status:
   phase: Running`,
 					},
 				},
-				getObjectsExpected{
+				{
 					err:       nil,
 					namespace: "my-ns",
 					resType:   k8s.Pod,
@@ -330,7 +330,7 @@ status:
 
 		t.Run("Don't return failed or succeeded pods", func(t *testing.T) {
 			expectations := []getObjectsExpected{
-				getObjectsExpected{
+				{
 					err:       nil,
 					namespace: "my-ns",
 					resType:   k8s.Pod,
@@ -348,7 +348,7 @@ status:
   phase: Succeeded`,
 					},
 				},
-				getObjectsExpected{
+				{
 					err:       nil,
 					namespace: "my-ns",
 					resType:   k8s.Pod,
@@ -401,7 +401,7 @@ func TestGetPodsFor(t *testing.T) {
 
 	t.Run("Returns expected pods based on input", func(t *testing.T) {
 		expectations := []getPodsForExpected{
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: apps/v1beta2
@@ -427,7 +427,7 @@ status:
 				},
 			},
 			// Retrieve pods associated to a ClusterIP service
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: v1
@@ -453,7 +453,7 @@ status:
 				k8sResMisc: []string{},
 			},
 			// ExternalName services shouldn't return any pods
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: v1
@@ -477,7 +477,7 @@ status:
   phase: Running`,
 				},
 			},
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: apps/v1
@@ -502,7 +502,7 @@ status:
 				},
 				k8sResMisc: []string{},
 			},
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: apps/v1beta2
@@ -537,7 +537,7 @@ status:
   phase: Finished`,
 				},
 			},
-			getPodsForExpected{
+			{
 				err: nil,
 				k8sResInput: `
 apiVersion: v1

--- a/controller/proxy-injector/patch_test.go
+++ b/controller/proxy-injector/patch_test.go
@@ -56,19 +56,19 @@ func TestPatch(t *testing.T) {
 
 	expected := NewPatch()
 	expected.patchOps = []*patchOp{
-		&patchOp{Op: "add", Path: patchPathContainer, Value: sidecar},
-		&patchOp{Op: "add", Path: patchPathInitContainerRoot, Value: []*v1.Container{}},
-		&patchOp{Op: "add", Path: patchPathInitContainer, Value: init},
-		&patchOp{Op: "add", Path: patchPathVolumeRoot, Value: []*v1.Volume{}},
-		&patchOp{Op: "add", Path: patchPathVolume, Value: trustAnchors},
-		&patchOp{Op: "add", Path: patchPathVolume, Value: secrets},
-		&patchOp{Op: "add", Path: patchPathPodLabels, Value: map[string]string{
+		{Op: "add", Path: patchPathContainer, Value: sidecar},
+		{Op: "add", Path: patchPathInitContainerRoot, Value: []*v1.Container{}},
+		{Op: "add", Path: patchPathInitContainer, Value: init},
+		{Op: "add", Path: patchPathVolumeRoot, Value: []*v1.Volume{}},
+		{Op: "add", Path: patchPathVolume, Value: trustAnchors},
+		{Op: "add", Path: patchPathVolume, Value: secrets},
+		{Op: "add", Path: patchPathPodLabels, Value: map[string]string{
 			k8sPkg.ControllerNSLabel: controllerNamespace,
 		}},
-		&patchOp{Op: "add", Path: patchPathDeploymentLabels, Value: map[string]string{
+		{Op: "add", Path: patchPathDeploymentLabels, Value: map[string]string{
 			k8sPkg.ControllerNSLabel: controllerNamespace,
 		}},
-		&patchOp{Op: "add", Path: patchPathPodAnnotations, Value: map[string]string{k8sPkg.CreatedByAnnotation: createdBy}},
+		{Op: "add", Path: patchPathPodAnnotations, Value: map[string]string{k8sPkg.CreatedByAnnotation: createdBy}},
 	}
 
 	if !reflect.DeepEqual(actual, expected) {

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -86,6 +86,9 @@ func tlsConfig(rootCA *pkgTls.CA, controllerNamespace string) (*tls.Config, erro
 	}
 	dnsName := tlsIdentity.ToDNSName()
 	certAndPrivateKey, err := rootCA.IssueEndEntityCertificate(dnsName)
+	if err != nil {
+		return nil, err
+	}
 
 	certPEM, err := certAndPrivateKey.EncodedCertificate()
 	if err != nil {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -184,10 +184,8 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	deployment.Labels[k8sPkg.ProxyDeploymentLabel] = deployment.ObjectMeta.Name
 	patch.addDeploymentLabels(deployment.Labels)
 
-	var (
-		image    = strings.Split(proxy.Image, ":")
-		imageTag = ""
-	)
+	image := strings.Split(proxy.Image, ":")
+	var imageTag string
 
 	if len(image) < 2 {
 		imageTag = "latest"

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -20,12 +20,12 @@ type tapExpected struct {
 func TestTapByResource(t *testing.T) {
 	t.Run("Returns expected response", func(t *testing.T) {
 		expectations := []tapExpected{
-			tapExpected{
+			{
 				msg:    "rpc error: code = InvalidArgument desc = TapByResource received nil target ResourceSelection",
 				k8sRes: []string{},
 				req:    public.TapByResourceRequest{},
 			},
-			tapExpected{
+			{
 				msg: "rpc error: code = Unimplemented desc = unexpected match specified: any:<> ",
 				k8sRes: []string{`
 apiVersion: v1
@@ -57,7 +57,7 @@ status:
 					},
 				},
 			},
-			tapExpected{
+			{
 				msg: "rpc error: code = NotFound desc = no pods found for pod/emojivoto-not-meshed",
 				k8sRes: []string{`
 apiVersion: v1
@@ -81,7 +81,7 @@ status:
 					},
 				},
 			},
-			tapExpected{
+			{
 				msg:    "rpc error: code = Unimplemented desc = unimplemented resource type: bad-type",
 				k8sRes: []string{},
 				req: public.TapByResourceRequest{
@@ -94,7 +94,7 @@ status:
 					},
 				},
 			},
-			tapExpected{
+			{
 				msg: "rpc error: code = NotFound desc = pod \"emojivoto-meshed-not-found\" not found",
 				k8sRes: []string{`
 apiVersion: v1
@@ -120,7 +120,7 @@ status:
 					},
 				},
 			},
-			tapExpected{
+			{
 				msg: "rpc error: code = NotFound desc = no pods found for pod/emojivoto-meshed",
 				k8sRes: []string{`
 apiVersion: v1
@@ -146,7 +146,7 @@ status:
 					},
 				},
 			},
-			tapExpected{
+			{
 				// indicates we will accept EOF, in addition to the deadline exceeded message
 				eofOk: true,
 				// success, underlying tap events tested in http_server_test.go

--- a/pkg/addr/addr_test.go
+++ b/pkg/addr/addr_test.go
@@ -17,11 +17,11 @@ func TestNetToPublic(t *testing.T) {
 	}
 
 	expectations := []addrExp{
-		addrExp{
+		{
 			proxyAddr:     &proxy.TcpAddress{},
 			publicAddress: &public.TcpAddress{},
 		},
-		addrExp{
+		{
 			proxyAddr: &proxy.TcpAddress{
 				Ip:   &proxy.IPAddress{Ip: &proxy.IPAddress_Ipv4{Ipv4: 1}},
 				Port: 1234,
@@ -31,7 +31,7 @@ func TestNetToPublic(t *testing.T) {
 				Port: 1234,
 			},
 		},
-		addrExp{
+		{
 			proxyAddr: &proxy.TcpAddress{
 				Ip: &proxy.IPAddress{
 					Ip: &proxy.IPAddress_Ipv6{

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -609,7 +609,7 @@ func (hc *HealthChecker) Add(categoryID CategoryID, description string, hintAnch
 		category{
 			id: categoryID,
 			checkers: []checker{
-				checker{
+				{
 					description: description,
 					check:       check,
 					hintAnchor:  hintAnchor,

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -21,7 +21,7 @@ func TestHealthChecker(t *testing.T) {
 	passingCheck1 := category{
 		id: "cat1",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc1",
 				check: func(context.Context) error {
 					return nil
@@ -34,7 +34,7 @@ func TestHealthChecker(t *testing.T) {
 	passingCheck2 := category{
 		id: "cat2",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc2",
 				check: func(context.Context) error {
 					return nil
@@ -47,7 +47,7 @@ func TestHealthChecker(t *testing.T) {
 	failingCheck := category{
 		id: "cat3",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc3",
 				check: func(context.Context) error {
 					return fmt.Errorf("error")
@@ -60,7 +60,7 @@ func TestHealthChecker(t *testing.T) {
 	passingRPCClient := public.MockAPIClient{
 		SelfCheckResponseToReturn: &healthcheckPb.SelfCheckResponse{
 			Results: []*healthcheckPb.CheckResult{
-				&healthcheckPb.CheckResult{
+				{
 					SubsystemName:    "rpc1",
 					CheckDescription: "rpc desc1",
 					Status:           healthcheckPb.CheckStatus_OK,
@@ -72,7 +72,7 @@ func TestHealthChecker(t *testing.T) {
 	passingRPCCheck := category{
 		id: "cat4",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc4",
 				checkRPC: func(context.Context) (*healthcheckPb.SelfCheckResponse, error) {
 					return passingRPCClient.SelfCheck(context.Background(),
@@ -86,7 +86,7 @@ func TestHealthChecker(t *testing.T) {
 	failingRPCClient := public.MockAPIClient{
 		SelfCheckResponseToReturn: &healthcheckPb.SelfCheckResponse{
 			Results: []*healthcheckPb.CheckResult{
-				&healthcheckPb.CheckResult{
+				{
 					SubsystemName:         "rpc2",
 					CheckDescription:      "rpc desc2",
 					Status:                healthcheckPb.CheckStatus_FAIL,
@@ -99,7 +99,7 @@ func TestHealthChecker(t *testing.T) {
 	failingRPCCheck := category{
 		id: "cat5",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc5",
 				checkRPC: func(context.Context) (*healthcheckPb.SelfCheckResponse, error) {
 					return failingRPCClient.SelfCheck(context.Background(),
@@ -113,7 +113,7 @@ func TestHealthChecker(t *testing.T) {
 	fatalCheck := category{
 		id: "cat6",
 		checkers: []checker{
-			checker{
+			{
 				description: "desc6",
 				fatal:       true,
 				check: func(context.Context) error {
@@ -246,7 +246,7 @@ func TestHealthChecker(t *testing.T) {
 		retryCheck := category{
 			id: "cat7",
 			checkers: []checker{
-				checker{
+				{
 					description:   "desc7",
 					retryDeadline: time.Now().Add(100 * time.Second),
 					check: func(context.Context) error {
@@ -297,7 +297,7 @@ func TestValidateControlPlanePods(t *testing.T) {
 			Status: v1.PodStatus{
 				Phase: phase,
 				ContainerStatuses: []v1.ContainerStatus{
-					v1.ContainerStatus{
+					{
 						Name:  strings.Split(name, "-")[1],
 						Ready: ready,
 					},
@@ -384,10 +384,10 @@ func TestValidateDataPlanePods(t *testing.T) {
 
 	t.Run("Returns an error if not all pods are running", func(t *testing.T) {
 		pods := []*pb.Pod{
-			&pb.Pod{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "voting-65b9fffd77-rlwsd", Status: "Failed", ProxyReady: false},
-			&pb.Pod{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
+			{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
+			{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: true},
+			{Name: "voting-65b9fffd77-rlwsd", Status: "Failed", ProxyReady: false},
+			{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
 		}
 
 		err := validateDataPlanePods(pods, "emojivoto")
@@ -401,10 +401,10 @@ func TestValidateDataPlanePods(t *testing.T) {
 
 	t.Run("Returns an error if the proxy container is not ready", func(t *testing.T) {
 		pods := []*pb.Pod{
-			&pb.Pod{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: false},
-			&pb.Pod{Name: "voting-65b9fffd77-rlwsd", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
+			{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
+			{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: false},
+			{Name: "voting-65b9fffd77-rlwsd", Status: "Running", ProxyReady: true},
+			{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
 		}
 
 		err := validateDataPlanePods(pods, "emojivoto")
@@ -418,10 +418,10 @@ func TestValidateDataPlanePods(t *testing.T) {
 
 	t.Run("Returns nil if all pods are running and all proxy containers are ready", func(t *testing.T) {
 		pods := []*pb.Pod{
-			&pb.Pod{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "voting-65b9fffd77-rlwsd", Status: "Running", ProxyReady: true},
-			&pb.Pod{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
+			{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},
+			{Name: "vote-bot-644b8cb6b4-g8nlr", Status: "Running", ProxyReady: true},
+			{Name: "voting-65b9fffd77-rlwsd", Status: "Running", ProxyReady: true},
+			{Name: "web-6cfbccc48-5g8px", Status: "Running", ProxyReady: true},
 		}
 
 		err := validateDataPlanePods(pods, "emojivoto")
@@ -441,8 +441,8 @@ func TestValidateDataPlanePodReporting(t *testing.T) {
 
 	t.Run("Returns success if all pods are added", func(t *testing.T) {
 		pods := []*pb.Pod{
-			&pb.Pod{Name: "ns1/test1", Added: true},
-			&pb.Pod{Name: "ns2/test2", Added: true},
+			{Name: "ns1/test1", Added: true},
+			{Name: "ns2/test2", Added: true},
 		}
 
 		err := validateDataPlanePodReporting(pods)
@@ -453,8 +453,8 @@ func TestValidateDataPlanePodReporting(t *testing.T) {
 
 	t.Run("Returns an error if any of the pod was not added to Prometheus", func(t *testing.T) {
 		pods := []*pb.Pod{
-			&pb.Pod{Name: "ns1/test1", Added: true},
-			&pb.Pod{Name: "ns2/test2", Added: false},
+			{Name: "ns1/test1", Added: true},
+			{Name: "ns2/test2", Added: false},
 		}
 
 		err := validateDataPlanePodReporting(pods)

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -16,14 +16,14 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 		SwaggerProps: spec.SwaggerProps{
 			Paths: &spec.Paths{
 				Paths: map[string]spec.PathItem{
-					"/authors/{id}": spec.PathItem{
+					"/authors/{id}": {
 						PathItemProps: spec.PathItemProps{
 							Post: &spec.Operation{
 								OperationProps: spec.OperationProps{
 									Responses: &spec.Responses{
 										ResponsesProps: spec.ResponsesProps{
 											StatusCodeResponses: map[int]spec.Response{
-												500: spec.Response{},
+												500: {},
 											},
 										},
 									},
@@ -44,14 +44,14 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 		},
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Name: "POST /authors/{id}",
 					Condition: &sp.RequestMatch{
 						PathRegex: "/authors/[^/]*",
 						Method:    "POST",
 					},
 					ResponseClasses: []*sp.ResponseClass{
-						&sp.ResponseClass{
+						{
 							Condition: &sp.ResponseMatch{
 								Status: &sp.Range{
 									Min: 500,

--- a/pkg/profiles/proto_test.go
+++ b/pkg/profiles/proto_test.go
@@ -39,7 +39,7 @@ service VotingService {
 		},
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Name: "VotePoop",
 					Condition: &sp.RequestMatch{
 						PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,

--- a/pkg/profiles/tap_test.go
+++ b/pkg/profiles/tap_test.go
@@ -84,14 +84,14 @@ func TestTapToServiceProfile(t *testing.T) {
 		},
 		Spec: sp.ServiceProfileSpec{
 			Routes: []*sp.RouteSpec{
-				&sp.RouteSpec{
+				{
 					Name: "GET /my/path/hi",
 					Condition: &sp.RequestMatch{
 						PathRegex: `/my/path/hi`,
 						Method:    "GET",
 					},
 				},
-				&sp.RouteSpec{
+				{
 					Name: "POST /emojivoto.v1.VotingService/VoteFire",
 					Condition: &sp.RequestMatch{
 						PathRegex: `/emojivoto\.v1\.VotingService/VoteFire`,

--- a/pkg/profiles/test_helper.go
+++ b/pkg/profiles/test_helper.go
@@ -19,14 +19,14 @@ func GenServiceProfile(service, namespace string) v1alpha1.ServiceProfile {
 		},
 		Spec: v1alpha1.ServiceProfileSpec{
 			Routes: []*v1alpha1.RouteSpec{
-				&v1alpha1.RouteSpec{
+				{
 					Name: "/authors/{id}",
 					Condition: &v1alpha1.RequestMatch{
 						PathRegex: "/authors/\\d+",
 						Method:    "POST",
 					},
 					ResponseClasses: []*v1alpha1.ResponseClass{
-						&v1alpha1.ResponseClass{
+						{
 							Condition: &v1alpha1.ResponseMatch{
 								Status: &v1alpha1.Range{
 									Min: 500,

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:9c6adbc7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:9c6adbc7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
`golangci-lint` performs numerous checks on Go code, including golint,
ineffassign, govet, and gofmt.

This change modifies `bin/lint` to use `golangci-lint`, and replaces
usage of golint and govet.

Also perform a one-time gofmt cleanup:
- `gofmt -s -w controller/`
- `gofmt -s -w pkg/`

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>