### PR TITLE
Bump base Docker images

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  deadline: 5m
 issues:
   exclude-use-default: false
 linters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - language: go
       # Quote the version number to avoid parsing issues like
       # https://github.com/travis-ci/gimme/issues/132.
-      go: "1.10.3"
+      go: "1.11.5"
       go_import_path: github.com/linkerd/linkerd2
       cache:
         directories:
@@ -116,7 +116,7 @@ jobs:
     - stage: integration-test
 
       language: go
-      go: "1.10.3"
+      go: "1.11.5"
       go_import_path: github.com/linkerd/linkerd2
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
       go_import_path: github.com/linkerd/linkerd2
       cache:
         directories:
+          - $HOME/.cache/go-build
           - target
           - vendor
       install:
@@ -36,7 +37,7 @@ jobs:
         # this or we should error if it dirties the repo.
         - ./bin/protoc-go.sh
         - go test -cover -race -v ./...
-        - ./bin/lint
+        - ./bin/lint --verbose
 
     - language: node_js
       node_js:

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -3,7 +3,7 @@
 # This means that all Linkerd containers share a common set of tools, and furthermore, they
 # are highly cacheable at runtime.
 
-FROM debian:buster-20190204-slim
+FROM debian:stretch-20190204-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -3,7 +3,7 @@
 # This means that all Linkerd containers share a common set of tools, and furthermore, they
 # are highly cacheable at runtime.
 
-FROM debian:jessie-slim
+FROM debian:buster-20190204-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.10.3
+FROM golang:1.11.5
 ENV TEMP_GOPATH=/temp-gopath
 WORKDIR ${TEMP_GOPATH}/src/github.com/linkerd/linkerd2
 

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,6 +1,6 @@
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2017-10-30.01
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2019-02-08.01
 
-FROM gcr.io/linkerd-io/base:2017-10-30.01 as fetch
+FROM gcr.io/linkerd-io/base:2019-02-08.01 as fetch
 RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,6 +1,6 @@
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2019-02-08.01
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2019-02-19.01
 
-FROM gcr.io/linkerd-io/base:2019-02-08.01 as fetch
+FROM gcr.io/linkerd-io/base:2019-02-19.01 as fetch
 RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -14,7 +14,7 @@ rootdir="$( cd $bindir/.. && pwd )"
 
 . $bindir/_docker.sh
 
-tag="2017-10-30.01"
+tag="2019-02-08.01"
 
 if (docker_pull base "${tag}"); then
     echo "$(docker_repo base):${tag}"

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -14,7 +14,7 @@ rootdir="$( cd $bindir/.. && pwd )"
 
 . $bindir/_docker.sh
 
-tag="2019-02-08.01"
+tag="2019-02-19.01"
 
 if (docker_pull base "${tag}"); then
     echo "$(docker_repo base):${tag}"

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_pull base       2017-10-30.01       || true
+docker_pull base       2019-02-08.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_pull base       2019-02-08.01       || true
+docker_pull base       2019-02-19.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_push base         2017-10-30.01
+docker_push base         2019-02-08.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_push base         2019-02-08.01
+docker_push base         2019-02-19.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.14.0
+lintversion=1.15.0
 
 cd "$(pwd -P)"
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:ddae80d2 as golang
+FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:ddae80d2 as golang
+FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg
@@ -7,7 +7,7 @@ COPY controller controller
 COPY cni-plugin cni-plugin
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/linkerd-cni -v ./cni-plugin/
 
-FROM gcr.io/linkerd-io/base:2017-10-30.01
+FROM gcr.io/linkerd-io/base:2019-02-08.01
 WORKDIR /linkerd
 RUN curl -kL -o $(which jq) https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -7,7 +7,7 @@ COPY controller controller
 COPY cni-plugin cni-plugin
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/linkerd-cni -v ./cni-plugin/
 
-FROM gcr.io/linkerd-io/base:2019-02-08.01
+FROM gcr.io/linkerd-io/base:2019-02-19.01
 WORKDIR /linkerd
 RUN curl -kL -o $(which jq) https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:ddae80d2 as golang
+FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -5,7 +5,7 @@ COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/
 
 ## package runtime
-FROM gcr.io/linkerd-io/base:2019-02-08.01
+FROM gcr.io/linkerd-io/base:2019-02-19.01
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /go/bin/proxy-init /usr/local/bin/proxy-init
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,11 +1,11 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:ddae80d2 as golang
+FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/
 
 ## package runtime
-FROM gcr.io/linkerd-io/base:2017-10-30.01
+FROM gcr.io/linkerd-io/base:2019-02-08.01
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /go/bin/proxy-init /usr/local/bin/proxy-init
 ENTRYPOINT ["/usr/local/bin/proxy-init"]

--- a/proxy-init/integration_test/iptables/Dockerfile-tester
+++ b/proxy-init/integration_test/iptables/Dockerfile-tester
@@ -1,4 +1,4 @@
-FROM golang:1.10.3
+FROM golang:1.11.5
 
 ADD iptables/ /go
 # Kubernetes Jobs will be retried until they return status 0,

--- a/proxy-init/iptables/iptables.go
+++ b/proxy-init/iptables/iptables.go
@@ -22,6 +22,11 @@ const (
 
 	// IptablesOutputChainName specifies an iptables `OUTPUT` chain.
 	IptablesOutputChainName = "OUTPUT"
+
+	// iptablesBin defined as `iptables-legacy`, because the base Docker image,
+	// `debian:buster-20190204-slim`, uses `iptables v1.8.2 (nf_tables)`
+	// by default.
+	iptablesBin = "iptables-legacy"
 )
 
 var (
@@ -184,7 +189,7 @@ func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd) 
 }
 
 func makeIgnoreUserID(chainName string, uid int, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-m", "owner",
@@ -195,7 +200,7 @@ func makeIgnoreUserID(chainName string, uid int, comment string) *exec.Cmd {
 }
 
 func makeCreateNewChain(name string, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-N", name,
 		"-m", "comment",
@@ -203,19 +208,19 @@ func makeCreateNewChain(name string, comment string) *exec.Cmd {
 }
 
 func makeFlushChain(name string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-F", name)
 }
 
 func makeDeleteChain(name string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-X", name)
 }
 
 func makeRedirectChainToPort(chainName string, portToRedirect int, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -226,7 +231,7 @@ func makeRedirectChainToPort(chainName string, portToRedirect int, comment strin
 }
 
 func makeIgnorePort(chainName string, portToIgnore int, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -237,7 +242,7 @@ func makeIgnorePort(chainName string, portToIgnore int, comment string) *exec.Cm
 }
 
 func makeIgnoreLoopback(chainName string, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-o", "lo",
@@ -247,7 +252,7 @@ func makeIgnoreLoopback(chainName string, comment string) *exec.Cmd {
 }
 
 func makeRedirectChainToPortBasedOnDestinationPort(chainName string, destinationPort int, portToRedirect int, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -259,7 +264,7 @@ func makeRedirectChainToPortBasedOnDestinationPort(chainName string, destination
 }
 
 func makeJumpFromChainToAnotherForAllProtocols(chainName string, targetChain string, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-j", targetChain,
@@ -268,7 +273,7 @@ func makeJumpFromChainToAnotherForAllProtocols(chainName string, targetChain str
 }
 
 func makeRedirectChainForOutgoingTraffic(chainName string, redirectChainName string, uid int, comment string) *exec.Cmd {
-	return exec.Command("iptables",
+	return exec.Command(iptablesBin,
 		"-t", "nat",
 		"-A", chainName,
 		"-m", "owner",
@@ -281,5 +286,5 @@ func makeRedirectChainForOutgoingTraffic(chainName string, redirectChainName str
 }
 
 func makeShowAllRules() *exec.Cmd {
-	return exec.Command("iptables", "-t", "nat", "-vnL")
+	return exec.Command(iptablesBin, "-t", "nat", "-vnL")
 }

--- a/proxy-init/iptables/iptables.go
+++ b/proxy-init/iptables/iptables.go
@@ -22,11 +22,6 @@ const (
 
 	// IptablesOutputChainName specifies an iptables `OUTPUT` chain.
 	IptablesOutputChainName = "OUTPUT"
-
-	// iptablesBin defined as `iptables-legacy`, because the base Docker image,
-	// `debian:buster-20190204-slim`, uses `iptables v1.8.2 (nf_tables)`
-	// by default.
-	iptablesBin = "iptables-legacy"
 )
 
 var (
@@ -189,7 +184,7 @@ func executeCommand(firewallConfiguration FirewallConfiguration, cmd *exec.Cmd) 
 }
 
 func makeIgnoreUserID(chainName string, uid int, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-m", "owner",
@@ -200,7 +195,7 @@ func makeIgnoreUserID(chainName string, uid int, comment string) *exec.Cmd {
 }
 
 func makeCreateNewChain(name string, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-N", name,
 		"-m", "comment",
@@ -208,19 +203,19 @@ func makeCreateNewChain(name string, comment string) *exec.Cmd {
 }
 
 func makeFlushChain(name string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-F", name)
 }
 
 func makeDeleteChain(name string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-X", name)
 }
 
 func makeRedirectChainToPort(chainName string, portToRedirect int, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -231,7 +226,7 @@ func makeRedirectChainToPort(chainName string, portToRedirect int, comment strin
 }
 
 func makeIgnorePort(chainName string, portToIgnore int, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -242,7 +237,7 @@ func makeIgnorePort(chainName string, portToIgnore int, comment string) *exec.Cm
 }
 
 func makeIgnoreLoopback(chainName string, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-o", "lo",
@@ -252,7 +247,7 @@ func makeIgnoreLoopback(chainName string, comment string) *exec.Cmd {
 }
 
 func makeRedirectChainToPortBasedOnDestinationPort(chainName string, destinationPort int, portToRedirect int, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-p", "tcp",
@@ -264,7 +259,7 @@ func makeRedirectChainToPortBasedOnDestinationPort(chainName string, destination
 }
 
 func makeJumpFromChainToAnotherForAllProtocols(chainName string, targetChain string, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-j", targetChain,
@@ -273,7 +268,7 @@ func makeJumpFromChainToAnotherForAllProtocols(chainName string, targetChain str
 }
 
 func makeRedirectChainForOutgoingTraffic(chainName string, redirectChainName string, uid int, comment string) *exec.Cmd {
-	return exec.Command(iptablesBin,
+	return exec.Command("iptables",
 		"-t", "nat",
 		"-A", chainName,
 		"-m", "owner",
@@ -286,5 +281,5 @@ func makeRedirectChainForOutgoingTraffic(chainName string, redirectChainName str
 }
 
 func makeShowAllRules() *exec.Cmd {
-	return exec.Command(iptablesBin, "-t", "nat", "-vnL")
+	return exec.Command("iptables", "-t", "nat", "-vnL")
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -37,7 +37,7 @@ COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -o web/web ./web
 
 ## package it all up
-FROM gcr.io/linkerd-io/base:2019-02-08.01
+FROM gcr.io/linkerd-io/base:2019-02-19.01
 WORKDIR /linkerd
 
 COPY LICENSE .

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:ddae80d2 as golang
+FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web
@@ -37,7 +37,7 @@ COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -o web/web ./web
 
 ## package it all up
-FROM gcr.io/linkerd-io/base:2017-10-30.01
+FROM gcr.io/linkerd-io/base:2019-02-08.01
 WORKDIR /linkerd
 
 COPY LICENSE .


### PR DESCRIPTION
- debian:jessie-slim -> buster-20190204-slim
  - this change required moving from `iptables` to `iptables-legacy`
- golang:1.10.3 -> 1.11.5
- gcr.io/linkerd-io/base:2017-10-30.01 -> 2019-02-08.01

Signed-off-by: Andrew Seigner <siggy@buoyant.io>