### PR TITLE
Recreate the MWC when the proxy injector is restarted

### DIFF
--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -78,7 +78,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "delete", "watch"]
+  verbs: ["create", "get", "delete"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -78,7 +78,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "watch"]
+  verbs: ["create", "update", "get", "delete", "watch"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -1384,7 +1384,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "watch"]
+  verbs: ["create", "update", "get", "delete", "watch"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -1384,7 +1384,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "delete", "watch"]
+  verbs: ["create", "get", "delete"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1369,7 +1369,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "delete", "watch"]
+  verbs: ["create", "get", "delete"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1369,7 +1369,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "update", "get", "watch"]
+  verbs: ["create", "update", "get", "delete", "watch"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -43,11 +43,11 @@ func main() {
 		log.Fatalf("failed to read the trust anchor file: %s", err)
 	}
 
-	mwc, err := webhookConfig.CreateOrUpdate()
+	mwc, err := webhookConfig.Create()
 	if err != nil {
 		log.Fatalf("failed to create the mutating webhook configurations resource: %s", err)
 	}
-	log.Infof("created or updated mutating webhook configuration: %s", mwc.ObjectMeta.SelfLink)
+	log.Infof("created mutating webhook configuration: %s", mwc.ObjectMeta.SelfLink)
 
 	s, err := injector.NewWebhookServer(k8sClient, *addr, *controllerNamespace, *noInitContainer, *tlsEnabled, rootCA)
 	if err != nil {

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -78,6 +78,9 @@ func (w *WebhookServer) Shutdown() error {
 }
 
 func tlsConfig(rootCA *pkgTls.CA, controllerNamespace string) (*tls.Config, error) {
+	// must use the service short name in this TLS identity as the k8s api server
+	// looks for the webhook at <svc_name>.<namespace>.svc, without the cluster
+	// domain.
 	tlsIdentity := k8s.TLSIdentity{
 		Name:                "linkerd-proxy-injector",
 		Kind:                k8s.Service,

--- a/controller/proxy-injector/webhook_config_test.go
+++ b/controller/proxy-injector/webhook_config_test.go
@@ -29,11 +29,11 @@ func TestCreate(t *testing.T) {
 	}
 
 	// expect mutating webhook configuration to not exist
-	_, exist, err := webhookConfig.exist()
+	exists, err := webhookConfig.exists()
 	if err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
-	if exist {
+	if exists {
 		t.Error("Unexpected mutating webhook configuration. Expect resources to not exist")
 	}
 
@@ -43,11 +43,11 @@ func TestCreate(t *testing.T) {
 	}
 
 	// expect mutating webhook configuration to exist
-	_, exist, err = webhookConfig.exist()
+	exists, err = webhookConfig.exists()
 	if err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
-	if !exist {
+	if !exists {
 		t.Error("Expected mutating webhook configuration to exist")
 	}
 

--- a/controller/proxy-injector/webhook_config_test.go
+++ b/controller/proxy-injector/webhook_config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/tls"
 )
 
-func TestCreateOrUpdate(t *testing.T) {
+func TestCreate(t *testing.T) {
 	var (
 		namespace          = fake.DefaultControllerNamespace
 		webhookServiceName = "test.linkerd.io"
@@ -38,7 +38,7 @@ func TestCreateOrUpdate(t *testing.T) {
 	}
 
 	// create the mutating webhook configuration
-	if _, err := webhookConfig.CreateOrUpdate(); err != nil {
+	if _, err := webhookConfig.Create(); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
 
@@ -51,8 +51,8 @@ func TestCreateOrUpdate(t *testing.T) {
 		t.Error("Expected mutating webhook configuration to exist")
 	}
 
-	// update the mutating webhook configuration using the same trust anchors
-	if _, err := webhookConfig.CreateOrUpdate(); err != nil {
+	// expect the mutating webhook configuration to be created without errors
+	if _, err := webhookConfig.Create(); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
 }


### PR DESCRIPTION
This ensures that the MWC always picks up the latest config template during version upgrade. The `update()` method is removed since it's superseded by #2163.

To test:
```
# install stable-2.2.1
$ ./linkerd2-cli-stable-2.2.1-linux install --proxy-auto-inject | k apply -f -
$ kubectl describe mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config
...
Webhooks:
  ...
  Rules:
    ...
    Operations: # supports only create events
      CREATE
....

# upgrade to edge-19.2.5
$ ./linkerd2-cli-edge-19.2.5-linux install --proxy-auto-inject | k apply -f -
$ kubectl describe mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config
...
Webhooks:
    ...
    Operations: # operations list isn't updated
      CREATE 
...


# install fix from this branch
$ bin/linkerd install --proxy-auto-inject | kubectl apply -f -
$ kubectl describe mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config
....
Webhooks:
   ...
   Operations: # operations list is updated
      CREATE
      UPDATE
...
```

Fixes #2425.

Signed-off-by: Ivan Sim <ivan@buoyant.io>