### PR TITLE
Clicking Linkerd logo on web UI redirects to /overview

### DIFF
--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -218,7 +218,7 @@ class NavigationBase extends React.Component {
           open={this.state.drawerOpen}>
           <div className={classNames(classes.navToolbar)}>
             <div className={classNames(classes.linkerdNavLogo, {[classes.linkerdNavLogoClose]: !this.state.drawerOpen} )}>
-              {linkerdWordLogo}
+              <Link to="/overview">{linkerdWordLogo}</Link>
             </div>
             <IconButton className="drawer-toggle-btn" onClick={this.handleDrawerClick}>
               {this.state.drawerOpen ? <ChevronLeftIcon /> : <MenuIcon />}


### PR DESCRIPTION
Fixes #2232 

The Linkerd logo on the top left of the web UI is now wrapped in a 
`react-router-dom` Link component so that clicking it redirects to `/overview`. 