### PR TITLE
Align dashboard nav items

### DIFF
--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -121,6 +121,7 @@ const styles = theme => {
     shrinkIcon: {
       fontSize: "18px",
       paddingLeft: "3px",
+      paddingRight: "3px",
     }
   };
 };


### PR DESCRIPTION
The `Overview` and `Resources` nav items were slightly out of alignment
with the other nav items.

Add paddingRight to the other nav items, to compensate for their
shrunken icons.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

# Before

![before](https://user-images.githubusercontent.com/236915/53370449-98ee9080-3902-11e9-8671-864e587c5570.png)

# After

![after](https://user-images.githubusercontent.com/236915/53370457-9be98100-3902-11e9-928d-dd9b5a925ded.png)
