### PR TITLE
Fix egress integration test to accomodate httpbin

### DIFF
--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -77,9 +77,10 @@ func TestEgressHttp(t *testing.T) {
 			var messagePayload map[string]interface{}
 			json.Unmarshal([]byte(payloadText.(string)), &messagePayload)
 
+			expectedResponseURL := fmt.Sprintf("https://%s/%s", dnsName, strings.ToLower(methodToUse))
 			actualURL := messagePayload["url"]
-			if actualURL != expectedURL {
-				t.Fatalf("Expecting response to say egress sent [%s] request to URL [%s] but got [%s]. Response:\n%s\n", methodToUse, expectedURL, actualURL, output)
+			if actualURL != expectedResponseURL {
+				t.Fatalf("Expecting response to say egress sent [%s] request to URL [%s] but got [%s]. Response:\n%s\n", methodToUse, expectedResponseURL, actualURL, output)
 			}
 		})
 	}


### PR DESCRIPTION
The httpbin responses recently started returning `url` fields starting
with `https`, regardless of the protocol used in the request.

This change modifies the egress integration test to always expect
`https` in the `url` response field.

This is a workaround until #2316 is implemented.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>