### PR TITLE
Issue 2276: Do not log error when timeout is blank

### DIFF
--- a/controller/api/proxy/profile_listener.go
+++ b/controller/api/proxy/profile_listener.go
@@ -44,7 +44,7 @@ func (l *profileListener) Update(profile *sp.ServiceProfile) {
 		l.stream.Send(&profiles.DefaultServiceProfile)
 		return
 	}
-	destinationProfile, err := profiles.ToServiceProfile(&profile.Spec)
+	destinationProfile, err := profiles.ToServiceProfile(profile)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -105,10 +105,13 @@ func ToRoute(route *sp.RouteSpec) (*pb.Route, error) {
 		}
 		rcs = append(rcs, pbRc)
 	}
-	timeout, err := time.ParseDuration(route.Timeout)
-	if err != nil {
-		log.Errorf("failed to parse duration for route %s: %s", route.Name, err)
-		timeout = DefaultRouteTimeout
+	timeout := DefaultRouteTimeout
+	if route.Timeout != "" {
+		timeout, err = time.ParseDuration(route.Timeout)
+		if err != nil {
+			log.Errorf("failed to parse duration for route %s: %s", route.Name, err)
+			timeout = DefaultRouteTimeout
+		}
 	}
 	ret := pb.Route{
 		Condition:       cond,

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -112,8 +112,8 @@ func ToRoute(profile *sp.ServiceProfile, route *sp.RouteSpec) (*pb.Route, error)
 			log.Errorf(
 				"failed to parse duration for route '%s' in service profile '%s' in namespace '%s': %s",
 				route.Name,
-				profile.ObjectMeta.Name,
-				profile.ObjectMeta.Namespace,
+				profile.Name,
+				profile.Namespace,
 				err,
 			)
 			timeout = DefaultRouteTimeout


### PR DESCRIPTION
# Problem

When a route does not specify a timeout, the proxy-api defaults to the default
timeout and logs an error:

```
time="2019-02-13T16:29:12Z" level=error msg="failed to parse duration for route POST /io.linkerd.proxy.destination.Destination/GetProfile: time: invalid duration"
```

# Solution

We now check if a route timeout is blank. If it is not set, it is set to
`DefaultRouteTimeout`. If it is set, we try to parse it into a `Duration`.

A request was made to improve logging to include the service profile and
namespace as well.

# Validation

With valid service profiles installed, edit the `.yaml` to include an invalid
`timeout`:

```
...
name: GET /
timeout: foo
```

We should now see the following errors:

```
proxy-api time="2019-02-13T22:27:32Z" level=error msg="failed to parse duration for route 'GET /' in service profile 'webapp.default.svc.cluster.local' in namespace 'default': time: invalid duration foo"
```

This error does not show up when `timeout` is blank.

Fixes #2276

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
