### PR TITLE
Fix golangci-lint config to use default golint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ web/app/yarn-error.log
 .protoc
 .gorun
 .dep*
-.golangci*
+.golangci-lint*
 **.gogen*
 **/*.swp

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+issues:
+  exclude-use-default: false
+linters:
+  enable:
+  - gofmt
+  - golint
+  disable:
+  - deadcode
+  - errcheck
+  - gosimple
+  - staticcheck
+  - structcheck
+  - unused
+  - varcheck

--- a/bin/lint
+++ b/bin/lint
@@ -27,7 +27,4 @@ if [ ! -f "$lintbin" ]; then
   mv ./golangci-lint${exe} $lintbin
 fi
 
-$lintbin run \
-  --enable gofmt,golint \
-  --disable deadcode,errcheck,gosimple,staticcheck,structcheck,unused,varcheck \
-  "$@"
+$lintbin run "$@"


### PR DESCRIPTION
golangci-lint disables some checks for golint, including checks for
well-formed comments on all exported symbols

This change disables the golangci-lint's `exclude-use-default` setting,
to run golint with default settings.

Also introduce a `.golangci.yml` file to centralize config.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Fixes https://github.com/linkerd/linkerd2/pull/2239#discussion_r256675986

Verified comment checks are working:
```bash
$ bin/lint
controller/proxy-injector/webhook.go:28:6: exported type Webhook should have comment or be unexported (golint)
type Webhook struct {
     ^
```