### PR TITLE
proxy: Log canonicalization warnings on only the first error

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-7add4fc}"
+PROXY_VERSION="${PROXY_VERSION:-59d00f6}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
commit 59d00f69653730353ec246b8cb2eb39d80a54d3e
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Feb 11 10:51:37 2019 -0800

    Log canonicalization warnings on only the first error (#189)

    When a canonicalization task fails to resolve a name, our logging is not
    particularly clear about the current state of the stack. Specifically,
    it's difficult to know whether the stack has resolved the name
    successfully before.

    With this change, canonicalization failures are logged (at warning, not
    error) only when the task has not previously resolved a name.
    Subsequent errors are now logged at the debug level (instead of
    warning).