### PR TITLE
identity/master: Disable identity hinting

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -57,7 +57,6 @@ printf "Testing Linkerd version [%s] namespace [%s]\\n" "$linkerd_version" "$lin
 exit_code=0
 
 run_test "$test_directory/install_test.go" || exit_code=$?
-run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
 run_test "$test_directory/install_test.go" "-single-namespace" || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?

--- a/chart/templates/base.yaml
+++ b/chart/templates/base.yaml
@@ -206,7 +206,6 @@ spec:
         - "-addr=:{{.Values.DestinationAPIPort}}"
         - "-controller-namespace={{.Values.Namespace}}"
         - "-single-namespace={{.Values.SingleNamespace}}"
-        - "-enable-tls={{.Values.EnableTLS}}"
         - "-enable-h2-upgrade={{.Values.EnableH2Upgrade}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
         livenessProbe:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -173,7 +173,6 @@ spec:
         - -addr=:8086
         - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -176,7 +176,6 @@ spec:
         - -addr=:8086
         - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -176,7 +176,6 @@ spec:
         - -addr=:8086
         - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -173,7 +173,6 @@ spec:
         - -addr=:8086
         - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -175,7 +175,6 @@ spec:
         - -addr=:8086
         - -controller-namespace=linkerd
         - -single-namespace=false
-        - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -176,7 +176,6 @@ spec:
         - -addr=:123
         - -controller-namespace=Namespace
         - -single-namespace=false
-        - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
         image: ControllerImage

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -173,7 +173,6 @@ spec:
         - -addr=:123
         - -controller-namespace=Namespace
         - -single-namespace=true
-        - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
         image: ControllerImage

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -20,7 +20,6 @@ type server struct {
 	k8sAPI          *k8s.API
 	resolver        streamingDestinationResolver
 	enableH2Upgrade bool
-	enableTLS       bool
 	log             *log.Entry
 }
 
@@ -39,7 +38,7 @@ type server struct {
 func NewServer(
 	addr, k8sDNSZone string,
 	controllerNamespace string,
-	enableTLS, enableH2Upgrade, singleNamespace bool,
+	enableH2Upgrade, singleNamespace bool,
 	k8sAPI *k8s.API,
 	done chan struct{},
 ) (*grpc.Server, error) {
@@ -52,7 +51,6 @@ func NewServer(
 		k8sAPI:          k8sAPI,
 		resolver:        resolver,
 		enableH2Upgrade: enableH2Upgrade,
-		enableTLS:       enableTLS,
 		log: log.WithFields(log.Fields{
 			"addr":      addr,
 			"component": "server",
@@ -150,7 +148,7 @@ func (s *server) Endpoints(ctx context.Context, params *discovery.EndpointsParam
 }
 
 func (s *server) streamResolution(host string, port int, stream pb.Destination_GetServer) error {
-	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableTLS, s.enableH2Upgrade)
+	listener := newEndpointListener(stream, s.k8sAPI.GetOwnerKindAndName, s.enableH2Upgrade)
 
 	resolverCanResolve, err := s.resolver.canResolve(host, port)
 	if err != nil {

--- a/controller/api/destination/test_helper.go
+++ b/controller/api/destination/test_helper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -146,7 +146,7 @@ func InitFakeDiscoveryServer(t *testing.T, k8sAPI *k8s.API) (discovery.Discovery
 	lis := bufconn.Listen(1024 * 1024)
 	gRPCServer, err := NewServer(
 		"fake-addr", "", "controller-ns",
-		false, false, false, k8sAPI, nil,
+		false, false, k8sAPI, nil,
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -21,7 +21,6 @@ func main() {
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	k8sDNSZone := flag.String("kubernetes-dns-zone", "", "The DNS suffix for the local Kubernetes zone.")
 	enableH2Upgrade := flag.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
-	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	flags.ConfigureAndParse()
@@ -63,7 +62,7 @@ func main() {
 		log.Fatalf("Failed to listen on %s: %s", *addr, err)
 	}
 
-	server, err := destination.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, *singleNamespace, k8sAPI, done)
+	server, err := destination.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableH2Upgrade, *singleNamespace, k8sAPI, done)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -81,10 +81,6 @@ func TestInstall(t *testing.T) {
 		"--proxy-log-level", "warn,linkerd2_proxy=debug",
 		"--linkerd-version", TestHelper.GetVersion(),
 	}
-	if TestHelper.TLS() {
-		cmd = append(cmd, []string{"--tls", "optional"}...)
-		linkerdDeployReplicas["linkerd-ca"] = 1
-	}
 	if TestHelper.SingleNamespace() {
 		cmd = append(cmd, "--single-namespace")
 	}
@@ -183,9 +179,6 @@ func TestDashboard(t *testing.T) {
 
 func TestInject(t *testing.T) {
 	cmd := []string{"inject", "testdata/smoke_test.yaml"}
-	if TestHelper.TLS() {
-		cmd = append(cmd, []string{"--tls", "optional"}...)
-	}
 
 	out, injectReport, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -21,7 +21,6 @@ type TestHelper struct {
 	version         string
 	namespace       string
 	singleNamespace bool
-	tls             bool
 	httpClient      http.Client
 	KubernetesHelper
 }
@@ -37,7 +36,6 @@ func NewTestHelper() *TestHelper {
 	linkerd := flag.String("linkerd", "", "path to the linkerd binary to test")
 	namespace := flag.String("linkerd-namespace", "l5d-integration", "the namespace where linkerd is installed")
 	singleNamespace := flag.Bool("single-namespace", false, "configure the control plane to only operate in the installed namespace")
-	tls := flag.Bool("enable-tls", false, "enable TLS in tests")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
 	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	flag.Parse()
@@ -66,9 +64,6 @@ func NewTestHelper() *TestHelper {
 	}
 
 	ns := *namespace
-	if *tls {
-		ns += "-tls"
-	}
 	if *singleNamespace {
 		ns += "-single-namespace"
 	}
@@ -77,7 +72,6 @@ func NewTestHelper() *TestHelper {
 		linkerd:         *linkerd,
 		namespace:       ns,
 		singleNamespace: *singleNamespace,
-		tls:             *tls,
 	}
 
 	version, _, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -119,11 +113,6 @@ func (h *TestHelper) GetTestNamespace(testName string) string {
 		return h.namespace
 	}
 	return h.namespace + "-" + testName
-}
-
-// TLS returns whether or not TLS is enabled for the given test.
-func (h *TestHelper) TLS() bool {
-	return h.tls
 }
 
 // SingleNamespace returns whether --single-namespace is enabled for the given test or not.


### PR DESCRIPTION
The destination service's identity hinting is going to change
substantially with the new identity system.

While we're in a transitionary state, let's just disable identity
hinting entirely until the new system is in place.

Relates to #2217