### PR TITLE
Fix goconst linter breakage following master merge

### DIFF
--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -3,6 +3,7 @@ package srv
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -101,13 +102,15 @@ func (h *handler) handleAPIServices(w http.ResponseWriter, req *http.Request, p 
 }
 
 func (h *handler) handleAPIStat(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	trueStr := fmt.Sprintf("%t", true)
+
 	requestParams := util.StatsSummaryRequestParams{
 		StatsBaseRequestParams: util.StatsBaseRequestParams{
 			TimeWindow:    req.FormValue("window"),
 			ResourceName:  req.FormValue("resource_name"),
 			ResourceType:  req.FormValue("resource_type"),
 			Namespace:     req.FormValue("namespace"),
-			AllNamespaces: req.FormValue("all_namespaces") == "true",
+			AllNamespaces: req.FormValue("all_namespaces") == trueStr,
 		},
 		ToName:        req.FormValue("to_name"),
 		ToType:        req.FormValue("to_type"),
@@ -115,8 +118,8 @@ func (h *handler) handleAPIStat(w http.ResponseWriter, req *http.Request, p http
 		FromName:      req.FormValue("from_name"),
 		FromType:      req.FormValue("from_type"),
 		FromNamespace: req.FormValue("from_namespace"),
-		SkipStats:     req.FormValue("skip_stats") == "true",
-		TCPStats:      req.FormValue("tcp_stats") == "true",
+		SkipStats:     req.FormValue("skip_stats") == trueStr,
+		TCPStats:      req.FormValue("tcp_stats") == trueStr,
 	}
 
 	// default to returning deployment stats


### PR DESCRIPTION
linkerd/linkerd2#2365 introduced the goconst linter and fixes, but additional lint
errors had been introduced to master.

This change fixes the one remaining goconst issue.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>