### PR TITLE
lint: Enable goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   - depguard
   - goconst
   - gofmt
+  - goimports
   - golint
   - gosimple
   - govet
@@ -23,7 +24,6 @@ linters:
   # - gochecknoglobals
   # - gochecknoinits
   # - gocyclo
-  # - goimports
   # - gosec
   # - interfacer
   # - lll

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sMeta "k8s.io/apimachinery/pkg/api/meta"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 )
@@ -53,7 +53,7 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, options *i
 
 // objMeta provides a generic struct to parse the names of Kubernetes objects
 type objMeta struct {
-	metaV1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 }
 
 func newInjectOptions() *injectOptions {
@@ -115,7 +115,7 @@ func uninjectAndInject(inputs []io.Reader, errWriter, outWriter io.Writer, optio
 }
 
 // injectObjectMeta adds linkerd labels & annotations to the provided ObjectMeta.
-func injectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string, options *injectOptions) {
+func injectObjectMeta(t *metav1.ObjectMeta, k8sLabels map[string]string, options *injectOptions) {
 	if t.Annotations == nil {
 		t.Annotations = make(map[string]string)
 	}
@@ -132,7 +132,7 @@ func injectObjectMeta(t *metaV1.ObjectMeta, k8sLabels map[string]string, options
 }
 
 // injectPodSpec adds linkerd sidecars to the provided PodSpec.
-func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameOverride string, options *injectOptions) {
+func injectPodSpec(t *corev1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameOverride string, options *injectOptions) {
 
 	f := false
 	inboundSkipPorts := append(options.ignoreInboundPorts, options.proxyControlPort, options.proxyMetricsPort)
@@ -171,9 +171,9 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		IntVal: int32(options.proxyMetricsPort),
 	}
 
-	proxyProbe := v1.Probe{
-		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
+	proxyProbe := corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/metrics",
 				Port: metricsPort,
 			},
@@ -181,9 +181,9 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		InitialDelaySeconds: 10,
 	}
 
-	resources := v1.ResourceRequirements{
-		Requests: v1.ResourceList{},
-		Limits:   v1.ResourceList{},
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
 	}
 
 	if options.proxyCPURequest != "" {
@@ -206,15 +206,15 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	if options.disableExternalProfiles {
 		profileSuffixes = "svc.cluster.local."
 	}
-	sidecar := v1.Container{
+	sidecar := corev1.Container{
 		Name:                     k8s.ProxyContainerName,
 		Image:                    options.taggedProxyImage(),
-		ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
-		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-		SecurityContext: &v1.SecurityContext{
+		ImagePullPolicy:          corev1.PullPolicy(options.imagePullPolicy),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: &options.proxyUID,
 		},
-		Ports: []v1.ContainerPort{
+		Ports: []corev1.ContainerPort{
 			{
 				Name:          "linkerd-proxy",
 				ContainerPort: int32(options.inboundPort),
@@ -225,7 +225,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 			},
 		},
 		Resources: resources,
-		Env: []v1.EnvVar{
+		Env: []corev1.EnvVar{
 			{Name: "LINKERD2_PROXY_LOG", Value: options.proxyLogLevel},
 			{
 				Name:  "LINKERD2_PROXY_CONTROL_URL",
@@ -238,7 +238,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 			{Name: "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES", Value: profileSuffixes},
 			{
 				Name:      PodNamespaceEnvVarName,
-				ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+				ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 			},
 			{Name: "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE", Value: fmt.Sprintf("%dms", defaultKeepaliveMs)},
 			{Name: "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE", Value: fmt.Sprintf("%dms", defaultKeepaliveMs)},
@@ -257,7 +257,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	for _, container := range t.Containers {
 		if capacity, ok := options.proxyOutboundCapacity[container.Image]; ok {
 			sidecar.Env = append(sidecar.Env,
-				v1.EnvVar{
+				corev1.EnvVar{
 					Name:  "LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY",
 					Value: fmt.Sprintf("%d", capacity),
 				},
@@ -269,19 +269,19 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	if options.enableTLS() {
 		yes := true
 
-		configMapVolume := v1.Volume{
+		configMapVolume := corev1.Volume{
 			Name: k8s.TLSTrustAnchorVolumeName,
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{Name: k8s.TLSTrustAnchorConfigMapName},
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: k8s.TLSTrustAnchorConfigMapName},
 					Optional:             &yes,
 				},
 			},
 		}
-		secretVolume := v1.Volume{
+		secretVolume := corev1.Volume{
 			Name: k8s.TLSSecretsVolumeName,
-			VolumeSource: v1.VolumeSource{
-				Secret: &v1.SecretVolumeSource{
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					SecretName: identity.ToSecretName(),
 					Optional:   &yes,
 				},
@@ -291,7 +291,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		base := "/var/linkerd-io"
 		configMapBase := base + "/trust-anchors"
 		secretBase := base + "/identity"
-		tlsEnvVars := []v1.EnvVar{
+		tlsEnvVars := []corev1.EnvVar{
 			{Name: "LINKERD2_PROXY_TLS_TRUST_ANCHORS", Value: configMapBase + "/" + k8s.TLSTrustAnchorFileName},
 			{Name: "LINKERD2_PROXY_TLS_CERT", Value: secretBase + "/" + k8s.TLSCertFileName},
 			{Name: "LINKERD2_PROXY_TLS_PRIVATE_KEY", Value: secretBase + "/" + k8s.TLSPrivateKeyFileName},
@@ -304,7 +304,7 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 		}
 
 		sidecar.Env = append(sidecar.Env, tlsEnvVars...)
-		sidecar.VolumeMounts = []v1.VolumeMount{
+		sidecar.VolumeMounts = []corev1.VolumeMount{
 			{Name: configMapVolume.Name, MountPath: configMapBase, ReadOnly: true},
 			{Name: secretVolume.Name, MountPath: secretBase, ReadOnly: true},
 		}
@@ -316,15 +316,15 @@ func injectPodSpec(t *v1.PodSpec, identity k8s.TLSIdentity, controlPlaneDNSNameO
 	if !options.noInitContainer {
 		nonRoot := false
 		runAsUser := int64(0)
-		initContainer := v1.Container{
+		initContainer := corev1.Container{
 			Name:                     k8s.InitContainerName,
 			Image:                    options.taggedProxyInitImage(),
-			ImagePullPolicy:          v1.PullPolicy(options.imagePullPolicy),
-			TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
+			ImagePullPolicy:          corev1.PullPolicy(options.imagePullPolicy),
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			Args:                     initArgs,
-			SecurityContext: &v1.SecurityContext{
-				Capabilities: &v1.Capabilities{
-					Add: []v1.Capability{v1.Capability("NET_ADMIN")},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{corev1.Capability("NET_ADMIN")},
 				},
 				Privileged:   &f,
 				RunAsNonRoot: &nonRoot,

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -12,8 +12,8 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
 	"github.com/wercker/stern/stern"
-	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
@@ -105,7 +105,7 @@ func (o *logsOptions) toSternConfig(controlPlaneComponents, availableContainers 
 	return config, nil
 }
 
-func getControlPlaneComponentsAndContainers(pods *v1.PodList) ([]string, []string) {
+func getControlPlaneComponentsAndContainers(pods *corev1.PodList) ([]string, []string) {
 	var controlPlaneComponents, containers []string
 	for _, pod := range pods.Items {
 		controlPlaneComponents = append(controlPlaneComponents, pod.Labels["linkerd.io/control-plane-component"])
@@ -127,7 +127,7 @@ func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext string) (
 		return nil, err
 	}
 
-	podList, err := clientset.CoreV1().Pods(controlPlaneNamespace).List(meta_v1.ListOptions{})
+	podList, err := clientset.CoreV1().Pods(controlPlaneNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -126,8 +126,8 @@ func (resourceTransformerUninjectSilent) generateReport(uninjectReports []inject
 
 // Given a PodSpec, update the PodSpec in place with the sidecar
 // and init-container uninjected
-func uninjectPodSpec(t *v1.PodSpec, report *injectReport) {
-	initContainers := []v1.Container{}
+func uninjectPodSpec(t *corev1.PodSpec, report *injectReport) {
+	initContainers := []corev1.Container{}
 	for _, container := range t.InitContainers {
 		if container.Name != k8s.InitContainerName {
 			initContainers = append(initContainers, container)
@@ -137,7 +137,7 @@ func uninjectPodSpec(t *v1.PodSpec, report *injectReport) {
 	}
 	t.InitContainers = initContainers
 
-	containers := []v1.Container{}
+	containers := []corev1.Container{}
 	for _, container := range t.Containers {
 		if container.Name != k8s.ProxyContainerName {
 			containers = append(containers, container)
@@ -145,7 +145,7 @@ func uninjectPodSpec(t *v1.PodSpec, report *injectReport) {
 	}
 	t.Containers = containers
 
-	volumes := []v1.Volume{}
+	volumes := []corev1.Volume{}
 	for _, volume := range t.Volumes {
 		// TODO: move those strings to constants
 		if volume.Name != k8s.TLSTrustAnchorVolumeName && volume.Name != k8s.TLSSecretsVolumeName {
@@ -155,7 +155,7 @@ func uninjectPodSpec(t *v1.PodSpec, report *injectReport) {
 	t.Volumes = volumes
 }
 
-func uninjectObjectMeta(t *metaV1.ObjectMeta) {
+func uninjectObjectMeta(t *metav1.ObjectMeta) {
 	newAnnotations := make(map[string]string)
 	for key, val := range t.Annotations {
 		if key != k8s.CreatedByAnnotation && key != k8s.ProxyVersionAnnotation {

--- a/controller/api/destination/endpoint_listener.go
+++ b/controller/api/destination/endpoint_listener.go
@@ -9,7 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type endpointUpdateListener interface {
@@ -21,12 +21,12 @@ type endpointUpdateListener interface {
 	Stop()
 }
 
-type ownerKindAndNameFn func(*coreV1.Pod) (string, string)
+type ownerKindAndNameFn func(*corev1.Pod) (string, string)
 
 // updateAddress is a pairing of TCP address to Kubernetes pod object
 type updateAddress struct {
 	address *net.TcpAddress
-	pod     *coreV1.Pod
+	pod     *corev1.Pod
 }
 
 func (ua updateAddress) String() string {
@@ -203,7 +203,7 @@ func (l *endpointListener) toAddrSet(addresses []*updateAddress) *pb.AddrSet {
 	return &pb.AddrSet{Addrs: addrs}
 }
 
-func (l *endpointListener) getAddrMetadata(pod *coreV1.Pod) (map[string]string, *pb.ProtocolHint, *pb.TlsIdentity) {
+func (l *endpointListener) getAddrMetadata(pod *corev1.Pod) (map[string]string, *pb.ProtocolHint, *pb.TlsIdentity) {
 	controllerNs := pod.Labels[pkgK8s.ControllerNSLabel]
 	ownerKind, ownerName := l.ownerKindAndName(pod)
 	labels := pkgK8s.GetPodLabels(ownerKind, ownerName, pod)

--- a/controller/api/destination/endpoint_listener_test.go
+++ b/controller/api/destination/endpoint_listener_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/linkerd/linkerd2-proxy-api/go/net"
 	pkgAddr "github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,14 +31,14 @@ var (
 		Port: 100,
 	}
 
-	pod1 = &v1.Pod{
+	pod1 = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod1",
 			Namespace: "ns",
 		},
 	}
 
-	pod2 = &v1.Pod{
+	pod2 = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod2",
 			Namespace: "ns",
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func defaultOwnerKindAndName(pod *v1.Pod) (string, string) {
+func defaultOwnerKindAndName(pod *corev1.Pod) (string, string) {
 	return "", ""
 }
 
@@ -149,17 +149,17 @@ func TestEndpointListener(t *testing.T) {
 		expectedNamespace := thisNS
 		expectedReplicationControllerName := "rc-name"
 
-		podForAddedAddress1 := &v1.Pod{
+		podForAddedAddress1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedNamespace,
 			},
-			Status: v1.PodStatus{
-				Phase: v1.PodRunning,
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
 			},
 		}
 
-		ownerKindAndName := func(pod *v1.Pod) (string, string) {
+		ownerKindAndName := func(pod *corev1.Pod) (string, string) {
 			return "replicationcontroller", expectedReplicationControllerName
 		}
 
@@ -206,7 +206,7 @@ func TestEndpointListener(t *testing.T) {
 			ControllerNs: "linkerd-namespace",
 		}
 
-		podForAddedAddress1 := &v1.Pod{
+		podForAddedAddress1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
@@ -215,12 +215,12 @@ func TestEndpointListener(t *testing.T) {
 					pkgK8s.ProxyDeploymentLabel: expectedPodDeployment,
 				},
 			},
-			Status: v1.PodStatus{
-				Phase: v1.PodRunning,
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
 			},
 		}
 
-		ownerKindAndName := func(pod *v1.Pod) (string, string) {
+		ownerKindAndName := func(pod *corev1.Pod) (string, string) {
 			return "deployment", expectedPodDeployment
 		}
 
@@ -254,7 +254,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedControllerNamespace := "linkerd-namespace"
 		expectedPodDeployment := "pod-deployment"
 
-		podForAddedAddress1 := &v1.Pod{
+		podForAddedAddress1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
@@ -263,12 +263,12 @@ func TestEndpointListener(t *testing.T) {
 					pkgK8s.ProxyDeploymentLabel: expectedPodDeployment,
 				},
 			},
-			Status: v1.PodStatus{
-				Phase: v1.PodRunning,
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
 			},
 		}
 
-		ownerKindAndName := func(pod *v1.Pod) (string, string) {
+		ownerKindAndName := func(pod *corev1.Pod) (string, string) {
 			return "deployment", expectedPodDeployment
 		}
 

--- a/controller/api/destination/endpoints_watcher_test.go
+++ b/controller/api/destination/endpoints_watcher_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/addr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -106,28 +106,28 @@ status:
 							makeUpdateAddress("172.17.0.20", 8989, "ns", "name1-3"),
 						},
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8989},
-						endpoints: &v1.Endpoints{
+						endpoints: &corev1.Endpoints{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name1",
 								Namespace: "ns",
 							},
-							Subsets: []v1.EndpointSubset{
+							Subsets: []corev1.EndpointSubset{
 								{
-									Addresses: []v1.EndpointAddress{
+									Addresses: []corev1.EndpointAddress{
 										{
 											IP:        "172.17.0.12",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
 										},
 										{
 											IP:        "172.17.0.19",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
 										},
 										{
 											IP:        "172.17.0.20",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
 										},
 									},
-									Ports: []v1.EndpointPort{{Port: 8989}},
+									Ports: []corev1.EndpointPort{{Port: 8989}},
 								},
 							},
 						},
@@ -205,24 +205,24 @@ status:
 							makeUpdateAddress("10.233.88.244", 8990, "ns", "name1-f748fb6b4-6vcmw"),
 						},
 						targetPort: intstr.IntOrString{Type: intstr.String, StrVal: ""},
-						endpoints: &v1.Endpoints{
+						endpoints: &corev1.Endpoints{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name1",
 								Namespace: "ns",
 							},
-							Subsets: []v1.EndpointSubset{
+							Subsets: []corev1.EndpointSubset{
 								{
-									Addresses: []v1.EndpointAddress{
+									Addresses: []corev1.EndpointAddress{
 										{
 											IP:        "10.233.66.239",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-hpwpw"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-hpwpw"},
 										},
 										{
 											IP:        "10.233.88.244",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-6vcmw"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-f748fb6b4-6vcmw"},
 										},
 									},
-									Ports: []v1.EndpointPort{{Port: 8990, Protocol: "TCP"}},
+									Ports: []corev1.EndpointPort{{Port: 8990, Protocol: "TCP"}},
 								},
 							},
 						},
@@ -286,20 +286,20 @@ status:
 							makeUpdateAddress("10.1.30.135", 7779, "ns", "world-575bf846b4-tp4hw"),
 						},
 						targetPort: intstr.IntOrString{Type: intstr.String, StrVal: "app"},
-						endpoints: &v1.Endpoints{
+						endpoints: &corev1.Endpoints{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "world",
 								Namespace: "ns",
 							},
-							Subsets: []v1.EndpointSubset{
+							Subsets: []corev1.EndpointSubset{
 								{
-									Addresses: []v1.EndpointAddress{
+									Addresses: []corev1.EndpointAddress{
 										{
 											IP:        "10.1.30.135",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
 										},
 									},
-									Ports: []v1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
+									Ports: []corev1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
 								},
 							},
 						},
@@ -368,28 +368,28 @@ status:
 							makeUpdateAddress("172.17.0.25", 8989, "ns", "name1-3"),
 						},
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 8989},
-						endpoints: &v1.Endpoints{
+						endpoints: &corev1.Endpoints{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "name1",
 								Namespace: "ns",
 							},
-							Subsets: []v1.EndpointSubset{
+							Subsets: []corev1.EndpointSubset{
 								{
-									Addresses: []v1.EndpointAddress{
+									Addresses: []corev1.EndpointAddress{
 										{
 											IP:        "172.17.0.23",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-1"},
 										},
 										{
 											IP:        "172.17.0.24",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-2"},
 										},
 										{
 											IP:        "172.17.0.25",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "name1-3"},
 										},
 									},
-									Ports: []v1.EndpointPort{{Port: 8989}},
+									Ports: []corev1.EndpointPort{{Port: 8989}},
 								},
 							},
 						},
@@ -419,7 +419,7 @@ spec:
 				serviceID{namespace: "ns", name: "name2"}: map[uint32]*servicePort{
 					7979: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 7979},
-						endpoints:  &v1.Endpoints{},
+						endpoints:  &corev1.Endpoints{},
 					},
 				},
 			},
@@ -445,7 +445,7 @@ spec:
 				serviceID{namespace: "ns", name: "name3"}: map[uint32]*servicePort{
 					6969: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 6969},
-						endpoints:  &v1.Endpoints{},
+						endpoints:  &corev1.Endpoints{},
 					},
 				},
 			},
@@ -462,7 +462,7 @@ spec:
 				serviceID{namespace: "ns", name: "name4"}: map[uint32]*servicePort{
 					5959: {
 						targetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 5959},
-						endpoints:  &v1.Endpoints{},
+						endpoints:  &corev1.Endpoints{},
 					},
 				},
 			},

--- a/controller/api/destination/k8s_resolver_test.go
+++ b/controller/api/destination/k8s_resolver_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -74,20 +74,20 @@ func TestGetState(t *testing.T) {
 						addresses: []*updateAddress{
 							makeUpdateAddress("10.1.30.135", 7779, "ns", "world-575bf846b4-tp4hw"),
 						},
-						endpoints: &v1.Endpoints{
+						endpoints: &corev1.Endpoints{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "world",
 								Namespace: "ns",
 							},
-							Subsets: []v1.EndpointSubset{
+							Subsets: []corev1.EndpointSubset{
 								{
-									Addresses: []v1.EndpointAddress{
+									Addresses: []corev1.EndpointAddress{
 										{
 											IP:        "10.1.30.135",
-											TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
+											TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: "world-575bf846b4-tp4hw"},
 										},
 									},
-									Ports: []v1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
+									Ports: []corev1.EndpointPort{{Name: "app", Port: 7779, Protocol: "TCP"}},
 								},
 							},
 						},

--- a/controller/api/destination/test_helper.go
+++ b/controller/api/destination/test_helper.go
@@ -7,7 +7,7 @@ import (
 	proxyNet "github.com/linkerd/linkerd2-proxy-api/go/net"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
 	"github.com/linkerd/linkerd2/pkg/addr"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -116,7 +116,7 @@ func makeUpdateAddress(ipStr string, portNum uint32, ns string, name string) *up
 	ip, _ := addr.ParseProxyIPV4(ipStr)
 	return &updateAddress{
 		address: &proxyNet.TcpAddress{Ip: ip, Port: portNum},
-		pod: &v1.Pod{
+		pod: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
 				Name:      name,

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	k8sV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -134,7 +134,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 		}
 	}
 
-	var pods []*k8sV1.Pod
+	var pods []*corev1.Pod
 	if namespace != "" {
 		pods, err = s.k8sAPI.Pod().Lister().Pods(namespace).List(labelSelector)
 	} else {
@@ -249,7 +249,7 @@ func (s *grpcServer) TapByResource(req *pb.TapByResourceRequest, stream pb.Api_T
 	}
 }
 
-func (s *grpcServer) shouldIgnore(pod *k8sV1.Pod) bool {
+func (s *grpcServer) shouldIgnore(pod *corev1.Pod) bool {
 	for _, namespace := range s.ignoredNamespaces {
 		if pod.Namespace == namespace {
 			return true

--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -9,7 +9,7 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/prometheus/common/model"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -433,7 +433,7 @@ func (s *grpcServer) getPodStats(obj runtime.Object) (*podStats, error) {
 	meshCount := &podStats{}
 
 	for _, pod := range pods {
-		if pod.Status.Phase == apiv1.PodFailed {
+		if pod.Status.Phase == corev1.PodFailed {
 			meshCount.failed++
 		} else {
 			meshCount.total++
@@ -466,7 +466,7 @@ func toPodError(container, image, reason, message string) *pb.PodErrors_PodError
 	}
 }
 
-func checkContainerErrors(containerStatuses []apiv1.ContainerStatus, containerName string) []*pb.PodErrors_PodError {
+func checkContainerErrors(containerStatuses []corev1.ContainerStatus, containerName string) []*pb.PodErrors_PodError {
 	errors := []*pb.PodErrors_PodError{}
 	for _, st := range containerStatuses {
 		if !st.Ready {

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -13,7 +13,7 @@ import (
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"google.golang.org/grpc"
 )
@@ -120,7 +120,7 @@ func (m *mockProm) Query(ctx context.Context, query string, ts time.Time) (model
 	m.QueriesExecuted = append(m.QueriesExecuted, query)
 	return m.Res, nil
 }
-func (m *mockProm) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+func (m *mockProm) QueryRange(ctx context.Context, query string, r promv1.Range) (model.Value, error) {
 	m.rwLock.Lock()
 	defer m.rwLock.Unlock()
 	m.QueriesExecuted = append(m.QueriesExecuted, query)

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -149,7 +149,7 @@ func BuildStatSummaryRequest(p StatsSummaryRequestParams) (*pb.StatSummaryReques
 	if p.AllNamespaces {
 		targetNamespace = ""
 	} else if p.Namespace == "" {
-		targetNamespace = v1.NamespaceDefault
+		targetNamespace = corev1.NamespaceDefault
 	}
 
 	resourceType, err := k8s.CanonicalResourceNameFromFriendlyName(p.ResourceType)
@@ -239,7 +239,7 @@ func BuildTopRoutesRequest(p TopRoutesRequestParams) (*pb.TopRoutesRequest, erro
 	if p.AllNamespaces {
 		targetNamespace = ""
 	} else if p.Namespace == "" {
-		targetNamespace = v1.NamespaceDefault
+		targetNamespace = corev1.NamespaceDefault
 	}
 
 	resourceType, err := k8s.CanonicalResourceNameFromFriendlyName(p.ResourceType)
@@ -516,7 +516,7 @@ func CreateTapEvent(eventHTTP *pb.TapEvent_Http, dstMeta map[string]string, prox
 }
 
 // K8sPodToPublicPod converts a Kubernetes Pod to a Public API Pod
-func K8sPodToPublicPod(pod v1.Pod, ownerKind string, ownerName string) pb.Pod {
+func K8sPodToPublicPod(pod corev1.Pod, ownerKind string, ownerName string) pb.Pod {
 	status := string(pod.Status.Phase)
 	if pod.DeletionTimestamp != nil {
 		status = "Terminating"

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,8 +18,8 @@ import (
 func TestGRPCError(t *testing.T) {
 	t.Run("Maps errors to gRPC errors", func(t *testing.T) {
 		expectations := map[error]error{
-			nil:                       nil,
-			errors.New("normal erro"): errors.New("rpc error: code = Unknown desc = normal erro"),
+			nil:                        nil,
+			errors.New("normal error"): errors.New("rpc error: code = Unknown desc = normal error"),
 			status.Error(codes.NotFound, "grpc not found"):                                              errors.New("rpc error: code = NotFound desc = grpc not found"),
 			k8sError.NewNotFound(schema.GroupResource{Group: "foo", Resource: "bar"}, "http not found"): errors.New("rpc error: code = NotFound desc = bar.foo \"http not found\" not found"),
 			k8sError.NewServiceUnavailable("unavailable"):                                               errors.New("rpc error: code = Unavailable desc = unavailable"),
@@ -402,7 +402,7 @@ func TestBuildResources(t *testing.T) {
 
 func TestK8sPodToPublicPod(t *testing.T) {
 	type podExp struct {
-		k8sPod    v1.Pod
+		k8sPod    corev1.Pod
 		ownerKind string
 		ownerName string
 		publicPod pb.Pod
@@ -411,13 +411,13 @@ func TestK8sPodToPublicPod(t *testing.T) {
 	t.Run("Returns expected pods", func(t *testing.T) {
 		expectations := []podExp{
 			{
-				k8sPod: v1.Pod{},
+				k8sPod: corev1.Pod{},
 				publicPod: pb.Pod{
 					Name: "/",
 				},
 			},
 			{
-				k8sPod: v1.Pod{
+				k8sPod: corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace:       "ns",
 						Name:            "name",
@@ -427,18 +427,18 @@ func TestK8sPodToPublicPod(t *testing.T) {
 							k8s.ControllerNSLabel:        "controller-ns",
 						},
 					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
 							{
 								Name:  k8s.ProxyContainerName,
 								Image: "linkerd-proxy:test-version",
 							},
 						},
 					},
-					Status: v1.PodStatus{
+					Status: corev1.PodStatus{
 						PodIP: "pod-ip",
 						Phase: "status",
-						ContainerStatuses: []v1.ContainerStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
 							{
 								Name:  k8s.ProxyContainerName,
 								Ready: true,

--- a/controller/ca/controller.go
+++ b/controller/ca/controller.go
@@ -9,7 +9,7 @@ import (
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -108,7 +108,7 @@ func (c *CertificateController) syncObject(key string) error {
 
 func (c *CertificateController) syncNamespace(ns string) error {
 	log.Debugf("syncNamespace(%s)", ns)
-	configMap := &v1.ConfigMap{
+	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: pkgK8s.TLSTrustAnchorConfigMapName},
 		Data: map[string]string{
 			pkgK8s.TLSTrustAnchorFileName: c.ca.Cred.EncodeCertificatePEM(),
@@ -151,7 +151,7 @@ func (c *CertificateController) syncSecret(key string) error {
 		log.Errorf("Failed to issue certificate for %s", dnsName)
 		return err
 	}
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: secretName},
 		Data: map[string][]byte{
 			pkgK8s.TLSCertFileName:       cred.Certificate.Raw,
@@ -167,7 +167,7 @@ func (c *CertificateController) syncSecret(key string) error {
 }
 
 func (c *CertificateController) handlePodAdd(obj interface{}) {
-	pod := obj.(*v1.Pod)
+	pod := obj.(*corev1.Pod)
 	if pkgK8s.IsMeshed(pod, c.namespace) {
 		log.Debugf("enqueuing update of CA bundle configmap in %s", pod.Namespace)
 		c.queue.Add(pod.Namespace)

--- a/controller/ca/controller_test.go
+++ b/controller/ca/controller_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
-	"k8s.io/api/core/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -31,8 +31,8 @@ func TestCertificateController(t *testing.T) {
 		}
 		defer close(stopCh)
 
-		controller.handlePodUpdate(nil, &v1.Pod{
-			ObjectMeta: meta.ObjectMeta{
+		controller.handlePodUpdate(nil, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      injectedPodName,
 				Namespace: injectedNS,
 				Labels: map[string]string{

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -274,7 +274,7 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 // GetOwnerKindAndName returns the pod owner's kind and name, using owner
 // references from the Kubernetes API. The kind is represented as the Kubernetes
 // singular resource type (e.g. deployment, daemonset, job, etc.)
-func (api *API) GetOwnerKindAndName(pod *apiv1.Pod) (string, string) {
+func (api *API) GetOwnerKindAndName(pod *corev1.Pod) (string, string) {
 	if len(pod.GetOwnerReferences()) != 1 {
 		return "pod", pod.Name
 	}
@@ -294,14 +294,14 @@ func (api *API) GetOwnerKindAndName(pod *apiv1.Pod) (string, string) {
 
 // GetPodsFor returns all running and pending Pods associated with a given
 // Kubernetes object. Use includeFailed to also get failed Pods
-func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod, error) {
+func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Pod, error) {
 	var namespace string
 	var selector labels.Selector
-	var pods []*apiv1.Pod
+	var pods []*corev1.Pod
 	var err error
 
 	switch typed := obj.(type) {
-	case *apiv1.Namespace:
+	case *corev1.Namespace:
 		namespace = typed.Name
 		selector = labels.Everything()
 
@@ -317,13 +317,13 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
 
-	case *apiv1.ReplicationController:
+	case *corev1.ReplicationController:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
 
-	case *apiv1.Service:
-		if typed.Spec.Type == apiv1.ServiceTypeExternalName {
-			return []*apiv1.Pod{}, nil
+	case *corev1.Service:
+		if typed.Spec.Type == corev1.ServiceTypeExternalName {
+			return []*corev1.Pod{}, nil
 		}
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
@@ -332,7 +332,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
 
-	case *apiv1.Pod:
+	case *corev1.Pod:
 		// Special case for pods:
 		// GetPodsFor a pod should just return the pod itself
 		namespace = typed.Namespace
@@ -340,7 +340,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 		if err != nil {
 			return nil, err
 		}
-		pods = []*apiv1.Pod{pod}
+		pods = []*corev1.Pod{pod}
 
 	default:
 		return nil, fmt.Errorf("Cannot get object selector: %v", obj)
@@ -355,7 +355,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 		}
 	}
 
-	allPods := []*apiv1.Pod{}
+	allPods := []*corev1.Pod{}
 	for _, pod := range pods {
 		if isPendingOrRunning(pod) || (includeFailed && isFailed(pod)) {
 			allPods = append(allPods, pod)
@@ -368,7 +368,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Pod
 // GetNameAndNamespaceOf returns the name and namespace of the given object.
 func GetNameAndNamespaceOf(obj runtime.Object) (string, string, error) {
 	switch typed := obj.(type) {
-	case *apiv1.Namespace:
+	case *corev1.Namespace:
 		return typed.Name, typed.Name, nil
 
 	case *appsv1.DaemonSet:
@@ -380,16 +380,16 @@ func GetNameAndNamespaceOf(obj runtime.Object) (string, string, error) {
 	case *appsv1beta2.ReplicaSet:
 		return typed.Name, typed.Namespace, nil
 
-	case *apiv1.ReplicationController:
+	case *corev1.ReplicationController:
 		return typed.Name, typed.Namespace, nil
 
-	case *apiv1.Service:
+	case *corev1.Service:
 		return typed.Name, typed.Namespace, nil
 
 	case *appsv1.StatefulSet:
 		return typed.Name, typed.Namespace, nil
 
-	case *apiv1.Pod:
+	case *corev1.Pod:
 		return typed.Name, typed.Namespace, nil
 
 	default:
@@ -420,7 +420,7 @@ func GetNamespaceOf(obj runtime.Object) (string, error) {
 // work with a single namespace, in which case it returns that namespace. Note
 // that namespace reads are not cached.
 func (api *API) getNamespaces(name string) ([]runtime.Object, error) {
-	namespaces := make([]*apiv1.Namespace, 0)
+	namespaces := make([]*corev1.Namespace, 0)
 
 	if name == "" && api.namespace != "" {
 		name = api.namespace
@@ -440,7 +440,7 @@ func (api *API) getNamespaces(name string) ([]runtime.Object, error) {
 		if err != nil {
 			return nil, err
 		}
-		namespaces = []*apiv1.Namespace{namespace}
+		namespaces = []*corev1.Namespace{namespace}
 	}
 
 	objects := []runtime.Object{}
@@ -479,16 +479,16 @@ func (api *API) getDeployments(namespace, name string) ([]runtime.Object, error)
 
 func (api *API) getPods(namespace, name string) ([]runtime.Object, error) {
 	var err error
-	var pods []*apiv1.Pod
+	var pods []*corev1.Pod
 
 	if namespace == "" {
 		pods, err = api.Pod().Lister().List(labels.Everything())
 	} else if name == "" {
 		pods, err = api.Pod().Lister().Pods(namespace).List(labels.Everything())
 	} else {
-		var pod *apiv1.Pod
+		var pod *corev1.Pod
 		pod, err = api.Pod().Lister().Pods(namespace).Get(name)
-		pods = []*apiv1.Pod{pod}
+		pods = []*corev1.Pod{pod}
 	}
 
 	if err != nil {
@@ -508,16 +508,16 @@ func (api *API) getPods(namespace, name string) ([]runtime.Object, error) {
 
 func (api *API) getRCs(namespace, name string) ([]runtime.Object, error) {
 	var err error
-	var rcs []*apiv1.ReplicationController
+	var rcs []*corev1.ReplicationController
 
 	if namespace == "" {
 		rcs, err = api.RC().Lister().List(labels.Everything())
 	} else if name == "" {
 		rcs, err = api.RC().Lister().ReplicationControllers(namespace).List(labels.Everything())
 	} else {
-		var rc *apiv1.ReplicationController
+		var rc *corev1.ReplicationController
 		rc, err = api.RC().Lister().ReplicationControllers(namespace).Get(name)
-		rcs = []*apiv1.ReplicationController{rc}
+		rcs = []*corev1.ReplicationController{rc}
 	}
 
 	if err != nil {
@@ -601,18 +601,18 @@ func (api *API) getServices(namespace, name string) ([]runtime.Object, error) {
 
 // GetServices returns a list of Service resources, based on input namespace and
 // name.
-func (api *API) GetServices(namespace, name string) ([]*apiv1.Service, error) {
+func (api *API) GetServices(namespace, name string) ([]*corev1.Service, error) {
 	var err error
-	var services []*apiv1.Service
+	var services []*corev1.Service
 
 	if namespace == "" {
 		services, err = api.Svc().Lister().List(labels.Everything())
 	} else if name == "" {
 		services, err = api.Svc().Lister().Services(namespace).List(labels.Everything())
 	} else {
-		var svc *apiv1.Service
+		var svc *corev1.Service
 		svc, err = api.Svc().Lister().Services(namespace).Get(name)
-		services = []*apiv1.Service{svc}
+		services = []*corev1.Service{svc}
 	}
 
 	return services, err
@@ -621,9 +621,9 @@ func (api *API) GetServices(namespace, name string) ([]*apiv1.Service, error) {
 // GetServicesFor returns all Service resources which include a pod of the given
 // resource object.  In other words, it returns all Services of which the given
 // resource object is a part of.
-func (api *API) GetServicesFor(obj runtime.Object, includeFailed bool) ([]*apiv1.Service, error) {
-	if svc, ok := obj.(*apiv1.Service); ok {
-		return []*apiv1.Service{svc}, nil
+func (api *API) GetServicesFor(obj runtime.Object, includeFailed bool) ([]*corev1.Service, error) {
+	if svc, ok := obj.(*corev1.Service); ok {
+		return []*corev1.Service{svc}, nil
 	}
 
 	pods, err := api.GetPodsFor(obj, includeFailed)
@@ -638,7 +638,7 @@ func (api *API) GetServicesFor(obj runtime.Object, includeFailed bool) ([]*apiv1
 	if err != nil {
 		return nil, err
 	}
-	services := make([]*apiv1.Service, 0)
+	services := make([]*corev1.Service, 0)
 	for _, svc := range allServices {
 		svcPods, err := api.GetPodsFor(svc, includeFailed)
 		if err != nil {
@@ -655,7 +655,7 @@ func (api *API) GetServicesFor(obj runtime.Object, includeFailed bool) ([]*apiv1
 // first look for a matching service profile in the client's namespace.  If not
 // found, we then look in the service's namespace.  If no service profile is
 // found, we return the default service profile.
-func (api *API) GetServiceProfileFor(svc *apiv1.Service, clientNs string) *spv1alpha1.ServiceProfile {
+func (api *API) GetServiceProfileFor(svc *corev1.Service, clientNs string) *spv1alpha1.ServiceProfile {
 	dst := fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
 	// First attempt to lookup profile in client namespace
 	if clientNs != "" {
@@ -688,7 +688,7 @@ func (api *API) GetServiceProfileFor(svc *apiv1.Service, clientNs string) *spv1a
 	}
 }
 
-func hasOverlap(as, bs []*apiv1.Pod) bool {
+func hasOverlap(as, bs []*corev1.Pod) bool {
 	for _, a := range as {
 		for _, b := range bs {
 			if a.Name == b.Name {
@@ -699,13 +699,13 @@ func hasOverlap(as, bs []*apiv1.Pod) bool {
 	return false
 }
 
-func isPendingOrRunning(pod *apiv1.Pod) bool {
-	pending := pod.Status.Phase == apiv1.PodPending
-	running := pod.Status.Phase == apiv1.PodRunning
+func isPendingOrRunning(pod *corev1.Pod) bool {
+	pending := pod.Status.Phase == corev1.PodPending
+	running := pod.Status.Phase == corev1.PodRunning
 	terminating := pod.DeletionTimestamp != nil
 	return (pending || running) && !terminating
 }
 
-func isFailed(pod *apiv1.Pod) bool {
-	return pod.Status.Phase == apiv1.PodFailed
+func isFailed(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodFailed
 }

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apiv1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -262,7 +262,7 @@ metadata:
 				t.Fatalf("expected 1 namespace, got %d", len(namespaces))
 			}
 
-			if namespaces[0].(*apiv1.Namespace).Name != "namespace1" {
+			if namespaces[0].(*corev1.Namespace).Name != "namespace1" {
 				t.Fatalf("expected namespace1, got %v", namespaces[0])
 			}
 		})
@@ -583,9 +583,9 @@ status:
 				t.Fatalf("newAPI error: %s", err)
 			}
 
-			k8sResultPods := []*apiv1.Pod{}
+			k8sResultPods := []*corev1.Pod{}
 			for _, obj := range k8sResults {
-				k8sResultPods = append(k8sResultPods, obj.(*apiv1.Pod))
+				k8sResultPods = append(k8sResultPods, obj.(*corev1.Pod))
 			}
 
 			pods, err := api.GetPodsFor(k8sInputObj, false)
@@ -690,7 +690,7 @@ metadata:
 			t.Fatalf("newAPI error: %s", err)
 		}
 
-		pod := objs[0].(*apiv1.Pod)
+		pod := objs[0].(*corev1.Pod)
 		ownerKind, ownerName := api.GetOwnerKindAndName(pod)
 
 		if ownerKind != tt.expectedOwnerKind {
@@ -794,7 +794,7 @@ spec:
 			t.Fatalf("newAPI error: %s", err)
 		}
 
-		svc := apiv1.Service{
+		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "books",
 				Namespace: "server",

--- a/controller/proxy-injector/patch_test.go
+++ b/controller/proxy-injector/patch_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/proxy-injector/fake"
 	k8sPkg "github.com/linkerd/linkerd2/pkg/k8s"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestPatch(t *testing.T) {
@@ -57,9 +57,9 @@ func TestPatch(t *testing.T) {
 	expected := NewPatch()
 	expected.patchOps = []*patchOp{
 		{Op: "add", Path: patchPathContainer, Value: sidecar},
-		{Op: "add", Path: patchPathInitContainerRoot, Value: []*v1.Container{}},
+		{Op: "add", Path: patchPathInitContainerRoot, Value: []*corev1.Container{}},
 		{Op: "add", Path: patchPathInitContainer, Value: init},
-		{Op: "add", Path: patchPathVolumeRoot, Value: []*v1.Volume{}},
+		{Op: "add", Path: patchPathVolumeRoot, Value: []*corev1.Volume{}},
 		{Op: "add", Path: patchPathVolume, Value: trustAnchors},
 		{Op: "add", Path: patchPathVolume, Value: secrets},
 		{Op: "add", Path: patchPathPodLabels, Value: map[string]string{

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/public"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
-	"k8s.io/api/core/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestHealthChecker(t *testing.T) {
@@ -291,12 +291,12 @@ func TestHealthChecker(t *testing.T) {
 }
 
 func TestValidateControlPlanePods(t *testing.T) {
-	pod := func(name string, phase v1.PodPhase, ready bool) v1.Pod {
-		return v1.Pod{
-			ObjectMeta: meta.ObjectMeta{Name: name},
-			Status: v1.PodStatus{
+	pod := func(name string, phase corev1.PodPhase, ready bool) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: corev1.PodStatus{
 				Phase: phase,
-				ContainerStatuses: []v1.ContainerStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
 					{
 						Name:  strings.Split(name, "-")[1],
 						Ready: ready,
@@ -307,11 +307,11 @@ func TestValidateControlPlanePods(t *testing.T) {
 	}
 
 	t.Run("Returns an error if not all pods are running", func(t *testing.T) {
-		pods := []v1.Pod{
-			pod("linkerd-controller-6f78cbd47-bc557", v1.PodRunning, true),
-			pod("linkerd-grafana-5b7d796646-hh46d", v1.PodRunning, true),
-			pod("linkerd-prometheus-74d6879cd6-bbdk6", v1.PodFailed, false),
-			pod("linkerd-web-98c9ddbcd-7b5lh", v1.PodRunning, true),
+		pods := []corev1.Pod{
+			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
+			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodFailed, false),
+			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
 
 		err := validateControlPlanePods(pods)
@@ -324,11 +324,11 @@ func TestValidateControlPlanePods(t *testing.T) {
 	})
 
 	t.Run("Returns an error if not all containers are ready", func(t *testing.T) {
-		pods := []v1.Pod{
-			pod("linkerd-controller-6f78cbd47-bc557", v1.PodRunning, true),
-			pod("linkerd-grafana-5b7d796646-hh46d", v1.PodRunning, false),
-			pod("linkerd-prometheus-74d6879cd6-bbdk6", v1.PodRunning, true),
-			pod("linkerd-web-98c9ddbcd-7b5lh", v1.PodRunning, true),
+		pods := []corev1.Pod{
+			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
+			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, false),
+			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
+			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
 
 		err := validateControlPlanePods(pods)
@@ -341,11 +341,11 @@ func TestValidateControlPlanePods(t *testing.T) {
 	})
 
 	t.Run("Returns nil if all pods are running and all containers are ready", func(t *testing.T) {
-		pods := []v1.Pod{
-			pod("linkerd-controller-6f78cbd47-bc557", v1.PodRunning, true),
-			pod("linkerd-grafana-5b7d796646-hh46d", v1.PodRunning, true),
-			pod("linkerd-prometheus-74d6879cd6-bbdk6", v1.PodRunning, true),
-			pod("linkerd-web-98c9ddbcd-7b5lh", v1.PodRunning, true),
+		pods := []corev1.Pod{
+			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
+			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
+			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
 
 		err := validateControlPlanePods(pods)
@@ -355,12 +355,12 @@ func TestValidateControlPlanePods(t *testing.T) {
 	})
 
 	t.Run("Returns nil if all linkerd pods are running and pod list includes non-linkerd pod", func(t *testing.T) {
-		pods := []v1.Pod{
-			pod("linkerd-controller-6f78cbd47-bc557", v1.PodRunning, true),
-			pod("linkerd-grafana-5b7d796646-hh46d", v1.PodRunning, true),
-			pod("linkerd-prometheus-74d6879cd6-bbdk6", v1.PodRunning, true),
-			pod("linkerd-web-98c9ddbcd-7b5lh", v1.PodRunning, true),
-			pod("hello-43c25d", v1.PodRunning, true),
+		pods := []corev1.Pod{
+			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
+			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
+			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
+			pod("hello-43c25d", corev1.PodRunning, true),
 		}
 
 		err := validateControlPlanePods(pods)

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 
@@ -91,11 +91,11 @@ func (kubeAPI *KubernetesAPI) NamespaceExists(ctx context.Context, client *http.
 }
 
 // GetPodsByNamespace returns all pods in a given namespace
-func (kubeAPI *KubernetesAPI) GetPodsByNamespace(ctx context.Context, client *http.Client, namespace string) ([]v1.Pod, error) {
+func (kubeAPI *KubernetesAPI) GetPodsByNamespace(ctx context.Context, client *http.Client, namespace string) ([]corev1.Pod, error) {
 	return kubeAPI.getPods(ctx, client, "/api/v1/namespaces/"+namespace+"/pods")
 }
 
-func (kubeAPI *KubernetesAPI) getPods(ctx context.Context, client *http.Client, path string) ([]v1.Pod, error) {
+func (kubeAPI *KubernetesAPI) getPods(ctx context.Context, client *http.Client, path string) ([]corev1.Pod, error) {
 	rsp, err := kubeAPI.getRequest(ctx, client, path)
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (kubeAPI *KubernetesAPI) getPods(ctx context.Context, client *http.Client, 
 		return nil, err
 	}
 
-	var podList v1.PodList
+	var podList corev1.PodList
 	err = json.Unmarshal(bytes, &podList)
 	if err != nil {
 		return nil, err

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	"github.com/linkerd/linkerd2/pkg/version"
-	appsV1 "k8s.io/api/apps/v1"
-	coreV1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -178,7 +178,7 @@ func CreatedByAnnotationValue() string {
 }
 
 // GetPodLabels returns the set of prometheus owner labels for a given pod
-func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]string {
+func GetPodLabels(ownerKind, ownerName string, pod *corev1.Pod) map[string]string {
 	labels := map[string]string{"pod": pod.Name}
 
 	l5dLabel := KindToL5DLabel(ownerKind)
@@ -188,7 +188,7 @@ func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]strin
 		labels["control_plane_ns"] = controllerNS
 	}
 
-	if pth := pod.Labels[appsV1.DefaultDeploymentUniqueLabelKey]; pth != "" {
+	if pth := pod.Labels[appsv1.DefaultDeploymentUniqueLabelKey]; pth != "" {
 		labels["pod_template_hash"] = pth
 	}
 
@@ -196,7 +196,7 @@ func GetPodLabels(ownerKind, ownerName string, pod *coreV1.Pod) map[string]strin
 }
 
 // IsMeshed returns whether a given Pod is in a given controller's service mesh.
-func IsMeshed(pod *coreV1.Pod, controllerNS string) bool {
+func IsMeshed(pod *corev1.Pod, controllerNS string) bool {
 	return pod.Labels[ControllerNSLabel] == controllerNS
 }
 

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -4,19 +4,19 @@ import (
 	"reflect"
 	"testing"
 
-	appsV1 "k8s.io/api/apps/v1"
-	coreV1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetPodLabels(t *testing.T) {
 	t.Run("Maps proxy labels to prometheus labels", func(t *testing.T) {
-		pod := &coreV1.Pod{
-			ObjectMeta: metaV1.ObjectMeta{
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-pod",
 				Labels: map[string]string{
 					ControllerNSLabel:                      "linkerd-namespace",
-					appsV1.DefaultDeploymentUniqueLabelKey: "test-pth",
+					appsv1.DefaultDeploymentUniqueLabelKey: "test-pth",
 				},
 			},
 		}

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
@@ -67,7 +67,7 @@ func NewPortForward(
 
 	podName := ""
 	for _, pod := range pods {
-		if pod.Status.Phase == v1.PodRunning {
+		if pod.Status.Phase == corev1.PodRunning {
 			if strings.HasPrefix(pod.Name, deployName) {
 				podName = pod.Name
 				break

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -49,7 +49,7 @@ func RenderOpenAPI(fileName, namespace, name string, w io.Writer) error {
 
 func swaggerToServiceProfile(swagger spec.Swagger, namespace, name string) sp.ServiceProfile {
 	profile := sp.ServiceProfile{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -14,7 +14,7 @@ import (
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
 	"github.com/linkerd/linkerd2/pkg/util"
 	log "github.com/sirupsen/logrus"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 )
@@ -35,7 +35,7 @@ var (
 		},
 	}
 	// ServiceProfileMeta is the TypeMeta for the ServiceProfile custom resource.
-	ServiceProfileMeta = meta_v1.TypeMeta{
+	ServiceProfileMeta = metav1.TypeMeta{
 		APIVersion: "linkerd.io/v1alpha1",
 		Kind:       "ServiceProfile",
 	}

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/emicklei/proto"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // RenderProto reads a protobuf definition file and renders the corresponding
@@ -60,7 +60,7 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name string) (*sp.Se
 	proto.Walk(definition, handle)
 
 	return &sp.ServiceProfile{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -14,7 +14,7 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/util"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha1"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -49,7 +49,7 @@ func RenderTapOutputProfile(client pb.ApiClient, tapResource, namespace, name st
 
 func tapToServiceProfile(client pb.ApiClient, tapReq *pb.TapByResourceRequest, namespace, name string, tapDuration time.Duration, routeLimit int) (sp.ServiceProfile, error) {
 	profile := sp.ServiceProfile{
-		ObjectMeta: meta_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
 			Namespace: namespace,
 		},

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -57,7 +57,7 @@ func (h *KubernetesHelper) CreateNamespaceIfNotExists(namespace string) error {
 	err := h.CheckIfNamespaceExists(namespace)
 
 	if err != nil {
-		ns := &coreV1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		_, err = h.clientset.CoreV1().Namespaces().Create(ns)
 
 		if err != nil {


### PR DESCRIPTION
goimports checks import lines, adding missing ones and removing
unreferenced ones:
https://godoc.org/golang.org/x/tools/cmd/goimports

It also requires named imports for packages whose
import paths don't match their package names:
- https://github.com/golang/go/issues/28428
- https://go-review.googlesource.com/c/tools/+/145699/

Also standardized named imports of common Kubernetes packaages.

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>