### PR TITLE
Enable `unused` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,5 +12,4 @@ linters:
   - gosimple
   - staticcheck
   - structcheck
-  - unused
   - varcheck

--- a/cli/cmd/install-sp.go
+++ b/cli/cmd/install-sp.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type installSPConfig struct {
-	Namespace string
-}
-
 func newCmdInstallSP() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install-sp [flags]",

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -11,13 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-type templateConfig struct {
-	ControlPlaneNamespace string
-	ServiceNamespace      string
-	ServiceName           string
-	ClusterZone           string
-}
-
 type profileOptions struct {
 	name          string
 	namespace     string

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	defaultNamespace = "linkerd"
-	lineWidth        = 80
 )
 
 var (

--- a/cli/cmd/routes.go
+++ b/cli/cmd/routes.go
@@ -30,8 +30,6 @@ type routeRowStats struct {
 	actualSuccessRate float64
 }
 
-const defaultRoute = "[UNKNOWN]"
-
 func newRoutesOptions() *routesOptions {
 	return &routesOptions{
 		statOptionsBase: *newStatOptionsBase(),

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -571,13 +571,6 @@ func (t *topTable) renderHeaders() {
 	}
 }
 
-func max(i, j int) int {
-	if i > j {
-		return i
-	}
-	return j
-}
-
 func (t *topTable) adjustColumnWidths() {
 	for i, col := range t.columns {
 		if !col.flexible {

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -13,10 +13,9 @@ import (
 func TestUninjectYAML(t *testing.T) {
 
 	testCases := []struct {
-		inputFileName     string
-		goldenFileName    string
-		reportFileName    string
-		testInjectOptions *injectOptions
+		inputFileName  string
+		goldenFileName string
+		reportFileName string
 	}{
 		{
 			inputFileName:  "inject_emojivoto_deployment.golden.yml",

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -240,7 +240,3 @@ func cmdDel(args *skel.CmdArgs) error {
 	logrus.Info("linkerd-cni: cmdDel not implemented")
 	return nil
 }
-
-func cmdGet(args *skel.CmdArgs) error {
-	return fmt.Errorf("linkerd-cni: cmdGet not implemented")
-}

--- a/controller/api/destination/endpoint_listener_test.go
+++ b/controller/api/destination/endpoint_listener_test.go
@@ -13,13 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type podExpected struct {
-	pod                   string
-	namespace             string
-	replicationController string
-	phase                 v1.PodPhase
-}
-
 var (
 	addedAddress1 = &net.TcpAddress{
 		Ip:   &net.IPAddress{Ip: &net.IPAddress_Ipv4{Ipv4: 1}},

--- a/controller/api/destination/endpoints_watcher.go
+++ b/controller/api/destination/endpoints_watcher.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	kubeSystem       = "kube-system"
-	endpointResource = "endpoints"
+	kubeSystem = "kube-system"
 )
 
 // TODO: prom metrics for all the queues/caches

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -72,28 +72,6 @@ func (c *MockAPIClient) SelfCheck(ctx context.Context, in *healthcheckPb.SelfChe
 	return c.SelfCheckResponseToReturn, c.ErrorToReturn
 }
 
-type mockAPITapClient struct {
-	TapEventsToReturn []pb.TapEvent
-	ErrorsToReturn    []error
-	grpc.ClientStream
-}
-
-func (a *mockAPITapClient) Recv() (*pb.TapEvent, error) {
-	var eventPopped pb.TapEvent
-	var errorPopped error
-	if len(a.TapEventsToReturn) == 0 && len(a.ErrorsToReturn) == 0 {
-		return nil, io.EOF
-	}
-	if len(a.TapEventsToReturn) != 0 {
-		eventPopped, a.TapEventsToReturn = a.TapEventsToReturn[0], a.TapEventsToReturn[1:]
-	}
-	if len(a.ErrorsToReturn) != 0 {
-		errorPopped, a.ErrorsToReturn = a.ErrorsToReturn[0], a.ErrorsToReturn[1:]
-	}
-
-	return &eventPopped, errorPopped
-}
-
 // MockAPITapByResourceClient satisfies the TapByResourceClient gRPC interface.
 type MockAPITapByResourceClient struct {
 	TapEventsToReturn []pb.TapEvent

--- a/controller/api/public/top_routes_test.go
+++ b/controller/api/public/top_routes_test.go
@@ -131,16 +131,6 @@ type topRoutesExpected struct {
 	expectedResponse pb.TopRoutesResponse // the routes response we expect
 }
 
-func genEmptyTopRoutesResponse() pb.TopRoutesResponse {
-	return pb.TopRoutesResponse{
-		Response: &pb.TopRoutesResponse_Ok_{
-			Ok: &pb.TopRoutesResponse_Ok{
-				Routes: []*pb.RouteTable{},
-			},
-		},
-	}
-}
-
 func routesMetric(routes []string) model.Vector {
 	samples := make(model.Vector, 0)
 	for _, route := range routes {

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/proxy-injector/fake"
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -178,22 +177,5 @@ func TestVolumesSpec(t *testing.T) {
 
 	if !reflect.DeepEqual(expectedLinkerdSecrets, actualLinkerdSecrets) {
 		t.Errorf("Content mismatch\nExpected: %+v\nActual: %+v", expectedLinkerdSecrets, actualLinkerdSecrets)
-	}
-}
-
-func assertEqualAdmissionReview(t *testing.T, expected, actual *admissionv1beta1.AdmissionReview) {
-	if !reflect.DeepEqual(expected.Request, actual.Request) {
-		if !reflect.DeepEqual(expected.Request.Object, actual.Request.Object) {
-			t.Errorf("Request object mismatch\nExpected: %s\nActual: %s", expected.Request.Object, actual.Request.Object)
-		} else {
-			t.Errorf("Request mismatch\nExpected: %+v\nActual: %+v", expected.Request, actual.Request)
-		}
-	}
-
-	if !reflect.DeepEqual(expected.Response, actual.Response) {
-		if actual.Response.Result != nil {
-			t.Errorf("Actual response message: %s", actual.Response.Result.Message)
-		}
-		t.Errorf("Response patch mismatch\nExpected: %s\nActual: %s", expected.Response.Patch, actual.Response.Patch)
 	}
 }

--- a/pkg/healthcheck/version_test.go
+++ b/pkg/healthcheck/version_test.go
@@ -10,14 +10,6 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 )
 
-func createMockPublicAPI(version string) *public.MockAPIClient {
-	return &public.MockAPIClient{
-		VersionInfoToReturn: &pb.VersionInfo{
-			ReleaseVersion: version,
-		},
-	}
-}
-
 func TestGetServerVersion(t *testing.T) {
 	t.Run("Returns existing version from server", func(t *testing.T) {
 		expectedServerVersion := "1.2.3"


### PR DESCRIPTION
`unused` checks Go code for unused constants, variables, functions, and
types.

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>