### PR TITLE
Add Go code coverage to ci and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         # TODO decide whether protoc should be committed or not. If so, we shouldn't do
         # this or we should error if it dirties the repo.
         - ./bin/protoc-go.sh
-        - go test -race -v ./...
+        - go test -cover -race -v ./...
         - ./bin/lint
 
     - language: node_js
@@ -160,7 +160,7 @@ jobs:
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |
           # Run linkerd-cni integration tests.
-          TAG="$(./linkerd version --client --short)" go test -v -race ./cni-plugin/test -integration-tests
+          TAG="$(./linkerd version --client --short)" go test -cover -race -v ./cni-plugin/test -integration-tests
       after_script:
         - |
           # Cleanup after integration test run.

--- a/TEST.md
+++ b/TEST.md
@@ -28,7 +28,15 @@ dependencies and run tests, run:
 
 ```bash
 bin/dep ensure
-go test -race ./...
+go test -cover -race ./...
+```
+
+To investigate code coverage:
+
+```bash
+cov=`mktemp`
+go test -coverprofile=$cov ./...
+go tool cover -html=$cov
 ```
 
 To analyze and lint the Go code using golangci-lint, run:


### PR DESCRIPTION
Add a `-cover` param to the Go tests in ci, along with instructions in
`TEST.md` for manually evaluating test coverage.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>