### PR TITLE
Require cluster-wide k8s API access

### DIFF
--- a/controller/api/destination/endpoints_watcher_test.go
+++ b/controller/api/destination/endpoints_watcher_test.go
@@ -470,7 +470,7 @@ spec:
 	} {
 		tt := tt // pin
 		t.Run("subscribes listener to "+tt.serviceType, func(t *testing.T) {
-			k8sAPI, err := k8s.NewFakeAPI("", tt.k8sConfigs...)
+			k8sAPI, err := k8s.NewFakeAPI(tt.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}

--- a/controller/api/destination/k8s_resolver.go
+++ b/controller/api/destination/k8s_resolver.go
@@ -15,23 +15,20 @@ var containsAlphaRegexp = regexp.MustCompile("[a-zA-Z]")
 
 // implements the streamingDestinationResolver interface
 type k8sResolver struct {
-	k8sDNSZoneLabels    []string
-	controllerNamespace string
-	endpointsWatcher    *endpointsWatcher
-	profileWatcher      *profileWatcher
+	k8sDNSZoneLabels []string
+	endpointsWatcher *endpointsWatcher
+	profileWatcher   *profileWatcher
 }
 
 func newK8sResolver(
 	k8sDNSZoneLabels []string,
-	controllerNamespace string,
 	ew *endpointsWatcher,
 	pw *profileWatcher,
 ) *k8sResolver {
 	return &k8sResolver{
-		k8sDNSZoneLabels:    k8sDNSZoneLabels,
-		controllerNamespace: controllerNamespace,
-		endpointsWatcher:    ew,
-		profileWatcher:      pw,
+		k8sDNSZoneLabels: k8sDNSZoneLabels,
+		endpointsWatcher: ew,
+		profileWatcher:   pw,
 	}
 }
 

--- a/controller/api/destination/k8s_resolver_test.go
+++ b/controller/api/destination/k8s_resolver_test.go
@@ -55,7 +55,7 @@ func TestK8sResolver(t *testing.T) {
 }
 
 func TestGetState(t *testing.T) {
-	k8sAPI, err := k8s.NewFakeAPI("")
+	k8sAPI, err := k8s.NewFakeAPI()
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
@@ -104,7 +104,6 @@ func TestGetState(t *testing.T) {
 			endpointsWatcher.servicePorts = tt.servicePorts
 			resolver := newK8sResolver(
 				[]string{"some", "namespace"},
-				"controller-ns",
 				endpointsWatcher,
 				newProfileWatcher(k8sAPI),
 			)

--- a/controller/api/destination/profile_watcher_test.go
+++ b/controller/api/destination/profile_watcher_test.go
@@ -67,7 +67,7 @@ spec:
 	} {
 		tt := tt // pin
 		t.Run(tt.name, func(t *testing.T) {
-			k8sAPI, err := k8s.NewFakeAPI("", tt.k8sConfigs...)
+			k8sAPI, err := k8s.NewFakeAPI(tt.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -49,7 +49,7 @@ func (m *mockDestinationServer) SendMsg(x interface{}) error  { return m.errorTo
 func (m *mockDestinationServer) RecvMsg(x interface{}) error  { return m.errorToReturn }
 
 func TestBuildResolver(t *testing.T) {
-	k8sAPI, err := k8s.NewFakeAPI("")
+	k8sAPI, err := k8s.NewFakeAPI()
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
@@ -57,7 +57,7 @@ func TestBuildResolver(t *testing.T) {
 	t.Run("Doesn't build a resolver if Kubernetes DNS zone isnt valid", func(t *testing.T) {
 		invalidK8sDNSZones := []string{"1", "-a", "a-", "-"}
 		for _, dsnZone := range invalidK8sDNSZones {
-			resolver, err := buildResolver(dsnZone, "linkerd", k8sAPI)
+			resolver, err := buildResolver(dsnZone, k8sAPI)
 			if err == nil {
 				t.Fatalf("Expecting error when k8s zone is [%s], got nothing. Resolver: %v", dsnZone, resolver)
 			}
@@ -100,7 +100,7 @@ func TestStreamResolutionUsingCorrectResolverFor(t *testing.T) {
 	stream := &mockDestinationGetServer{}
 	host := "something"
 	port := 666
-	k8sAPI, err := k8s.NewFakeAPI("")
+	k8sAPI, err := k8s.NewFakeAPI()
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
@@ -149,7 +149,7 @@ func TestStreamResolutionUsingCorrectResolverFor(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
-	k8sAPI, err := k8s.NewFakeAPI("")
+	k8sAPI, err := k8s.NewFakeAPI()
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -392,7 +392,7 @@ status:
 		}
 
 		for _, exp := range expectations {
-			k8sAPI, err := k8s.NewFakeAPI("", exp.k8sRes...)
+			k8sAPI, err := k8s.NewFakeAPI(exp.k8sRes...)
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
@@ -496,7 +496,7 @@ metadata:
 		}
 
 		for _, exp := range expectations {
-			k8sAPI, err := k8s.NewFakeAPI("", exp.k8sRes...)
+			k8sAPI, err := k8s.NewFakeAPI(exp.k8sRes...)
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
@@ -541,7 +541,7 @@ func TestEndpoints(t *testing.T) {
 		}
 
 		for _, exp := range expectations {
-			k8sAPI, err := k8s.NewFakeAPI("")
+			k8sAPI, err := k8s.NewFakeAPI()
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1043,7 +1043,7 @@ status:
 	})
 
 	t.Run("Given an invalid resource type, returns error", func(t *testing.T) {
-		k8sAPI, err := k8s.NewFakeAPI("")
+		k8sAPI, err := k8s.NewFakeAPI()
 		if err != nil {
 			t.Fatalf("NewFakeAPI returned an error: %s", err)
 		}
@@ -1109,7 +1109,7 @@ status:
 	})
 
 	t.Run("Validates service stat requests", func(t *testing.T) {
-		k8sAPI, err := k8s.NewFakeAPI("")
+		k8sAPI, err := k8s.NewFakeAPI()
 		if err != nil {
 			t.Fatalf("NewFakeAPI returned an error: %s", err)
 		}

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -278,7 +278,7 @@ type expectedStatRPC struct {
 }
 
 func newMockGrpcServer(exp expectedStatRPC) (*mockProm, *grpcServer, error) {
-	k8sAPI, err := k8s.NewFakeAPI("", exp.k8sConfigs...)
+	k8sAPI, err := k8s.NewFakeAPI(exp.k8sConfigs...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controller/ca/controller_test.go
+++ b/controller/ca/controller_test.go
@@ -61,7 +61,7 @@ func TestCertificateController(t *testing.T) {
 }
 
 func newController(fixtures ...string) (*CertificateController, chan bool, chan struct{}, error) {
-	k8sAPI, err := k8s.NewFakeAPI("", fixtures...)
+	k8sAPI, err := k8s.NewFakeAPI(fixtures...)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("NewFakeAPI returned an error: %s", err)
 	}

--- a/controller/cmd/ca/main.go
+++ b/controller/cmd/ca/main.go
@@ -22,7 +22,7 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	k8sAPI, err := k8s.InitializeAPI(*kubeConfigPath, *controllerNamespace, k8s.Pod, k8s.RS)
+	k8sAPI, err := k8s.InitializeAPI(*kubeConfigPath, k8s.Pod, k8s.RS)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)
 	}

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -28,7 +28,7 @@ func main() {
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	k8sAPI, err := k8s.InitializeAPI(
-		*kubeConfigPath, *controllerNamespace,
+		*kubeConfigPath,
 		k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP,
 	)
 	if err != nil {

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath,
-		k8s.DS, k8s.Deploy, k8s.Job, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
+		k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
 	)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -45,7 +45,7 @@ func main() {
 	defer discoveryConn.Close()
 
 	k8sAPI, err := k8s.InitializeAPI(
-		*kubeConfigPath, *controllerNamespace,
+		*kubeConfigPath,
 		k8s.DS, k8s.Deploy, k8s.Job, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
 	)
 	if err != nil {

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -30,6 +30,7 @@ func main() {
 		k8s.SS,
 		k8s.Deploy,
 		k8s.Job,
+		k8s.NS,
 		k8s.Pod,
 		k8s.RC,
 		k8s.Svc,

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -25,7 +25,7 @@ func main() {
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	k8sAPI, err := k8s.InitializeAPI(
-		*kubeConfigPath, *controllerNamespace,
+		*kubeConfigPath,
 		k8s.DS,
 		k8s.SS,
 		k8s.Deploy,

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -72,82 +73,54 @@ type API struct {
 	syncChecks        []cache.InformerSynced
 	sharedInformers   informers.SharedInformerFactory
 	spSharedInformers sp.SharedInformerFactory
-	namespace         string
 }
 
 // InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
-func InitializeAPI(kubeConfig string, namespace string, resources ...APIResource) (*API, error) {
+func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
 	k8sClient, err := NewClientSet(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// check for cluster-wide vs. namespace-wide access
-	clusterAccess, err := k8s.ClusterAccess(k8sClient, namespace)
+	// check for cluster-wide access
+	clusterAccess, err := k8s.ClusterAccess(k8sClient)
 	if err != nil {
 		return nil, err
 	}
-	restrictToNamespace := ""
 	if !clusterAccess {
-		log.Warnf("Not authorized for cluster-wide access, limiting access to \"%s\" namespace", namespace)
-		restrictToNamespace = namespace
+		return nil, fmt.Errorf("not authorized for cluster-wide access")
 	}
 
 	// check for need and access to ServiceProfiles
 	var spClient *spclient.Clientset
-	idxSP := 0
-	needSP := false
-	for i := range resources {
-		if resources[i] == SP {
-			needSP = true
-			idxSP = i
-			break
-		}
-	}
-	if needSP {
-		serviceProfiles, err := k8s.ServiceProfilesAccess(k8sClient)
-		if err != nil {
-			return nil, err
-		}
-		if serviceProfiles {
+	for _, res := range resources {
+		if res == SP {
+			serviceProfiles, err := k8s.ServiceProfilesAccess(k8sClient)
+			if err != nil {
+				return nil, err
+			}
+			if !serviceProfiles {
+				return nil, errors.New("not authorized for ServiceProfile access")
+			}
+
 			spClient, err = NewSpClientSet(kubeConfig)
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			log.Warn("ServiceProfiles not available")
-			// remove SP from resources list
-			resources = append(resources[:idxSP], resources[idxSP+1:]...)
+
+			break
 		}
 	}
-
-	return NewAPI(k8sClient, spClient, restrictToNamespace, resources...), nil
+	return NewAPI(k8sClient, spClient, resources...), nil
 }
 
 // NewAPI takes a Kubernetes client and returns an initialized API.
-func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, namespace string, resources ...APIResource) *API {
-	var sharedInformers informers.SharedInformerFactory
+func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, resources ...APIResource) *API {
+	sharedInformers := informers.NewSharedInformerFactory(k8sClient, 10*time.Minute)
+
 	var spSharedInformers sp.SharedInformerFactory
-	if namespace == "" {
-		sharedInformers = informers.NewSharedInformerFactory(k8sClient, 10*time.Minute)
-		if spClient != nil {
-			spSharedInformers = sp.NewSharedInformerFactory(spClient, 10*time.Minute)
-		}
-	} else {
-		sharedInformers = informers.NewFilteredSharedInformerFactory(
-			k8sClient,
-			10*time.Minute,
-			namespace,
-			nil,
-		)
-		if spClient != nil {
-			spSharedInformers = sp.NewFilteredSharedInformerFactory(
-				spClient,
-				10*time.Minute,
-				namespace,
-				nil,
-			)
-		}
+	if spClient != nil {
+		spSharedInformers = sp.NewSharedInformerFactory(spClient, 10*time.Minute)
 	}
 
 	api := &API{
@@ -155,7 +128,6 @@ func NewAPI(k8sClient kubernetes.Interface, spClient spclient.Interface, namespa
 		syncChecks:        make([]cache.InformerSynced, 0),
 		sharedInformers:   sharedInformers,
 		spSharedInformers: spSharedInformers,
-		namespace:         namespace,
 	}
 
 	for _, resource := range resources {
@@ -499,15 +471,10 @@ func GetNamespaceOf(obj runtime.Object) (string, error) {
 }
 
 // getNamespaces returns the namespace matching the specified name. If no name
-// is given, it returns all namespaces, unless the API was configured to only
-// work with a single namespace, in which case it returns that namespace. Note
-// that namespace reads are not cached.
+// is given, it returns all namespaces. Note that namespace reads are not
+// cached.
 func (api *API) getNamespaces(name string) ([]runtime.Object, error) {
 	namespaces := make([]*corev1.Namespace, 0)
-
-	if name == "" && api.namespace != "" {
-		name = api.namespace
-	}
 
 	if name == "" {
 		namespaceList, err := api.Client.CoreV1().Namespaces().List(metav1.ListOptions{})

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -29,7 +29,7 @@ func newAPI(resourceConfigs []string, extraConfigs ...string) (*API, []runtime.O
 
 	k8sConfigs = append(k8sConfigs, extraConfigs...)
 
-	api, err := NewFakeAPI("", k8sConfigs...)
+	api, err := NewFakeAPI(k8sConfigs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("NewFakeAPI returned an error: %s", err)
 	}
@@ -251,41 +251,6 @@ metadata:
 				}
 			}
 		}
-	})
-
-	t.Run("In single-namespace mode", func(t *testing.T) {
-		t.Run("Returns only the configured namespace", func(t *testing.T) {
-
-			ns1 := `
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace1`
-
-			ns2 := `
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace2`
-
-			api, err := NewFakeAPI("namespace1", ns1, ns2)
-			if err != nil {
-				t.Fatalf("NewFakeAPI returned an error: %s", err)
-			}
-
-			namespaces, err := api.GetObjects("", k8s.Namespace, "")
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
-
-			if len(namespaces) != 1 {
-				t.Fatalf("expected 1 namespace, got %d", len(namespaces))
-			}
-
-			if namespaces[0].(*corev1.Namespace).Name != "namespace1" {
-				t.Fatalf("expected namespace1, got %v", namespaces[0])
-			}
-		})
 	})
 
 	t.Run("If objects are pods", func(t *testing.T) {

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -17,14 +17,15 @@ func NewFakeAPI(configs ...string) (*API, error) {
 		CM,
 		Deploy,
 		DS,
-		SS,
 		Endpoint,
 		Job,
+		MWC,
+		NS,
 		Pod,
 		RC,
 		RS,
-		Svc,
 		SP,
-		MWC,
+		SS,
+		Svc,
 	), nil
 }

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -5,7 +5,7 @@ import (
 )
 
 // NewFakeAPI provides a mock Kubernetes API for testing.
-func NewFakeAPI(namespace string, configs ...string) (*API, error) {
+func NewFakeAPI(configs ...string) (*API, error) {
 	clientSet, spClientSet, err := k8s.NewFakeClientSets(configs...)
 	if err != nil {
 		return nil, err
@@ -14,7 +14,6 @@ func NewFakeAPI(namespace string, configs ...string) (*API, error) {
 	return NewAPI(
 		clientSet,
 		spClientSet,
-		namespace,
 		CM,
 		Deploy,
 		DS,

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -184,7 +184,7 @@ status:
 		}
 
 		for _, exp := range expectations {
-			k8sAPI, err := k8s.NewFakeAPI("", exp.k8sRes...)
+			k8sAPI, err := k8s.NewFakeAPI(exp.k8sRes...)
 			if err != nil {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}


### PR DESCRIPTION
linkerd/linkerd2#2349 removed the `--single-namespace` flag, in favor of
runtime detection of cluster vs. namespace access, and also
ServiceProfile availability. This maintained control-plane support for
running in these two states.

This change requires control-plane components have cluster-wide
Kubernetes API access and ServiceProfile availability, and will error
out if not. Once #2349 merges, stage 1 install will be a requirement for
a successful stage 2 install.

Part of #2337

Signed-off-by: Andrew Seigner <siggy@buoyant.io>