### PR TITLE
Make test-cleanup delete clusterrole[binding]s

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -13,7 +13,18 @@ echo "cleaning up namespace [${linkerd_namespace}] and associated test namespace
 
 if ! namespaces=$(kubectl get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
   echo "no namespaces found for [$linkerd_namespace]" >&2
-  exit 1
 else
   kubectl delete $namespaces
+fi
+
+if ! clusterrolebindings=$(kubectl get clusterrolebindings -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no clusterrolebindings found for [$linkerd_namespace]" >&2
+else
+  kubectl delete $clusterrolebindings
+fi
+
+if ! clusterroles=$(kubectl get clusterroles -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no clusterroles found for [$linkerd_namespace]" >&2
+else
+  kubectl delete $clusterroles
 fi


### PR DESCRIPTION
The `bin/test-cleanup` script was correctly deleting all namespaces
created by `bin/test-run`, but was leaving behind clusterroles and
clusterrolebindings, defined cluster-wide.

Update `test-cleanup` to delete clusterroles and clusterrolebindings
created by `test-run`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>