### PR TITLE
Enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
   # - dupl
   # - gochecknoglobals
   # - gochecknoinits
-  # - goconst # TODO
+  # - goconst
   # - gocyclo
   # - goimports
   # - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,35 @@ issues:
   exclude-use-default: false
 linters:
   enable:
+  - deadcode
+  - depguard
   - gofmt
   - golint
+  - gosimple
+  - govet
+  - ineffassign
+  - misspell
+  - nakedret
+  - typecheck
+  - unused
+  - varcheck
+  # TODO: enable more linters!
+  # - dupl
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst # TODO
+  # - gocyclo
+  # - goimports
+  # - gosec
+  # - interfacer
+  # - lll
+  # - maligned
+  # - prealloc
+  # - scopelint
+  # - stylecheck
+  # - unconvert
+  # - unparam
   disable:
-  - deadcode
   - errcheck
   - staticcheck
   - structcheck
-  - varcheck


### PR DESCRIPTION
Enables the following linters:
- `deadcode` finds unused code.
- `depguard` checks if package imports are in a list of acceptable
  packages.
- `misspell` finds commonly misspelled English words in comments.
- `nakedret` finds naked returns in functions greater than a specified
  function length.
- `varcheck` finds unused global variables and constants.

Our repo was already passing these linters so no fixes needed.

Also explicitly list all linters enabled by default, for reference.

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>