### PR TITLE
lint: Enable unconvert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
   - misspell
   - nakedret
   - typecheck
+  - unconvert
   - unused
   - varcheck
   # TODO: enable more linters!
@@ -30,7 +31,6 @@ linters:
   # - prealloc
   # - scopelint
   # - stylecheck
-  # - unconvert
   # - unparam
   disable:
   - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,10 @@
+# This file specifies which linters golangci-lint should run.
+#
+# For descriptions of all available linters, run:
+# ./.golangci-lint-1.15.0 linters
+# or browse to:
+# https://github.com/golangci/golangci-lint#supported-linters
+
 run:
   deadline: 5m
 issues:

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -336,7 +336,7 @@ func ToRequestMatch(reqMatch *sp.RequestMatch) (*pb.RequestMatch, error) {
 // - recursive fields
 func Validate(data []byte) error {
 	var serviceProfile sp.ServiceProfile
-	err := yaml.UnmarshalStrict([]byte(data), &serviceProfile)
+	err := yaml.UnmarshalStrict(data, &serviceProfile)
 	if err != nil {
 		return fmt.Errorf("failed to validate ServiceProfile: %s", err)
 	}

--- a/pkg/profiles/tap_test.go
+++ b/pkg/profiles/tap_test.go
@@ -102,7 +102,7 @@ func TestTapToServiceProfile(t *testing.T) {
 		},
 	}
 
-	actualServiceProfile, err := tapToServiceProfile(mockAPIClient, tapReq, namespace, name, tapDuration, int(routeLimit))
+	actualServiceProfile, err := tapToServiceProfile(mockAPIClient, tapReq, namespace, name, tapDuration, routeLimit)
 	if err != nil {
 		t.Fatalf("Failed to create ServiceProfile: %v", err)
 	}


### PR DESCRIPTION
unconvert removes unnecessary type conversions:
https://github.com/mdempsky/unconvert

Part of #217

Signed-off-by: Andrew Seigner <siggy@buoyant.io>