### PR TITLE
Enable gosimple linter, fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   disable:
   - deadcode
   - errcheck
-  - gosimple
   - staticcheck
   - structcheck
   - unused

--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -104,7 +104,7 @@ func renderEndpoints(endpoints *pb.EndpointsResponse, options *endpointsOptions)
 	writeEndpointsToBuffer(endpoints, w, options)
 	w.Flush()
 
-	return string(buffer.Bytes())
+	return buffer.String()
 }
 
 type rowEndpoint struct {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -200,7 +200,7 @@ func renderStats(buffer bytes.Buffer, options *statOptionsBase) string {
 	var out string
 	switch options.outputFormat {
 	case "json":
-		out = string(buffer.Bytes())
+		out = buffer.String()
 	default:
 		// strip left padding on the first column
 		out = string(buffer.Bytes()[padding:])

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -27,9 +27,7 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 		k8sResults = append(k8sResults, obj)
 	}
 
-	for _, config := range extraConfigs {
-		k8sConfigs = append(k8sConfigs, config)
-	}
+	k8sConfigs = append(k8sConfigs, extraConfigs...)
 
 	api, err := NewFakeAPI("", k8sConfigs...)
 	if err != nil {

--- a/controller/proxy-injector/server_test.go
+++ b/controller/proxy-injector/server_test.go
@@ -2,7 +2,6 @@ package injector
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -92,7 +91,7 @@ func TestNewWebhookServer(t *testing.T) {
 		t.Fatal("Unexpected error: ", err)
 	}
 
-	if server.Addr != fmt.Sprintf("%s", addr) {
+	if server.Addr != addr {
 		t.Errorf("Expected server address to be :%q", addr)
 	}
 }

--- a/pkg/tls/cred_test.go
+++ b/pkg/tls/cred_test.go
@@ -44,6 +44,6 @@ func TestCredEncodeCertificateAndTrustChain(t *testing.T) {
 
 	expected := EncodeCertificatesPEM(cred.Crt.Certificate, root.Cred.Crt.Certificate)
 	if cred.EncodePEM() != expected {
-		t.Errorf("Encoded Certificate And TrustChain does not match expected ouput")
+		t.Errorf("Encoded Certificate And TrustChain does not match expected output")
 	}
 }

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -195,7 +195,7 @@ func (h *KubernetesHelper) GetPodsForDeployment(namespace string, deploymentName
 // that's in the format namespace/resource. If the strings is in a different
 // format it returns an error.
 func (h *KubernetesHelper) ParseNamespacedResource(resource string) (string, string, error) {
-	r := regexp.MustCompile("^(.+)\\/(.+)$")
+	r := regexp.MustCompile(`^(.+)\/(.+)$`)
 	matches := r.FindAllStringSubmatch(resource, 2)
 	if len(matches) == 0 {
 		return "", "", fmt.Errorf("string [%s] didn't contain expected format for namespace/resource, extracted: %v", resource, matches)

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -236,7 +236,7 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 				break
 			}
 
-			if err := ws.WriteMessage(websocket.TextMessage, []byte(buf.String())); err != nil {
+			if err := ws.WriteMessage(websocket.TextMessage, buf.Bytes()); err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure) {
 					log.Error(err)
 				}


### PR DESCRIPTION
gosimple is a Go linter that specializes in simplifying code

Also fix one spelling error in `cred_test.go`

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>