### PR TITLE
Proxy: bump pinned version to 0fe8063

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-59d00f6}"
+PROXY_VERSION="${PROXY_VERSION:-0fe8063}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This picks up the following commits:

* 0fe8063 replace `Error::cause` with `Error::source` (#2370) (linkerd/linkerd2-proxy#201)
* 1ea7559 Minor cleanup in the config tests (linkerd/linkerd2-proxy#188)
* d0ef56b Update *ring* to 0.14.6 (linkerd/linkerd2-proxy#197)
* c54377f fs-watch: Use a properly sized buffer for inotify events (linkerd/linkerd2-proxy#195)
* 23e02a6 Update Router to wait for inner poll_ready before calling inner call
* 2de8e9b Update metrics quickcheck to 0.8, and hyper to 0.12.24
* d1bbd4b make: Optionally include debug symbols with builds (linkerd/linkerd2-proxy#193)
* 738a541 Fix compilation warnings in fs-watch (linkerd/linkerd2-proxy#192)
* 6cc7558 Apply rustfmt (linkerd/linkerd2-proxy#191)

Signed-off-by: Ivan Sim <ivan@buoyant.io>