### PR TITLE
Introduce logging and restart integration tests

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -57,6 +57,24 @@ var (
 		`linkerd-proxy ERR! admin={bg=tls-config} linkerd2_proxy::transport::tls::config error loading /var/linkerd-io/trust-anchors/trust-anchors.pem: No such file or directory (os error 2)`,
 		`linkerd-proxy WARN admin={bg=tls-config} linkerd2_proxy::transport::tls::config error reloading TLS config: Io("/var/linkerd-io/identity/certificate.crt", Some(2)), falling back`,
 		`linkerd-proxy WARN admin={bg=tls-config} linkerd2_proxy::transport::tls::config error reloading TLS config: Io("/var/linkerd-io/trust-anchors/trust-anchors.pem", Some(2)), falling back`,
+
+		// k8s hitting `:3000/api/health` before grafana is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:3000)`,
+
+		// k8s hitting `:9994/ready` before web is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:9994)`,
+
+		// k8s hitting `:9995/ready` before public-api is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:9995)`,
+
+		// k8s hitting `:9996/ready` before destination is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:9996)`,
+
+		// k8s hitting `:9997/ready` before ca is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:9997)`,
+
+		// k8s hitting `:9998/ready` before tap is ready
+		`linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:9998)`,
 	}
 )
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -19,7 +19,6 @@ type deploySpec struct {
 
 const (
 	proxyContainer = "linkerd-proxy"
-	initContainer  = "linkerd-init"
 )
 
 //////////////////////

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -87,6 +87,13 @@ func (h *KubernetesHelper) KubectlApply(stdin string, namespace string) (string,
 	return string(out), err
 }
 
+// Kubectl executes an arbitrary Kubectl command
+func (h *KubernetesHelper) Kubectl(arg ...string) (string, error) {
+	cmd := exec.Command("kubectl", arg...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // getDeployments gets all deployments with a count of their ready replicas in
 // the specified namespace.
 func (h *KubernetesHelper) getDeployments(namespace string) (map[string]int, error) {


### PR DESCRIPTION
The integration tests deploy complete Linkerd environments into
Kubernetes, but do not check if the components are logging errors or
restarting.

Introduce integration tests to validation that all expected
control-plane containers (including `linkerd-proxy` and `linkerd-init`)
are found, logging no errors, and not restarting.

Fixes #2348

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

# Test examples

## TestLogs

Prior to adding the `knownProxyErrors` check, linkerd-proxy fails with TLS:
```bash
$ go test github.com/linkerd/linkerd2/test -run ^TestLogs$ -enable-tls -linkerd `pwd`/target/cli/darwin/linkerd -integration-tests
--- FAIL: TestLogs (11.01s)
    install_test.go:306: Found error in web/linkerd-proxy log: l5d-integration-tls linkerd-web-5cbdb887fd-hqszx linkerd-proxy ERR! admin={bg=tls-config} linkerd2_proxy::transport::tls::config error loading /var/linkerd-io/trust-anchors/trust-anchors.pem: No such file or directory (os error 2)
FAIL
FAIL	github.com/linkerd/linkerd2/test	11.111s
```

Modified:
```go
proxyRegex := regexp.MustCompile(fmt.Sprintf("%s (ERR|WARN|DBUG)", proxyContainer))
```

Returns:
```bash
$ go test github.com/linkerd/linkerd2/test -run ^TestLogs$ -linkerd `pwd`/target/cli/darwin/linkerd -integration-tests
--- FAIL: TestLogs (2.04s)
    install_test.go:313: Found error in controller/linkerd-proxy log: l5d-integration linkerd-controller-d67b9b4c9-7ks4s linkerd-proxy DBUG proxy={server=out listen=127.0.0.1:4140 remote=10.1.2.24:48158} linkerd2_proxy::transport::metrics::io client connection open
FAIL
FAIL	github.com/linkerd/linkerd2/test	2.288s
```

Modified:
```go
controllerRegex := regexp.MustCompile("level=(panic|fatal|error|warn|info)")
```

Returns:
```bash
$ go test github.com/linkerd/linkerd2/test -run ^TestLogs$ -linkerd `pwd`/target/cli/darwin/linkerd -integration-tests
--- FAIL: TestLogs (0.50s)
    install_test.go:306: Found error in controller/destination log: l5d-integration linkerd-controller-d67b9b4c9-7ks4s destination time="2019-02-27T22:29:51Z" level=info msg="running version git-9c0537c3"
FAIL
FAIL	github.com/linkerd/linkerd2/test	0.654s
```

## TestRestarts

On a recent master, with unexpected restarts:

```bash
$ kubectl -n l5d-integration get po
NAME                                 READY     STATUS    RESTARTS   AGE
linkerd-controller-d67b9b4c9-7ks4s   4/4       Running   3          3h
linkerd-grafana-86b96ddb67-kjzts     2/2       Running   0          3h
linkerd-prometheus-f4f6986db-7skmj   2/2       Running   0          3h
linkerd-web-c47b5b94-kqkdp           2/2       Running   1          3h
```

```
$ go test github.com/linkerd/linkerd2/test -run ^TestRestarts$ -linkerd `pwd`/target/cli/darwin/linkerd -integration-tests
--- FAIL: TestRestarts (0.36s)
    install_test.go:338: Found '1' restarts on controller/destination
FAIL
FAIL	github.com/linkerd/linkerd2/test	0.619s
```
