### PR TITLE
Remove GOPATH dependency from cli dev environment

### DIFF
--- a/cli/static/templates.go
+++ b/cli/static/templates.go
@@ -3,20 +3,29 @@
 package static
 
 import (
-	"go/build"
 	"net/http"
-	"os"
 	"path"
+	"path/filepath"
+	"runtime"
 )
 
 // Templates that will be rendered by `linkerd install`. This is only used on
 // dev builds so we can assume GOPATH is set properly (either explicitly through
 // an env var, or defaulting to $HOME/go)
-var Templates http.FileSystem = http.Dir(path.Join(getGOPATH(), "src/github.com/linkerd/linkerd2/chart"))
+var Templates http.FileSystem = http.Dir(path.Join(getRepoRoot(), "chart"))
 
-func getGOPATH() string {
-	if goPath := os.Getenv("GOPATH"); goPath != "" {
-		return goPath
-	}
-	return build.Default.GOPATH
+// getRepoRoot returns the full path to the root of the repo. We assume this
+// function is only called from the `Templates` var above, and that this source
+// file lives at `cli/static`, relative to the root of the repo.
+func getRepoRoot() string {
+	// /foo/bar/linkerd2/cli/static/templates.go
+	_, filename, _, _ := runtime.Caller(0)
+
+	// /foo/bar/linkerd2/cli/static
+	dir := filepath.Dir(filename)
+
+	// filepath.Dir returns the parent directory, so that combined with joining
+	// ".." walks 2 levels up the tree:
+	// /foo/bar/linkerd2
+	return filepath.Dir(path.Join(dir, ".."))
 }


### PR DESCRIPTION
The `linkerd install` output relies on Helm templates in the `chart`
directory. In production cli builds, these templates are compiled into
the binary. In development, they are read from the file system. This
development code path relied on GOPATH to determine the location of the
`chart` directory. In anticipation of Go Modules support (#1488), we
cannot assume the repo is within the GOPATH.

This change removes the GOPATH dependency, and instead relies on
`runtime.Caller` to determine the root of the code repo. This change
only affects development (!prod) builds.

Prerequisite to #1488.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>