### PR TITLE
proxy: bump pinned version to 7e55196

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-0fe8063}"
+PROXY_VERSION="${PROXY_VERSION:-7e55196}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This picks up the following commit:

* 7e55196 Bump tower-grpc (linkerd/linkerd2-proxy#202)

The new `tower-grpc` version (tower-rs/tower-grpc#115) improves the
messages attached to internal gRPC issues. This will aid significantly
in debugging the proxy's gRPC communication with the control plane.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>