### PR TITLE
Revert CRD deletion in integration test-cleanup

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -28,9 +28,3 @@ if ! clusterroles=$(kubectl get clusterroles -oname | grep -E "/linkerd-$linkerd
 else
   kubectl delete $clusterroles
 fi
-
-if ! crd=$(kubectl get crd/serviceprofiles.linkerd.io -oname); then
-  echo "no serviceprofile crd found for [$linkerd_namespace]" >&2
-else
-  kubectl delete $crd
-fi


### PR DESCRIPTION
linkerd/linkerd#2349 introduced ServiceProfile CRD deletion to
`bin/test-cleanup`. Unfortunately that CRD is cluster-wide and shared
across any Linkerd's currently installed.

Revert CRD deletion.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>