### PR TITLE
Check kubectl version as part of checks

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -264,6 +264,13 @@ func (hc *HealthChecker) allCategories() []category {
 						return hc.kubeAPI.CheckVersion(hc.kubeVersion)
 					},
 				},
+				{
+					description: "is running the minimum kubectl version",
+					hintAnchor:  "kubectl-version",
+					check: func(context.Context) error {
+						return k8s.CheckKubectlVersion()
+					},
+				},
 			},
 		},
 		{

--- a/pkg/k8s/kubectl.go
+++ b/pkg/k8s/kubectl.go
@@ -1,0 +1,43 @@
+package k8s
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+// minKubectlVersion is effectively minAPIVersion.
+// It's unlikely that the minimum supported kubectl version
+// will be different from that of the k8s API.
+var minKubectlVersion = minAPIVersion
+
+// CheckKubectlVersion validates whether the installed kubectl version is
+// running a minimum kubectl version.
+func CheckKubectlVersion() error {
+	cmd := exec.Command("kubectl", "version", "--client", "--short")
+	bytes, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	clientVersion := fmt.Sprintf("%s\n", bytes)
+	kubectlVersion, err := parseKubectlShortVersion(clientVersion)
+	if err != nil {
+		return err
+	}
+
+	if !isCompatibleVersion(minKubectlVersion, kubectlVersion) {
+		return fmt.Errorf("kubectl is on version [%d.%d.%d], but version [%d.%d.%d] or more recent is required",
+			kubectlVersion[0], kubectlVersion[1], kubectlVersion[2],
+			minKubectlVersion[0], minKubectlVersion[1], minKubectlVersion[2])
+	}
+
+	return nil
+}
+
+var semVer = regexp.MustCompile("(v[0-9]+.[0-9]+.[0-9]+)")
+
+func parseKubectlShortVersion(version string) ([3]int, error) {
+	versionString := semVer.FindString(version)
+	return getK8sVersion(versionString)
+}

--- a/pkg/k8s/kubectl_test.go
+++ b/pkg/k8s/kubectl_test.go
@@ -1,0 +1,34 @@
+package k8s
+
+import "testing"
+
+var versionTests = []struct {
+	v        string // input
+	expected [3]int // expected
+}{
+	{"Client Version: v1.10.1", [3]int{1, 10, 1}},
+	{"client Version: v1.10.1", [3]int{1, 10, 1}},
+	{"Client Version - v1.10.1", [3]int{1, 10, 1}},
+	{"v1.10.1", [3]int{1, 10, 1}},
+	{"Client Version: v1.10.1 beta:2", [3]int{1, 10, 1}},
+	{"Client Version: v2.1348.1", [3]int{2, 1348, 1}},
+}
+
+func TestParseKubectlShortVersion(t *testing.T) {
+	for _, tt := range versionTests {
+		actual, err := parseKubectlShortVersion(tt.v)
+		if err != nil {
+			t.Fatalf("Unexpected error while parsing kubectl short version: %v", err)
+		}
+		if actual != tt.expected {
+			t.Fatalf("Expected to get %v but got %v", tt.expected, actual)
+		}
+	}
+}
+
+func TestParseKubectlShortVersionIncorrectVersion(t *testing.T) {
+	_, err := parseKubectlShortVersion("Not really a version")
+	if err == nil {
+		t.Fatalf("Expected to get an error")
+	}
+}

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 linkerd-existence
 -----------------

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 pre-kubernetes-cluster-setup
 ----------------------------

--- a/test/testdata/check.pre.single_namespace.golden
+++ b/test/testdata/check.pre.single_namespace.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 pre-kubernetes-single-namespace-setup
 -------------------------------------

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 linkerd-existence
 -----------------

--- a/test/testdata/check.proxy.single_namespace.golden
+++ b/test/testdata/check.proxy.single_namespace.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 linkerd-existence
 -----------------

--- a/test/testdata/check.single_namespace.golden
+++ b/test/testdata/check.single_namespace.golden
@@ -6,6 +6,7 @@ kubernetes-api
 kubernetes-version
 ------------------
 √ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
 
 linkerd-existence
 -----------------


### PR DESCRIPTION
Runs `exec.Command("kubectl", "version", "--client", "--output=json")` and checks that version of kubectl is at least minimal required version.

Solves #2354

Signed-off-by: Yan Babitski [yan.babitski@gmail.com](yan.babitski@gmail.com)