### PR TITLE
Fix compilation with Go 1.12

### DIFF
--- a/controller/proxy-injector/patch_test.go
+++ b/controller/proxy-injector/patch_test.go
@@ -72,6 +72,6 @@ func TestPatch(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Content mismatch\nExpected: %s\nActual: %s", expected, actual)
+		t.Errorf("Content mismatch\nExpected: %+v\nActual: %+v", expected, actual)
 	}
 }


### PR DESCRIPTION
One format string breaks when using go-1.12.