### PR TITLE
Instrument k8s clients

### DIFF
--- a/controller/k8s/clientset.go
+++ b/controller/k8s/clientset.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/prometheus"
 	"k8s.io/client-go/kubernetes"
 
 	// Load all the auth plugins for the cloud providers.
@@ -16,6 +17,8 @@ func NewClientSet(kubeConfig string) (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 
+	wt := config.WrapTransport
+	config.WrapTransport = prometheus.ClientWithTelemetry("k8s", wt)
 	return kubernetes.NewForConfig(config)
 }
 
@@ -27,5 +30,7 @@ func NewSpClientSet(kubeConfig string) (*spclient.Clientset, error) {
 		return nil, err
 	}
 
+	wt := config.WrapTransport
+	config.WrapTransport = prometheus.ClientWithTelemetry("sp", wt)
 	return spclient.NewForConfig(config)
 }

--- a/grafana/dashboards/authority.json
+++ b/grafana/dashboards/authority.json
@@ -1226,6 +1226,6 @@
   },
   "timezone": "",
   "title": "Linkerd Authority",
-  "uid": "saCMyibmk",
+  "uid": "authority",
   "version": 1
 }

--- a/grafana/dashboards/daemonset.json
+++ b/grafana/dashboards/daemonset.json
@@ -2236,6 +2236,6 @@
   },
   "timezone": "",
   "title": "Linkerd DaemonSet",
-  "uid": "QLL-ZKQmk",
+  "uid": "daemonset",
   "version": 1
 }

--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -2236,6 +2236,6 @@
   },
   "timezone": "",
   "title": "Linkerd Deployment",
-  "uid": "6svnwykmk",
+  "uid": "deployment",
   "version": 1
 }

--- a/grafana/dashboards/grafana.json
+++ b/grafana/dashboards/grafana.json
@@ -1059,6 +1059,6 @@
   },
   "timezone": "",
   "title": "Grafana metrics",
-  "uid": "U3t5kkniz",
+  "uid": "grafana-metrics",
   "version": 1
 }

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -1261,6 +1261,118 @@
       }
     },
     {
+      "content": "<div class=\"text-center dashboard-header\">\n  <span>Control-Plane Clients/Servers</span>\n</div>",
+      "gridPos": {
+        "h": 2.2,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 625,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44.2
+      },
+      "id": 90,
+      "panels": [],
+      "title": "",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 45.2
+      },
+      "id": 622,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(http_server_requests_total{job=\"linkerd-controller\"}[30s])) by (component, method, code)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{component}}/{{method}}/{{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Server Request Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "rps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1271,7 +1383,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 45.2
       },
       "id": 12,
       "legend": {
@@ -1297,31 +1409,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(http_request_duration_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.5, sum(rate(http_server_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "P50 {{component}}/{{code}}",
+          "legendFormat": "P50 {{component}}/{{method}}/{{code}}",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "P95 {{component}}/{{code}}",
+          "legendFormat": "P95 {{component}}/{{method}}/{{code}}",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, code))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "P99 {{component}}/{{code}}",
+          "legendFormat": "P99 {{component}}/{{method}}/{{code}}",
           "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "HTTP Latency",
+      "title": "HTTP Server Latency",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1359,12 +1471,376 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 45.2
+      },
+      "id": 624,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(http_server_response_size_bytes_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P50 {{component}}/{{method}}/{{code}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_response_size_bytes_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P95 {{component}}/{{method}}/{{code}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_response_size_bytes_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P99 {{component}}/{{method}}/{{code}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "HTTP Server Response Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 52.2
+      },
+      "id": 623,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(http_client_requests_total{job=\"linkerd-controller\"}[30s])) by (component, client, method, code)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{component}}/{{client}}/{{method}}/{{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Request Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "rps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 52.2
+      },
+      "id": 570,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(http_client_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, client, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P50 {{component}}/{{client}}/{{method}}/{{code}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_client_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, client, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P95 {{component}}/{{client}}/{{method}}/{{code}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_client_request_latency_seconds_bucket{job=\"linkerd-controller\"}[30s])) by (le, component, client, method, code))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "P99 {{component}}/{{client}}/{{method}}/{{code}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "HTTP Client Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 52.2
+      },
+      "id": 621,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(http_client_in_flight_requests{job=\"linkerd-controller\"}) by (component, client)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{component}}/{{client}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client In-Flight Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 59.2
       },
       "id": 458,
       "panels": [],
@@ -1378,7 +1854,7 @@
         "h": 2.2,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 60.2
       },
       "id": 30,
       "links": [],
@@ -1398,7 +1874,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 46.2
+        "y": 62.400000000000006
       },
       "id": 6,
       "legend": {
@@ -1503,7 +1979,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 46.2
+        "y": 62.400000000000006
       },
       "id": 8,
       "legend": {
@@ -1601,7 +2077,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 46.2
+        "y": 62.400000000000006
       },
       "id": 14,
       "legend": {
@@ -1687,7 +2163,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53.2
+        "y": 69.4
       },
       "id": 515,
       "panels": [],
@@ -1700,7 +2176,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 54.2
+        "y": 70.4
       },
       "height": "1px",
       "id": 519,
@@ -1812,6 +2288,6 @@
   },
   "timezone": "",
   "title": "Linkerd Health",
-  "uid": "Og9nanzmk",
+  "uid": "linkerd-health",
   "version": 1
 }

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -1637,6 +1637,6 @@
   },
   "timezone": "",
   "title": "Linkerd Pod",
-  "uid": "VleHJpWmk",
+  "uid": "linkerd-pod",
   "version": 1
 }

--- a/grafana/dashboards/prometheus-benchmark.json
+++ b/grafana/dashboards/prometheus-benchmark.json
@@ -2766,6 +2766,6 @@
   },
   "timezone": "browser",
   "title": "Prometheus Benchmark - 2.0.x",
-  "uid": "LpQ0xIViz",
+  "uid": "prometheus-benchmark",
   "version": 2
 }

--- a/grafana/dashboards/prometheus.json
+++ b/grafana/dashboards/prometheus.json
@@ -1307,6 +1307,6 @@
   },
   "timezone": "browser",
   "title": "Prometheus 2.0 Stats",
-  "uid": "V45ckk7mk",
+  "uid": "prometheus",
   "version": 1
 }

--- a/grafana/dashboards/replicationcontroller.json
+++ b/grafana/dashboards/replicationcontroller.json
@@ -1726,6 +1726,6 @@
   },
   "timezone": "",
   "title": "Linkerd ReplicationController",
-  "uid": "eIYYYkGmz",
+  "uid": "replicationcontroller",
   "version": 1
 }

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -1266,6 +1266,6 @@
   },
   "timezone": "",
   "title": "Linkerd Service",
-  "uid": "sRnSbbWmk",
+  "uid": "linkerd-service",
   "version": 1
 }

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -1026,6 +1026,6 @@
   },
   "timezone": "",
   "title": "Linkerd Top Line",
-  "uid": "XKy9QWRmz",
+  "uid": "linkerd-top-line",
   "version": 1
 }

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -9,6 +9,87 @@ import (
 	"google.golang.org/grpc"
 )
 
+// WrapTransport provides a function for wrapping an http.RoundTripper
+type WrapTransport func(http.RoundTripper) http.RoundTripper
+
+var (
+	// RequestLatencyBucketsSeconds represents latency buckets to record (seconds)
+	RequestLatencyBucketsSeconds = append(append(append(append(
+		prometheus.LinearBuckets(0.01, 0.01, 5),
+		prometheus.LinearBuckets(0.1, 0.1, 5)...),
+		prometheus.LinearBuckets(1, 1, 5)...),
+		prometheus.LinearBuckets(10, 10, 5)...),
+	)
+
+	// ResponseSizeBuckets represents response size buckets (bytes)
+	ResponseSizeBuckets = append(append(append(append(
+		prometheus.LinearBuckets(100, 100, 5),
+		prometheus.LinearBuckets(1000, 1000, 5)...),
+		prometheus.LinearBuckets(10000, 10000, 5)...),
+		prometheus.LinearBuckets(1000000, 1000000, 5)...),
+	)
+
+	// server metrics
+	serverCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_server_requests_total",
+			Help: "A counter for requests to the wrapped handler.",
+		},
+		[]string{"code", "method"},
+	)
+
+	serverLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_server_request_latency_seconds",
+			Help:    "A histogram of latencies for requests in seconds.",
+			Buckets: RequestLatencyBucketsSeconds,
+		},
+		[]string{"code", "method"},
+	)
+
+	serverResponseSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_server_response_size_bytes",
+			Help:    "A histogram of response sizes for requests.",
+			Buckets: ResponseSizeBuckets,
+		},
+		[]string{"code", "method"},
+	)
+
+	// client metrics
+	clientCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_client_requests_total",
+			Help: "A counter for requests from the wrapped client.",
+		},
+		[]string{"client", "code", "method"},
+	)
+
+	clientLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_client_request_latency_seconds",
+			Help:    "A histogram of request latencies.",
+			Buckets: RequestLatencyBucketsSeconds,
+		},
+		[]string{"client", "code", "method"},
+	)
+
+	clientInFlight = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "http_client_in_flight_requests",
+			Help: "A gauge of in-flight requests for the wrapped client.",
+		},
+		[]string{"client"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		serverCounter, serverLatency, serverResponseSize,
+		clientCounter, clientLatency, clientInFlight,
+	)
+}
+
 // NewGrpcServer returns a grpc server pre-configured with prometheus interceptors
 func NewGrpcServer() *grpc.Server {
 	server := grpc.NewServer(
@@ -21,53 +102,28 @@ func NewGrpcServer() *grpc.Server {
 	return server
 }
 
-// RequestDurationBucketsSeconds represents latency buckets to record (seconds)
-var RequestDurationBucketsSeconds = append(append(append(append(
-	prometheus.LinearBuckets(0.01, 0.01, 5),
-	prometheus.LinearBuckets(0.1, 0.1, 5)...),
-	prometheus.LinearBuckets(1, 1, 5)...),
-	prometheus.LinearBuckets(10, 10, 5)...),
-)
-
-// ResponseSizeBuckets represents response size buckets (bytes)
-var ResponseSizeBuckets = append(append(append(append(
-	prometheus.LinearBuckets(100, 100, 5),
-	prometheus.LinearBuckets(1000, 1000, 5)...),
-	prometheus.LinearBuckets(10000, 10000, 5)...),
-	prometheus.LinearBuckets(1000000, 1000000, 5)...),
-)
-
 // WithTelemetry instruments the HTTP server with prometheus
 func WithTelemetry(handler http.Handler) http.HandlerFunc {
-	counter := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "http_requests_total",
-			Help: "A counter for requests to the wrapped handler.",
-		},
-		[]string{"code"},
-	)
+	return promhttp.InstrumentHandlerDuration(serverLatency,
+		promhttp.InstrumentHandlerResponseSize(serverResponseSize,
+			promhttp.InstrumentHandlerCounter(serverCounter, handler)))
+}
 
-	duration := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "http_request_duration_seconds",
-			Help:    "A histogram of latencies for requests in seconds.",
-			Buckets: RequestDurationBucketsSeconds,
-		},
-		[]string{"code"},
-	)
+// ClientWithTelemetry instruments the HTTP client with prometheus
+func ClientWithTelemetry(name string, wt WrapTransport) WrapTransport {
+	latency := clientLatency.MustCurryWith(prometheus.Labels{"client": name})
+	counter := clientCounter.MustCurryWith(prometheus.Labels{"client": name})
+	inFlight := clientInFlight.With(prometheus.Labels{"client": name})
 
-	responseSize := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "http_response_size_bytes",
-			Help:    "A histogram of response sizes for requests.",
-			Buckets: ResponseSizeBuckets,
-		},
-		[]string{},
-	)
+	return func(rt http.RoundTripper) http.RoundTripper {
+		if wt != nil {
+			rt = wt(rt)
+		}
 
-	prometheus.MustRegister(counter, duration, responseSize)
-
-	return promhttp.InstrumentHandlerDuration(duration,
-		promhttp.InstrumentHandlerResponseSize(responseSize,
-			promhttp.InstrumentHandlerCounter(counter, handler)))
+		return promhttp.InstrumentRoundTripperInFlight(inFlight,
+			promhttp.InstrumentRoundTripperCounter(counter,
+				promhttp.InstrumentRoundTripperDuration(latency, rt),
+			),
+		)
+	}
 }


### PR DESCRIPTION
The control-plane's clients, specifically the Kubernetes clients, did
not provide telemetry information.

Introduce a `prometheus.ClientWithTelemetry` wrapper to instrument
arbitrary clients. Apply this wrapper to Kubernetes clients.

Fixes #2183

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<img width="1186" alt="screen shot 2019-02-09 at 7 29 21 pm" src="https://user-images.githubusercontent.com/236915/52529193-92291200-2ca2-11e9-8fde-e38f8df3f5bb.png">
