### PR TITLE
Update check command hint URLs to new alias

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -170,8 +170,8 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 		fmt.Fprintf(w, "%s %s\n", status, result.Description)
 		if result.Err != nil {
 			fmt.Fprintf(w, "    %s\n", result.Err)
-			if result.HintURL != "" {
-				fmt.Fprintf(w, "    see %s for hints\n", result.HintURL)
+			if result.HintAnchor != "" {
+				fmt.Fprintf(w, "    see %s%s for hints\n", healthcheck.HintBaseURL, result.HintAnchor)
 			}
 		}
 	}

--- a/cli/cmd/check_test.go
+++ b/cli/cmd/check_test.go
@@ -19,7 +19,7 @@ func TestCheckStatus(t *testing.T) {
 		hc.Add("category", "check1", "", func(context.Context) error {
 			return nil
 		})
-		hc.Add("category", "check2", "http://linkerd.io/hint-url", func(context.Context) error {
+		hc.Add("category", "check2", "hint-anchor", func(context.Context) error {
 			return fmt.Errorf("This should contain instructions for fail")
 		})
 

--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -3,4 +3,4 @@ category
 √ check1
 × check2
     This should contain instructions for fail
-    see http://linkerd.io/hint-url for hints
+    see https://linkerd.io/checks/#hint-anchor for hints

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -211,7 +211,7 @@ func NewHealthChecker(categoryIDs []CategoryID, options *Options) *HealthChecker
 // controlPlanePods, etc.
 // Note that all checks should include a `hintURL` with a corresponding section
 // in the linkerd check faq:
-// https://github.com/linkerd/website/blob/master/linkerd.io/content/2/faq/_index.md
+// https://linkerd.io/checks/
 func (hc *HealthChecker) allCategories() []category {
 	return []category{
 		{
@@ -219,7 +219,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "can initialize the client",
-					hintURL:     "https://linkerd.io/2/faq/#k8s-api",
+					hintURL:     "https://linkerd.io/checks/#k8s-api",
 					fatal:       true,
 					check: func(context.Context) (err error) {
 						hc.kubeAPI, err = k8s.NewAPI(hc.KubeConfig, hc.KubeContext)
@@ -235,7 +235,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "can query the Kubernetes API",
-					hintURL:     "https://linkerd.io/2/faq/#k8s-api",
+					hintURL:     "https://linkerd.io/checks/#k8s-api",
 					fatal:       true,
 					check: func(ctx context.Context) (err error) {
 						hc.httpClient, err = hc.kubeAPI.NewClient()
@@ -253,7 +253,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "is running the minimum Kubernetes API version",
-					hintURL:     "https://linkerd.io/2/faq/#k8s-version",
+					hintURL:     "https://linkerd.io/checks/#k8s-version",
 					check: func(context.Context) error {
 						return hc.kubeAPI.CheckVersion(hc.kubeVersion)
 					},
@@ -265,35 +265,35 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "control plane namespace does not already exist",
-					hintURL:     "https://linkerd.io/2/faq/#pre-ns",
+					hintURL:     "https://linkerd.io/checks/#pre-ns",
 					check: func(ctx context.Context) error {
 						return hc.checkNamespace(ctx, hc.ControlPlaneNamespace, false)
 					},
 				},
 				{
 					description: "can create Namespaces",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate("", "", "v1", "Namespace")
 					},
 				},
 				{
 					description: "can create ClusterRoles",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRole")
 					},
 				},
 				{
 					description: "can create ClusterRoleBindings",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRoleBinding")
 					},
 				},
 				{
 					description: "can create CustomResourceDefinitions",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
 					},
@@ -305,21 +305,21 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "control plane namespace exists",
-					hintURL:     "https://linkerd.io/2/faq/#pre-single-ns",
+					hintURL:     "https://linkerd.io/checks/#pre-single-ns",
 					check: func(ctx context.Context) error {
 						return hc.checkNamespace(ctx, hc.ControlPlaneNamespace, true)
 					},
 				},
 				{
 					description: "can create Roles",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "rbac.authorization.k8s.io", "v1beta1", "Role")
 					},
 				},
 				{
 					description: "can create RoleBindings",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s-cluster-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
 					},
@@ -331,28 +331,28 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "can create ServiceAccounts",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "ServiceAccount")
 					},
 				},
 				{
 					description: "can create Services",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "Service")
 					},
 				},
 				{
 					description: "can create Deployments",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "extensions", "v1beta1", "Deployments")
 					},
 				},
 				{
 					description: "can create ConfigMaps",
-					hintURL:     "https://linkerd.io/2/faq/#pre-k8s",
+					hintURL:     "https://linkerd.io/checks/#pre-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "ConfigMap")
 					},
@@ -364,7 +364,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "control plane namespace exists",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-existence-ns",
+					hintURL:     "https://linkerd.io/checks/#l5d-existence-ns",
 					fatal:       true,
 					check: func(ctx context.Context) error {
 						return hc.checkNamespace(ctx, hc.ControlPlaneNamespace, true)
@@ -372,7 +372,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description:   "controller pod is running",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-existence-controller",
+					hintURL:       "https://linkerd.io/checks/#l5d-existence-controller",
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(ctx context.Context) error {
@@ -386,7 +386,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "can initialize the client",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-existence-client",
+					hintURL:     "https://linkerd.io/checks/#l5d-existence-client",
 					fatal:       true,
 					check: func(context.Context) (err error) {
 						if hc.APIAddr != "" {
@@ -399,7 +399,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description:   "can query the control plane API",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-existence-api",
+					hintURL:       "https://linkerd.io/checks/#l5d-existence-api",
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(ctx context.Context) (err error) {
@@ -414,7 +414,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description:   "control plane pods are ready",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-api-control-ready",
+					hintURL:       "https://linkerd.io/checks/#l5d-api-control-ready",
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(ctx context.Context) error {
@@ -428,7 +428,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description:   "can query the control plane API",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-api-control-api",
+					hintURL:       "https://linkerd.io/checks/#l5d-api-control-api",
 					fatal:         true,
 					retryDeadline: hc.RetryDeadline,
 					checkRPC: func(ctx context.Context) (*healthcheckPb.SelfCheckResponse, error) {
@@ -442,7 +442,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "no invalid service profiles",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-sp",
+					hintURL:     "https://linkerd.io/checks/#l5d-sp",
 					warning:     true,
 					check: func(context.Context) error {
 						return hc.validateServiceProfiles()
@@ -455,7 +455,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "can determine the latest version",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-version-latest",
+					hintURL:     "https://linkerd.io/checks/#l5d-version-latest",
 					check: func(ctx context.Context) (err error) {
 						if hc.VersionOverride != "" {
 							hc.latestVersions, err = version.NewChannels(hc.VersionOverride)
@@ -483,7 +483,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "cli is up-to-date",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-version-cli",
+					hintURL:     "https://linkerd.io/checks/#l5d-version-cli",
 					warning:     true,
 					check: func(context.Context) error {
 						return hc.latestVersions.Match(version.Version)
@@ -496,7 +496,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "control plane is up-to-date",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-version-control",
+					hintURL:     "https://linkerd.io/checks/#l5d-version-control",
 					warning:     true,
 					check: func(context.Context) error {
 						return hc.latestVersions.Match(hc.serverVersion)
@@ -504,7 +504,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "control plane and cli versions match",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-version-control",
+					hintURL:     "https://linkerd.io/checks/#l5d-version-control",
 					warning:     true,
 					check: func(context.Context) error {
 						if hc.serverVersion != version.Version {
@@ -520,7 +520,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "data plane namespace exists",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-data-plane-exists",
+					hintURL:     "https://linkerd.io/checks/#l5d-data-plane-exists",
 					fatal:       true,
 					check: func(ctx context.Context) error {
 						return hc.checkNamespace(ctx, hc.DataPlaneNamespace, true)
@@ -528,7 +528,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description:   "data plane proxies are ready",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-data-plane-ready",
+					hintURL:       "https://linkerd.io/checks/#l5d-data-plane-ready",
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(ctx context.Context) error {
@@ -542,7 +542,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description:   "data plane proxy metrics are present in Prometheus",
-					hintURL:       "https://linkerd.io/2/faq/#l5d-data-plane-prom",
+					hintURL:       "https://linkerd.io/checks/#l5d-data-plane-prom",
 					retryDeadline: hc.RetryDeadline,
 					check: func(ctx context.Context) error {
 						pods, err := hc.getDataPlanePods(ctx)
@@ -555,7 +555,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "data plane is up-to-date",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-data-plane-version",
+					hintURL:     "https://linkerd.io/checks/#l5d-data-plane-version",
 					warning:     true,
 					check: func(ctx context.Context) error {
 						pods, err := hc.getDataPlanePods(ctx)
@@ -574,7 +574,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "data plane and cli versions match",
-					hintURL:     "https://linkerd.io/2/faq/#l5d-data-plane-cli-version",
+					hintURL:     "https://linkerd.io/checks/#l5d-data-plane-cli-version",
 					warning:     true,
 					check: func(ctx context.Context) error {
 						pods, err := hc.getDataPlanePods(ctx)


### PR DESCRIPTION
The existing hint URLs printing by `linkerd check` pointed to locations
that would change if the linkerd.io website was reorganized.

linkerd/website#148 introduces an alias for hint URLs at
https://linkerd.io/checks/. This is the corresponding change to update
`linkerd check` output.

Depends on linkerd/website#148, relates to linkerd/website#146.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>