### PR TITLE
Fix Dockerfile-proxy to error out if fetch fails

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -5,9 +5,9 @@ RUN apt-get update && apt-get install -y ca-certificates
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy
 ARG PROXY_VERSION
-RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION); \
-    version=$(basename "$proxy" | sed 's/linkerd2-proxy-//'); \
-    mv "$proxy" linkerd2-proxy; \
+RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION) && \
+    version=$(basename "$proxy" | sed 's/linkerd2-proxy-//') && \
+    mv "$proxy" linkerd2-proxy && \
     echo "$version" >version.txt)
 
 FROM $RUNTIME_IMAGE as runtime


### PR DESCRIPTION
`Dockerfile-proxy` executes several commands following
`bin/fetch-proxy`, but the subsequent commands were separated by
semicolon, so the overall RUN command would succeed regardless of what
`bin/fetch-proxy` returned. This meant that if `bin/docker-build-proxy`
was run on a proxy SHA prior to it being available, it would fail the
build, but cache the unsuccessful `fetch-proxy` command, and continue to
fail after the proxy becomes available.

This change concatenates `fetch-proxy` and subsequent commands using
ampersands, failing the build if `fetch-proxy` fails.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>