### PR TITLE
Authorization-aware control-plane components

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1290,7 +1290,7 @@
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta2",
-    "k8s.io/api/authorization/v1beta1",
+    "k8s.io/api/authorization/v1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -28,3 +28,9 @@ if ! clusterroles=$(kubectl get clusterroles -oname | grep -E "/linkerd-$linkerd
 else
   kubectl delete $clusterroles
 fi
+
+if ! crd=$(kubectl get crd/serviceprofiles.linkerd.io -oname); then
+  echo "no serviceprofile crd found for [$linkerd_namespace]" >&2
+else
+  kubectl delete $crd
+fi

--- a/chart/templates/ca.yaml
+++ b/chart/templates/ca.yaml
@@ -80,7 +80,6 @@ spec:
         args:
         - "ca"
         - "-controller-namespace={{.Values.Namespace}}"
-        - "-single-namespace={{.Values.SingleNamespace}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
         livenessProbe:
           httpGet:

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -118,7 +118,6 @@ spec:
         - "public-api"
         - "-prometheus-url=http://linkerd-prometheus.{{.Values.Namespace}}.svc.cluster.local:9090"
         - "-controller-namespace={{.Values.Namespace}}"
-        - "-single-namespace={{.Values.SingleNamespace}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
         livenessProbe:
           httpGet:
@@ -150,7 +149,6 @@ spec:
         - "destination"
         - "-addr=:{{.Values.DestinationAPIPort}}"
         - "-controller-namespace={{.Values.Namespace}}"
-        - "-single-namespace={{.Values.SingleNamespace}}"
         - "-enable-tls={{.Values.EnableTLS}}"
         - "-enable-h2-upgrade={{.Values.EnableH2Upgrade}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
@@ -183,7 +181,6 @@ spec:
         args:
         - "tap"
         - "-controller-namespace={{.Values.Namespace}}"
-        - "-single-namespace={{.Values.SingleNamespace}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
         livenessProbe:
           httpGet:

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -62,7 +62,6 @@ spec:
         - "-grafana-addr=linkerd-grafana.{{.Values.Namespace}}.svc.cluster.local:3000"
         - "-uuid={{.Values.UUID}}"
         - "-controller-namespace={{.Values.Namespace}}"
-        - "-single-namespace={{.Values.SingleNamespace}}"
         - "-log-level={{.Values.ControllerLogLevel}}"
         livenessProbe:
           httpGet:

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
+FROM gcr.io/linkerd-io/go-deps:c9486134 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -107,7 +107,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -134,7 +133,6 @@ spec:
         - destination
         - -addr=:8086
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
@@ -162,7 +160,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -440,7 +437,6 @@ spec:
         - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -107,7 +107,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -137,7 +136,6 @@ spec:
         - destination
         - -addr=:8086
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
@@ -168,7 +166,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -452,7 +449,6 @@ spec:
         - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -107,7 +107,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -137,7 +136,6 @@ spec:
         - destination
         - -addr=:8086
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
@@ -168,7 +166,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -452,7 +449,6 @@ spec:
         - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -107,7 +107,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -134,7 +133,6 @@ spec:
         - destination
         - -addr=:8086
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -enable-tls=false
         - -enable-h2-upgrade=true
         - -log-level=info
@@ -162,7 +160,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -418,7 +415,6 @@ spec:
         - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -109,7 +109,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -136,7 +135,6 @@ spec:
         - destination
         - -addr=:8086
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=info
@@ -164,7 +162,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -448,7 +445,6 @@ spec:
         - -grafana-addr=linkerd-grafana.linkerd.svc.cluster.local:3000
         - -uuid=deaab91a-f4ab-448a-b7d1-c832a2fa0a60
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/web:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1128,7 +1124,6 @@ spec:
       - args:
         - ca
         - -controller-namespace=linkerd
-        - -single-namespace=false
         - -log-level=info
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -110,7 +110,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090
         - -controller-namespace=Namespace
-        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -137,7 +136,6 @@ spec:
         - destination
         - -addr=:123
         - -controller-namespace=Namespace
-        - -single-namespace=false
         - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
@@ -165,7 +163,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=Namespace
-        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -444,7 +441,6 @@ spec:
         - -grafana-addr=linkerd-grafana.Namespace.svc.cluster.local:3000
         - -uuid=UUID
         - -controller-namespace=Namespace
-        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: WebImage
         imagePullPolicy: ImagePullPolicy
@@ -1111,7 +1107,6 @@ spec:
       - args:
         - ca
         - -controller-namespace=Namespace
-        - -single-namespace=false
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -106,7 +106,6 @@ spec:
         - public-api
         - -prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090
         - -controller-namespace=Namespace
-        - -single-namespace=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -133,7 +132,6 @@ spec:
         - destination
         - -addr=:123
         - -controller-namespace=Namespace
-        - -single-namespace=true
         - -enable-tls=true
         - -enable-h2-upgrade=true
         - -log-level=ControllerLogLevel
@@ -161,7 +159,6 @@ spec:
       - args:
         - tap
         - -controller-namespace=Namespace
-        - -single-namespace=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
@@ -334,7 +331,6 @@ spec:
         - -grafana-addr=linkerd-grafana.Namespace.svc.cluster.local:3000
         - -uuid=UUID
         - -controller-namespace=Namespace
-        - -single-namespace=true
         - -log-level=ControllerLogLevel
         image: WebImage
         imagePullPolicy: ImagePullPolicy
@@ -1007,7 +1003,6 @@ spec:
       - args:
         - ca
         - -controller-namespace=Namespace
-        - -single-namespace=true
         - -log-level=ControllerLogLevel
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
+FROM gcr.io/linkerd-io/go-deps:c9486134 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
+FROM gcr.io/linkerd-io/go-deps:c9486134 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -57,7 +57,7 @@ func TestBuildResolver(t *testing.T) {
 	t.Run("Doesn't build a resolver if Kubernetes DNS zone isnt valid", func(t *testing.T) {
 		invalidK8sDNSZones := []string{"1", "-a", "a-", "-"}
 		for _, dsnZone := range invalidK8sDNSZones {
-			resolver, err := buildResolver(dsnZone, "linkerd", k8sAPI, false)
+			resolver, err := buildResolver(dsnZone, "linkerd", k8sAPI)
 			if err == nil {
 				t.Fatalf("Expecting error when k8s zone is [%s], got nothing. Resolver: %v", dsnZone, resolver)
 			}
@@ -158,7 +158,7 @@ func TestEndpoints(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	gRPCServer, err := NewServer(
 		"fake-addr", "", "controller-ns",
-		false, false, false, k8sAPI, nil,
+		false, false, k8sAPI, nil,
 	)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -405,8 +405,6 @@ status:
 				nil,
 				k8sAPI,
 				"linkerd",
-				[]string{},
-				false,
 			)
 
 			k8sAPI.Sync()
@@ -508,8 +506,6 @@ metadata:
 				nil,
 				k8sAPI,
 				"linkerd",
-				[]string{},
-				false,
 			)
 
 			k8sAPI.Sync()
@@ -559,8 +555,6 @@ func TestEndpoints(t *testing.T) {
 				discoveryClient,
 				k8sAPI,
 				"linkerd",
-				[]string{},
-				false,
 			)
 
 			rsp, err := fakeGrpcServer.Endpoints(context.TODO(), exp.req)

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -405,6 +405,7 @@ status:
 				nil,
 				k8sAPI,
 				"linkerd",
+				[]string{},
 			)
 
 			k8sAPI.Sync()
@@ -506,6 +507,7 @@ metadata:
 				nil,
 				k8sAPI,
 				"linkerd",
+				[]string{},
 			)
 
 			k8sAPI.Sync()
@@ -555,6 +557,7 @@ func TestEndpoints(t *testing.T) {
 				discoveryClient,
 				k8sAPI,
 				"linkerd",
+				[]string{},
 			)
 
 			rsp, err := fakeGrpcServer.Endpoints(context.TODO(), exp.req)

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -264,6 +264,7 @@ func NewServer(
 	discoveryClient discoveryPb.DiscoveryClient,
 	k8sAPI *k8s.API,
 	controllerNamespace string,
+	ignoredNamespaces []string,
 ) *http.Server {
 	baseHandler := &handler{
 		grpcServer: newGrpcServer(
@@ -272,6 +273,7 @@ func NewServer(
 			discoveryClient,
 			k8sAPI,
 			controllerNamespace,
+			ignoredNamespaces,
 		),
 	}
 

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -264,8 +264,6 @@ func NewServer(
 	discoveryClient discoveryPb.DiscoveryClient,
 	k8sAPI *k8s.API,
 	controllerNamespace string,
-	ignoredNamespaces []string,
-	singleNamespace bool,
 ) *http.Server {
 	baseHandler := &handler{
 		grpcServer: newGrpcServer(
@@ -274,8 +272,6 @@ func NewServer(
 			discoveryClient,
 			k8sAPI,
 			controllerNamespace,
-			ignoredNamespaces,
-			singleNamespace,
 		),
 	}
 

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1011,6 +1011,7 @@ status:
 				nil,
 				k8sAPI,
 				"linkerd",
+				[]string{},
 			)
 
 			_, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)
@@ -1035,6 +1036,7 @@ status:
 			nil,
 			k8sAPI,
 			"linkerd",
+			[]string{},
 		)
 
 		invalidRequests := []statSumExpected{

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1011,8 +1011,6 @@ status:
 				nil,
 				k8sAPI,
 				"linkerd",
-				[]string{},
-				false,
 			)
 
 			_, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)
@@ -1037,8 +1035,6 @@ status:
 			nil,
 			k8sAPI,
 			"linkerd",
-			[]string{},
-			false,
 		)
 
 		invalidRequests := []statSumExpected{

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -268,8 +268,6 @@ func newMockGrpcServer(exp expectedStatRPC) (*mockProm, *grpcServer, error) {
 		nil,
 		k8sAPI,
 		"linkerd",
-		[]string{},
-		false,
 	)
 
 	k8sAPI.Sync()

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -268,6 +268,7 @@ func newMockGrpcServer(exp expectedStatRPC) (*mockProm, *grpcServer, error) {
 		nil,
 		k8sAPI,
 		"linkerd",
+		[]string{},
 	)
 
 	k8sAPI.Sync()

--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -41,8 +41,8 @@ type resourceTable struct {
 func (s *grpcServer) TopRoutes(ctx context.Context, req *pb.TopRoutesRequest) (*pb.TopRoutesResponse, error) {
 	log.Debugf("TopRoutes request: %+v", req)
 
-	if s.singleNamespace {
-		return topRoutesError(req, "Routes are not available in single-namespace mode"), nil
+	if !s.k8sAPI.SPAvailable() {
+		return topRoutesError(req, "Routes are not available"), nil
 	}
 
 	errRsp := validateRequest(req)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	"github.com/linkerd/linkerd2/controller/api/destination"
-	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
@@ -23,38 +22,18 @@ func main() {
 	enableH2Upgrade := flag.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
 	enableTLS := flag.Bool("enable-tls", false, "Enable TLS connections among pods in the service mesh")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
-	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	k8sClient, err := k8s.NewClientSet(*kubeConfigPath)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	var spClient *spclient.Clientset
-	restrictToNamespace := ""
-	resources := []k8s.APIResource{k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc}
-
-	if *singleNamespace {
-		restrictToNamespace = *controllerNamespace
-	} else {
-		spClient, err = k8s.NewSpClientSet(*kubeConfigPath)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		resources = append(resources, k8s.SP)
-	}
-
-	k8sAPI := k8s.NewAPI(
-		k8sClient,
-		spClient,
-		restrictToNamespace,
-		resources...,
+	k8sAPI, err := k8s.InitializeAPI(
+		*kubeConfigPath, *controllerNamespace,
+		k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP,
 	)
+	if err != nil {
+		log.Fatalf("Failed to initialize K8s API: %s", err)
+	}
 
 	done := make(chan struct{})
 
@@ -63,7 +42,7 @@ func main() {
 		log.Fatalf("Failed to listen on %s: %s", *addr, err)
 	}
 
-	server, err := destination.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, *singleNamespace, k8sAPI, done)
+	server, err := destination.NewServer(*addr, *k8sDNSZone, *controllerNamespace, *enableTLS, *enableH2Upgrade, k8sAPI, done)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -5,12 +5,10 @@ import (
 	"flag"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/linkerd/linkerd2/controller/api/discovery"
 	"github.com/linkerd/linkerd2/controller/api/public"
-	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/controller/tap"
 	"github.com/linkerd/linkerd2/pkg/admin"
@@ -27,8 +25,6 @@ func main() {
 	destinationAPIAddr := flag.String("destination-addr", "127.0.0.1:8086", "address of destination service")
 	tapAddr := flag.String("tap-addr", "127.0.0.1:8088", "address of tap service")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
-	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
-	ignoredNamespaces := flag.String("ignore-namespaces", "kube-system", "comma separated list of namespaces to not list pods from")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
@@ -46,32 +42,13 @@ func main() {
 	}
 	defer discoveryConn.Close()
 
-	k8sClient, err := k8s.NewClientSet(*kubeConfigPath)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	var spClient *spclient.Clientset
-	restrictToNamespace := ""
-	resources := []k8s.APIResource{k8s.DS, k8s.Deploy, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS}
-
-	if *singleNamespace {
-		restrictToNamespace = *controllerNamespace
-	} else {
-		spClient, err = k8s.NewSpClientSet(*kubeConfigPath)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-
-		resources = append(resources, k8s.SP)
-	}
-
-	k8sAPI := k8s.NewAPI(
-		k8sClient,
-		spClient,
-		restrictToNamespace,
-		resources...,
+	k8sAPI, err := k8s.InitializeAPI(
+		*kubeConfigPath, *controllerNamespace,
+		k8s.DS, k8s.Deploy, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
 	)
+	if err != nil {
+		log.Fatalf("Failed to initialize K8s API: %s", err)
+	}
 
 	prometheusClient, err := promApi.NewClient(promApi.Config{Address: *prometheusURL})
 	if err != nil {
@@ -85,8 +62,6 @@ func main() {
 		discoveryClient,
 		k8sAPI,
 		*controllerNamespace,
-		strings.Split(*ignoredNamespaces, ","),
-		*singleNamespace,
 	)
 
 	k8sAPI.Sync() // blocks until caches are synced

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/linkerd/linkerd2/controller/api/discovery"
@@ -25,6 +26,7 @@ func main() {
 	destinationAPIAddr := flag.String("destination-addr", "127.0.0.1:8086", "address of destination service")
 	tapAddr := flag.String("tap-addr", "127.0.0.1:8088", "address of tap service")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	ignoredNamespaces := flag.String("ignore-namespaces", "kube-system", "comma separated list of namespaces to not list pods from")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
@@ -62,6 +64,7 @@ func main() {
 		discoveryClient,
 		k8sAPI,
 		*controllerNamespace,
+		strings.Split(*ignoredNamespaces, ","),
 	)
 
 	k8sAPI.Sync() // blocks until caches are synced

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -18,25 +18,14 @@ func main() {
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
-	singleNamespace := flag.Bool("single-namespace", false, "only operate in the controller namespace")
 	tapPort := flag.Uint("tap-port", 4190, "proxy tap port to connect to")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	k8sClient, err := k8s.NewClientSet(*kubeConfigPath)
-	if err != nil {
-		log.Fatalf("failed to create Kubernetes client: %s", err)
-	}
-	restrictToNamespace := ""
-	if *singleNamespace {
-		restrictToNamespace = *controllerNamespace
-	}
-	k8sAPI := k8s.NewAPI(
-		k8sClient,
-		nil,
-		restrictToNamespace,
+	k8sAPI, err := k8s.InitializeAPI(
+		*kubeConfigPath, *controllerNamespace,
 		k8s.DS,
 		k8s.SS,
 		k8s.Deploy,
@@ -45,6 +34,9 @@ func main() {
 		k8s.Svc,
 		k8s.RS,
 	)
+	if err != nil {
+		log.Fatalf("Failed to initialize K8s API: %s", err)
+	}
 
 	server, lis, err := tap.NewServer(*addr, *tapPort, *controllerNamespace, k8sAPI)
 	if err != nil {

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -71,13 +71,64 @@ type API struct {
 	namespace         string
 }
 
-// NewAPI takes a Kubernetes client and returns an initialized API
+// InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
+func InitializeAPI(kubeConfig string, namespace string, resources ...APIResource) (*API, error) {
+	k8sClient, err := NewClientSet(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// check for cluster-wide vs. namespace-wide access
+	clusterAccess, err := k8s.ClusterAccess(k8sClient, namespace)
+	if err != nil {
+		return nil, err
+	}
+	restrictToNamespace := ""
+	if !clusterAccess {
+		log.Warnf("Not authorized for cluster-wide access, limiting access to \"%s\" namespace", namespace)
+		restrictToNamespace = namespace
+	}
+
+	// check for need and access to ServiceProfiles
+	var spClient *spclient.Clientset
+	idxSP := 0
+	needSP := false
+	for i := range resources {
+		if resources[i] == SP {
+			needSP = true
+			idxSP = i
+			break
+		}
+	}
+	if needSP {
+		serviceProfiles, err := k8s.ServiceProfilesAccess(k8sClient)
+		if err != nil {
+			return nil, err
+		}
+		if serviceProfiles {
+			spClient, err = NewSpClientSet(kubeConfig)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			log.Warn("ServiceProfiles not available")
+			// remove SP from resources list
+			resources = append(resources[:idxSP], resources[idxSP+1:]...)
+		}
+	}
+
+	return NewAPI(k8sClient, spClient, restrictToNamespace, resources...), nil
+}
+
+// NewAPI takes a Kubernetes client and returns an initialized API.
 func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, namespace string, resources ...APIResource) *API {
 	var sharedInformers informers.SharedInformerFactory
 	var spSharedInformers sp.SharedInformerFactory
 	if namespace == "" {
 		sharedInformers = informers.NewSharedInformerFactory(k8sClient, 10*time.Minute)
-		spSharedInformers = sp.NewSharedInformerFactory(spClient, 10*time.Minute)
+		if spClient != nil {
+			spSharedInformers = sp.NewSharedInformerFactory(spClient, 10*time.Minute)
+		}
 	} else {
 		sharedInformers = informers.NewFilteredSharedInformerFactory(
 			k8sClient,
@@ -85,12 +136,14 @@ func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, namespa
 			namespace,
 			nil,
 		)
-		spSharedInformers = sp.NewFilteredSharedInformerFactory(
-			spClient,
-			10*time.Minute,
-			namespace,
-			nil,
-		)
+		if spClient != nil {
+			spSharedInformers = sp.NewFilteredSharedInformerFactory(
+				spClient,
+				10*time.Minute,
+				namespace,
+				nil,
+			)
+		}
 	}
 
 	api := &API{
@@ -244,6 +297,12 @@ func (api *API) MWC() arinformers.MutatingWebhookConfigurationInformer {
 		panic("MWC informer not configured")
 	}
 	return api.mwc
+}
+
+// SPAvailable informs the caller whether this API is configured to retrieve
+// ServiceProfiles
+func (api *API) SPAvailable() bool {
+	return api.sp != nil
 }
 
 // GetObjects returns a list of Kubernetes objects, given a namespace, type, and name.

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -19,7 +19,7 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 	k8sResults := []runtime.Object{}
 
 	for _, config := range resourceConfigs {
-		obj, err := toRuntimeObject(config)
+		obj, err := k8s.ToRuntimeObject(config)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -573,7 +573,7 @@ status:
 		}
 
 		for _, exp := range expectations {
-			k8sInputObj, err := toRuntimeObject(exp.k8sResInput)
+			k8sInputObj, err := k8s.ToRuntimeObject(exp.k8sResInput)
 			if err != nil {
 				t.Fatalf("could not decode yml: %s", err)
 			}

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -1,41 +1,13 @@
 package k8s
 
 import (
-	"strings"
-
-	spfake "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/fake"
-	spscheme "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/scheme"
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 )
-
-func toRuntimeObject(config string) (runtime.Object, error) {
-	spscheme.AddToScheme(scheme.Scheme)
-	decode := scheme.Codecs.UniversalDeserializer().Decode
-	obj, _, err := decode([]byte(config), nil, nil)
-	return obj, err
-}
 
 // NewFakeAPI provides a mock Kubernetes API for testing.
 func NewFakeAPI(namespace string, configs ...string) (*API, error) {
-	objs := []runtime.Object{}
-	spObjs := []runtime.Object{}
-	for _, config := range configs {
-		obj, err := toRuntimeObject(config)
-		if err != nil {
-			return nil, err
-		}
-		if strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind) == k8s.ServiceProfile {
-			spObjs = append(spObjs, obj)
-		} else {
-			objs = append(objs, obj)
-		}
-	}
+	clientSet, spClientSet := k8s.NewFakeClientSets(configs...)
 
-	clientSet := fake.NewSimpleClientset(objs...)
-	spClientSet := spfake.NewSimpleClientset(spObjs...)
 	return NewAPI(
 		clientSet,
 		spClientSet,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -16,7 +16,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
-	authorizationapi "k8s.io/api/authorization/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sVersion "k8s.io/apimachinery/pkg/version"
@@ -783,28 +782,21 @@ func (hc *HealthChecker) checkCanCreate(namespace, group, version, resource stri
 		}
 	}
 
-	auth := hc.clientset.AuthorizationV1beta1()
-
-	sar := &authorizationapi.SelfSubjectAccessReview{
-		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationapi.ResourceAttributes{
-				Namespace: namespace,
-				Verb:      "create",
-				Group:     group,
-				Version:   version,
-				Resource:  resource,
-			},
-		},
-	}
-
-	response, err := auth.SelfSubjectAccessReviews().Create(sar)
+	allowed, reason, err := k8s.ResourceAuthz(
+		hc.clientset,
+		namespace,
+		"create",
+		group,
+		version,
+		resource,
+	)
 	if err != nil {
 		return err
 	}
 
-	if !response.Status.Allowed {
-		if len(response.Status.Reason) > 0 {
-			return fmt.Errorf("Missing permissions to create %s: %v", resource, response.Status.Reason)
+	if !allowed {
+		if len(reason) > 0 {
+			return fmt.Errorf("Missing permissions to create %s: %v", resource, reason)
 		}
 		return fmt.Errorf("Missing permissions to create %s", resource)
 	}

--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -1,0 +1,112 @@
+package k8s
+
+import (
+	"fmt"
+
+	authV1 "k8s.io/api/authorization/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ResourceAuthz checks whether a given Kubernetes client is authorized to
+// perform a given action.
+func ResourceAuthz(
+	k8sClient kubernetes.Interface,
+	namespace, verb, group, version, resource string,
+) (bool, string, error) {
+	ssar := &authV1.SelfSubjectAccessReview{
+		Spec: authV1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authV1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      verb,
+				Group:     group,
+				Version:   version,
+				Resource:  resource,
+			},
+		},
+	}
+
+	result, err := k8sClient.
+		AuthorizationV1().
+		SelfSubjectAccessReviews().
+		Create(ssar)
+	if err != nil {
+		return false, "", err
+	}
+
+	return result.Status.Allowed, result.Status.Reason, nil
+}
+
+// ServiceProfilesAccess checks whether the ServiceProfile CRD is installed
+// on the cluster and the client is authorized to access ServiceProfiles.
+func ServiceProfilesAccess(k8sClient kubernetes.Interface) (bool, error) {
+	res, err := k8sClient.Discovery().ServerResources()
+	if err != nil {
+		return false, err
+	}
+
+	for _, r := range res {
+		if r.GroupVersion == ServiceProfileAPIVersion {
+			for _, apiRes := range r.APIResources {
+				if apiRes.Kind == ServiceProfileKind {
+					// TODO: Modify this to honor the error returned, once we give the
+					// control-plane namespace-wide access to ServiceProfiles.
+					access, _ := resourceAccess(k8sClient, "", "linkerd.io", "serviceprofiles")
+					return access, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// ClusterAccess verifies whether k8sClient is authorized to access all
+// namespaces in the cluster, or only the given namespace. If k8sClient does not
+// have at least namespace-wide access, it returns an error.
+func ClusterAccess(k8sClient kubernetes.Interface, namespace string) (bool, error) {
+	return resourceAccess(k8sClient, namespace, "", "pods")
+}
+
+// resourceAccess verifies whether k8sClient is authorized to access a resource
+// in all namespaces in the cluster, or only the given namespace. If k8sClient
+// does not have at least namespace-wide access, it returns an error.
+func resourceAccess(k8sClient kubernetes.Interface, namespace, group, resource string) (bool, error) {
+	// first check for cluster-wide access
+	allowed, _, err := ResourceAuthz(
+		k8sClient,
+		"",
+		"list",
+		group,
+		"",
+		resource,
+	)
+	if err != nil {
+		return false, err
+	}
+	if allowed {
+		// authorized for cluster-wide access
+		return true, nil
+	}
+
+	// next check for namespace-wide access
+	allowed, reason, err := ResourceAuthz(
+		k8sClient,
+		namespace,
+		"list",
+		group,
+		"",
+		resource,
+	)
+	if err != nil {
+		return false, err
+	}
+	if allowed {
+		// authorized for namespace-wide access
+		return false, nil
+	}
+
+	if len(reason) > 0 {
+		return false, fmt.Errorf("not authorized to access \"%s\" namespace: %s", namespace, reason)
+	}
+	return false, fmt.Errorf("not authorized to access \"%s\" namespace", namespace)
+}

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -1,0 +1,65 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestResourceAuthz(t *testing.T) {
+	tests := []struct {
+		k8sConfigs []string
+		allowed    bool
+		reason     string
+		err        error
+	}{
+		{
+			// TODO: determine the objects that will affect ResourceAuthz
+			[]string{`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cr-test
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments"]
+  verbs: ["list"]`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crb-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cr-test
+subjects:
+- kind: Group
+  name: system:unauthenticated
+  apiGroup: rbac.authorization.k8s.io`,
+			},
+			false,
+			"",
+			nil,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d: returns expected authorization", i), func(t *testing.T) {
+			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
+			allowed, reason, err := ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments")
+			if err != nil || test.err != nil {
+				if (err == nil && test.err != nil) ||
+					(err != nil && test.err == nil) ||
+					(err.Error() != test.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", test.err, err)
+				}
+			}
+			if allowed != test.allowed {
+				t.Errorf("Allowed mismatch. Expected %v, but got %v", test.allowed, allowed)
+			}
+			if reason != test.reason {
+				t.Errorf("Reason mismatch. Expected %v, but got %v", test.reason, reason)
+			}
+		})
+	}
+}

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -44,6 +44,7 @@ subjects:
 	}
 
 	for i, test := range tests {
+		test := test // pin
 		t.Run(fmt.Sprintf("%d: returns expected authorization", i), func(t *testing.T) {
 			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
 			allowed, reason, err := ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments")

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -24,6 +24,9 @@ const (
 	ServiceProfile        = "serviceprofile"
 	StatefulSet           = "statefulset"
 
+	ServiceProfileAPIVersion = "linkerd.io/v1alpha1"
+	ServiceProfileKind       = "ServiceProfile"
+
 	// special case k8s job label, to not conflict with Prometheus' job label
 	l5dJob = "k8s_job"
 )

--- a/pkg/k8s/test_helper.go
+++ b/pkg/k8s/test_helper.go
@@ -1,0 +1,40 @@
+package k8s
+
+import (
+	"strings"
+
+	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
+	spfake "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/fake"
+	spscheme "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// NewFakeClientSets provides a mock Kubernetes ClientSet for testing.
+func NewFakeClientSets(configs ...string) (kubernetes.Interface, spclient.Interface) {
+	objs := []runtime.Object{}
+	spObjs := []runtime.Object{}
+	for _, config := range configs {
+		obj, err := ToRuntimeObject(config)
+		if err != nil {
+			return nil, nil
+		}
+		if strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind) == ServiceProfile {
+			spObjs = append(spObjs, obj)
+		} else {
+			objs = append(objs, obj)
+		}
+	}
+
+	return fake.NewSimpleClientset(objs...), spfake.NewSimpleClientset(spObjs...)
+}
+
+// ToRuntimeObject deserializes Kubernetes YAML into a Runtime Object
+func ToRuntimeObject(config string) (runtime.Object, error) {
+	spscheme.AddToScheme(scheme.Scheme)
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode([]byte(config), nil, nil)
+	return obj, err
+}

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -53,7 +53,7 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name string) sp.Se
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 	}
 
 	routes := make([]*sp.RouteSpec, 0)

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -37,7 +37,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 	}
 
 	expectedServiceProfile := sp.ServiceProfile{
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "." + namespace + ".svc.cluster.local",
 			Namespace: namespace,

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes/duration"
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
-	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
+	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1" // TODO: pkg/profiles should not depend on controller/gen
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/util"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,10 +35,10 @@ var (
 			Seconds: 10,
 		},
 	}
-	// ServiceProfileMeta is the TypeMeta for the ServiceProfile custom resource.
-	ServiceProfileMeta = metav1.TypeMeta{
-		APIVersion: "linkerd.io/v1alpha1",
-		Kind:       "ServiceProfile",
+	// serviceProfileMeta is the TypeMeta for the ServiceProfile custom resource.
+	serviceProfileMeta = metav1.TypeMeta{
+		APIVersion: k8s.ServiceProfileAPIVersion,
+		Kind:       k8s.ServiceProfileKind,
 	}
 	// DefaultServiceProfile is used for services with no service profile.
 	DefaultServiceProfile = pb.DestinationProfile{

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -64,7 +64,7 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name string) (*sp.Se
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 		Spec: sp.ServiceProfileSpec{
 			Routes: routes,
 		},

--- a/pkg/profiles/proto_test.go
+++ b/pkg/profiles/proto_test.go
@@ -32,7 +32,7 @@ service VotingService {
 	parser := proto.NewParser(strings.NewReader(protobuf))
 
 	expectedServiceProfile := sp.ServiceProfile{
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "." + namespace + ".svc.cluster.local",
 			Namespace: namespace,

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -53,7 +53,7 @@ func tapToServiceProfile(client pb.ApiClient, tapReq *pb.TapByResourceRequest, n
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 	}
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(tapDuration))

--- a/pkg/profiles/tap_test.go
+++ b/pkg/profiles/tap_test.go
@@ -77,7 +77,7 @@ func TestTapToServiceProfile(t *testing.T) {
 	}
 
 	expectedServiceProfile := sp.ServiceProfile{
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "." + namespace + ".svc.cluster.local",
 			Namespace: namespace,

--- a/pkg/profiles/test_helper.go
+++ b/pkg/profiles/test_helper.go
@@ -12,7 +12,7 @@ import (
 // GenServiceProfile generates a mock ServiceProfile.
 func GenServiceProfile(service, namespace string) v1alpha1.ServiceProfile {
 	return v1alpha1.ServiceProfile{
-		TypeMeta: ServiceProfileMeta,
+		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service + "." + namespace + ".svc.cluster.local",
 			Namespace: namespace,

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
+FROM gcr.io/linkerd-io/go-deps:c9486134 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:d7f5ab37 as golang
+FROM gcr.io/linkerd-io/go-deps:c9486134 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web

--- a/web/app/js/components/ConfigureProfilesMsg.jsx
+++ b/web/app/js/components/ConfigureProfilesMsg.jsx
@@ -139,8 +139,7 @@ class ConfigureProfilesMsg extends React.Component {
 
   render() {
     const { showAsIcon } = this.props;
-
-    if (this.props.singleNamespace === "true") {
+    if (this.props.serviceProfiles === "false") {
       return null;
     } else if (showAsIcon) {
       return this.renderDownloadProfileForm();
@@ -163,8 +162,8 @@ ConfigureProfilesMsg.propTypes = {
     prefixedUrl: PropTypes.func.isRequired,
   }).isRequired,
   classes: PropTypes.shape({}).isRequired,
+  serviceProfiles: PropTypes.string.isRequired,
   showAsIcon: PropTypes.bool,
-  singleNamespace: PropTypes.string.isRequired,
 };
 
 ConfigureProfilesMsg.defaultProps = {

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -63,7 +63,7 @@ class TopRoutes extends React.Component {
     }).isRequired,
     classes: PropTypes.shape({}).isRequired,
     query: topRoutesQueryPropType,
-    singleNamespace: PropTypes.string.isRequired,
+    serviceProfiles: PropTypes.string.isRequired,
   }
   static defaultProps = {
     query: {
@@ -237,7 +237,7 @@ class TopRoutes extends React.Component {
           </Grid>
         </Grid>
         <Divider light className={classes.root} />
-        {this.props.singleNamespace === "true" ? null :
+        {this.props.serviceProfiles === "false" ? null :
         <Typography variant="caption">You can also create a new profile <ConfigureProfilesMsg showAsIcon={true} /></Typography>}
       </CardContent>
     );

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -23,7 +23,7 @@ type (
 		apiClient           public.APIClient
 		uuid                string
 		controllerNamespace string
-		singleNamespace     bool
+		serviceProfiles     bool
 		grafanaProxy        *grafanaProxy
 	}
 )
@@ -38,7 +38,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httpro
 	params := appParams{
 		UUID:                h.uuid,
 		ControllerNamespace: h.controllerNamespace,
-		SingleNamespace:     h.singleNamespace,
+		ServiceProfiles:     h.serviceProfiles,
 		PathPrefix:          pathPfx,
 	}
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -35,7 +35,7 @@ type (
 		Data                pb.VersionInfo
 		UUID                string
 		ControllerNamespace string
-		SingleNamespace     bool
+		ServiceProfiles     bool
 		Error               bool
 		ErrorMessage        string
 		PathPrefix          string
@@ -57,7 +57,7 @@ func NewServer(
 	staticDir string,
 	uuid string,
 	controllerNamespace string,
-	singleNamespace bool,
+	serviceProfiles bool,
 	reload bool,
 	apiClient public.APIClient,
 ) *http.Server {
@@ -78,7 +78,7 @@ func NewServer(
 		render:              server.RenderTemplate,
 		uuid:                uuid,
 		controllerNamespace: controllerNamespace,
-		singleNamespace:     singleNamespace,
+		serviceProfiles:     serviceProfiles,
 		grafanaProxy:        newGrafanaProxy(grafanaAddr),
 	}
 

--- a/web/templates/app.tmpl.html
+++ b/web/templates/app.tmpl.html
@@ -3,7 +3,7 @@
     data-release-version="{{.Data.ReleaseVersion}}"
     data-go-version="{{.Data.GoVersion}}"
     data-controller-namespace="{{.ControllerNamespace}}"
-    data-single-namespace="{{.SingleNamespace}}"
+    data-service-profiles="{{.ServiceProfiles}}"
     data-uuid="{{.UUID}}">
     {{ if .Error }}
       <p>Failed to call public API: {{ .ErrorMessage }}</p>


### PR DESCRIPTION
The control-plane components relied on a `--single-namespace` param,
passed from `linkerd install` into each individual component, to
determine which namespaces they were authorized to access, and whether
to support ServiceProfiles. This command-line flag was redundant given
the authorization rules encoded in the parent `linkerd install` output,
via [Cluster]Role[Binding]s.

Modify the control-plane components to query Kubernetes at startup to
determine which namespaces they are authorized to access, and whether
ServiceProfile support is available. This allows removal of the
`--single-namespace` flag on the components.

Also update `bin/test-cleanup` to cleanup the ServiceProfile CRD.

TODO:
- Remove `--single-namespace` flag on `linkerd install`, part of #2164

Signed-off-by: Andrew Seigner <siggy@buoyant.io>