### PR TITLE
Increase integration test timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,12 @@ branches:
     - master
     - /^(edge|stable)-\d+\.\d+\.[\w-]+$/ # build version tags
 
-# TESTING integration tests prior to master merge
 stages:
   - name: test
   - name: docker-deploy
-    # if: type != pull_request
+    if: type != pull_request
   - name: integration-test
-    # if: type != pull_request
+    if: type != pull_request
 
 jobs:
   include:
@@ -110,8 +109,7 @@ jobs:
       after_success:
         - bin/docker-push-deps
         - bin/docker-push $LINKERD_TAG
-        # TESTING integration tests prior to master merge
-        # - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
+        - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
         - target/cli/linux/linkerd install --linkerd-version=$LINKERD_TAG |tee linkerd.yml
         - kubectl -n linkerd apply -f linkerd.yml --prune --selector='linkerd.io/control-plane-component'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ branches:
     - master
     - /^(edge|stable)-\d+\.\d+\.[\w-]+$/ # build version tags
 
+# TESTING integration tests prior to master merge
 stages:
   - name: test
   - name: docker-deploy
-    if: type != pull_request
+    # if: type != pull_request
   - name: integration-test
-    if: type != pull_request
+    # if: type != pull_request
 
 jobs:
   include:
@@ -26,9 +27,9 @@ jobs:
       go_import_path: github.com/linkerd/linkerd2
       cache:
         directories:
-          - $HOME/.cache/go-build
           - target
           - vendor
+          - "$HOME/.cache"
       install:
         - ./bin/dep ensure -vendor-only -v
         - ./bin/dep status -v
@@ -109,7 +110,8 @@ jobs:
       after_success:
         - bin/docker-push-deps
         - bin/docker-push $LINKERD_TAG
-        - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
+        # TESTING integration tests prior to master merge
+        # - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
         - target/cli/linux/linkerd install --linkerd-version=$LINKERD_TAG |tee linkerd.yml
         - kubectl -n linkerd apply -f linkerd.yml --prune --selector='linkerd.io/control-plane-component'
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -131,7 +131,7 @@ func TestVersionPostInstall(t *testing.T) {
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=30s"}
+	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=1m"}
 	golden := "check.golden"
 	if TestHelper.SingleNamespace() {
 		cmd = append(cmd, "--single-namespace")
@@ -229,7 +229,7 @@ func TestInject(t *testing.T) {
 
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=30s"}
+	cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=1m"}
 	golden := "check.proxy.golden"
 	if TestHelper.SingleNamespace() {
 		cmd = append(cmd, "--single-namespace")

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -131,7 +131,7 @@ func TestVersionPostInstall(t *testing.T) {
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
+	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=30s"}
 	golden := "check.golden"
 	if TestHelper.SingleNamespace() {
 		cmd = append(cmd, "--single-namespace")
@@ -229,7 +229,7 @@ func TestInject(t *testing.T) {
 
 func TestCheckProxy(t *testing.T) {
 	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=0"}
+	cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=30s"}
 	golden := "check.proxy.golden"
 	if TestHelper.SingleNamespace() {
 		cmd = append(cmd, "--single-namespace")

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -237,7 +237,7 @@ func (h *TestHelper) RetryFor(timeout time.Duration, fn func() error) error {
 // giving pods time to start.
 func (h *TestHelper) HTTPGetURL(url string) (string, error) {
 	var body string
-	err := h.RetryFor(30*time.Second, func() error {
+	err := h.RetryFor(time.Minute, func() error {
 		resp, err := h.httpClient.Get(url)
 		if err != nil {
 			return err


### PR DESCRIPTION
The integration tests occasionally timeout in ci when talking to
Kubernetes and Linkerd:
https://travis-ci.org/linkerd/linkerd2/jobs/497300669#L972
https://travis-ci.org/linkerd/linkerd2/jobs/497329339#L7284

Increase `linkerd check --wait` from `0` to `30s`.
Increase `HTTPGetURL` timeout from 30s to 1 minute.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>