### PR TITLE
Consolidate endpointListener.Update with logging

### DIFF
--- a/controller/api/destination/endpoint_listener.go
+++ b/controller/api/destination/endpoint_listener.go
@@ -1,6 +1,8 @@
 package destination
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	net "github.com/linkerd/linkerd2-proxy-api/go/net"
@@ -25,6 +27,11 @@ type ownerKindAndNameFn func(*corev1.Pod) (string, string)
 type updateAddress struct {
 	address *net.TcpAddress
 	pod     *corev1.Pod
+}
+
+// String is used by tests for comparison and logging.
+func (ua *updateAddress) String() string {
+	return fmt.Sprintf("{address=%s, pod=%s, ns=%s}", ua.Address(), ua.Name(), ua.Namespace())
 }
 
 func (ua *updateAddress) Address() string {

--- a/controller/api/destination/test_helper.go
+++ b/controller/api/destination/test_helper.go
@@ -102,14 +102,8 @@ func equalServicePorts(servicePorts1, servicePorts2 servicePorts) error {
 				return fmt.Errorf("servicePort endpoints mismatch: [%s] != [%s]", sp1.endpoints, sp2.endpoints)
 			}
 			for i := range sp1.addresses {
-				if sp1.addresses[i].Address() != sp2.addresses[i].Address() {
-					return fmt.Errorf("servicePort address mismatch: [%s] != [%s]", sp1.addresses[i].Address(), sp2.addresses[i].Address())
-				}
-				if sp1.addresses[i].Name() != sp2.addresses[i].Name() {
-					return fmt.Errorf("servicePort name mismatch: [%s] != [%s]", sp1.addresses[i].Name(), sp2.addresses[i].Name())
-				}
-				if sp1.addresses[i].Namespace() != sp2.addresses[i].Namespace() {
-					return fmt.Errorf("servicePort namespace mismatch: [%s] != [%s]", sp1.addresses[i].Namespace(), sp2.addresses[i].Namespace())
+				if sp1.addresses[i].String() != sp2.addresses[i].String() {
+					return fmt.Errorf("servicePort address mismatch: [%s] != [%s]", sp1.addresses[i], sp2.addresses[i])
 				}
 			}
 		}

--- a/controller/api/destination/test_helper.go
+++ b/controller/api/destination/test_helper.go
@@ -102,8 +102,14 @@ func equalServicePorts(servicePorts1, servicePorts2 servicePorts) error {
 				return fmt.Errorf("servicePort endpoints mismatch: [%s] != [%s]", sp1.endpoints, sp2.endpoints)
 			}
 			for i := range sp1.addresses {
-				if sp1.addresses[i].String() != sp2.addresses[i].String() {
-					return fmt.Errorf("servicePort address mismatch: [%s] != [%s]", sp1.addresses[i], sp2.addresses[i])
+				if sp1.addresses[i].Address() != sp2.addresses[i].Address() {
+					return fmt.Errorf("servicePort address mismatch: [%s] != [%s]", sp1.addresses[i].Address(), sp2.addresses[i].Address())
+				}
+				if sp1.addresses[i].Name() != sp2.addresses[i].Name() {
+					return fmt.Errorf("servicePort name mismatch: [%s] != [%s]", sp1.addresses[i].Name(), sp2.addresses[i].Name())
+				}
+				if sp1.addresses[i].Namespace() != sp2.addresses[i].Namespace() {
+					return fmt.Errorf("servicePort namespace mismatch: [%s] != [%s]", sp1.addresses[i].Namespace(), sp2.addresses[i].Namespace())
 				}
 			}
 		}


### PR DESCRIPTION
Previously, the update-handling logic was spread across several very
small functions that were only called within this file. I've
consolidated this logic into endpointListener.Update so that all of the
debug logging can be instrumented in one place without having to iterate
over lists multiple times.

Also, I've fixed the formatting of IP addresses in some places.

Logs now look as follows:

    msg="Establishing watch on endpoint linkerd-prometheus.linkerd:9090" component=endpoints-watcher
    msg="Subscribing linkerd-prometheus.linkerd:9090 exists=true" component=service-port id=linkerd-prometheus.linkerd target-port=admin-http
    msg="Update: add=1; remove=0" component=endpoint-listener namespace=linkerd service=linkerd-prometheus
    msg="Update: add: addr=10.1.1.160; pod=linkerd-prometheus-7bbc899687-nd9zt; addr:<ip:<ipv4:167838112 > port:9090 > weight:1 metric_labels:<key:\"control_plane_ns\" value:\"linkerd\" > metric_labels:<key:\"deployment\" value:\"linkerd-prometheus\" > metric_labels:<key:\"pod\" value:\"linkerd-prometheus-7bbc899687-nd9zt\" > metric_labels:<key:\"pod_template_hash\" value:\"7bbc899687\" > protocol_hint:<h2:<> > " component=endpoint-listener namespace=linkerd service=linkerd-prometheus