### PR TITLE
Embellish dashboard cli output with Linkerd logo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -408,6 +408,14 @@
   version = "v1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:db3e74e12ad83aaa22a0e270573b923d8034efb6328a116c08d3e50f9f36508f"
+  name = "github.com/kris-nova/lolgopher"
+  packages = ["."]
+  pruneopts = ""
+  revision = "313b3abb0d9bb53e3c43230132061a7a9cb100fc"
+
+[[projects]]
   digest = "1:b54147c462536e1d92f5dfd0e0c94816c4e27e5349b06524d4269aaecd387ed4"
   name = "github.com/linkerd/linkerd2-proxy-api"
   packages = [
@@ -1255,6 +1263,7 @@
     "github.com/gorilla/websocket",
     "github.com/grpc-ecosystem/go-grpc-prometheus",
     "github.com/julienschmidt/httprouter",
+    "github.com/kris-nova/lolgopher",
     "github.com/linkerd/linkerd2-proxy-api/go/destination",
     "github.com/linkerd/linkerd2-proxy-api/go/http_types",
     "github.com/linkerd/linkerd2-proxy-api/go/net",

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:069eb85f as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
+	lol "github.com/kris-nova/lolgopher"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/version"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -123,6 +126,35 @@ func newCmdDashboard() *cobra.Command {
 			case showURL:
 				// no-op, we already printed the URLs
 			}
+
+			l5dVer := fmt.Sprintf("Linkerd %s", version.Version)
+			tagLine := fmt.Sprintf("%s%s",
+				strings.Repeat(" ", len("    ss/  .+syyyo/:+yyyy+:`  `/oyyys+.  /ss")-len(l5dVer)),
+				l5dVer,
+			)
+			w := lol.NewLolWriter()
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "               :ohhs+:  :+shho")
+			fmt.Fprintln(w, "            .   -+syys++syys+-   .")
+			fmt.Fprintln(w, "         `+yys+-`  .:oyyyyo. `-+syy+`")
+			fmt.Fprintln(w, "    `-/.  `-/syyyo/.  `:+syyyyyys/-`  ./-`")
+			fmt.Fprintln(w, "    syyyyo:`  `:oyyys+-`  ./oyyyo/-:oyyyys")
+			fmt.Fprintln(w, "    ss++syyyo/-   -+syyyo:.  `-+syyyys++ss")
+			fmt.Fprintln(w, "    ssyyyyo+syys+:`  .:oyyys+-   ./oyyyyss")
+			fmt.Fprintln(w, "    yyy+:`  `oyyyyys/.  `-+syyyo/`  `:+yyy")
+			fmt.Fprintln(w, "    ss/  .+syyyo/:+yyyy+:`  `/oyyys+.  /ss")
+			fmt.Fprintln(w, "    ss/  /syo-`  ./oyyyyyyo/.  `-oys/  /ss")
+			fmt.Fprintln(w, "    oo:  /ss/  :syyyo:``:+syys:  /ss/  :os")
+			fmt.Fprintln(w, "    oo:  /ss/  /ssyyys+.  `+ss/  /ss/  :oo")
+			fmt.Fprintln(w, "    oo:  :oo:  /ss/-+syyyo:+ss/  :oo:  :oo")
+			fmt.Fprintln(w, "    ++:  :oo:  /ss/`  ./oyyyss/  :oo:  :++")
+			fmt.Fprintln(w, "    `-.  :oo:  :oosyo:.  `-ooo:  :oo:  .-`")
+			fmt.Fprintln(w, "         -++:  :ooooyyys+- :oo:  :++-")
+			fmt.Fprintln(w, "           ``  :oooyyyssyyyooo:  ``")
+			fmt.Fprintln(w, "               ./+so/`  `/os+/.")
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, tagLine)
+			fmt.Fprintln(w)
 
 			<-wait
 			return nil

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:069eb85f as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:069eb85f as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:069eb85f as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:fb05ef23 as golang
+FROM gcr.io/linkerd-io/go-deps:069eb85f as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
This introduces a Linkerd color logo to the `linkerd dashboard` command,
to better indicate to the user that the terminal session is occupied by
a Linkerd dashboard port-forward.

Part of #1700

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![screen shot 2019-02-12 at 5 11 56 pm](https://user-images.githubusercontent.com/236915/52679398-d1956f80-2ee9-11e9-92ad-dfb3d407a441.png)
