### PR TITLE
Add an Endpoints view to the web dashboard

### DIFF
--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -12,7 +12,8 @@ const routeToCrumbTitle = {
   "overview": "Overview",
   "tap": "Tap",
   "top": "Top",
-  "routes": "Top Routes"
+  "routes": "Top Routes",
+  "endpoints": "Service Discovery Endpoints"
 };
 
 class BreadcrumbHeader extends React.Component {

--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -13,7 +13,7 @@ const routeToCrumbTitle = {
   "tap": "Tap",
   "top": "Top",
   "routes": "Top Routes",
-  "endpoints": "Service Discovery Endpoints"
+  "debug": "Debugging"
 };
 
 class BreadcrumbHeader extends React.Component {

--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -13,7 +13,7 @@ const routeToCrumbTitle = {
   "tap": "Tap",
   "top": "Top",
   "routes": "Top Routes",
-  "debug": "Debugging"
+  "debug": "Debug"
 };
 
 class BreadcrumbHeader extends React.Component {

--- a/web/app/js/components/Debug.jsx
+++ b/web/app/js/components/Debug.jsx
@@ -22,7 +22,8 @@ const endpointColumns = [
   },
   {
     title: "IP",
-    dataIndex: "ip"
+    dataIndex: "ip",
+    sorter: (a, b) => (a.ip).localeCompare(b.ip)
   },
   {
     title: "Port",
@@ -102,12 +103,12 @@ class Debug extends React.Component {
         {this.banner()}
         <Typography variant="h6">Endpoints</Typography>
         <Typography>
-        This table allow you to see Linkerd&#39;s service discovery state. It provides
-        debug information about the internal state of the
-        control-plane&#39;s proxy-api container. Note that this cache of service discovery
-        information is populated on-demand via linkerd-proxy requests. No endpoints
-        will be found  until a linkerd-proxy begins routing
-        requests.
+          This table allows you to see Linkerd&#39;s service discovery state. It
+          provides debug information about the internal state of the
+          control-plane&#39;s proxy-api container. Note that this cache of service
+          discovery information is populated on-demand via linkerd-proxy requests.
+          No endpoints will be found  until a linkerd-proxy begins routing
+          requests.
         </Typography>
 
         <BaseTable

--- a/web/app/js/components/Debug.jsx
+++ b/web/app/js/components/Debug.jsx
@@ -9,6 +9,7 @@ import _get from 'lodash/get';
 import _reduce from 'lodash/reduce';
 import { apiErrorPropType } from './util/ApiHelpers.jsx';
 import { numericSort } from './util/Utils.js';
+import Typography from '@material-ui/core/Typography';
 import { withContext } from './util/AppContext.jsx';
 import withREST from './util/withREST.jsx';
 
@@ -45,7 +46,7 @@ const endpointColumns = [
     sorter: (a, b) => (a.service).localeCompare(b.service)
   }
 ];
-class Endpoints extends React.Component {
+class Debug extends React.Component {
   static defaultProps = {
     error: null
   }
@@ -99,6 +100,15 @@ class Endpoints extends React.Component {
       <React.Fragment>
         {this.loading()}
         {this.banner()}
+        <Typography variant="h6">Endpoints</Typography>
+        <Typography>
+        This table allow you to see Linkerd's service discovery state. It provides
+        debug information about the internal state of the
+        control-plane's proxy-api container. Note that this cache of service discovery
+        information is populated on-demand via linkerd-proxy requests. No endpoints
+        will be found  until a linkerd-proxy begins routing
+        requests.
+        </Typography>
 
         <BaseTable
           tableRows={rows}
@@ -114,6 +124,6 @@ class Endpoints extends React.Component {
 }
 
 export default withREST(
-  withContext(Endpoints),
+  withContext(Debug),
   ({api}) => [api.fetch("/api/endpoints")]
 );

--- a/web/app/js/components/Debug.jsx
+++ b/web/app/js/components/Debug.jsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Spinner from './util/Spinner.jsx';
+import Typography from '@material-ui/core/Typography';
 import _each from 'lodash/each';
 import _get from 'lodash/get';
 import _reduce from 'lodash/reduce';
 import { apiErrorPropType } from './util/ApiHelpers.jsx';
 import { numericSort } from './util/Utils.js';
-import Typography from '@material-ui/core/Typography';
 import { withContext } from './util/AppContext.jsx';
 import withREST from './util/withREST.jsx';
 
@@ -102,9 +102,9 @@ class Debug extends React.Component {
         {this.banner()}
         <Typography variant="h6">Endpoints</Typography>
         <Typography>
-        This table allow you to see Linkerd's service discovery state. It provides
+        This table allow you to see Linkerd&#39;s service discovery state. It provides
         debug information about the internal state of the
-        control-plane's proxy-api container. Note that this cache of service discovery
+        control-plane&#39;s proxy-api container. Note that this cache of service discovery
         information is populated on-demand via linkerd-proxy requests. No endpoints
         will be found  until a linkerd-proxy begins routing
         requests.

--- a/web/app/js/components/Endpoints.jsx
+++ b/web/app/js/components/Endpoints.jsx
@@ -1,0 +1,110 @@
+import BaseTable from './BaseTable.jsx';
+import ErrorBanner from './ErrorBanner.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Spinner from './util/Spinner.jsx';
+import _each from 'lodash/each';
+import _get from 'lodash/get';
+import _reduce from 'lodash/reduce';
+import { apiErrorPropType } from './util/ApiHelpers.jsx';
+import { numericSort } from './util/Utils.js';
+import { withContext } from './util/AppContext.jsx';
+import withREST from './util/withREST.jsx';
+
+const endpointColumns = [
+  {
+    title: "Namespace",
+    dataIndex: "namespace",
+    sorter: (a, b) => (a.namespace).localeCompare(b.namespace)
+  },
+  {
+    title: "IP",
+    dataIndex: "pod.podIP"
+  },
+  {
+    title: "Port",
+    dataIndex: "addr.port",
+    sorter: (a, b) => numericSort(a.addr.port, b.addr.port)
+  },
+  {
+    title: "Pod",
+    dataIndex: "name",
+    sorter: (a, b) => (a.name).localeCompare(b.name)
+  },
+  {
+    title: "Resource Version",
+    dataIndex: "pod.resourceVersion"
+  },
+  {
+    title: "Service",
+    dataIndex: "service",
+    sorter: (a, b) => (a.service).localeCompare(b.service)
+  }
+];
+class Endpoints extends React.Component {
+  static defaultProps = {
+    error: null
+  }
+
+  static propTypes = {
+    data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    error:  apiErrorPropType,
+    loading: PropTypes.bool.isRequired,
+  }
+
+  banner = () => {
+    const { error } = this.props;
+    if (!error) {
+      return;
+    }
+    return <ErrorBanner message={error} />;
+  }
+
+  loading = () => {
+    const { loading } = this.props;
+    if (!loading) {
+      return;
+    }
+
+    return <Spinner />;
+  }
+
+  render() {
+    const { data } = this.props;
+    let results = _get(data, '[0].servicePorts', {});
+    let rows = _reduce(results, (mem, svc, svcName) => {
+      let pods = [];
+      _each(svc.portEndpoints, info => {
+        info.podAddresses.forEach(podAddress => {
+          podAddress.service = svcName;
+          let [podNamespace, podName] = podAddress.pod.name.split("/");
+          podAddress.name = podName;
+          podAddress.namespace = podNamespace;
+          pods.push(podAddress);
+        });
+      });
+      return mem.concat(pods);
+    }, []);
+
+    return (
+      <React.Fragment>
+        {this.loading()}
+        {this.banner()}
+
+        <BaseTable
+          tableRows={rows}
+          tableColumns={endpointColumns}
+          tableClassName="metric-table"
+          defaultOrderBy="namespace"
+          rowKey={r => r.service + r.pod.name}
+          padding="dense" />
+
+      </React.Fragment>
+    );
+  }
+}
+
+export default withREST(
+  withContext(Endpoints),
+  ({api}) => [api.fetchMetrics("/api/endpoints")]
+);

--- a/web/app/js/components/Endpoints.jsx
+++ b/web/app/js/components/Endpoints.jsx
@@ -21,12 +21,12 @@ const endpointColumns = [
   },
   {
     title: "IP",
-    dataIndex: "pod.podIP"
+    dataIndex: "ip"
   },
   {
     title: "Port",
-    dataIndex: "addr.port",
-    sorter: (a, b) => numericSort(a.addr.port, b.addr.port)
+    dataIndex: "port",
+    sorter: (a, b) => numericSort(a.port, b.port)
   },
   {
     title: "Pod",
@@ -36,8 +36,8 @@ const endpointColumns = [
   },
   {
     title: "Resource Version",
-    dataIndex: "pod.resourceVersion",
-    sorter: (a, b) => numericSort(a.pod.resourceVersion, b.pod.resourceVersion)
+    dataIndex: "resourceVersion",
+    sorter: (a, b) => numericSort(a.resourceVersion, b.resourceVersion)
   },
   {
     title: "Service",
@@ -80,12 +80,16 @@ class Endpoints extends React.Component {
       let pods = [];
       _each(svc.portEndpoints, info => {
         info.podAddresses.forEach(podAddress => {
-          podAddress.service = svcName;
           let [podNamespace, podName] = podAddress.pod.name.split("/");
-          podAddress.name = podName;
-          podAddress.namespace = podNamespace;
-          podAddress.pod.resourceVersion = parseInt(podAddress.pod.resourceVersion, 10);
-          pods.push(podAddress);
+
+          pods.push({
+            service: svcName,
+            name: podName,
+            namespace: podNamespace,
+            resourceVersion: parseInt(podAddress.pod.resourceVersion, 10),
+            ip: podAddress.pod.podIP,
+            port: podAddress.addr.port,
+          });
         });
       });
       return mem.concat(pods);
@@ -101,7 +105,7 @@ class Endpoints extends React.Component {
           tableColumns={endpointColumns}
           tableClassName="metric-table"
           defaultOrderBy="namespace"
-          rowKey={r => r.service + r.pod.name}
+          rowKey={r => r.service + r.name}
           padding="dense" />
 
       </React.Fragment>

--- a/web/app/js/components/Endpoints.jsx
+++ b/web/app/js/components/Endpoints.jsx
@@ -37,7 +37,7 @@ const endpointColumns = [
   {
     title: "Resource Version",
     dataIndex: "pod.resourceVersion",
-    sorter: (a, b) => (a.pod.resourceVersion).localeCompare(b.resourceVersion)
+    sorter: (a, b) => numericSort(a.pod.resourceVersion, b.pod.resourceVersion)
   },
   {
     title: "Service",
@@ -84,6 +84,7 @@ class Endpoints extends React.Component {
           let [podNamespace, podName] = podAddress.pod.name.split("/");
           podAddress.name = podName;
           podAddress.namespace = podNamespace;
+          podAddress.pod.resourceVersion = parseInt(podAddress.pod.resourceVersion, 10);
           pods.push(podAddress);
         });
       });

--- a/web/app/js/components/Endpoints.jsx
+++ b/web/app/js/components/Endpoints.jsx
@@ -33,7 +33,8 @@ const endpointColumns = [
   },
   {
     title: "Resource Version",
-    dataIndex: "pod.resourceVersion"
+    dataIndex: "pod.resourceVersion",
+    sorter: (a, b) => (a.pod.resourceVersion).localeCompare(b.resourceVersion)
   },
   {
     title: "Service",
@@ -106,5 +107,5 @@ class Endpoints extends React.Component {
 
 export default withREST(
   withContext(Endpoints),
-  ({api}) => [api.fetchMetrics("/api/endpoints")]
+  ({api}) => [api.fetch("/api/endpoints")]
 );

--- a/web/app/js/components/Endpoints.jsx
+++ b/web/app/js/components/Endpoints.jsx
@@ -1,5 +1,6 @@
 import BaseTable from './BaseTable.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Spinner from './util/Spinner.jsx';
@@ -15,6 +16,7 @@ const endpointColumns = [
   {
     title: "Namespace",
     dataIndex: "namespace",
+    render: d => <Link to={"/namespaces/" + d.namespace}>{d.namespace}</Link>,
     sorter: (a, b) => (a.namespace).localeCompare(b.namespace)
   },
   {
@@ -29,7 +31,8 @@ const endpointColumns = [
   {
     title: "Pod",
     dataIndex: "name",
-    sorter: (a, b) => (a.name).localeCompare(b.name)
+    sorter: (a, b) => (a.name).localeCompare(b.name),
+    render: d => <Link to={`/namespaces/${d.namespace}/pods/${d.name}`}>{d.name}</Link>
   },
   {
     title: "Resource Version",

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,6 +1,7 @@
 import { githubIcon, linkerdWordLogo, slackIcon } from './util/SvgWrappers.jsx';
 import AppBar from '@material-ui/core/AppBar';
 import BreadcrumbHeader from './BreadcrumbHeader.jsx';
+import BuildIcon from '@material-ui/icons/Build';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import CloudQueueIcon from '@material-ui/icons/CloudQueue';
 import Collapse from '@material-ui/core/Collapse';
@@ -234,6 +235,7 @@ class NavigationBase extends React.Component {
             { this.menuItem("/routes", "Top Routes", <Icon className={classNames("fas fa-random", classes.shrinkIcon)} />) }
             { this.menuItem("/servicemesh", "Service Mesh", <CloudQueueIcon className={classes.shrinkIcon} />) }
             <NavigationResources />
+            { this.menuItem("/debug", "Debug", <BuildIcon className={classes.shrinkIcon} />) }
           </MenuList>
 
           <Divider />

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -7,6 +7,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import ApiHelpers from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import Endpoints from './components/Endpoints.jsx';
 import Namespace from './components/Namespace.jsx';
 import NamespaceLanding from './components/NamespaceLanding.jsx';
 import Navigation from './components/Navigation.jsx';
@@ -104,6 +105,9 @@ let applicationHtml = (
               <Route
                 path={`${pathPrefix}/authorities`}
                 render={props => <Navigation {...props} ChildComponent={ResourceList} resource="authority" />} />
+              <Route
+                path={`${pathPrefix}/endpoints`}
+                render={props => <Navigation {...props} ChildComponent={Endpoints} />} />
               <Route component={NoMatch} />
             </Switch>
           </RouterToUrlQuery>

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -7,7 +7,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import ApiHelpers from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Endpoints from './components/Endpoints.jsx';
+import Debug from './components/Debug.jsx';
 import Namespace from './components/Namespace.jsx';
 import NamespaceLanding from './components/NamespaceLanding.jsx';
 import Navigation from './components/Navigation.jsx';
@@ -106,8 +106,8 @@ let applicationHtml = (
                 path={`${pathPrefix}/authorities`}
                 render={props => <Navigation {...props} ChildComponent={ResourceList} resource="authority" />} />
               <Route
-                path={`${pathPrefix}/endpoints`}
-                render={props => <Navigation {...props} ChildComponent={Endpoints} />} />
+                path={`${pathPrefix}/debug`}
+                render={props => <Navigation {...props} ChildComponent={Debug} />} />
               <Route component={NoMatch} />
             </Switch>
           </RouterToUrlQuery>

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/julienschmidt/httprouter"
 	"github.com/linkerd/linkerd2/controller/api/util"
+	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
@@ -254,4 +255,13 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 			return
 		}
 	}
+}
+
+func (h *handler) handleAPIEndpoints(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	result, err := h.apiClient.Endpoints(req.Context(), &discovery.EndpointsParams{})
+	if err != nil {
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+	renderJSONPb(w, result)
 }

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/linkerd/linkerd2/controller/api/public"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	profiles "github.com/linkerd/linkerd2/pkg/profiles"
 	log "github.com/sirupsen/logrus"
@@ -19,7 +20,7 @@ type (
 
 	handler struct {
 		render              renderTemplate
-		apiClient           pb.ApiClient
+		apiClient           public.APIClient
 		uuid                string
 		controllerNamespace string
 		singleNamespace     bool

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -108,7 +108,7 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/replicationcontrollers/:replicationcontroller", handler.handleIndex)
 	server.router.GET("/tap", handler.handleIndex)
 	server.router.GET("/top", handler.handleIndex)
-	server.router.GET("/endpoints", handler.handleIndex)
+	server.router.GET("/debug", handler.handleIndex)
 	server.router.GET("/routes", handler.handleIndex)
 	server.router.GET("/profiles/new", handler.handleProfileDownload)
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -108,8 +108,10 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/replicationcontrollers/:replicationcontroller", handler.handleIndex)
 	server.router.GET("/tap", handler.handleIndex)
 	server.router.GET("/top", handler.handleIndex)
+	server.router.GET("/endpoints", handler.handleIndex)
 	server.router.GET("/routes", handler.handleIndex)
 	server.router.GET("/profiles/new", handler.handleProfileDownload)
+
 	// add catch-all parameter to match all files in dir
 	server.router.GET("/dist/*filepath", mkStaticHandler(staticDir))
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/linkerd/linkerd2/controller/api/public"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/filesonly"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
@@ -58,7 +59,7 @@ func NewServer(
 	controllerNamespace string,
 	singleNamespace bool,
 	reload bool,
-	apiClient pb.ApiClient,
+	apiClient public.APIClient,
 ) *http.Server {
 	server := &Server{
 		templateDir: templateDir,
@@ -122,6 +123,7 @@ func NewServer(
 	server.router.GET("/api/services", handler.handleAPIServices)
 	server.router.GET("/api/tap", handler.handleAPITap)
 	server.router.GET("/api/routes", handler.handleAPITopRoutes)
+	server.router.GET("/api/endpoints", handler.handleAPIEndpoints)
 
 	// grafana proxy
 	server.router.DELETE("/grafana/*grafanapath", handler.handleGrafana)


### PR DESCRIPTION
In #2195 we introduced `linkerd endpoints` on the CLI. I would like similar information to be on the web.

This PR adds an api endpoint at `/api/endpoints`, and introduces a new page with a table that is the same as the CLI table, available at `/endpoints` but currently not linked in the nav.

![screen shot 2019-02-19 at 4 58 20 pm](https://user-images.githubusercontent.com/549258/53058375-a077ea80-3467-11e9-83c5-93927cceeb29.png)

