### PR TITLE
remove Brian from maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,6 @@ The Linkerd2 maintainers are:
 * Oliver Gould <ver@buoyant.io> @olix0r (super-maintainer)
 * Kevin Lingerfelt <kl@buoyant.io> @klingerf (super-maintainer)
 * Risha Mars <mars@buoyant.io> @rmars
-* Brian Smith <brian@buoyant.io> @briansmith
 * Andrew Seigner <siggy@buoyant.io> @siggy
 
 <!--


### PR DESCRIPTION
Signed-off-by: William Morgan <william@buoyant.io>