### PR TITLE
gitignore: Fix invalid glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ web/app/yarn-error.log
 .gorun
 .dep*
 .golangci-lint*
-**.gogen*
+**/*.gogen*
 **/*.swp


### PR DESCRIPTION
66070c26 introduced an invalid glob, causing tools like rg(1) to emit
warnings like:

    ./.gitignore: line 17: error parsing glob '**.gogen*': invalid use of **; must be one path component