### PR TITLE
inject: Use k8s templating for identities

### DIFF
--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -168,10 +168,6 @@ data:
       value: tcp://0.0.0.0:{{.Values.InboundPort}}
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: {{.Values.ProfileSuffixes}}
-    - name: LINKERD2_PROXY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
     {{- if .Values.InboundAcceptKeepaliveMs }}
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
       value: {{.Values.InboundAcceptKeepaliveMs}}ms
@@ -189,7 +185,7 @@ data:
       value: /var/linkerd-io/identity/{{.Values.TLSCertFileName}}
     - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
       value: /var/linkerd-io/identity/{{.Values.TLSPrivateKeyFileName}}
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
       value: "" # this value will be computed by the webhook
     - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
       value: {{.Values.Namespace}}

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -42,7 +42,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -51,7 +51,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: nginx.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: nginx.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -42,7 +42,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -51,7 +51,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: redis.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: redis.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -142,7 +142,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -151,7 +151,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: nginx.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: nginx.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -42,7 +42,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -51,7 +51,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: redis.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: redis.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web1.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web1.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -164,7 +164,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -173,7 +173,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web2.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web2.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -275,7 +275,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -284,7 +284,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web3.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web3.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -386,7 +386,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -395,7 +395,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web4.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web4.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -164,7 +164,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -173,7 +173,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: not-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: not-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -54,7 +54,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -63,7 +63,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_tls.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,15 +62,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -55,7 +55,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -64,7 +64,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -55,7 +55,7 @@ items:
             value: tcp://0.0.0.0:4143
           - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
             value: .
-          - name: LINKERD2_PROXY_POD_NAMESPACE
+          - name: K8S_NS
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
@@ -64,7 +64,7 @@ items:
           - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
             value: 10000ms
           - name: LINKERD2_PROXY_ID
-            value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+            value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
           image: gcr.io/linkerd-io/proxy:testinjectversion
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -160,7 +160,7 @@ items:
             value: tcp://0.0.0.0:4143
           - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
             value: .
-          - name: LINKERD2_PROXY_POD_NAMESPACE
+          - name: K8S_NS
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
@@ -169,7 +169,7 @@ items:
           - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
             value: 10000ms
           - name: LINKERD2_PROXY_ID
-            value: emoji.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+            value: emoji.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
           image: gcr.io/linkerd-io/proxy:testinjectversion
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -55,7 +55,7 @@ items:
             value: tcp://0.0.0.0:4143
           - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
             value: .
-          - name: LINKERD2_PROXY_POD_NAMESPACE
+          - name: K8S_NS
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
@@ -64,7 +64,7 @@ items:
           - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
             value: 10000ms
           - name: LINKERD2_PROXY_ID
-            value: web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+            value: web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
           image: gcr.io/linkerd-io/proxy:testinjectversion
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -160,7 +160,7 @@ items:
             value: tcp://0.0.0.0:4143
           - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
             value: .
-          - name: LINKERD2_PROXY_POD_NAMESPACE
+          - name: K8S_NS
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
@@ -169,7 +169,7 @@ items:
           - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
             value: 10000ms
           - name: LINKERD2_PROXY_ID
-            value: emoji.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+            value: emoji.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
           image: gcr.io/linkerd-io/proxy:testinjectversion
           imagePullPolicy: IfNotPresent
           livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -36,7 +36,7 @@ spec:
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: .
-    - name: LINKERD2_PROXY_POD_NAMESPACE
+    - name: K8S_NS
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
@@ -45,7 +45,7 @@ spec:
     - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
       value: 10000ms
     - name: LINKERD2_PROXY_ID
-      value: vote-bot.pod.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+      value: vote-bot.pod.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
     image: gcr.io/linkerd-io/proxy:testinjectversion
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_tls.golden.yml
@@ -36,7 +36,7 @@ spec:
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: .
-    - name: LINKERD2_PROXY_POD_NAMESPACE
+    - name: K8S_NS
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
@@ -45,15 +45,15 @@ spec:
     - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
       value: 10000ms
     - name: LINKERD2_PROXY_ID
-      value: vote-bot.pod.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+      value: vote-bot.pod.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
     - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
       value: /var/linkerd-io/trust-anchors/trust-anchors.pem
     - name: LINKERD2_PROXY_TLS_CERT
       value: /var/linkerd-io/identity/certificate.crt
     - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
       value: /var/linkerd-io/identity/private-key.p8
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-      value: vote-bot.pod.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+      value: vote-bot.pod.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
     - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
       value: linkerd
     - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -36,7 +36,7 @@ spec:
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: .
-    - name: LINKERD2_PROXY_POD_NAMESPACE
+    - name: K8S_NS
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
@@ -45,7 +45,7 @@ spec:
     - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
       value: 10000ms
     - name: LINKERD2_PROXY_ID
-      value: vote-bot.pod.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+      value: vote-bot.pod.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
     image: gcr.io/linkerd-io/proxy:testinjectversion
     imagePullPolicy: IfNotPresent
     livenessProbe:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -53,7 +53,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -62,7 +62,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: web.statefulset.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: web.statefulset.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -55,7 +55,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -64,7 +64,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: get-test-deploy-injected-1.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: get-test-deploy-injected-1.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -168,7 +168,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -177,7 +177,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: get-test-deploy-injected-2.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: get-test-deploy-injected-2.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:testinjectversion
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -201,7 +201,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -210,7 +210,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -480,7 +480,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -489,7 +489,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -659,7 +659,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -668,7 +668,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -908,7 +908,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -917,7 +917,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -210,7 +210,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -219,7 +219,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -495,7 +495,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -504,7 +504,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -680,7 +680,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -689,7 +689,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -935,7 +935,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -944,7 +944,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -210,7 +210,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -219,7 +219,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -495,7 +495,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -504,7 +504,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -680,7 +680,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -689,7 +689,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -935,7 +935,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -944,7 +944,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -201,7 +201,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -210,7 +210,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -458,7 +458,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -467,7 +467,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -615,7 +615,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -624,7 +624,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -842,7 +842,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -851,7 +851,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -203,7 +203,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -212,15 +212,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -488,7 +488,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -497,15 +497,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -673,7 +673,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -682,7 +682,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
@@ -691,8 +691,8 @@ spec:
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -927,7 +927,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -936,15 +936,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -1169,7 +1169,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -1178,15 +1178,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-ca.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-ca.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-ca.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-ca.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -1308,7 +1308,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -1317,15 +1317,15 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-proxy-injector.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+          value: linkerd-proxy-injector.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
           value: /var/linkerd-io/trust-anchors/trust-anchors.pem
         - name: LINKERD2_PROXY_TLS_CERT
           value: /var/linkerd-io/identity/certificate.crt
         - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
           value: /var/linkerd-io/identity/private-key.p8
-        - name: LINKERD2_PROXY_TLS_POD_IDENTITY
-          value: linkerd-proxy-injector.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.linkerd.svc.cluster.local
+        - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+          value: linkerd-proxy-injector.deployment.$(K8S_NS).linkerd-managed.linkerd.svc.cluster.local
         - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
           value: linkerd
         - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
@@ -1471,10 +1471,6 @@ data:
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: .
-    - name: LINKERD2_PROXY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
       value: 10000ms
     - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
@@ -1487,7 +1483,7 @@ data:
       value: /var/linkerd-io/identity/certificate.crt
     - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
       value: /var/linkerd-io/identity/private-key.p8
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
       value: "" # this value will be computed by the webhook
     - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
       value: linkerd

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -204,7 +204,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -213,7 +213,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -484,7 +484,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -493,7 +493,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -664,7 +664,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -673,7 +673,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -914,7 +914,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -923,7 +923,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1152,7 +1152,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -1161,7 +1161,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-ca.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-ca.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1286,7 +1286,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -1295,7 +1295,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-proxy-injector.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-proxy-injector.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1446,10 +1446,6 @@ data:
       value: tcp://0.0.0.0:4143
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: suffix.
-    - name: LINKERD2_PROXY_POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
       value: 10000ms
     - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
@@ -1462,7 +1458,7 @@ data:
       value: /var/linkerd-io/identity/TLSCertFileName
     - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
       value: /var/linkerd-io/identity/TLSPrivateKeyFileName
-    - name: LINKERD2_PROXY_TLS_POD_IDENTITY
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
       value: "" # this value will be computed by the webhook
     - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
       value: Namespace

--- a/cli/cmd/testdata/install_single_namespace_output.golden
+++ b/cli/cmd/testdata/install_single_namespace_output.golden
@@ -200,7 +200,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -209,7 +209,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-controller.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-controller.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -374,7 +374,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -383,7 +383,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-web.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-web.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -556,7 +556,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -565,7 +565,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-prometheus.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-prometheus.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         image: gcr.io/linkerd-io/proxy:dev-undefined
@@ -808,7 +808,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -817,7 +817,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-grafana.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-grafana.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1048,7 +1048,7 @@ spec:
           value: tcp://0.0.0.0:4143
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: .
-        - name: LINKERD2_PROXY_POD_NAMESPACE
+        - name: K8S_NS
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
@@ -1057,7 +1057,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
           value: 10000ms
         - name: LINKERD2_PROXY_ID
-          value: linkerd-ca.deployment.$LINKERD2_PROXY_POD_NAMESPACE.linkerd-managed.Namespace.svc.cluster.local
+          value: linkerd-ca.deployment.$(K8S_NS).linkerd-managed.Namespace.svc.cluster.local
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/controller/proxy-injector/fake/data/config-proxy.yaml
+++ b/controller/proxy-injector/fake/data/config-proxy.yaml
@@ -1,66 +1,62 @@
 env:
-- name: LINKERD2_PROXY_LOG
-  value: warn,linkerd2_proxy=info
-- name: LINKERD2_PROXY_CONTROL_URL
-  value: tcp://linkerd-destination.linkerd.svc.cluster.local:8086
-- name: LINKERD2_PROXY_CONTROL_LISTENER
-  value: tcp://0.0.0.0:4190
-- name: LINKERD2_PROXY_METRICS_LISTENER
-  value: tcp://0.0.0.0:4191
-- name: LINKERD2_PROXY_OUTBOUND_LISTENER
-  value: tcp://127.0.0.1:4140
-- name: LINKERD2_PROXY_INBOUND_LISTENER
-  value: tcp://0.0.0.0:4143
-- name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-  value: .
-- name: LINKERD2_PROXY_POD_NAMESPACE
-  valueFrom:
-    fieldRef:
-      fieldPath: metadata.namespace
-- name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-  value: 10000ms
-- name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-  value: 10000ms
-- name: LINKERD2_PROXY_ID
-  value: ""
-- name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
-  value: /var/linkerd-io/trust-anchors/trust-anchors.pem
-- name: LINKERD2_PROXY_TLS_CERT
-  value: /var/linkerd-io/identity/certificate.crt
-- name: LINKERD2_PROXY_TLS_PRIVATE_KEY
-  value: /var/linkerd-io/identity/private-key.p8
-- name: LINKERD2_PROXY_TLS_POD_IDENTITY
-  value: ""
-- name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
-  value: linkerd
-- name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
-  value: ""
+    - name: LINKERD2_PROXY_LOG
+      value: warn,linkerd2_proxy=info
+    - name: LINKERD2_PROXY_CONTROL_URL
+      value: tcp://linkerd-destination.linkerd.svc.cluster.local:8086
+    - name: LINKERD2_PROXY_CONTROL_LISTENER
+      value: tcp://0.0.0.0:4190
+    - name: LINKERD2_PROXY_METRICS_LISTENER
+      value: tcp://0.0.0.0:4191
+    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
+      value: tcp://127.0.0.1:4140
+    - name: LINKERD2_PROXY_INBOUND_LISTENER
+      value: tcp://0.0.0.0:4143
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+      value: .
+    - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_ID
+      value: ""
+    - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
+      value: /var/linkerd-io/trust-anchors/trust-anchors.pem
+    - name: LINKERD2_PROXY_TLS_CERT
+      value: /var/linkerd-io/identity/certificate.crt
+    - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
+      value: /var/linkerd-io/identity/private-key.p8
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+      value: ""
+    - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
+      value: linkerd
+    - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
+      value: ""
 image: gcr.io/linkerd-io/proxy:v18.8.4
 imagePullPolicy: IfNotPresent
 livenessProbe:
-  httpGet:
-    path: /metrics
-    port: 4191
-  initialDelaySeconds: 10
+    httpGet:
+        path: /metrics
+        port: 4191
+    initialDelaySeconds: 10
 name: linkerd-proxy
 ports:
-- containerPort: 4143
-  name: linkerd-proxy
-- containerPort: 4191
-  name: linkerd-metrics
+    - containerPort: 4143
+      name: linkerd-proxy
+    - containerPort: 4191
+      name: linkerd-metrics
 readinessProbe:
-  httpGet:
-    path: /metrics
-    port: 4191
-  initialDelaySeconds: 10
+    httpGet:
+        path: /metrics
+        port: 4191
+    initialDelaySeconds: 10
 resources: {}
 securityContext:
-  runAsUser: 2102
+    runAsUser: 2102
 terminationMessagePolicy: FallbackToLogsOnError
 volumeMounts:
-- mountPath: /var/linkerd-io/trust-anchors
-  name: linkerd-trust-anchors
-  readOnly: true
-- mountPath: /var/linkerd-io/identity
-  name: linkerd-secrets
-  readOnly: true
+    - mountPath: /var/linkerd-io/trust-anchors
+      name: linkerd-trust-anchors
+      readOnly: true
+    - mountPath: /var/linkerd-io/identity
+      name: linkerd-secrets
+      readOnly: true

--- a/controller/proxy-injector/fake/data/inject-sidecar-container-spec.yaml
+++ b/controller/proxy-injector/fake/data/inject-sidecar-container-spec.yaml
@@ -1,66 +1,62 @@
 env:
-- name: LINKERD2_PROXY_LOG
-  value: warn,linkerd2_proxy=info
-- name: LINKERD2_PROXY_CONTROL_URL
-  value: tcp://linkerd-destination.linkerd.svc.cluster.local:8086
-- name: LINKERD2_PROXY_CONTROL_LISTENER
-  value: tcp://0.0.0.0:4190
-- name: LINKERD2_PROXY_METRICS_LISTENER
-  value: tcp://0.0.0.0:4191
-- name: LINKERD2_PROXY_OUTBOUND_LISTENER
-  value: tcp://127.0.0.1:4140
-- name: LINKERD2_PROXY_INBOUND_LISTENER
-  value: tcp://0.0.0.0:4143
-- name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-  value: .
-- name: LINKERD2_PROXY_POD_NAMESPACE
-  valueFrom:
-    fieldRef:
-      fieldPath: metadata.namespace
-- name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-  value: 10000ms
-- name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-  value: 10000ms
-- name: LINKERD2_PROXY_ID
-  value: nginx.deployment.default.linkerd-managed.linkerd.svc.cluster.local
-- name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
-  value: /var/linkerd-io/trust-anchors/trust-anchors.pem
-- name: LINKERD2_PROXY_TLS_CERT
-  value: /var/linkerd-io/identity/certificate.crt
-- name: LINKERD2_PROXY_TLS_PRIVATE_KEY
-  value: /var/linkerd-io/identity/private-key.p8
-- name: LINKERD2_PROXY_TLS_POD_IDENTITY
-  value: nginx.deployment.default.linkerd-managed.linkerd.svc.cluster.local
-- name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
-  value: linkerd
-- name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
-  value: linkerd-controller.deployment.linkerd.linkerd-managed.linkerd.svc.cluster.local
+    - name: LINKERD2_PROXY_LOG
+      value: warn,linkerd2_proxy=info
+    - name: LINKERD2_PROXY_CONTROL_URL
+      value: tcp://linkerd-destination.linkerd.svc.cluster.local:8086
+    - name: LINKERD2_PROXY_CONTROL_LISTENER
+      value: tcp://0.0.0.0:4190
+    - name: LINKERD2_PROXY_METRICS_LISTENER
+      value: tcp://0.0.0.0:4191
+    - name: LINKERD2_PROXY_OUTBOUND_LISTENER
+      value: tcp://127.0.0.1:4140
+    - name: LINKERD2_PROXY_INBOUND_LISTENER
+      value: tcp://0.0.0.0:4143
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+      value: .
+    - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_ID
+      value: nginx.deployment.default.linkerd-managed.linkerd.svc.cluster.local
+    - name: LINKERD2_PROXY_TLS_TRUST_ANCHORS
+      value: /var/linkerd-io/trust-anchors/trust-anchors.pem
+    - name: LINKERD2_PROXY_TLS_CERT
+      value: /var/linkerd-io/identity/certificate.crt
+    - name: LINKERD2_PROXY_TLS_PRIVATE_KEY
+      value: /var/linkerd-io/identity/private-key.p8
+    - name: LINKERD2_PROXY_TLS_LOCAL_IDENTITY
+      value: nginx.deployment.default.linkerd-managed.linkerd.svc.cluster.local
+    - name: LINKERD2_PROXY_CONTROLLER_NAMESPACE
+      value: linkerd
+    - name: LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY
+      value: linkerd-controller.deployment.linkerd.linkerd-managed.linkerd.svc.cluster.local
 image: gcr.io/linkerd-io/proxy:v18.8.4
 imagePullPolicy: IfNotPresent
 livenessProbe:
-  httpGet:
-    path: /metrics
-    port: 4191
-  initialDelaySeconds: 10
+    httpGet:
+        path: /metrics
+        port: 4191
+    initialDelaySeconds: 10
 name: linkerd-proxy
 ports:
-- containerPort: 4143
-  name: linkerd-proxy
-- containerPort: 4191
-  name: linkerd-metrics
+    - containerPort: 4143
+      name: linkerd-proxy
+    - containerPort: 4191
+      name: linkerd-metrics
 readinessProbe:
-  httpGet:
-    path: /metrics
-    port: 4191
-  initialDelaySeconds: 10
+    httpGet:
+        path: /metrics
+        port: 4191
+    initialDelaySeconds: 10
 resources: {}
 securityContext:
-  runAsUser: 2102
+    runAsUser: 2102
 terminationMessagePolicy: FallbackToLogsOnError
 volumeMounts:
-- mountPath: /var/linkerd-io/trust-anchors
-  name: linkerd-trust-anchors
-  readOnly: true
-- mountPath: /var/linkerd-io/identity
-  name: linkerd-secrets
-  readOnly: true
+    - mountPath: /var/linkerd-io/trust-anchors
+      name: linkerd-trust-anchors
+      readOnly: true
+    - mountPath: /var/linkerd-io/identity
+      name: linkerd-secrets
+      readOnly: true

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	envVarKeyProxyTLSPodIdentity        = "LINKERD2_PROXY_TLS_POD_IDENTITY"
+	envVarKeyProxyTLSPodIdentity        = "LINKERD2_PROXY_TLS_LOCAL_IDENTITY"
 	envVarKeyProxyTLSControllerIdentity = "LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY"
 	envVarKeyProxyID                    = "LINKERD2_PROXY_ID"
 )


### PR DESCRIPTION
linkerd/linkerd2-proxy#199 changes the proxy to accept
`LINKERD2_PROXY_LOCAL_IDENTITY` without namespace templating.

This changes inject to set LOCAL_IDENTITY instead of POD_IDENTITY and,
in the case of cli inject, uses kubernetes templating to materialize the
identity into the environment.