### PR TITLE
Add note about brew dependency in `build-cli-bin`

### DIFF
--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -3,6 +3,8 @@
 set -eu
 
 # Builds CLI binary for current platform only and outside docker to speed up things. Suitable for local development.
+# Note: This script is used by Brew when running `brew install linkerd`:
+# https://github.com/Homebrew/homebrew-core/pull/36957
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"


### PR DESCRIPTION
Homebrew/homebrew-core#36957 introduces a brew formula for the linkerd
cli. It depends on `bin/build-cli-bin` to build a local linkerd cli
binary.

This change adds a note to `bin/build-cli-bin`, to consider brew when
making changes to that script.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>