### PR TITLE
Introduce NET_ADMIN cli check

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -20,6 +20,7 @@ type checkOptions struct {
 	wait            time.Duration
 	namespace       string
 	singleNamespace bool
+	cniEnabled      bool
 }
 
 func newCheckOptions() *checkOptions {
@@ -30,6 +31,7 @@ func newCheckOptions() *checkOptions {
 		wait:            300 * time.Second,
 		namespace:       "",
 		singleNamespace: false,
+		cniEnabled:      false,
 	}
 }
 
@@ -66,6 +68,7 @@ non-zero exit code.`,
 	cmd.PersistentFlags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 	cmd.PersistentFlags().BoolVar(&options.singleNamespace, "single-namespace", options.singleNamespace, "When running pre-installation checks (--pre), only check the permissions required to operate the control plane in a single namespace")
+	cmd.PersistentFlags().BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled, "When running pre-installation checks (--pre), assume the linkerd-cni plugin is already installed, and a NET_ADMIN check is not needed")
 
 	return cmd
 }
@@ -87,7 +90,9 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 		} else {
 			checks = append(checks, healthcheck.LinkerdPreInstallClusterChecks)
 		}
-		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
+		if !options.cniEnabled {
+			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
+		}
 	} else {
 		checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
 		checks = append(checks, healthcheck.LinkerdAPIChecks)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -180,8 +180,7 @@ type HealthChecker struct {
 	// these fields are set in the process of running checks
 	kubeAPI          *k8s.KubernetesAPI
 	httpClient       *http.Client
-	clientset        *kubernetes.Clientset
-	spClientset      *spclient.Clientset
+	clientset        kubernetes.Interface
 	kubeVersion      *k8sVersion.Info
 	controlPlanePods []corev1.Pod
 	apiClient        public.APIClient
@@ -235,6 +234,11 @@ func (hc *HealthChecker) allCategories() []category {
 						// https://github.com/kubernetes/kubernetes/issues/46503
 						// but we can set the timeout manually
 						hc.kubeAPI.Timeout = requestTimeout
+
+						hc.clientset, err = kubernetes.NewForConfig(hc.kubeAPI.Config)
+						if err != nil {
+							return err
+						}
 						return
 					},
 				},
@@ -307,7 +311,14 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "can create CustomResourceDefinitions",
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
+						return hc.checkCanCreate("", "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
+					},
+				},
+				{
+					description: "has NET_ADMIN capability",
+					hintAnchor:  "pre-k8s-cluster-net-admin",
+					check: func(context.Context) error {
+						return hc.checkNetAdmin()
 					},
 				},
 			},
@@ -782,11 +793,8 @@ func (hc *HealthChecker) getDataPlanePods(ctx context.Context) ([]*pb.Pod, error
 
 func (hc *HealthChecker) checkCanCreate(namespace, group, version, resource string) error {
 	if hc.clientset == nil {
-		var err error
-		hc.clientset, err = kubernetes.NewForConfig(hc.kubeAPI.Config)
-		if err != nil {
-			return err
-		}
+		// we should never get here
+		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
 	}
 
 	allowed, reason, err := k8s.ResourceAuthz(
@@ -796,6 +804,7 @@ func (hc *HealthChecker) checkCanCreate(namespace, group, version, resource stri
 		group,
 		version,
 		resource,
+		"",
 	)
 	if err != nil {
 		return err
@@ -803,23 +812,66 @@ func (hc *HealthChecker) checkCanCreate(namespace, group, version, resource stri
 
 	if !allowed {
 		if len(reason) > 0 {
-			return fmt.Errorf("Missing permissions to create %s: %v", resource, reason)
+			return fmt.Errorf("missing permissions to create %s: %v", resource, reason)
 		}
-		return fmt.Errorf("Missing permissions to create %s", resource)
+		return fmt.Errorf("missing permissions to create %s", resource)
 	}
 	return nil
 }
 
-func (hc *HealthChecker) validateServiceProfiles() error {
-	if hc.spClientset == nil {
-		var err error
-		hc.spClientset, err = spclient.NewForConfig(hc.kubeAPI.Config)
+func (hc *HealthChecker) checkNetAdmin() error {
+	if hc.clientset == nil {
+		// we should never get here
+		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
+	}
+
+	pspList, err := hc.clientset.PolicyV1beta1().PodSecurityPolicies().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(pspList.Items) == 0 {
+		// no PodSecurityPolicies found, assume PodSecurityPolicy admission controller is disabled
+		return nil
+	}
+
+	// if PodSecurityPolicies are found, validate one exists that:
+	// 1) permits usage
+	// AND
+	// 2) provides NET_ADMIN
+	for _, psp := range pspList.Items {
+		allowed, _, err := k8s.ResourceAuthz(
+			hc.clientset,
+			"",
+			"use",
+			"policy",
+			"v1beta1",
+			"PodSecurityPolicy",
+			psp.GetName(),
+		)
 		if err != nil {
 			return err
 		}
+
+		if allowed {
+			for _, capability := range psp.Spec.AllowedCapabilities {
+				if capability == "*" || capability == "NET_ADMIN" {
+					return nil
+				}
+			}
+		}
 	}
 
-	svcProfiles, err := hc.spClientset.LinkerdV1alpha1().ServiceProfiles("").List(metav1.ListOptions{})
+	return fmt.Errorf("found %d PodSecurityPolicies, but none provide NET_ADMIN", len(pspList.Items))
+}
+
+func (hc *HealthChecker) validateServiceProfiles() error {
+	spClientset, err := spclient.NewForConfig(hc.kubeAPI.Config)
+	if err != nil {
+		return err
+	}
+
+	svcProfiles, err := spClientset.LinkerdV1alpha1().ServiceProfiles("").List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -827,7 +879,7 @@ func (hc *HealthChecker) validateServiceProfiles() error {
 	for _, p := range svcProfiles.Items {
 		// TODO: remove this check once we implement ServiceProfile validation via a
 		// ValidatingAdmissionWebhook
-		result := hc.spClientset.RESTClient().Get().RequestURI(p.GetSelfLink()).Do()
+		result := spClientset.RESTClient().Get().RequestURI(p.GetSelfLink()).Do()
 		raw, err := result.Raw()
 		if err != nil {
 			return err

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -53,6 +53,12 @@ const (
 	// checks must be added first.
 	LinkerdPreInstallSingleNamespaceChecks CategoryID = "pre-kubernetes-single-namespace-setup"
 
+	// LinkerdPreInstallCapabilityChecks adds a check to validate the user has the
+	// capabilities necessary to deploy Linkerd. For example, the NET_ADMIN
+	// capability is required by the `linkerd-init` container to modify IP tables.
+	// These checks are no run when the `--linkerd-cni-enabled` flag is set.
+	LinkerdPreInstallCapabilityChecks CategoryID = "pre-kubernetes-capability"
+
 	// LinkerdPreInstallChecks adds checks to validate that the user can create
 	// Kubernetes objects necessary to install the control plane, including
 	// Service, Deployment, and ConfigMap. This check only runs as part of the set
@@ -314,13 +320,6 @@ func (hc *HealthChecker) allCategories() []category {
 						return hc.checkCanCreate("", "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
 					},
 				},
-				{
-					description: "has NET_ADMIN capability",
-					hintAnchor:  "pre-k8s-cluster-net-admin",
-					check: func(context.Context) error {
-						return hc.checkNetAdmin()
-					},
-				},
 			},
 		},
 		{
@@ -345,6 +344,18 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "rbac.authorization.k8s.io", "v1beta1", "RoleBinding")
+					},
+				},
+			},
+		},
+		{
+			id: LinkerdPreInstallCapabilityChecks,
+			checkers: []checker{
+				{
+					description: "has NET_ADMIN capability",
+					hintAnchor:  "pre-k8s-cluster-net-admin",
+					check: func(context.Context) error {
+						return hc.checkNetAdmin()
 					},
 				},
 			},

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/public"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -288,6 +289,64 @@ func TestHealthChecker(t *testing.T) {
 			t.Fatalf("Expected results %v, but got %v", expectedResults, observedResults)
 		}
 	})
+}
+
+func TestCheckCanCreate(t *testing.T) {
+	exp := fmt.Errorf("missing permissions to create deployments")
+
+	hc := NewHealthChecker(
+		[]CategoryID{},
+		&Options{},
+	)
+	hc.clientset, _ = k8s.NewFakeClientSets()
+	err := hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
+	if err == nil ||
+		err.Error() != exp.Error() {
+		t.Fatalf("Unexpected error (Expected: %s, Got: %s)", exp, err)
+	}
+}
+
+func TestCheckNetAdmin(t *testing.T) {
+	tests := []struct {
+		k8sConfigs []string
+		err        error
+	}{
+		{
+			[]string{},
+			nil,
+		},
+		{
+			[]string{`apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+spec:
+  requiredDropCapabilities:
+    - ALL`,
+			},
+			fmt.Errorf("found 1 PodSecurityPolicies, but none provide NET_ADMIN"),
+		},
+	}
+
+	for i, test := range tests {
+		test := test // pin
+		t.Run(fmt.Sprintf("%d: returns expected NET_ADMIN result", i), func(t *testing.T) {
+			hc := NewHealthChecker(
+				[]CategoryID{},
+				&Options{},
+			)
+
+			hc.clientset, _ = k8s.NewFakeClientSets(test.k8sConfigs...)
+			err := hc.checkNetAdmin()
+			if err != nil || test.err != nil {
+				if (err == nil && test.err != nil) ||
+					(err != nil && test.err == nil) ||
+					(err.Error() != test.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", test.err, err)
+				}
+			}
+		})
+	}
 }
 
 func TestValidateControlPlanePods(t *testing.T) {

--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -11,7 +11,7 @@ import (
 // perform a given action.
 func ResourceAuthz(
 	k8sClient kubernetes.Interface,
-	namespace, verb, group, version, resource string,
+	namespace, verb, group, version, resource, name string,
 ) (bool, string, error) {
 	ssar := &authV1.SelfSubjectAccessReview{
 		Spec: authV1.SelfSubjectAccessReviewSpec{
@@ -21,6 +21,7 @@ func ResourceAuthz(
 				Group:     group,
 				Version:   version,
 				Resource:  resource,
+				Name:      name,
 			},
 		},
 	}
@@ -79,6 +80,7 @@ func resourceAccess(k8sClient kubernetes.Interface, namespace, group, resource s
 		group,
 		"",
 		resource,
+		"",
 	)
 	if err != nil {
 		return false, err
@@ -96,6 +98,7 @@ func resourceAccess(k8sClient kubernetes.Interface, namespace, group, resource s
 		group,
 		"",
 		resource,
+		"",
 	)
 	if err != nil {
 		return false, err

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -47,7 +47,7 @@ subjects:
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: returns expected authorization", i), func(t *testing.T) {
 			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
-			allowed, reason, err := ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments")
+			allowed, reason, err := ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments", "")
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -15,6 +15,9 @@ pre-kubernetes-cluster-setup
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
 √ can create CustomResourceDefinitions
+
+pre-kubernetes-capability
+-------------------------
 √ has NET_ADMIN capability
 
 pre-kubernetes-setup

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -15,6 +15,7 @@ pre-kubernetes-cluster-setup
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
 √ can create CustomResourceDefinitions
+√ has NET_ADMIN capability
 
 pre-kubernetes-setup
 --------------------


### PR DESCRIPTION
The `linkerd-init` container requires the NET_ADMIN capability to modify
iptables. The `linkerd check` command was not verifying this.

Introduce a `has NET_ADMIN capability` check, which does the following:
1) Lists all available PodSecurityPolicies, if none found, returns
success
2) For each PodSecurityPolicy, validate one exists that:
    - the user has `use` access AND
    - provides `*` or `NET_ADMIN` capability

A couple limitations to this approach:
- It is testing whether the user running `linkerd check` has NET_ADMIN,
  but during installation time it will be the `linkerd-init` pod that
  requires NET_ADMIN.
- It assumes the presense of PodSecurityPolicies in the cluster means
  the PodSecurityPolicy admission controller is installed. If the
  admission controller is not installed, but PSPs exists that restrict
  NET_ADMIN, `linkerd check` will incorrectly report the user does not
  have that capability.

This PR also fixes the `can create CustomResourceDefinitions` check to
not specify a namespace when doing a `create` check, as CRDs are
cluster-wide.

Fixes #1732

Signed-off-by: Andrew Seigner <siggy@buoyant.io>