### PR TITLE
Bump Prometheus client to v0.9.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -536,16 +536,18 @@
   version = "v1.7.3"
 
 [[projects]]
-  digest = "1:e76d0fea4ab688de44c38e57cc657a53aed582cdc1e67470d7f3fbbfc3afec1c"
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
     "api/prometheus/v1",
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -57,7 +57,7 @@ required = [
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  revision = "9bb6ab929dcbe1c8393cd9ef70387cb69811bd1c"
+  version = "v0.9.2"
 
 [[constraint]]
   name = "github.com/gorilla/websocket"

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:ee275c25 as golang
+FROM gcr.io/linkerd-io/go-deps:0074c10b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:ee275c25 as golang
+FROM gcr.io/linkerd-io/go-deps:0074c10b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:ee275c25 as golang
+FROM gcr.io/linkerd-io/go-deps:0074c10b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -126,11 +126,33 @@ func (m *mockProm) QueryRange(ctx context.Context, query string, r promv1.Range)
 	m.QueriesExecuted = append(m.QueriesExecuted, query)
 	return m.Res, nil
 }
+
+func (m *mockProm) AlertManagers(ctx context.Context) (promv1.AlertManagersResult, error) {
+	return promv1.AlertManagersResult{}, nil
+}
+func (m *mockProm) CleanTombstones(ctx context.Context) error {
+	return nil
+}
+func (m *mockProm) Config(ctx context.Context) (promv1.ConfigResult, error) {
+	return promv1.ConfigResult{}, nil
+}
+func (m *mockProm) DeleteSeries(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) error {
+	return nil
+}
+func (m *mockProm) Flags(ctx context.Context) (promv1.FlagsResult, error) {
+	return promv1.FlagsResult{}, nil
+}
 func (m *mockProm) LabelValues(ctx context.Context, label string) (model.LabelValues, error) {
 	return nil, nil
 }
 func (m *mockProm) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
 	return nil, nil
+}
+func (m *mockProm) Snapshot(ctx context.Context, skipHead bool) (promv1.SnapshotResult, error) {
+	return promv1.SnapshotResult{}, nil
+}
+func (m *mockProm) Targets(ctx context.Context) (promv1.TargetsResult, error) {
+	return promv1.TargetsResult{}, nil
 }
 
 // GenStatSummaryResponse generates a mock Public API StatSummaryResponse

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:ee275c25 as golang
+FROM gcr.io/linkerd-io/go-deps:0074c10b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:ee275c25 as golang
+FROM gcr.io/linkerd-io/go-deps:0074c10b as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
We were depending on an untagged version of prometheus/client_golang
from Feb 2018.

This bumps our dependency to v0.9.2, from Dec 2018.

Also, this is a prerequisite to #1488.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>