### PR TITLE
Uninject: remove labels at the top level

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -55,8 +55,8 @@ type ResourceConfig struct {
 	nsAnnotations         map[string]string
 	meta                  metav1.TypeMeta
 	obj                   runtime.Object
-	objMeta               *metav1.ObjectMeta
-	templateMeta          objMeta
+	workLoadMeta          *metav1.ObjectMeta
+	podMeta               objMeta
 	podLabels             map[string]string
 	podSpec               *v1.PodSpec
 	dnsNameOverride       string
@@ -114,10 +114,10 @@ func (conf *ResourceConfig) ParseMeta(bytes []byte) (bool, error) {
 	if err := yaml.Unmarshal(bytes, &conf.meta); err != nil {
 		return false, err
 	}
-	if err := yaml.Unmarshal(bytes, &conf.templateMeta); err != nil {
+	if err := yaml.Unmarshal(bytes, &conf.podMeta); err != nil {
 		return false, err
 	}
-	return conf.templateMeta.ObjectMeta != nil, nil
+	return conf.podMeta.ObjectMeta != nil, nil
 }
 
 // GetPatch returns the JSON patch containing the proxy and init containers specs, if any
@@ -250,7 +250,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyDeploymentLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -260,7 +260,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyReplicationControllerLabel] = v.Name
 		conf.complete(v.Spec.Template)
 
@@ -270,7 +270,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyReplicaSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -280,7 +280,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyJobLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -290,7 +290,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyDaemonSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -300,7 +300,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
-		conf.objMeta = &v.ObjectMeta
+		conf.workLoadMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyStatefulSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -311,7 +311,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 
 		conf.obj = v
 		conf.podSpec = &v.Spec
-		conf.templateMeta = objMeta{&v.ObjectMeta}
+		conf.podMeta = objMeta{&v.ObjectMeta}
 	}
 
 	return nil
@@ -319,7 +319,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 
 func (conf *ResourceConfig) complete(template *v1.PodTemplateSpec) {
 	conf.podSpec = &template.Spec
-	conf.templateMeta = objMeta{&template.ObjectMeta}
+	conf.podMeta = objMeta{&template.ObjectMeta}
 }
 
 // injectPodSpec adds linkerd sidecars to the provided PodSpec.
@@ -538,7 +538,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch, identity k8s.TLSIdentity
 // Given a ObjectMeta, update ObjectMeta in place with the new labels and
 // annotations.
 func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
-	if len(conf.templateMeta.Annotations) == 0 {
+	if len(conf.podMeta.Annotations) == 0 {
 		patch.addPodAnnotationsRoot()
 	}
 	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, conf.globalConfig.GetVersion())
@@ -597,7 +597,7 @@ func ShouldInjectWebhook(conf *ResourceConfig, r Report) bool {
 		return false
 	}
 
-	podAnnotation := conf.templateMeta.Annotations[k8s.ProxyInjectAnnotation]
+	podAnnotation := conf.podMeta.Annotations[k8s.ProxyInjectAnnotation]
 	nsAnnotation := conf.nsAnnotations[k8s.ProxyInjectAnnotation]
 	if nsAnnotation == k8s.ProxyInjectEnabled && podAnnotation != k8s.ProxyInjectDisabled {
 		return true

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -55,7 +55,8 @@ type ResourceConfig struct {
 	nsAnnotations         map[string]string
 	meta                  metav1.TypeMeta
 	obj                   runtime.Object
-	objMeta               objMeta
+	objMeta               *metav1.ObjectMeta
+	templateMeta          objMeta
 	podLabels             map[string]string
 	podSpec               *v1.PodSpec
 	dnsNameOverride       string
@@ -113,10 +114,10 @@ func (conf *ResourceConfig) ParseMeta(bytes []byte) (bool, error) {
 	if err := yaml.Unmarshal(bytes, &conf.meta); err != nil {
 		return false, err
 	}
-	if err := yaml.Unmarshal(bytes, &conf.objMeta); err != nil {
+	if err := yaml.Unmarshal(bytes, &conf.templateMeta); err != nil {
 		return false, err
 	}
-	return conf.objMeta.ObjectMeta != nil, nil
+	return conf.templateMeta.ObjectMeta != nil, nil
 }
 
 // GetPatch returns the JSON patch containing the proxy and init containers specs, if any
@@ -249,6 +250,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyDeploymentLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -258,6 +260,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyReplicationControllerLabel] = v.Name
 		conf.complete(v.Spec.Template)
 
@@ -267,6 +270,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyReplicaSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -276,6 +280,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyJobLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -285,6 +290,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyDaemonSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -294,6 +300,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 		conf.obj = v
+		conf.objMeta = &v.ObjectMeta
 		conf.podLabels[k8s.ProxyStatefulSetLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
@@ -304,7 +311,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 
 		conf.obj = v
 		conf.podSpec = &v.Spec
-		conf.objMeta = objMeta{&v.ObjectMeta}
+		conf.templateMeta = objMeta{&v.ObjectMeta}
 	}
 
 	return nil
@@ -312,7 +319,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 
 func (conf *ResourceConfig) complete(template *v1.PodTemplateSpec) {
 	conf.podSpec = &template.Spec
-	conf.objMeta = objMeta{&template.ObjectMeta}
+	conf.templateMeta = objMeta{&template.ObjectMeta}
 }
 
 // injectPodSpec adds linkerd sidecars to the provided PodSpec.
@@ -531,7 +538,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch, identity k8s.TLSIdentity
 // Given a ObjectMeta, update ObjectMeta in place with the new labels and
 // annotations.
 func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
-	if len(conf.objMeta.Annotations) == 0 {
+	if len(conf.templateMeta.Annotations) == 0 {
 		patch.addPodAnnotationsRoot()
 	}
 	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, conf.globalConfig.GetVersion())
@@ -590,7 +597,7 @@ func ShouldInjectWebhook(conf *ResourceConfig, r Report) bool {
 		return false
 	}
 
-	podAnnotation := conf.objMeta.Annotations[k8s.ProxyInjectAnnotation]
+	podAnnotation := conf.templateMeta.Annotations[k8s.ProxyInjectAnnotation]
 	nsAnnotation := conf.nsAnnotations[k8s.ProxyInjectAnnotation]
 	if nsAnnotation == k8s.ProxyInjectEnabled && podAnnotation != k8s.ProxyInjectDisabled {
 		return true

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -25,7 +25,7 @@ type Report struct {
 // from conf
 func newReport(conf *ResourceConfig) Report {
 	var name string
-	if m := conf.templateMeta.ObjectMeta; m != nil {
+	if m := conf.podMeta.ObjectMeta; m != nil {
 		name = m.Name
 	}
 	return Report{
@@ -47,7 +47,7 @@ func (r Report) Injectable() bool {
 
 // update updates the report for the provided resource conf.
 func (r *Report) update(conf *ResourceConfig) {
-	r.InjectDisabled = conf.templateMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
+	r.InjectDisabled = conf.podMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
 	r.HostNetwork = conf.podSpec.HostNetwork
 	r.Sidecar = healthcheck.HasExistingSidecars(conf.podSpec)
 	r.UDP = checkUDPPorts(conf.podSpec)

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -25,7 +25,7 @@ type Report struct {
 // from conf
 func newReport(conf *ResourceConfig) Report {
 	var name string
-	if m := conf.objMeta.ObjectMeta; m != nil {
+	if m := conf.templateMeta.ObjectMeta; m != nil {
 		name = m.Name
 	}
 	return Report{
@@ -47,7 +47,7 @@ func (r Report) Injectable() bool {
 
 // update updates the report for the provided resource conf.
 func (r *Report) update(conf *ResourceConfig) {
-	r.InjectDisabled = conf.objMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
+	r.InjectDisabled = conf.templateMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
 	r.HostNetwork = conf.podSpec.HostNetwork
 	r.Sidecar = healthcheck.HasExistingSidecars(conf.podSpec)
 	r.UDP = checkUDPPorts(conf.podSpec)

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -17,11 +17,11 @@ func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
 
 	conf.uninjectPodSpec(report)
 
-	if conf.objMeta != nil {
-		uninjectObjectMeta(conf.objMeta)
+	if conf.workLoadMeta != nil {
+		uninjectObjectMeta(conf.workLoadMeta)
 	}
 
-	uninjectObjectMeta(conf.templateMeta.ObjectMeta)
+	uninjectObjectMeta(conf.podMeta.ObjectMeta)
 	return conf.YamlMarshalObj()
 }
 

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -1,8 +1,11 @@
 package inject
 
 import (
+	"strings"
+
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Uninject removes from the workload in conf the init and proxy containers,
@@ -13,7 +16,12 @@ func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
 	}
 
 	conf.uninjectPodSpec(report)
-	conf.uninjectObjectMeta()
+
+	if conf.objMeta != nil {
+		uninjectObjectMeta(conf.objMeta)
+	}
+
+	uninjectObjectMeta(conf.templateMeta.ObjectMeta)
 	return conf.YamlMarshalObj()
 }
 
@@ -49,13 +57,10 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 	t.Volumes = volumes
 }
 
-func (conf *ResourceConfig) uninjectObjectMeta() {
-	t := conf.objMeta
+func uninjectObjectMeta(t *metav1.ObjectMeta) {
 	newAnnotations := make(map[string]string)
 	for key, val := range t.Annotations {
-		if key != k8s.CreatedByAnnotation &&
-			key != k8s.ProxyVersionAnnotation &&
-			key != k8s.IdentityModeAnnotation {
+		if !strings.HasPrefix(key, k8s.Prefix) || key == k8s.ProxyInjectAnnotation {
 			newAnnotations[key] = val
 		}
 	}
@@ -63,14 +68,7 @@ func (conf *ResourceConfig) uninjectObjectMeta() {
 
 	labels := make(map[string]string)
 	for key, val := range t.Labels {
-		keep := true
-		for _, label := range k8s.InjectedLabels {
-			if key == label {
-				keep = false
-				break
-			}
-		}
-		if keep {
+		if !strings.HasPrefix(key, k8s.Prefix) {
 			labels[key] = val
 		}
 	}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -18,37 +18,40 @@ const (
 	 * Labels
 	 */
 
+	// Prefix is the prefix common to all labels and annotations injected by Linkerd
+	Prefix = "linkerd.io"
+
 	// ControllerComponentLabel identifies this object as a component of Linkerd's
 	// control plane (e.g. web, controller).
-	ControllerComponentLabel = "linkerd.io/control-plane-component"
+	ControllerComponentLabel = Prefix + "/control-plane-component"
 
 	// ControllerNSLabel is injected into mesh-enabled apps, identifying the
 	// namespace of the Linkerd control plane.
-	ControllerNSLabel = "linkerd.io/control-plane-ns"
+	ControllerNSLabel = Prefix + "/control-plane-ns"
 
 	// ProxyDeploymentLabel is injected into mesh-enabled apps, identifying the
 	// deployment that this proxy belongs to.
-	ProxyDeploymentLabel = "linkerd.io/proxy-deployment"
+	ProxyDeploymentLabel = Prefix + "/proxy-deployment"
 
 	// ProxyReplicationControllerLabel is injected into mesh-enabled apps,
 	// identifying the ReplicationController that this proxy belongs to.
-	ProxyReplicationControllerLabel = "linkerd.io/proxy-replicationcontroller"
+	ProxyReplicationControllerLabel = Prefix + "/proxy-replicationcontroller"
 
 	// ProxyReplicaSetLabel is injected into mesh-enabled apps, identifying the
 	// ReplicaSet that this proxy belongs to.
-	ProxyReplicaSetLabel = "linkerd.io/proxy-replicaset"
+	ProxyReplicaSetLabel = Prefix + "/proxy-replicaset"
 
 	// ProxyJobLabel is injected into mesh-enabled apps, identifying the Job that
 	// this proxy belongs to.
-	ProxyJobLabel = "linkerd.io/proxy-job"
+	ProxyJobLabel = Prefix + "/proxy-job"
 
 	// ProxyDaemonSetLabel is injected into mesh-enabled apps, identifying the
 	// DaemonSet that this proxy belongs to.
-	ProxyDaemonSetLabel = "linkerd.io/proxy-daemonset"
+	ProxyDaemonSetLabel = Prefix + "/proxy-daemonset"
 
 	// ProxyStatefulSetLabel is injected into mesh-enabled apps, identifying the
 	// StatefulSet that this proxy belongs to.
-	ProxyStatefulSetLabel = "linkerd.io/proxy-statefulset"
+	ProxyStatefulSetLabel = Prefix + "/proxy-statefulset"
 
 	/*
 	 * Annotations
@@ -56,16 +59,16 @@ const (
 
 	// CreatedByAnnotation indicates the source of the injected data plane
 	// (e.g. linkerd/cli v2.0.0).
-	CreatedByAnnotation = "linkerd.io/created-by"
+	CreatedByAnnotation = Prefix + "/created-by"
 
 	// ProxyVersionAnnotation indicates the version of the injected data plane
 	// (e.g. v0.1.3).
-	ProxyVersionAnnotation = "linkerd.io/proxy-version"
+	ProxyVersionAnnotation = Prefix + "/proxy-version"
 
 	// ProxyInjectAnnotation controls whether or not a pod should be injected
 	// when set on a pod spec. When set on a namespace spec, it applies to all
 	// pods in the namespace. Supported values are "enabled" or "disabled"
-	ProxyInjectAnnotation = "linkerd.io/inject"
+	ProxyInjectAnnotation = Prefix + "/inject"
 
 	// ProxyInjectEnabled is assigned to the ProxyInjectAnnotation annotation to
 	// enable injection for a pod or namespace.
@@ -77,7 +80,7 @@ const (
 
 	// IdentityModeAnnotation controls how a pod participates
 	// in service identity.
-	IdentityModeAnnotation = "linkerd.io/identity-mode"
+	IdentityModeAnnotation = Prefix + "/identity-mode"
 
 	// IdentityModeDisabled is assigned to IdentityModeAnnotation to
 	// disable the proxy from participating in automatic identity.
@@ -134,10 +137,6 @@ const (
 	// MountPathBase is the base directory of the mount path
 	MountPathBase = "/var/linkerd-io"
 )
-
-// InjectedLabels contains the list of label keys subjected to be injected by Linkerd into resource definitions
-var InjectedLabels = []string{ControllerNSLabel, ProxyDeploymentLabel, ProxyReplicationControllerLabel,
-	ProxyReplicaSetLabel, ProxyJobLabel, ProxyDaemonSetLabel, ProxyStatefulSetLabel}
 
 var (
 	// MountPathTLSTrustAnchor is the path at which the trust anchor file is


### PR DESCRIPTION
Fixes #2377

In inject's `ResourceConfig`, renamed `objMeta` to `templateMeta` since
it really points to the pod template metadata. And created a new field
`objMeta` that really points to the main workload (e.g. Deployment) metadata.

Refactored uninject to clean up the labels at both `objMeta` and
`templateMeta`. Also it will remove all the labels and annotations that
start with "linkerd.io" except for the "linkerd.io/inject" annotation.