### PR TITLE
Remove namespace from serviceprofile CRD in install config

### DIFF
--- a/chart/templates/serviceprofile.yaml
+++ b/chart/templates/serviceprofile.yaml
@@ -8,7 +8,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: {{.Values.Namespace}}
   annotations:
     {{.Values.CreatedByAnnotation}}: {{.Values.CliVersion}}
 spec:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -279,7 +279,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -291,7 +291,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -291,7 +291,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -257,7 +257,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -287,7 +287,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -282,7 +282,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  namespace: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:


### PR DESCRIPTION
The `serviceprofiles.linkerd.io` CRD in our install config includes a `namespace` attribute, but that field is ignored by Kubernetes since CRDs are not namespaced. This branch removes it for clarity.