### PR TITLE
Lessen klog for security

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -39,7 +39,7 @@ func setLogLevel(logLevel string) {
 	if level == log.DebugLevel {
 		flag.Set("stderrthreshold", "INFO")
 		flag.Set("logtostderr", "true")
-		flag.Set("v", "10")
+		flag.Set("v", "6") // At 7 and higher, authorization tokens get logged.
 	}
 }
 


### PR DESCRIPTION
We currently set klog to maximum verbosity when debug logging is
enabled. This causes control plane components, however, to log their
serviceaccount tokens, leaking secret information into logs.

By setting the klog level to 8, we avoid this logging.

Fixes #2383