### PR TITLE
Ensure shared tooltips in Linkerd Health dashboard

### DIFF
--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -90,7 +90,7 @@
       "timeShift": null,
       "title": "MEMORY USAGE",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 2,
         "value_type": "individual"
       },
@@ -174,7 +174,7 @@
       "timeShift": null,
       "title": "CPU USAGE",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 2,
         "value_type": "individual"
       },
@@ -258,7 +258,7 @@
       "timeShift": null,
       "title": "OPEN FILE DESCRIPTORS",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 2,
         "value_type": "individual"
       },


### PR DESCRIPTION
All Grafana graphs use shared tooltips (display all series in the
tooltip rather than the one currently moused-over), except for 3 graphs
in the Linkerd Health dashboard.

This change ensures all tooltips are shared.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>