### PR TITLE
Fix hint URLs not display for RPC checks

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -433,7 +433,7 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
-					description:   "can query the control plane API",
+					description:   "control plane self-check",
 					hintAnchor:    "l5d-api-control-api",
 					fatal:         true,
 					retryDeadline: hc.RetryDeadline,
@@ -699,6 +699,7 @@ func (hc *HealthChecker) runCheckRPC(categoryID CategoryID, c *checker, observer
 	observer(&CheckResult{
 		Category:    categoryID,
 		Description: c.description,
+		HintAnchor:  c.hintAnchor,
 		Warning:     c.warning,
 		Err:         err,
 	})

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -17,7 +17,7 @@ linkerd-existence
 linkerd-api
 -----------
 √ control plane pods are ready
-√ can query the control plane API
+√ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
 

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -17,7 +17,7 @@ linkerd-existence
 linkerd-api
 -----------
 √ control plane pods are ready
-√ can query the control plane API
+√ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
 

--- a/test/testdata/check.proxy.single_namespace.golden
+++ b/test/testdata/check.proxy.single_namespace.golden
@@ -17,7 +17,7 @@ linkerd-existence
 linkerd-api
 -----------
 √ control plane pods are ready
-√ can query the control plane API
+√ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
 

--- a/test/testdata/check.single_namespace.golden
+++ b/test/testdata/check.single_namespace.golden
@@ -17,7 +17,7 @@ linkerd-existence
 linkerd-api
 -----------
 √ control plane pods are ready
-√ can query the control plane API
+√ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
 


### PR DESCRIPTION
Hint URLs should display for all failed checks in `linkerd check`, but
were not displaying for RPC checks.

Fix `runCheckRPC` to pass along the hintAnchor to the check result.

Also rename the second `can query the control plane API` to
`control plane self-check`, as there were two checks with that name.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>