### PR TITLE
pkg/tls: Make it possible to load a CA from disk

### DIFF
--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -111,7 +111,7 @@ func (c *CertificateController) syncNamespace(ns string) error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: pkgK8s.TLSTrustAnchorConfigMapName},
 		Data: map[string]string{
-			pkgK8s.TLSTrustAnchorFileName: tls.EncodeCertificatesPEM(c.ca.Certificate()),
+			pkgK8s.TLSTrustAnchorFileName: tls.EncodeCertificatesPEM(c.ca.Crt().Certificate),
 		},
 	}
 

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -111,7 +111,7 @@ func (c *CertificateController) syncNamespace(ns string) error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: pkgK8s.TLSTrustAnchorConfigMapName},
 		Data: map[string]string{
-			pkgK8s.TLSTrustAnchorFileName: c.ca.Cred.Crt.EncodeCertificatePEM(),
+			pkgK8s.TLSTrustAnchorFileName: c.ca.Cred.EncodeCertificatePEM(),
 		},
 	}
 

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -154,7 +154,7 @@ func (c *CertificateController) syncSecret(key string) error {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: secretName},
 		Data: map[string][]byte{
-			pkgK8s.TLSCertFileName:       cred.Crt.Certificate.Raw,
+			pkgK8s.TLSCertFileName:       cred.Certificate.Raw,
 			pkgK8s.TLSPrivateKeyFileName: pk,
 		},
 	}

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -111,7 +111,7 @@ func (c *CertificateController) syncNamespace(ns string) error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: pkgK8s.TLSTrustAnchorConfigMapName},
 		Data: map[string]string{
-			pkgK8s.TLSTrustAnchorFileName: tls.EncodeCertificatesPEM(c.ca.Crt().Certificate),
+			pkgK8s.TLSTrustAnchorFileName: c.ca.Cred.Crt.EncodeCertificatePEM(),
 		},
 	}
 

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatalf("failed to initialize Kubernetes client: %s", err)
 	}
 
-	rootCA, err := tls.NewCA()
+	rootCA, err := tls.GenerateRootCA("Proxy Injector Mutating Webhook Admission Controller CA")
 	if err != nil {
 		log.Fatalf("failed to create root CA: %s", err)
 	}

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatalf("failed to initialize Kubernetes client: %s", err)
 	}
 
-	rootCA, err := tls.GenerateRootCA("Proxy Injector Mutating Webhook Admission Controller CA")
+	rootCA, err := tls.GenerateRootCAWithDefaults("Proxy Injector Mutating Webhook Admission Controller CA")
 	if err != nil {
 		log.Fatalf("failed to create root CA: %s", err)
 	}

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -85,20 +85,20 @@ func tlsConfig(rootCA *pkgTls.CA, controllerNamespace string) (*tls.Config, erro
 		ControllerNamespace: controllerNamespace,
 	}
 	dnsName := tlsIdentity.ToDNSName()
-	endEntity, err := rootCA.GenerateEndEntity(dnsName)
+	cred, err := rootCA.GenerateEndEntityCred(dnsName)
 	if err != nil {
 		return nil, err
 	}
 
-	certPEM := endEntity.EncodePEM()
+	certPEM := cred.EncodeCertificateAndTrustChainPEM()
 	log.Debugf("PEM-encoded certificate: %s\n", certPEM)
 
-	keyPEM, err := pkgTls.EncodePrivateKeyPEM(endEntity.PrivateKey)
+	keyPEM, err := cred.EncodePrivateKeyPEM()
 	if err != nil {
 		return nil, err
 	}
 
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -85,18 +85,15 @@ func tlsConfig(rootCA *pkgTls.CA, controllerNamespace string) (*tls.Config, erro
 		ControllerNamespace: controllerNamespace,
 	}
 	dnsName := tlsIdentity.ToDNSName()
-	certAndPrivateKey, err := rootCA.IssueEndEntityCertificate(dnsName)
+	endEntity, err := rootCA.GenerateEndEntity(dnsName)
 	if err != nil {
 		return nil, err
 	}
 
-	certPEM, err := certAndPrivateKey.EncodedCertificate()
-	if err != nil {
-		return nil, err
-	}
+	certPEM := endEntity.EncodePEM()
 	log.Debugf("PEM-encoded certificate: %s\n", certPEM)
 
-	keyPEM, err := certAndPrivateKey.EncodedPrivateKey()
+	keyPEM, err := pkgTls.EncodePrivateKeyPEM(endEntity.PrivateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -90,14 +90,10 @@ func tlsConfig(rootCA *pkgTls.CA, controllerNamespace string) (*tls.Config, erro
 		return nil, err
 	}
 
-	certPEM := cred.EncodeCertificateAndTrustChainPEM()
+	certPEM := cred.EncodePEM()
 	log.Debugf("PEM-encoded certificate: %s\n", certPEM)
 
-	keyPEM, err := cred.EncodePrivateKeyPEM()
-	if err != nil {
-		return nil, err
-	}
-
+	keyPEM := cred.EncodePrivateKeyPEM()
 	cert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
 	if err != nil {
 		return nil, err

--- a/controller/proxy-injector/server_test.go
+++ b/controller/proxy-injector/server_test.go
@@ -76,7 +76,7 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestNewWebhookServer(t *testing.T) {
-	rootCA, err := tls.GenerateRootCA("Test CA")
+	rootCA, err := tls.GenerateRootCAWithDefaults("Test CA")
 	if err != nil {
 		log.Fatalf("failed to create root CA: %s", err)
 	}

--- a/controller/proxy-injector/server_test.go
+++ b/controller/proxy-injector/server_test.go
@@ -76,7 +76,7 @@ func TestShutdown(t *testing.T) {
 }
 
 func TestNewWebhookServer(t *testing.T) {
-	rootCA, err := tls.NewCA()
+	rootCA, err := tls.GenerateRootCA("Test CA")
 	if err != nil {
 		log.Fatalf("failed to create root CA: %s", err)
 	}

--- a/controller/proxy-injector/webhook_config.go
+++ b/controller/proxy-injector/webhook_config.go
@@ -27,7 +27,7 @@ type WebhookConfig struct {
 
 // NewWebhookConfig returns a new instance of initiator.
 func NewWebhookConfig(client kubernetes.Interface, controllerNamespace, webhookServiceName string, rootCA *tls.CA) (*WebhookConfig, error) {
-	trustAnchor := rootCA.Crt().EncodeCertificatePEM()
+	trustAnchor := rootCA.Cred.Crt.EncodeCertificatePEM()
 
 	t := template.New(k8sPkg.ProxyInjectorWebhookConfig)
 

--- a/controller/proxy-injector/webhook_config.go
+++ b/controller/proxy-injector/webhook_config.go
@@ -27,7 +27,7 @@ type WebhookConfig struct {
 
 // NewWebhookConfig returns a new instance of initiator.
 func NewWebhookConfig(client kubernetes.Interface, controllerNamespace, webhookServiceName string, rootCA *tls.CA) (*WebhookConfig, error) {
-	trustAnchor := tls.EncodeCertificatesPEM(rootCA.Certificate())
+	trustAnchor := rootCA.Crt().EncodeCertificatePEM()
 
 	t := template.New(k8sPkg.ProxyInjectorWebhookConfig)
 

--- a/controller/proxy-injector/webhook_config.go
+++ b/controller/proxy-injector/webhook_config.go
@@ -27,7 +27,7 @@ type WebhookConfig struct {
 
 // NewWebhookConfig returns a new instance of initiator.
 func NewWebhookConfig(client kubernetes.Interface, controllerNamespace, webhookServiceName string, rootCA *tls.CA) (*WebhookConfig, error) {
-	trustAnchor := rootCA.Cred.Crt.EncodeCertificatePEM()
+	trustAnchor := rootCA.Cred.EncodeCertificatePEM()
 
 	t := template.New(k8sPkg.ProxyInjectorWebhookConfig)
 

--- a/controller/proxy-injector/webhook_config.go
+++ b/controller/proxy-injector/webhook_config.go
@@ -27,7 +27,7 @@ type WebhookConfig struct {
 
 // NewWebhookConfig returns a new instance of initiator.
 func NewWebhookConfig(client kubernetes.Interface, controllerNamespace, webhookServiceName string, rootCA *tls.CA) (*WebhookConfig, error) {
-	trustAnchor := []byte(rootCA.TrustAnchorPEM())
+	trustAnchor := tls.EncodeCertificatePEM(rootCA.Crt.Certificate)
 
 	t := template.New(k8sPkg.ProxyInjectorWebhookConfig)
 

--- a/controller/proxy-injector/webhook_config.go
+++ b/controller/proxy-injector/webhook_config.go
@@ -27,14 +27,14 @@ type WebhookConfig struct {
 
 // NewWebhookConfig returns a new instance of initiator.
 func NewWebhookConfig(client kubernetes.Interface, controllerNamespace, webhookServiceName string, rootCA *tls.CA) (*WebhookConfig, error) {
-	trustAnchor := tls.EncodeCertificatePEM(rootCA.Crt.Certificate)
+	trustAnchor := tls.EncodeCertificatesPEM(rootCA.Certificate())
 
 	t := template.New(k8sPkg.ProxyInjectorWebhookConfig)
 
 	return &WebhookConfig{
 		controllerNamespace: controllerNamespace,
 		webhookServiceName:  webhookServiceName,
-		trustAnchor:         trustAnchor,
+		trustAnchor:         []byte(trustAnchor),
 		configTemplate:      template.Must(t.Parse(tmpl.MutatingWebhookConfigurationSpec)),
 		k8sAPI:              client,
 	}, nil

--- a/controller/proxy-injector/webhook_config_test.go
+++ b/controller/proxy-injector/webhook_config_test.go
@@ -18,7 +18,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 	client := fake.NewClient("")
 
-	rootCA, err := tls.NewCA()
+	rootCA, err := tls.GenerateRootCA("Test CA")
 	if err != nil {
 		t.Fatalf("failed to create root CA: %s", err)
 	}

--- a/controller/proxy-injector/webhook_config_test.go
+++ b/controller/proxy-injector/webhook_config_test.go
@@ -18,7 +18,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 	client := fake.NewClient("")
 
-	rootCA, err := tls.GenerateRootCA("Test CA")
+	rootCA, err := tls.GenerateRootCAWithDefaults("Test CA")
 	if err != nil {
 		t.Fatalf("failed to create root CA: %s", err)
 	}

--- a/pkg/tls/ca.go
+++ b/pkg/tls/ca.go
@@ -11,44 +11,57 @@ import (
 	"time"
 )
 
-// CA provides a certificate authority for TLS-enabled installs.
-// Issuing certificates concurrently is not supported.
-type CA struct {
-	// validity is the duration for which issued certificates are valid. This
-	// is approximately cert.NotAfter - cert.NotBefore with some additional
-	// allowance for clock skew.
-	//
-	// Currently this is used for the CA's validity too, but nothing should
-	// assume that the CA's validity period is the same as issued certificates'
-	// validity.
-	validity time.Duration
+type (
+	// CA provides a certificate authority for TLS-enabled installs.
+	// Issuing certificates concurrently is not supported.
+	CA struct {
+		// cred contains the CA's credentials.
+		cred Cred
 
-	// clockSkewAllowance is the maximum supported clock skew. Everything that
-	// processes the certificates must have a system clock that is off by no
-	// more than this allowance in either direction.
-	clockSkewAllowance time.Duration
+		// Validity configures the NotBefore and NotAfter parameters for certificates
+		// issued by this CA.
+		//
+		// Currently this is used for the CA's validity too, but nothing should
+		// assume that the CA's validity period is the same as issued certificates'
+		// validity.
+		Validity Validity
 
-	// cred contains the CA's credentials.
-	cred Cred
+		// nextSerialNumber is the serial number of the next certificate to issue.
+		// Serial numbers must not be reused.
+		//
+		// It is assumed there is only one instance of CA and it is assumed that a
+		// given CA object isn't requested to issue certificates concurrently.
+		//
+		// For now we do not attempt to meet CABForum requirements (e.g. regarding
+		// randomness).
+		nextSerialNumber uint64
+	}
 
-	// nextSerialNumber is the serial number of the next certificate to issue.
-	// Serial numbers must not be reused.
-	//
-	// It is assumed there is only one instance of CA and it is assumed that a
-	// given CA object isn't requested to issue certificates concurrently.
-	//
-	// For now we do not attempt to meet CABForum requirements (e.g. regarding
-	// randomness).
-	nextSerialNumber uint64
-}
+	// Validity configures the expiry times of issued certificates.
+	Validity struct {
+		// Validity is the duration for which issued certificates are valid. This
+		// is approximately cert.NotAfter - cert.NotBefore with some additional
+		// allowance for clock skew.
+		//
+		// Currently this is used for the CA's validity too, but nothing should
+		// assume that the CA's validity period is the same as issued certificates'
+		// validity.
+		Lifetime time.Duration
+
+		// ClockSkewAllowance is the maximum supported clock skew. Everything that
+		// processes the certificates must have a system clock that is off by no
+		// more than this allowance in either direction.
+		ClockSkewAllowance time.Duration
+	}
+)
 
 const (
-	// DefaultValidity configures certificate validity.
+	// DefaultLifetime configures certificate validity.
 	//
 	// Initially all certificates will be valid for one year.
 	//
 	// TODO: Shorten the validity duration of CA and end-entity certificates downward.
-	DefaultValidity = (24 * 365) * time.Hour
+	DefaultLifetime = (24 * 365) * time.Hour
 
 	// DefaultClockSkewAllowance indicates the maximum allowed difference in clocks
 	// in the network.
@@ -63,66 +76,69 @@ const (
 	DefaultClockSkewAllowance = 2 * time.Hour
 )
 
-// SetClockSkewAllowance sets the maximum allowable time for a node's clock to skew.
-func (ca *CA) SetClockSkewAllowance(csa time.Duration) {
-	ca.clockSkewAllowance = csa
-}
-
-// SetValidity sets the lifetime for cettificates issued by this CA.
-func (ca *CA) SetValidity(v time.Duration) {
-	ca.validity = v
-}
-
-// NewCA initializes a new CA with default settings.
-func NewCA(cred Cred) *CA {
-	return &CA{
-		nextSerialNumber:   1,
-		clockSkewAllowance: DefaultClockSkewAllowance,
-		validity:           DefaultValidity,
-		cred:               cred,
+// DefaultValidity creates the default certificate validity
+func DefaultValidity() Validity {
+	return Validity{
+		Lifetime:           DefaultLifetime,
+		ClockSkewAllowance: DefaultClockSkewAllowance,
 	}
 }
 
+// NewCA initializes a new CA with default settings.
+func NewCA(cred Cred, validity Validity) *CA {
+	return &CA{cred, validity, uint64(1)}
+}
+
+// CreateRootCA configures a new root CA with the given settings
+func CreateRootCA(
+	name string,
+	key *ecdsa.PrivateKey,
+	validity Validity,
+) (*CA, error) {
+	// Configure the root certificate.
+	t := createTemplate(1, &key.PublicKey, validity)
+	t.Subject = pkix.Name{CommonName: name}
+	t.IsCA = true
+	t.MaxPathLen = -1
+	t.BasicConstraintsValid = true
+	t.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+
+	// Self-sign the root certificate.
+	crtb, err := x509.CreateCertificate(rand.Reader, t, t, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+	c, err := x509.ParseCertificate(crtb)
+	if err != nil {
+		return nil, err
+	}
+
+	// The Crt has an empty TrustChain because it's at the root.
+	cred := Cred{Crt: Crt{Certificate: c}, PrivateKey: key}
+	ca := NewCA(cred, validity)
+	ca.nextSerialNumber++ // Because we've already created the root cert.
+	return ca, nil
+}
+
+// GenerateKey creates a new P-256 ECDSA private key from the default random
+// source.
+func GenerateKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
 // GenerateRootCAWithDefaults generates a new root CA with default settings.
-func GenerateRootCAWithDefaults(name string) (ca *CA, err error) {
+func GenerateRootCAWithDefaults(name string) (*CA, error) {
 	// Generate a new root key.
 	key, err := GenerateKey()
 	if err != nil {
 		return nil, err
 	}
 
-	return CreateRootCA(key, name, DefaultClockSkewAllowance, DefaultValidity)
-}
-
-// CreateRootCA configures a new root CA with the given settings
-func CreateRootCA(key *ecdsa.PrivateKey, name string, clockSkewAllowance, validity time.Duration) (*CA, error) {
-	// Create a self-signed certificate with the new root key.
-	t := createTemplate(1, &key.PublicKey, DefaultClockSkewAllowance, DefaultValidity)
-	t.Subject = pkix.Name{CommonName: name}
-	t.IsCA = true
-	t.MaxPathLen = -1
-	t.BasicConstraintsValid = true
-	t.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
-	der, err := x509.CreateCertificate(rand.Reader, t, t, key.Public(), key)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := x509.ParseCertificate(der)
-	if err != nil {
-		return nil, err
-	}
-	// crt has an empty TrustChain because it's at the root.
-	crt := Crt{Certificate: c}
-
-	ca := NewCA(Cred{Crt: &crt, PrivateKey: key})
-	ca.SetClockSkewAllowance(clockSkewAllowance)
-	ca.SetValidity(validity)
-	return ca, nil
+	return CreateRootCA(name, key, DefaultValidity())
 }
 
 // GenerateCA generates a new intermdiary CA.
-func (ca *CA) GenerateCA(name string, maxPathLen int) (*CA, error) {
+func (ca *CA) GenerateCA(name string, validity Validity, maxPathLen int) (*CA, error) {
 	key, err := GenerateKey()
 	if err != nil {
 		return nil, err
@@ -135,17 +151,13 @@ func (ca *CA) GenerateCA(name string, maxPathLen int) (*CA, error) {
 	t.MaxPathLenZero = true // 0-values are actually 0
 	t.BasicConstraintsValid = true
 	t.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
-	crt, err := ca.cred.CreateCrt(t)
+	crt, err := ca.cred.SignCrt(t)
 	if err != nil {
 		return nil, err
 	}
 
-	ica := CA{
-		validity:           ca.validity,
-		clockSkewAllowance: ca.clockSkewAllowance,
-		cred:               Cred{Crt: crt, PrivateKey: key},
-	}
-	return &ica, nil
+	cred := Cred{Crt: *crt, PrivateKey: key}
+	return NewCA(cred, ca.Validity), nil
 }
 
 // GenerateEndEntityCred creates a new certificate that is valid for the
@@ -166,7 +178,7 @@ func (ca *CA) GenerateEndEntityCred(dnsName string) (*Cred, error) {
 		return nil, err
 	}
 
-	c := Cred{Crt: crt, PrivateKey: key}
+	c := Cred{Crt: *crt, PrivateKey: key}
 	return &c, nil
 }
 
@@ -187,34 +199,20 @@ func (ca *CA) SignEndEntityCrt(csr *x509.CertificateRequest) (*Crt, error) {
 	t.EmailAddresses = csr.EmailAddresses
 	t.IPAddresses = csr.IPAddresses
 	t.URIs = csr.URIs
-	return ca.cred.CreateCrt(t)
+
+	return ca.cred.SignCrt(t)
 }
 
-// Certificate returns this CA's certificate.
-func (ca *CA) Certificate() *x509.Certificate {
-	return ca.cred.Crt.Certificate
-}
-
-// CertPool returns a CertPool containing this CA's certificate and trust chain.
-func (ca *CA) CertPool() *x509.CertPool {
-	p := x509.NewCertPool()
-	p.AddCert(ca.cred.Crt.Certificate)
-	for _, c := range ca.cred.Crt.TrustChain {
-		p.AddCert(c)
-	}
-	return p
-}
-
-// TrustChain returns this CA's trust chain from root to leaf.
-func (ca *CA) TrustChain() []*x509.Certificate {
-	return ca.cred.Crt.TrustChain
+// Crt returns this CA's certificate and trust chain.
+func (ca *CA) Crt() *Crt {
+	return &ca.cred.Crt
 }
 
 // createTemplate returns a certificate t for a non-CA certificate with
 // no subject name, no subjectAltNames. The t can then be modified into
 // a (root) CA t or an end-entity t by the caller.
 func (ca *CA) createTemplate(pubkey *ecdsa.PublicKey) *x509.Certificate {
-	c := createTemplate(ca.nextSerialNumber, pubkey, ca.clockSkewAllowance, ca.validity)
+	c := createTemplate(ca.nextSerialNumber, pubkey, ca.Validity)
 	ca.nextSerialNumber++
 	return c
 }
@@ -224,8 +222,8 @@ func (ca *CA) createTemplate(pubkey *ecdsa.PublicKey) *x509.Certificate {
 // a (root) CA t or an end-entity t by the caller.
 func createTemplate(
 	serialNumber uint64,
-	pubkey *ecdsa.PublicKey,
-	clockSkewAllowance, validity time.Duration,
+	k *ecdsa.PublicKey,
+	v Validity,
 ) *x509.Certificate {
 	// ECDSA is used instead of RSA because ECDSA key generation is
 	// straightforward and fast whereas RSA key generation is extremely slow
@@ -240,14 +238,14 @@ func createTemplate(
 	// anyway since a P-256 scalar is only 256 bits long.
 	const SignatureAlgorithm = x509.ECDSAWithSHA256
 
-	notBefore := time.Now()
+	notBefore, notAfter := v.Window(time.Now())
 
 	return &x509.Certificate{
 		SerialNumber:       big.NewInt(int64(serialNumber)),
 		SignatureAlgorithm: SignatureAlgorithm,
-		NotBefore:          notBefore.Add(-clockSkewAllowance),
-		NotAfter:           notBefore.Add(validity).Add(clockSkewAllowance),
-		PublicKey:          pubkey,
+		NotBefore:          notBefore,
+		NotAfter:           notAfter,
+		PublicKey:          k,
 		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageServerAuth,
@@ -256,8 +254,9 @@ func createTemplate(
 	}
 }
 
-// GenerateKey creates a new P-256 ECDSA private key from the default random
-// source.
-func GenerateKey() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// Window returns the time window for which a certificate should be valid.
+func (v *Validity) Window(t time.Time) (time.Time, time.Time) {
+	start := t.Add(-v.ClockSkewAllowance)
+	end := t.Add(v.Lifetime).Add(v.ClockSkewAllowance)
+	return start, end
 }

--- a/pkg/tls/ca.go
+++ b/pkg/tls/ca.go
@@ -106,7 +106,7 @@ func CreateRootCA(
 	}
 
 	// The Crt has an empty TrustChain because it's at the root.
-	cred := Cred{Crt: Crt{Certificate: c}, PrivateKey: key}
+	cred := validCredOrPanic(key, Crt{Certificate: c})
 	ca := NewCA(cred, validity)
 	ca.nextSerialNumber++ // Because we've already created the root cert.
 	return ca, nil
@@ -148,8 +148,7 @@ func (ca *CA) GenerateCA(name string, validity Validity, maxPathLen int) (*CA, e
 		return nil, err
 	}
 
-	cred := Cred{Crt: *crt, PrivateKey: key}
-	return NewCA(cred, ca.Validity), nil
+	return NewCA(validCredOrPanic(key, *crt), ca.Validity), nil
 }
 
 // GenerateEndEntityCred creates a new certificate that is valid for the
@@ -170,7 +169,7 @@ func (ca *CA) GenerateEndEntityCred(dnsName string) (*Cred, error) {
 		return nil, err
 	}
 
-	c := Cred{Crt: *crt, PrivateKey: key}
+	c := validCredOrPanic(key, *crt)
 	return &c, nil
 }
 

--- a/pkg/tls/ca.go
+++ b/pkg/tls/ca.go
@@ -15,7 +15,7 @@ type (
 	// CA provides a certificate authority for TLS-enabled installs.
 	// Issuing certificates concurrently is not supported.
 	CA struct {
-		// cred contains the CA's credentials.
+		// Cred contains the CA's credentials.
 		Cred Cred
 
 		// Validity configures the NotBefore and NotAfter parameters for certificates

--- a/pkg/tls/codec.go
+++ b/pkg/tls/codec.go
@@ -68,6 +68,21 @@ func DecodePEMCertificates(txt string) (certs []*x509.Certificate, err error) {
 	return
 }
 
+// DecodePEMCertPool parses a string containing PE-encoded certificates into a CertPool.
+func DecodePEMCertPool(txt string) (pool *x509.CertPool, err error) {
+	certs, err := DecodePEMCertificates(txt)
+	if err != nil {
+		return
+	}
+
+	pool = x509.NewCertPool()
+	for _, c := range certs {
+		pool.AddCert(c)
+	}
+
+	return
+}
+
 func decodeCertificatePEM(crtb []byte) (*x509.Certificate, []byte, error) {
 	block, crtb := pem.Decode(crtb)
 	if block == nil {

--- a/pkg/tls/codec.go
+++ b/pkg/tls/codec.go
@@ -7,43 +7,21 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 )
 
-func (crt *Crt) EncodePEM() []byte {
-	w := bytes.Buffer{}
-	n := len(crt.TrustChain)
+// === ENCODE ===
 
-	// Serialize certificates from leaf to root.
-	_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: crt.Certificate.Raw})
-	for i := n - 1; i >= 0; i-- {
-		_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: crt.TrustChain[i].Raw})
-	}
-
-	return w.Bytes()
-}
-
-func EncodeCertificatePEM(crts ...*x509.Certificate) []byte {
-	w := bytes.Buffer{}
+// EncodeCertificatesPEM encodes the collection of provided certificates as
+// a text blob of PEM-encoded certificates.
+func EncodeCertificatesPEM(crts ...*x509.Certificate) string {
+	buf := bytes.Buffer{}
 	for _, c := range crts {
-		_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+		encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
 	}
-	return w.Bytes()
+	return buf.String()
 }
 
-func (crt *Crt) EncodeTrustChainDER() [][]byte {
-	// Serialize certificates from leaf to root.
-	chain := make([][]byte, len(crt.TrustChain))
-	for i, c := range crt.TrustChain {
-		chain[len(crt.TrustChain)-i-1] = c.Raw
-	}
-	return chain
-}
-
-func EncodePrivateKeyP8(k *ecdsa.PrivateKey) ([]byte, error) {
-	return x509.MarshalPKCS8PrivateKey(k)
-}
-
+// EncodePrivateKeyPEM encodes the provided key as PEM-encoded text
 func EncodePrivateKeyPEM(k *ecdsa.PrivateKey) ([]byte, error) {
 	der, err := x509.MarshalECPrivateKey(k)
 	if err != nil {
@@ -53,46 +31,17 @@ func EncodePrivateKeyPEM(k *ecdsa.PrivateKey) ([]byte, error) {
 	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
 }
 
-// ReadCertificatePEm reads a PEM-encoded certificates from the given path.
-func ReadCertificatePEM(path string) (*x509.Certificate, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
+func encode(buf *bytes.Buffer, blk *pem.Block) {
+	if err := pem.Encode(buf, blk); err != nil {
+		panic("encoding to memory must not fail")
 	}
-
-	crt, _, err := decodeCertificatePEM(b)
-	return crt, err
 }
 
-// ReadCertificatePEM reads a PEM-encoded certificates from the given path.
-func ReadTrustAnchorsPEM(path string) ([]*x509.Certificate, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
+// === DECODE ===
 
-	return DecodeTrustAnchorsPEM(b)
-}
-
-// ReadCrtPEM reads PEM-encoded certificates from the named file
-func ReadCrtPEM(path string) (Crt, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return Crt{}, err
-	}
-	return DecodeCrtPEM(b)
-}
-
-func ReadKeyPEM(path string) (*ecdsa.PrivateKey, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return DecodeKeyPEM(b)
-}
-
-func DecodeKeyPEM(b []byte) (*ecdsa.PrivateKey, error) {
-	block, _ := pem.Decode(b)
+// DecodePEMKey parses a PEM-encoded ECDSA private key from the named path.
+func DecodePEMKey(txt string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(txt))
 	if block == nil {
 		return nil, errors.New("Not PEM-encoded")
 	}
@@ -102,42 +51,9 @@ func DecodeKeyPEM(b []byte) (*ecdsa.PrivateKey, error) {
 	return x509.ParseECPrivateKey(block.Bytes)
 }
 
-func decodeCertificatePEM(crtb []byte) (*x509.Certificate, []byte, error) {
-	block, crtb := pem.Decode(crtb)
-	if block == nil {
-		return nil, nil, errors.New("Failed to decode PEM certificate")
-	}
-	if block.Type != "CERTIFICATE" {
-		return nil, nil, nil
-	}
-	c, err := x509.ParseCertificate(block.Bytes)
-	return c, crtb, err
-}
-
-// DecodeCrtPEM decodes PEM-encoded certificates from leaf to root.
-func DecodeCrtPEM(buf []byte) (crt Crt, err error) {
-	certs, err := decodeCertificatesPEM(buf)
-	if err != nil {
-		return
-	}
-
-	crt.Certificate = certs[0]
-	certs = certs[1:]
-
-	// The chain is read from Leaf to Root, but we store it from Root to Leaf.
-	crt.TrustChain = make([]*x509.Certificate, len(certs))
-	for i, c := range certs {
-		crt.TrustChain[len(certs)-i-1] = c
-	}
-	return
-}
-
-// DecodeTrustAnchorsPEM decodes PEM-encoded certificates.
-func DecodeTrustAnchorsPEM(buf []byte) ([]*x509.Certificate, error) {
-	return decodeCertificatesPEM(buf)
-}
-
-func decodeCertificatesPEM(buf []byte) (certs []*x509.Certificate, err error) {
+// DecodePEMCertificates parses a string containing PEM-encoded certificates.
+func DecodePEMCertificates(txt string) (certs []*x509.Certificate, err error) {
+	buf := []byte(txt)
 	for len(buf) > 0 {
 		var c *x509.Certificate
 		c, buf, err = decodeCertificatePEM(buf)
@@ -150,4 +66,16 @@ func decodeCertificatesPEM(buf []byte) (certs []*x509.Certificate, err error) {
 		certs = append(certs, c)
 	}
 	return
+}
+
+func decodeCertificatePEM(crtb []byte) (*x509.Certificate, []byte, error) {
+	block, crtb := pem.Decode(crtb)
+	if block == nil {
+		return nil, nil, errors.New("Failed to decode PEM certificate")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, nil, nil
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	return c, crtb, err
 }

--- a/pkg/tls/codec.go
+++ b/pkg/tls/codec.go
@@ -1,0 +1,153 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+)
+
+func (crt *Crt) EncodePEM() []byte {
+	w := bytes.Buffer{}
+	n := len(crt.TrustChain)
+
+	// Serialize certificates from leaf to root.
+	_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: crt.Certificate.Raw})
+	for i := n - 1; i >= 0; i-- {
+		_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: crt.TrustChain[i].Raw})
+	}
+
+	return w.Bytes()
+}
+
+func EncodeCertificatePEM(crts ...*x509.Certificate) []byte {
+	w := bytes.Buffer{}
+	for _, c := range crts {
+		_ = pem.Encode(&w, &pem.Block{Type: "CERTIFICATE", Bytes: c.Raw})
+	}
+	return w.Bytes()
+}
+
+func (crt *Crt) EncodeTrustChainDER() [][]byte {
+	// Serialize certificates from leaf to root.
+	chain := make([][]byte, len(crt.TrustChain))
+	for i, c := range crt.TrustChain {
+		chain[len(crt.TrustChain)-i-1] = c.Raw
+	}
+	return chain
+}
+
+func EncodePrivateKeyP8(k *ecdsa.PrivateKey) ([]byte, error) {
+	return x509.MarshalPKCS8PrivateKey(k)
+}
+
+func EncodePrivateKeyPEM(k *ecdsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalECPrivateKey(k)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
+}
+
+// ReadCertificatePEm reads a PEM-encoded certificates from the given path.
+func ReadCertificatePEM(path string) (*x509.Certificate, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	crt, _, err := decodeCertificatePEM(b)
+	return crt, err
+}
+
+// ReadCertificatePEM reads a PEM-encoded certificates from the given path.
+func ReadTrustAnchorsPEM(path string) ([]*x509.Certificate, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeTrustAnchorsPEM(b)
+}
+
+// ReadCrtPEM reads PEM-encoded certificates from the named file
+func ReadCrtPEM(path string) (Crt, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return Crt{}, err
+	}
+	return DecodeCrtPEM(b)
+}
+
+func ReadKeyPEM(path string) (*ecdsa.PrivateKey, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeKeyPEM(b)
+}
+
+func DecodeKeyPEM(b []byte) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(b)
+	if block == nil {
+		return nil, errors.New("Not PEM-encoded")
+	}
+	if block.Type != "EC PRIVATE KEY" {
+		return nil, fmt.Errorf("Expected 'EC PRIVATE KEY'; found: '%s'", block.Type)
+	}
+	return x509.ParseECPrivateKey(block.Bytes)
+}
+
+func decodeCertificatePEM(crtb []byte) (*x509.Certificate, []byte, error) {
+	block, crtb := pem.Decode(crtb)
+	if block == nil {
+		return nil, nil, errors.New("Failed to decode PEM certificate")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, nil, nil
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	return c, crtb, err
+}
+
+// DecodeCrtPEM decodes PEM-encoded certificates from leaf to root.
+func DecodeCrtPEM(buf []byte) (crt Crt, err error) {
+	certs, err := decodeCertificatesPEM(buf)
+	if err != nil {
+		return
+	}
+
+	crt.Certificate = certs[0]
+	certs = certs[1:]
+
+	// The chain is read from Leaf to Root, but we store it from Root to Leaf.
+	crt.TrustChain = make([]*x509.Certificate, len(certs))
+	for i, c := range certs {
+		crt.TrustChain[len(certs)-i-1] = c
+	}
+	return
+}
+
+// DecodeTrustAnchorsPEM decodes PEM-encoded certificates.
+func DecodeTrustAnchorsPEM(buf []byte) ([]*x509.Certificate, error) {
+	return decodeCertificatesPEM(buf)
+}
+
+func decodeCertificatesPEM(buf []byte) (certs []*x509.Certificate, err error) {
+	for len(buf) > 0 {
+		var c *x509.Certificate
+		c, buf, err = decodeCertificatePEM(buf)
+		if err != nil {
+			return
+		}
+		if c == nil {
+			continue // not a CERTIFICATE, skip
+		}
+		certs = append(certs, c)
+	}
+	return
+}

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -56,9 +57,9 @@ func (crt *Crt) ExtractRaw() [][]byte {
 	return chain
 }
 
-// EncodeCertificateAndTrustChainPEM emits a certificate and trust chain as a
+// EncodePEM emits a certificate and trust chain as a
 // series of PEM-encoded certificates from leaf to root.
-func (crt *Crt) EncodeCertificateAndTrustChainPEM() string {
+func (crt *Crt) EncodePEM() string {
 	buf := bytes.Buffer{}
 	encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: crt.Certificate.Raw})
 
@@ -77,13 +78,13 @@ func (crt *Crt) EncodeCertificatePEM() string {
 }
 
 // EncodePrivateKeyPEM emits the private key as PEM-encoded text.
-func (cred *Cred) EncodePrivateKeyPEM() (string, error) {
-	der, err := x509.MarshalECPrivateKey(cred.PrivateKey)
+func (cred *Cred) EncodePrivateKeyPEM() string {
+	b, err := x509.MarshalECPrivateKey(cred.PrivateKey)
 	if err != nil {
-		return "", err
+		panic(fmt.Sprintf("Invalid elliptic curve: %s", err))
 	}
 
-	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})), nil
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: b}))
 }
 
 // EncodePrivateKeyP8 encodes the provided key to the PKCS#8 binary form.

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -1,0 +1,150 @@
+package tls
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+)
+
+// Cred is a container for a certificate, trust chain, and private key.
+type Cred struct {
+	PrivateKey *ecdsa.PrivateKey
+	*Crt
+}
+
+// Crt is a container for a certificate and trust chain.
+//
+// The trust chain stores all issuer certificates from root at the head direct
+// issuer at the tail.
+type Crt struct {
+	Certificate *x509.Certificate
+	TrustChain  []*x509.Certificate
+}
+
+// Verify the validity of the provided certificate
+func (crt *Crt) Verify(roots *x509.CertPool, name string) error {
+	i := x509.NewCertPool()
+	for _, c := range crt.TrustChain {
+		i.AddCert(c)
+	}
+	vo := x509.VerifyOptions{Roots: roots, Intermediates: i, DNSName: name}
+	_, err := crt.Certificate.Verify(vo)
+	return err
+}
+
+// ExtractRaw extracts the DER-encoded certificates in the Crt from leaf to root.
+func (crt *Crt) ExtractRaw() [][]byte {
+	chain := make([][]byte, len(crt.TrustChain)+1)
+	chain[0] = crt.Certificate.Raw
+	for i, c := range crt.TrustChain {
+		chain[len(crt.TrustChain)-i] = c.Raw
+	}
+	return chain
+}
+
+// EncodeCertificateAndTrustChainPEM emits a certificate and trust chain as a
+// series of PEM-encoded certificates from leaf to root.
+func (crt *Crt) EncodeCertificateAndTrustChainPEM() string {
+	buf := bytes.Buffer{}
+	n := len(crt.TrustChain)
+
+	// Serialize certificates from leaf to root.
+	encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: crt.Certificate.Raw})
+	for i := n - 1; i >= 0; i-- {
+		encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: crt.TrustChain[i].Raw})
+	}
+
+	return buf.String()
+}
+
+// EncodeCertificatePEM emits the Crt's leaf certificate as PEM-encoded text.
+func (crt *Crt) EncodeCertificatePEM() string {
+	return EncodeCertificatesPEM(crt.Certificate)
+}
+
+// EncodePrivateKeyPEM emits the private key as PEM-encoded text.
+func (cred *Cred) EncodePrivateKeyPEM() (string, error) {
+	der, err := x509.MarshalECPrivateKey(cred.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})), nil
+}
+
+// EncodePrivateKeyP8 encodes the provided key to the PKCS#8 binary form.
+func (cred *Cred) EncodePrivateKeyP8() ([]byte, error) {
+	return x509.MarshalPKCS8PrivateKey(cred.PrivateKey)
+}
+
+// CreateCrt uses this Cred to sign a new certificate.
+//
+// This may fail if the Cred contains an end-entity certificate.
+func (cred *Cred) CreateCrt(template *x509.Certificate) (*Crt, error) {
+	crtb, err := x509.CreateCertificate(
+		rand.Reader,
+		template,
+		cred.Crt.Certificate,
+		cred.PrivateKey.Public(),
+		cred.PrivateKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := x509.ParseCertificate(crtb)
+	if err != nil {
+		return nil, err
+	}
+
+	crt := Crt{
+		Certificate: c,
+		TrustChain:  append(cred.Crt.TrustChain, cred.Crt.Certificate),
+	}
+	return &crt, nil
+}
+
+// ReadPEMCreds reads PEM-encoded credentials from the named files.
+func ReadPEMCreds(keyPath, crtPath string) (*Cred, error) {
+	keyb, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	key, err := DecodePEMKey(string(keyb))
+	if err != nil {
+		return nil, err
+	}
+
+	crtb, err := ioutil.ReadFile(crtPath)
+	if err != nil {
+		return nil, err
+	}
+	crt, err := DecodePEMCrt(string(crtb))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cred{PrivateKey: key, Crt: crt}, nil
+}
+
+// DecodePEMCrt decodes PEM-encoded certificates from leaf to root.
+func DecodePEMCrt(txt string) (*Crt, error) {
+	certs, err := DecodePEMCertificates(txt)
+	if err != nil {
+		return nil, err
+	}
+
+	crt := Crt{Certificate: certs[0]}
+	certs = certs[1:]
+
+	// The chain is read from Leaf to Root, but we store it from Root to Leaf.
+	crt.TrustChain = make([]*x509.Certificate, len(certs))
+	for i, c := range certs {
+		crt.TrustChain[len(certs)-i-1] = c
+	}
+
+	return &crt, nil
+}

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -88,7 +88,7 @@ func (cred *Cred) CreateCrt(template *x509.Certificate) (*Crt, error) {
 		rand.Reader,
 		template,
 		cred.Crt.Certificate,
-		cred.PrivateKey.Public(),
+		template.PublicKey,
 		cred.PrivateKey,
 	)
 	if err != nil {

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -103,10 +103,9 @@ func (cred *Cred) EncodePrivateKeyP8() ([]byte, error) {
 }
 
 // certificateMatchesKey returns whether the key and certificate match.
-func certificateMatchesKey(c *x509.Certificate, k *ecdsa.PrivateKey) (ok bool) {
+func certificateMatchesKey(c *x509.Certificate, k *ecdsa.PrivateKey) bool {
 	pub, ok := c.PublicKey.(*ecdsa.PublicKey)
-	ok = ok && pub.X.Cmp(k.X) == 0 && pub.Y.Cmp(k.Y) == 0
-	return
+	return ok && pub.X.Cmp(k.X) == 0 && pub.Y.Cmp(k.Y) == 0
 }
 
 // SignCrt uses this Cred to sign a new certificate.

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -20,8 +20,8 @@ type (
 
 	// Crt is a container for a certificate and trust chain.
 	//
-	// The trust chain stores all issuer certificates from root at the head direct
-	// issuer at the tail.
+	// The trust chain stores all issuer certificates from the root at the head to
+	// the direct issuer at the tail.
 	Crt struct {
 		Certificate *x509.Certificate
 		TrustChain  []*x509.Certificate

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -14,7 +14,7 @@ func newRoot(t *testing.T) CA {
 
 func TestCrtRoundtrip(t *testing.T) {
 	root := newRoot(t)
-	rootTrust := root.Crt().CertPool()
+	rootTrust := root.Cred.Crt.CertPool()
 
 	cred, err := root.GenerateEndEntityCred("endentity.test")
 	if err != nil {
@@ -25,7 +25,7 @@ func TestCrtRoundtrip(t *testing.T) {
 		t.Fatal("Cert's public key does not match private key")
 	}
 
-	crt, err := DecodePEMCrt(cred.Crt.EncodeCertificateAndTrustChainPEM())
+	crt, err := DecodePEMCrt(cred.Crt.EncodePEM())
 	if err != nil {
 		t.Fatalf("Failed to decode PEM Crt: %s", err)
 	}
@@ -46,8 +46,8 @@ func TestCredEncodeCeritificateAndTrustChain(t *testing.T) {
 		t.Fatalf("failed to create end entity cred")
 	}
 
-	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Crt().Certificate)
-	if cred.EncodeCertificateAndTrustChainPEM() != expected {
+	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Cred.Crt.Certificate)
+	if cred.EncodePEM() != expected {
 		t.Errorf("Encoded Certificate And TrustChain does not match expected ouput")
 	}
 }

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -1,6 +1,9 @@
 package tls
 
-import "testing"
+import (
+	"crypto/ecdsa"
+	"testing"
+)
 
 func newRoot(t *testing.T) CA {
 	root, err := GenerateRootCAWithDefaults(t.Name())
@@ -17,6 +20,11 @@ func TestCrtRoundtrip(t *testing.T) {
 	cred, err := root.GenerateEndEntityCred("endentity.test")
 	if err != nil {
 		t.Fatalf("failed to create end entity cred: %s", err)
+	}
+
+	pub := cred.Crt.Certificate.PublicKey.(*ecdsa.PublicKey)
+	if pub.X.Cmp(cred.PrivateKey.X) != 0 || pub.Y.Cmp(cred.PrivateKey.Y) != 0 {
+		t.Fatal("Cert's public key does not match private key")
 	}
 
 	crt, err := DecodePEMCrt(cred.Crt.EncodeCertificateAndTrustChainPEM())

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -1,0 +1,47 @@
+package tls
+
+import "testing"
+
+func newRoot(t *testing.T) CA {
+	root, err := GenerateRootCAWithDefaults(t.Name())
+	if err != nil {
+		t.Fatalf("failed to create CA: %s", err)
+	}
+	return *root
+}
+
+func TestCrtRoundtrip(t *testing.T) {
+	root := newRoot(t)
+	rootTrust := root.CertPool()
+
+	cred, err := root.GenerateEndEntityCred("endentity.test")
+	if err != nil {
+		t.Fatalf("failed to create end entity cred: %s", err)
+	}
+
+	crt, err := DecodePEMCrt(cred.Crt.EncodeCertificateAndTrustChainPEM())
+	if err != nil {
+		t.Fatalf("Failed to decode PEM Crt: %s", err)
+	}
+
+	if err := crt.Verify(rootTrust, "endentity.test"); err != nil {
+		t.Fatal("Failed to verify round-tripped certificate")
+	}
+}
+
+func TestCredEncodeCeritificateAndTrustChain(t *testing.T) {
+	root, err := GenerateRootCAWithDefaults("Test Root CA")
+	if err != nil {
+		t.Fatalf("failed to create CA: %s", err)
+	}
+
+	cred, err := root.GenerateEndEntityCred("test end entity")
+	if err != nil {
+		t.Fatalf("failed to create end entity cred")
+	}
+
+	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Certificate())
+	if cred.EncodeCertificateAndTrustChainPEM() != expected {
+		t.Errorf("Encoded Certificate And TrustChain does not match expected ouput")
+	}
+}

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"crypto/ecdsa"
 	"testing"
 )
 
@@ -15,15 +14,14 @@ func newRoot(t *testing.T) CA {
 
 func TestCrtRoundtrip(t *testing.T) {
 	root := newRoot(t)
-	rootTrust := root.CertPool()
+	rootTrust := root.Crt().CertPool()
 
 	cred, err := root.GenerateEndEntityCred("endentity.test")
 	if err != nil {
 		t.Fatalf("failed to create end entity cred: %s", err)
 	}
 
-	pub := cred.Crt.Certificate.PublicKey.(*ecdsa.PublicKey)
-	if pub.X.Cmp(cred.PrivateKey.X) != 0 || pub.Y.Cmp(cred.PrivateKey.Y) != 0 {
+	if cred.check() {
 		t.Fatal("Cert's public key does not match private key")
 	}
 
@@ -48,7 +46,7 @@ func TestCredEncodeCeritificateAndTrustChain(t *testing.T) {
 		t.Fatalf("failed to create end entity cred")
 	}
 
-	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Certificate())
+	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Crt().Certificate)
 	if cred.EncodeCertificateAndTrustChainPEM() != expected {
 		t.Errorf("Encoded Certificate And TrustChain does not match expected ouput")
 	}

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -31,7 +31,7 @@ func TestCrtRoundtrip(t *testing.T) {
 	}
 }
 
-func TestCredEncodeCeritificateAndTrustChain(t *testing.T) {
+func TestCredEncodeCertificateAndTrustChain(t *testing.T) {
 	root, err := GenerateRootCAWithDefaults("Test Root CA")
 	if err != nil {
 		t.Fatalf("failed to create CA: %s", err)

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -21,10 +21,6 @@ func TestCrtRoundtrip(t *testing.T) {
 		t.Fatalf("failed to create end entity cred: %s", err)
 	}
 
-	if cred.check() {
-		t.Fatal("Cert's public key does not match private key")
-	}
-
 	crt, err := DecodePEMCrt(cred.Crt.EncodePEM())
 	if err != nil {
 		t.Fatalf("Failed to decode PEM Crt: %s", err)


### PR DESCRIPTION
In preparation for creating an Identity service that can chain off of an
existing CA, it's necessary to both (1) be able to create an
intermediate CA that can be used by the identity service and (2) be able
to load a CA from existing key material.

This changes the public API of the `tls` package to deal in actual key
types (rather than opaque blobs) and provides a set of helpers that can
be used to convert these credentials between common formats.