### PR TITLE
Honour install's `proxy-log-level` flag when autoinjecting proxies

### DIFF
--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -159,7 +159,7 @@ data:
   {{.Values.ProxySpecFileName}}: |
     env:
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd2_proxy=info
+      value: {{.Values.ProxyLogLevel}}
     - name: LINKERD2_PROXY_CONTROL_URL
       value: tcp://linkerd-proxy-api.{{.Values.Namespace}}.svc.cluster.local:{{.Values.ProxyAPIPort}}
     - name: LINKERD2_PROXY_CONTROL_LISTENER

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -56,6 +56,7 @@ type installConfig struct {
 	ProxyAutoInjectEnabled           bool
 	ProxyInjectAnnotation            string
 	ProxyInjectDisabled              string
+	ProxyLogLevel                    string
 	ProxyUID                         int64
 	ProxyMetricsPort                 uint
 	ProxyControlPort                 uint
@@ -210,6 +211,7 @@ func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
 		ProxyAutoInjectEnabled:           options.proxyAutoInject,
 		ProxyInjectAnnotation:            k8s.ProxyInjectAnnotation,
 		ProxyInjectDisabled:              k8s.ProxyInjectDisabled,
+		ProxyLogLevel:                    options.proxyLogLevel,
 		ProxyUID:                         options.proxyUID,
 		ProxyMetricsPort:                 options.proxyMetricsPort,
 		ProxyControlPort:                 options.proxyControlPort,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -51,6 +51,7 @@ func TestRender(t *testing.T) {
 		ProxyAutoInjectEnabled:           true,
 		ProxyInjectAnnotation:            "ProxyInjectAnnotation",
 		ProxyInjectDisabled:              "ProxyInjectDisabled",
+		ProxyLogLevel:                    "ProxyLogLevel",
 		ProxyUID:                         2102,
 		ControllerUID:                    2103,
 		InboundPort:                      4143,

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1421,7 +1421,7 @@ data:
   ProxySpecFileName: |
     env:
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd2_proxy=info
+      value: ProxyLogLevel
     - name: LINKERD2_PROXY_CONTROL_URL
       value: tcp://linkerd-proxy-api.Namespace.svc.cluster.local:123
     - name: LINKERD2_PROXY_CONTROL_LISTENER


### PR DESCRIPTION
Fixes #2248

It was hard-coded to `warn-linkerd2_proxy=info`.
Still, something that will have to be handled more generically in #1999 

Also still to do in a separate PR would be the syntax validation of this flag value.