### PR TITLE
Injection - parametrize func that checks if workload is injectable

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -113,7 +113,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		r := inject.Report{UnsupportedResource: true}
 		return bytes, []inject.Report{r}, nil
 	}
-	p, reports, err := conf.GetPatch(bytes)
+	p, reports, err := conf.GetPatch(bytes, inject.ShouldInjectCLI)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -119,7 +119,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 		return admissionResponse, nil
 	}
 
-	p, _, err := conf.GetPatch(request.Object.Raw)
+	p, _, err := conf.GetPatch(request.Object.Raw, inject.ShouldInjectWebhook)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -114,7 +114,7 @@ func TestShouldInject(t *testing.T) {
 
 				fakeReq := getFakeReq(deployment)
 				fullConf := testCase.conf.WithKind(fakeReq.Kind.Kind)
-				p, _, err := fullConf.GetPatch(fakeReq.Object.Raw)
+				p, _, err := fullConf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -141,7 +141,7 @@ func TestShouldInject(t *testing.T) {
 
 		fakeReq := getFakeReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		p, _, err := conf.GetPatch(fakeReq.Object.Raw)
+		p, _, err := conf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}


### PR DESCRIPTION
Follow-up to #2334 

Given the logic to check if a workload is injectable is different between CLI and webhook, pass it as a function parameter to `inject.GetPatch()`, to make things a bit more tractable. Let me know what you think :pray: 