### PR TITLE
CLI help updates: non-experimental auto-inject

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -31,8 +31,8 @@ func newCmdCompletion() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:       "completion [bash|zsh]",
-		Short:     "Shell completion",
-		Long:      "Output completion code for the specified shell (bash or zsh).",
+		Short:     "Output shell completion code for the specified shell (bash or zsh)",
+		Long:      "Output shell completion code for the specified shell (bash or zsh).",
 		Example:   example,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: []string{"bash", "zsh"},

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -133,11 +133,11 @@ func newCmdInstall() *cobra.Command {
 	addProxyConfigFlags(cmd, options.proxyConfigOptions)
 	cmd.PersistentFlags().UintVar(&options.controllerReplicas, "controller-replicas", options.controllerReplicas, "Replicas of the controller to deploy")
 	cmd.PersistentFlags().StringVar(&options.controllerLogLevel, "controller-log-level", options.controllerLogLevel, "Log level for the controller and web components")
-	cmd.PersistentFlags().BoolVar(&options.proxyAutoInject, "proxy-auto-inject", options.proxyAutoInject, "Experimental: Enable proxy sidecar auto-injection webhook (default false)")
+	cmd.PersistentFlags().BoolVar(&options.proxyAutoInject, "proxy-auto-inject", options.proxyAutoInject, "Enable proxy sidecar auto-injection via a webhook (default false)")
 	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "Experimental: Configure the control plane to only operate in the installed namespace (default false)")
-	cmd.PersistentFlags().BoolVar(&options.highAvailability, "ha", options.highAvailability, "Experimental: Enable HA deployment config for the control plane")
+	cmd.PersistentFlags().BoolVar(&options.highAvailability, "ha", options.highAvailability, "Experimental: Enable HA deployment config for the control plane (default false)")
 	cmd.PersistentFlags().Int64Var(&options.controllerUID, "controller-uid", options.controllerUID, "Run the control plane components under this user ID")
-	cmd.PersistentFlags().BoolVar(&options.disableH2Upgrade, "disable-h2-upgrade", options.disableH2Upgrade, "Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading")
+	cmd.PersistentFlags().BoolVar(&options.disableH2Upgrade, "disable-h2-upgrade", options.disableH2Upgrade, "Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)")
 	return cmd
 }
 


### PR DESCRIPTION
A few tweaks to our CLI help text, as follows:

* Removes the "experimental" text from the `--proxy-auto-inject` install flag (fixes #2311)
* ~~Unhides the `linkerd install-cni` command and `--linkerd-cni-enabled` flag and ensures that they're labeled as experimental~~
* Rewords the short and long descriptions for the `linkerd completion` command