### PR TITLE
Fix build-cli-bin to use generated templates

### DIFF
--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -23,6 +23,7 @@ fi
       $bindir/dep ensure -vendor-only -v
     fi
     target="target/cli/${host_platform}/linkerd"
-    CGO_ENABLED=0 go build -o $target -ldflags "-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=$($bindir/root-tag)" ./cli
+    go generate ./cli
+    CGO_ENABLED=0 go build -o $target -tags prod -ldflags "-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=$($bindir/root-tag)" ./cli
     echo "$target"
 )


### PR DESCRIPTION
The `bin/build-cli-bin` script, intended to build a local `linkerd` cli
binary, was compiling the binary configured to read template files out
of the local machine's GOPATH.

This change modifies `build-cli-bin` to build a `linkerd` binary the
same way `docker-build-cli-bin` does. Specifically, by generating static
template files for inclusion in the build, and adding the `-tags prod`
flag to ensure those files are compiled in.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>