### PR TITLE
Add discovery package for managing discovery API

### DIFF
--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -12,7 +12,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -94,11 +94,11 @@ requests.`,
 	return cmd
 }
 
-func requestEndpointsFromAPI(client public.APIClient) (*discovery.EndpointsResponse, error) {
-	return client.Endpoints(context.Background(), &discovery.EndpointsParams{})
+func requestEndpointsFromAPI(client public.APIClient) (*pb.EndpointsResponse, error) {
+	return client.Endpoints(context.Background(), &pb.EndpointsParams{})
 }
 
-func renderEndpoints(endpoints *discovery.EndpointsResponse, options *endpointsOptions) string {
+func renderEndpoints(endpoints *pb.EndpointsResponse, options *endpointsOptions) string {
 	var buffer bytes.Buffer
 	w := tabwriter.NewWriter(&buffer, 0, 0, padding, ' ', 0)
 	writeEndpointsToBuffer(endpoints, w, options)
@@ -116,7 +116,7 @@ type rowEndpoint struct {
 	Service   string `json:"service"`
 }
 
-func writeEndpointsToBuffer(endpoints *discovery.EndpointsResponse, w *tabwriter.Writer, options *endpointsOptions) {
+func writeEndpointsToBuffer(endpoints *pb.EndpointsResponse, w *tabwriter.Writer, options *endpointsOptions) {
 	maxPodLength := len(podHeader)
 	maxNamespaceLength := len(namespaceHeader)
 	endpointsTables := map[string][]rowEndpoint{}

--- a/cli/cmd/endpoints_test.go
+++ b/cli/cmd/endpoints_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"github.com/linkerd/linkerd2/controller/api/discovery"
 	"github.com/linkerd/linkerd2/controller/api/public"
 )
 
@@ -52,11 +53,11 @@ func TestEndpoints(t *testing.T) {
 }
 
 func testEndpointsCall(exp endpointsExp, t *testing.T) {
-	mockClient := &public.MockAPIClient{}
-
-	response := public.GenEndpointsResponse(exp.identities)
-
-	mockClient.EndpointsResponseToReturn = &response
+	mockClient := &public.MockAPIClient{
+		MockDiscoveryClient: &discovery.MockDiscoveryClient{
+			EndpointsResponseToReturn: discovery.GenEndpointsResponse(exp.identities),
+		},
+	}
 
 	endpoints, err := requestEndpointsFromAPI(mockClient)
 	if err != nil {

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -63,7 +63,7 @@ func NewServer(
 
 	// this server satisfies 2 gRPC interfaces:
 	// 1) linkerd2-proxy-api/destination.Destination (proxy-facing)
-	// 2) controller/discovery.Destination (controller-facing)
+	// 2) controller/discovery.Discovery (controller-facing)
 	pb.RegisterDestinationServer(s, &srv)
 	discoveryPb.RegisterDiscoveryServer(s, &srv)
 

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -8,7 +8,7 @@ import (
 
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	"github.com/linkerd/linkerd2/controller/api/util"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
@@ -63,9 +63,9 @@ func NewServer(
 
 	// this server satisfies 2 gRPC interfaces:
 	// 1) linkerd2-proxy-api/destination.Destination (proxy-facing)
-	// 2) controller/discovery.Api (controller-facing)
+	// 2) controller/discovery.Destination (controller-facing)
 	pb.RegisterDestinationServer(s, &srv)
-	discovery.RegisterDiscoveryServer(s, &srv)
+	discoveryPb.RegisterDiscoveryServer(s, &srv)
 
 	go func() {
 		<-done
@@ -108,22 +108,22 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 	return err
 }
 
-func (s *server) Endpoints(ctx context.Context, params *discovery.EndpointsParams) (*discovery.EndpointsResponse, error) {
+func (s *server) Endpoints(ctx context.Context, params *discoveryPb.EndpointsParams) (*discoveryPb.EndpointsResponse, error) {
 	s.log.Debugf("Endpoints(%+v)", params)
 
 	servicePorts := s.resolver.getState()
 
-	rsp := discovery.EndpointsResponse{
-		ServicePorts: make(map[string]*discovery.ServicePort),
+	rsp := discoveryPb.EndpointsResponse{
+		ServicePorts: make(map[string]*discoveryPb.ServicePort),
 	}
 
 	for serviceID, portMap := range servicePorts {
-		discoverySP := discovery.ServicePort{
-			PortEndpoints: make(map[uint32]*discovery.PodAddresses),
+		discoverySP := discoveryPb.ServicePort{
+			PortEndpoints: make(map[uint32]*discoveryPb.PodAddresses),
 		}
 		for port, sp := range portMap {
-			podAddrs := discovery.PodAddresses{
-				PodAddresses: []*discovery.PodAddress{},
+			podAddrs := discoveryPb.PodAddresses{
+				PodAddresses: []*discoveryPb.PodAddress{},
 			}
 
 			for _, ua := range sp.addresses {
@@ -132,7 +132,7 @@ func (s *server) Endpoints(ctx context.Context, params *discovery.EndpointsParam
 
 				podAddrs.PodAddresses = append(
 					podAddrs.PodAddresses,
-					&discovery.PodAddress{
+					&discoveryPb.PodAddress{
 						Addr: addr.NetToPublic(ua.address),
 						Pod:  &pod,
 					},

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -3,13 +3,17 @@ package destination
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 type mockDestinationServer struct {
@@ -151,18 +155,41 @@ func TestEndpoints(t *testing.T) {
 	}
 	k8sAPI.Sync()
 
-	discoveryClient, gRPCServer, proxyAPIConn := InitFakeDiscoveryServer(t, k8sAPI)
+	lis := bufconn.Listen(1024 * 1024)
+	gRPCServer, err := NewServer(
+		"fake-addr", "", "controller-ns",
+		false, false, false, k8sAPI, nil,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 	defer gRPCServer.GracefulStop()
-	defer proxyAPIConn.Close()
+	go func() { gRPCServer.Serve(lis) }()
+
+	destinationAPIConn, err := grpc.Dial(
+		"fake-buf-addr",
+		grpc.WithDialer(
+			func(string, time.Duration) (net.Conn, error) {
+				return lis.Dial()
+			},
+		),
+		grpc.WithInsecure(),
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	defer destinationAPIConn.Close()
+
+	discoveryClient := discoveryPb.NewDiscoveryClient(destinationAPIConn)
 
 	t.Run("Implements the Discovery interface", func(t *testing.T) {
-		resp, err := discoveryClient.Endpoints(context.Background(), &discovery.EndpointsParams{})
+		resp, err := discoveryClient.Endpoints(context.Background(), &discoveryPb.EndpointsParams{})
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
 
-		expectedResp := &discovery.EndpointsResponse{
-			ServicePorts: make(map[string]*discovery.ServicePort),
+		expectedResp := &discoveryPb.EndpointsResponse{
+			ServicePorts: make(map[string]*discoveryPb.ServicePort),
 		}
 
 		if !proto.Equal(resp, expectedResp) {

--- a/controller/api/discovery/client.go
+++ b/controller/api/discovery/client.go
@@ -1,0 +1,17 @@
+package discovery
+
+import (
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	"google.golang.org/grpc"
+)
+
+// NewClient creates a client for control plane APIs that implement the
+// Discovery service. This includes the public API and the destination API.
+func NewClient(addr string) (pb.DiscoveryClient, *grpc.ClientConn, error) {
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pb.NewDiscoveryClient(conn), conn, nil
+}

--- a/controller/api/discovery/test_helper.go
+++ b/controller/api/discovery/test_helper.go
@@ -1,0 +1,59 @@
+package discovery
+
+import (
+	"context"
+	"strings"
+
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	"github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/addr"
+	"google.golang.org/grpc"
+)
+
+// MockDiscoveryClient satisfies the Discovery API's gRPC interface
+// (discovery.DiscoveryClient).
+type MockDiscoveryClient struct {
+	ErrorToReturn             error
+	EndpointsResponseToReturn *pb.EndpointsResponse
+}
+
+// Endpoints provides a mock of a Discovery API method.
+func (c *MockDiscoveryClient) Endpoints(ctx context.Context, in *pb.EndpointsParams, _ ...grpc.CallOption) (*pb.EndpointsResponse, error) {
+	return c.EndpointsResponseToReturn, c.ErrorToReturn
+}
+
+// GenEndpointsResponse generates a mock Public API Endpoints object.
+// identities is a list of "pod.namespace" strings
+func GenEndpointsResponse(identities []string) *pb.EndpointsResponse {
+	resp := &pb.EndpointsResponse{
+		ServicePorts: make(map[string]*pb.ServicePort),
+	}
+	for _, identity := range identities {
+		parts := strings.SplitN(identity, ".", 2)
+		pod := parts[0]
+		ns := parts[1]
+		ip, _ := addr.ParsePublicIPV4("1.2.3.4")
+		resp.ServicePorts[identity] = &pb.ServicePort{
+			PortEndpoints: map[uint32]*pb.PodAddresses{
+				8080: {
+					PodAddresses: []*pb.PodAddress{
+						{
+							Addr: &public.TcpAddress{
+								Ip:   ip,
+								Port: 8080,
+							},
+							Pod: &public.Pod{
+								Name:            ns + "/" + pod,
+								Status:          "running",
+								PodIP:           "1.2.3.4",
+								ResourceVersion: "1234",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return resp
+}

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
@@ -28,12 +28,12 @@ const (
 
 // APIClient wraps two gRPC client interfaces:
 // 1) public.Api
-// 2) controller/discovery.Api
+// 2) controller/discovery.Discovery
 // This aligns with Public API Server's `handler` struct supporting both gRPC
 // servers.
 type APIClient interface {
 	pb.ApiClient
-	discovery.DiscoveryClient
+	discoveryPb.DiscoveryClient
 }
 
 type grpcOverHTTPClient struct {
@@ -103,8 +103,8 @@ func (c *grpcOverHTTPClient) TapByResource(ctx context.Context, req *pb.TapByRes
 	return &tapClient{ctx: ctx, reader: bufio.NewReader(httpRsp.Body)}, nil
 }
 
-func (c *grpcOverHTTPClient) Endpoints(ctx context.Context, req *discovery.EndpointsParams, _ ...grpc.CallOption) (*discovery.EndpointsResponse, error) {
-	var msg discovery.EndpointsResponse
+func (c *grpcOverHTTPClient) Endpoints(ctx context.Context, req *discoveryPb.EndpointsParams, _ ...grpc.CallOption) (*discoveryPb.EndpointsResponse, error) {
+	var msg discoveryPb.EndpointsResponse
 	err := c.apiRequest(ctx, "Endpoints", req, &msg)
 	return &msg, err
 }

--- a/controller/api/public/client_test.go
+++ b/controller/api/public/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 )
 
@@ -173,12 +173,12 @@ func TestEndpointsRequest(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	resp, err := client.Endpoints(context.Background(), &discovery.EndpointsParams{})
+	resp, err := client.Endpoints(context.Background(), &discoveryPb.EndpointsParams{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expectedResp := &discovery.EndpointsResponse{}
+	expectedResp := &discoveryPb.EndpointsResponse{}
 	if !proto.Equal(resp, expectedResp) {
 		t.Fatalf("Expected response [%v], got: [%v]", expectedResp, resp)
 	}

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/linkerd/linkerd2/controller/api/util"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	tapPb "github.com/linkerd/linkerd2/controller/gen/controller/tap"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -28,13 +28,13 @@ import (
 // APIServer specifies the interface the Public API server should implement
 type APIServer interface {
 	pb.ApiServer
-	discovery.DiscoveryServer
+	discoveryPb.DiscoveryServer
 }
 
 type grpcServer struct {
 	prometheusAPI       promv1.API
 	tapClient           tapPb.TapClient
-	discoveryClient     discovery.DiscoveryClient
+	discoveryClient     discoveryPb.DiscoveryClient
 	k8sAPI              *k8s.API
 	controllerNamespace string
 	ignoredNamespaces   []string
@@ -57,7 +57,7 @@ const (
 func newGrpcServer(
 	promAPI promv1.API,
 	tapClient tapPb.TapClient,
-	discoveryClient discovery.DiscoveryClient,
+	discoveryClient discoveryPb.DiscoveryClient,
 	k8sAPI *k8s.API,
 	controllerNamespace string,
 	ignoredNamespaces []string,
@@ -277,12 +277,12 @@ func (s *grpcServer) ListServices(ctx context.Context, req *pb.ListServicesReque
 	return &pb.ListServicesResponse{Services: svcs}, nil
 }
 
-func (s *grpcServer) Endpoints(ctx context.Context, params *discovery.EndpointsParams) (*discovery.EndpointsResponse, error) {
-	log.Debugf("Endpoints request %+v", params)
+func (s *grpcServer) Endpoints(ctx context.Context, params *discoveryPb.EndpointsParams) (*discoveryPb.EndpointsResponse, error) {
+	log.Debugf("Endpoints request: %+v", params)
 
 	rsp, err := s.discoveryClient.Endpoints(ctx, params)
 	if err != nil {
-		log.Errorf("endpoints request to proxy API failed: %s", err)
+		log.Errorf("endpoints request to destination API failed: %s", err)
 		return nil, err
 	}
 

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/duration"
-	"github.com/linkerd/linkerd2/controller/api/destination"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
-	tap "github.com/linkerd/linkerd2/controller/gen/controller/tap"
+	"github.com/linkerd/linkerd2/controller/api/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
@@ -402,8 +401,8 @@ status:
 
 			fakeGrpcServer := newGrpcServer(
 				&mProm,
-				tap.NewTapClient(nil),
-				discovery.NewDiscoveryClient(nil),
+				nil,
+				nil,
 				k8sAPI,
 				"linkerd",
 				[]string{},
@@ -462,6 +461,7 @@ func listServiceResponsesEqual(a pb.ListServicesResponse, b pb.ListServicesRespo
 
 	return true
 }
+
 func TestListServices(t *testing.T) {
 	t.Run("Successfully queryies for services", func(t *testing.T) {
 		expectations := []listServicesExpected{
@@ -504,8 +504,8 @@ metadata:
 
 			fakeGrpcServer := newGrpcServer(
 				&mockProm{},
-				tap.NewTapClient(nil),
-				discovery.NewDiscoveryClient(nil),
+				nil,
+				nil,
 				k8sAPI,
 				"linkerd",
 				[]string{},
@@ -528,8 +528,8 @@ metadata:
 
 type endpointsExpected struct {
 	err error
-	req *discovery.EndpointsParams
-	res *discovery.EndpointsResponse
+	req *discoveryPb.EndpointsParams
+	res *discoveryPb.EndpointsResponse
 }
 
 func TestEndpoints(t *testing.T) {
@@ -537,8 +537,8 @@ func TestEndpoints(t *testing.T) {
 		expectations := []endpointsExpected{
 			{
 				err: nil,
-				req: &discovery.EndpointsParams{},
-				res: &discovery.EndpointsResponse{},
+				req: &discoveryPb.EndpointsParams{},
+				res: &discoveryPb.EndpointsResponse{},
 			},
 		}
 
@@ -549,13 +549,13 @@ func TestEndpoints(t *testing.T) {
 			}
 			k8sAPI.Sync()
 
-			discoveryClient, gRPCServer, proxyAPIConn := destination.InitFakeDiscoveryServer(t, k8sAPI)
-			defer gRPCServer.GracefulStop()
-			defer proxyAPIConn.Close()
+			discoveryClient := &discovery.MockDiscoveryClient{
+				EndpointsResponseToReturn: exp.res,
+			}
 
 			fakeGrpcServer := newGrpcServer(
 				&mockProm{},
-				tap.NewTapClient(nil),
+				nil,
 				discoveryClient,
 				k8sAPI,
 				"linkerd",

--- a/controller/api/public/http_server_test.go
+++ b/controller/api/public/http_server_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	healcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 )
 
@@ -77,9 +77,9 @@ func (m *mockGrpcServer) TapByResource(req *pb.TapByResourceRequest, tapServer p
 	return m.ErrorToReturn
 }
 
-func (m *mockGrpcServer) Endpoints(ctx context.Context, req *discovery.EndpointsParams) (*discovery.EndpointsResponse, error) {
+func (m *mockGrpcServer) Endpoints(ctx context.Context, req *discoveryPb.EndpointsParams) (*discoveryPb.EndpointsResponse, error) {
 	m.LastRequestReceived = req
-	return m.ResponseToReturn.(*discovery.EndpointsResponse), m.ErrorToReturn
+	return m.ResponseToReturn.(*discoveryPb.EndpointsResponse), m.ErrorToReturn
 }
 
 type grpcCallTestCase struct {
@@ -139,10 +139,10 @@ func TestServer(t *testing.T) {
 			functionCall: func() (proto.Message, error) { return client.Version(context.TODO(), versionReq) },
 		}
 
-		endpointsReq := &discovery.EndpointsParams{}
+		endpointsReq := &discoveryPb.EndpointsParams{}
 		testEndpoints := grpcCallTestCase{
 			expectedRequest:  endpointsReq,
-			expectedResponse: &discovery.EndpointsResponse{},
+			expectedResponse: &discoveryPb.EndpointsResponse{},
 			functionCall:     func() (proto.Message, error) { return client.Endpoints(context.TODO(), endpointsReq) },
 		}
 

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
-	tap "github.com/linkerd/linkerd2/controller/gen/controller/tap"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
@@ -957,8 +955,8 @@ status:
 		for _, exp := range expectations {
 			fakeGrpcServer := newGrpcServer(
 				&mockProm{Res: exp.mockPromResponse},
-				tap.NewTapClient(nil),
-				discovery.NewDiscoveryClient(nil),
+				nil,
+				nil,
 				k8sAPI,
 				"linkerd",
 				[]string{},
@@ -983,8 +981,8 @@ status:
 		}
 		fakeGrpcServer := newGrpcServer(
 			&mockProm{Res: model.Vector{}},
-			tap.NewTapClient(nil),
-			discovery.NewDiscoveryClient(nil),
+			nil,
+			nil,
 			k8sAPI,
 			"linkerd",
 			[]string{},

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -8,16 +8,15 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/linkerd/linkerd2/controller/api/discovery"
 	"github.com/linkerd/linkerd2/controller/api/public"
 	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/controller/tap"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	promApi "github.com/prometheus/client_golang/api"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 )
 
 func main() {
@@ -41,12 +40,11 @@ func main() {
 	}
 	defer tapConn.Close()
 
-	destinationAPIConn, err := grpc.Dial(*destinationAPIAddr, grpc.WithInsecure())
+	discoveryClient, discoveryConn, err := discovery.NewClient(*destinationAPIAddr)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	defer destinationAPIConn.Close()
-	discoveryClient := discovery.NewDiscoveryClient(destinationAPIConn)
+	defer discoveryConn.Close()
 
 	k8sClient, err := k8s.NewClientSet(*kubeConfigPath)
 	if err != nil {

--- a/controller/script/discovery-client/main.go
+++ b/controller/script/discovery-client/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/linkerd/linkerd2/controller/gen/controller/discovery"
+	"github.com/linkerd/linkerd2/controller/api/discovery"
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 )
 
 // This is a throwaway script for testing the destination service
@@ -17,13 +17,13 @@ func main() {
 	addr := flag.String("addr", ":8086", "address of destination service")
 	flag.Parse()
 
-	client, conn, err := newClient(*addr)
+	client, conn, err := discovery.NewClient(*addr)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 	defer conn.Close()
 
-	rsp, err := client.Endpoints(context.Background(), &discovery.EndpointsParams{})
+	rsp, err := client.Endpoints(context.Background(), &pb.EndpointsParams{})
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -33,14 +33,4 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-}
-
-// newClient creates a new gRPC client to the Proxy API service.
-func newClient(addr string) (discovery.DiscoveryClient, *grpc.ClientConn, error) {
-	conn, err := grpc.Dial(addr, grpc.WithInsecure())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return discovery.NewDiscoveryClient(conn), conn, nil
 }

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -11,7 +11,7 @@ import (
 	proxy "github.com/linkerd/linkerd2-proxy-api/go/tap"
 	apiUtil "github.com/linkerd/linkerd2/controller/api/util"
 	pb "github.com/linkerd/linkerd2/controller/gen/controller/tap"
-	public "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	public "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 )

--- a/proto/controller/discovery.proto
+++ b/proto/controller/discovery.proto
@@ -1,10 +1,10 @@
 // Experimental
 
-// gRPC interface, implemented by the Public and Proxy API component of the
-// control-plane. While primarily intended to be implemented by the Proxy API,
-// it is separated from `destination.Get` and related APIs, as those are
-// side-effecting and proxy-facing. Instead, this API is control-plane and
-// CLI-facing, and depends on types defined in `public.proto`.
+// gRPC interface, implemented by the Public and Destination API components of
+// the control-plane. While primarily intended to be implemented by the
+// Destination API, it is separated from `destination.Get` and related APIs, as
+// those are side-effecting and proxy-facing. Instead, this API is control-plane
+// and CLI-facing, and depends on types defined in `public.proto`.
 
 syntax = "proto3";
 


### PR DESCRIPTION
This is a follow-up to #2195, which introduced the discovery API for the public and proxy APIs, and #2281, which renamed the proxy API to the destination API. The original goal of this change was to update the public API package to stop importing the destination API package, by introducing a shared discovery API package on which they can both depend. Here's a full list of changes in this branch:

* Add a `controller/api/discovery` package for building the discovery client and providing test helpers
* Update public API main and discovery-client main to use the client builder from the discovery package
* Rename all imports of the discovery protobuf to `pb` or `discoveryPb`, which is more consistent with how we handle `tapPb` and `healthcheckPb`
* Update public API tests to use new discovery mock client, instead of using the client builder from the destination package
* Remove the `InitFakeDiscoveryServer` helper from the destination package, since it is only used in one test now
* Fix a bunch of remaining references to the proxy API in comments and variables