### PR TITLE
Add integration tests for single-namespace mode

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -58,6 +58,7 @@ exit_code=0
 
 run_test "$test_directory/install_test.go" || exit_code=$?
 run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
+run_test "$test_directory/install_test.go" "-single-namespace" || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -75,6 +75,9 @@ func TestInstall(t *testing.T) {
 		cmd = append(cmd, []string{"--tls", "optional"}...)
 		linkerdDeployReplicas["linkerd-ca"] = 1
 	}
+	if TestHelper.SingleNamespace() {
+		cmd = append(cmd, "--single-namespace")
+	}
 
 	out, _, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -54,12 +54,22 @@ func TestVersionPreInstall(t *testing.T) {
 }
 
 func TestCheckPreInstall(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("check", "--pre", "--expected-version", TestHelper.GetVersion())
+	cmd := []string{"check", "--pre", "--expected-version", TestHelper.GetVersion()}
+	golden := "check.pre.golden"
+	if TestHelper.SingleNamespace() {
+		cmd = append(cmd, "--single-namespace")
+		golden = "check.pre.single_namespace.golden"
+		err := TestHelper.CreateNamespaceIfNotExists(TestHelper.GetLinkerdNamespace())
+		if err != nil {
+			t.Fatalf("Namespace creation failed\n%s", err.Error())
+		}
+	}
+	out, _, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)
 	}
 
-	err = TestHelper.ValidateOutput(out, "check.pre.golden")
+	err = TestHelper.ValidateOutput(out, golden)
 	if err != nil {
 		t.Fatalf("Received unexpected output\n%s", err.Error())
 	}
@@ -121,18 +131,19 @@ func TestVersionPostInstall(t *testing.T) {
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun(
-		"check",
-		"--expected-version",
-		TestHelper.GetVersion(),
-		"--wait=0",
-	)
+	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
+	golden := "check.golden"
+	if TestHelper.SingleNamespace() {
+		cmd = append(cmd, "--single-namespace")
+		golden = "check.single_namespace.golden"
+	}
+	out, _, err := TestHelper.LinkerdRun(cmd...)
 
 	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)
 	}
 
-	err = TestHelper.ValidateOutput(out, "check.golden")
+	err = TestHelper.ValidateOutput(out, golden)
 	if err != nil {
 		t.Fatalf("Received unexpected output\n%s", err.Error())
 	}
@@ -218,21 +229,19 @@ func TestInject(t *testing.T) {
 
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	out, _, err := TestHelper.LinkerdRun(
-		"check",
-		"--proxy",
-		"--expected-version",
-		TestHelper.GetVersion(),
-		"--namespace",
-		prefixedNs,
-		"--wait=0",
-	)
+	cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=0"}
+	golden := "check.proxy.golden"
+	if TestHelper.SingleNamespace() {
+		cmd = append(cmd, "--single-namespace")
+		golden = "check.proxy.single_namespace.golden"
+	}
+	out, _, err := TestHelper.LinkerdRun(cmd...)
 
 	if err != nil {
 		t.Fatalf("Check command failed\n%s", out)
 	}
 
-	err = TestHelper.ValidateOutput(out, "check.proxy.golden")
+	err = TestHelper.ValidateOutput(out, golden)
 	if err != nil {
 		t.Fatalf("Received unexpected output\n%s", err.Error())
 	}

--- a/test/testdata/check.pre.single_namespace.golden
+++ b/test/testdata/check.pre.single_namespace.golden
@@ -1,0 +1,28 @@
+kubernetes-api
+--------------
+√ can initialize the client
+√ can query the Kubernetes API
+
+kubernetes-version
+------------------
+√ is running the minimum Kubernetes API version
+
+pre-kubernetes-single-namespace-setup
+-------------------------------------
+√ control plane namespace exists
+√ can create Roles
+√ can create RoleBindings
+
+pre-kubernetes-setup
+--------------------
+√ can create ServiceAccounts
+√ can create Services
+√ can create Deployments
+√ can create ConfigMaps
+
+linkerd-version
+---------------
+√ can determine the latest version
+√ cli is up-to-date
+
+Status check results are √

--- a/test/testdata/check.proxy.single_namespace.golden
+++ b/test/testdata/check.proxy.single_namespace.golden
@@ -1,0 +1,37 @@
+kubernetes-api
+--------------
+√ can initialize the client
+√ can query the Kubernetes API
+
+kubernetes-version
+------------------
+√ is running the minimum Kubernetes API version
+
+linkerd-existence
+-----------------
+√ control plane namespace exists
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
+
+linkerd-api
+-----------
+√ control plane pods are ready
+√ can query the control plane API
+√ [kubernetes] control plane can talk to Kubernetes
+√ [prometheus] control plane can talk to Prometheus
+
+linkerd-version
+---------------
+√ can determine the latest version
+√ cli is up-to-date
+
+linkerd-data-plane
+------------------
+√ data plane namespace exists
+√ data plane proxies are ready
+√ data plane proxy metrics are present in Prometheus
+√ data plane is up-to-date
+√ data plane and cli versions match
+
+Status check results are √

--- a/test/testdata/check.single_namespace.golden
+++ b/test/testdata/check.single_namespace.golden
@@ -1,0 +1,34 @@
+kubernetes-api
+--------------
+√ can initialize the client
+√ can query the Kubernetes API
+
+kubernetes-version
+------------------
+√ is running the minimum Kubernetes API version
+
+linkerd-existence
+-----------------
+√ control plane namespace exists
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
+
+linkerd-api
+-----------
+√ control plane pods are ready
+√ can query the control plane API
+√ [kubernetes] control plane can talk to Kubernetes
+√ [prometheus] control plane can talk to Prometheus
+
+linkerd-version
+---------------
+√ can determine the latest version
+√ cli is up-to-date
+
+control-plane-version
+---------------------
+√ control plane is up-to-date
+√ control plane and cli versions match
+
+Status check results are √


### PR DESCRIPTION
Fixes #2127

Implemented just as an extra run of `install_test.go` with an extra arg to pass `--single-namespace` into `linkerd install`.
I verified the test fails under Edge-19.1.2, catching the bug described in #2119 (already fixed in a previous release).