### PR TITLE
Introduce cli command to fetch proxy metrics

### DIFF
--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -88,7 +88,7 @@ func newCmdMetrics() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("%s", string(bytes))
+			fmt.Printf("%s", bytes)
 
 			return nil
 		},

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -1,19 +1,44 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sort"
+	"time"
 
+	"github.com/linkerd/linkerd2/controller/api/util"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type metricsOptions struct {
 	namespace string
 	pod       string
+}
+
+type metricsResult struct {
+	pod     string
+	metrics []byte
+	err     error
+}
+type byResult []metricsResult
+
+func (s byResult) Len() int {
+	return len(s)
+}
+func (s byResult) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s byResult) Less(i, j int) bool {
+	return s[i].pod < s[i].pod
 }
 
 func newMetricsOptions() *metricsOptions {
@@ -27,20 +52,43 @@ func newCmdMetrics() *cobra.Command {
 	options := newMetricsOptions()
 
 	cmd := &cobra.Command{
-		Use:   "metrics [flags] (POD)",
-		Short: "Fetch metrics from a specific Linkerd proxy",
-		Long: `Fetch metrics from a specific Linkerd proxy.
+		Use:   "metrics [flags] (RESOURCE)",
+		Short: "Fetch metrics directly from Linkerd proxies",
+		Long: `Fetch metrics directly from Linkerd proxies.
 
-  This command initiates a port-forward to a given pod, and queries the /metrics
-  endpoint on the Linkerd proxy running in that pod.`,
+  This command initiates a port-forward to a given pod or set of pods, and
+  queries the /metrics endpoint on the Linkerd proxies.
+
+  The RESOURCE argument specifies the target resource to query metrics for:
+  (TYPE/NAME)
+
+  Examples:
+  * deploy/my-deploy
+  * ds/my-daemonset
+  * job/my-job
+  * po/mypod1
+  * rc/my-replication-controller
+  * sts/my-statefulset
+
+  Valid resource types include:
+  * daemonsets
+  * deployments
+  * jobs
+  * pods
+  * replicasets
+  * replicationcontrollers
+  * statefulsets`,
 		Example: `  # Get metrics from pod-foo-bar in the default namespace.
-  linkerd metrics pod-foo-bar
+  linkerd metrics po/pod-foo-bar
+
+  # Get metrics from the web deployment in the emojivoto namespace.
+  linkerd metrics -n emojivoto deploy/web
 
   # Get metrics from the linkerd-controller pod in the linkerd namespace.
   linkerd metrics -n linkerd $(
     kubectl --namespace linkerd get pod \
       --selector linkerd.io/control-plane-component=controller \
-      --output jsonpath='{.items[*].metadata.name}'
+      --output name
   )`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -54,47 +102,182 @@ func newCmdMetrics() *cobra.Command {
 				return err
 			}
 
-			portforward, err := k8s.NewProxyMetricsForward(
-				config,
-				clientset,
-				options.namespace,
-				args[0],
-				verbose,
-			)
+			pods, err := getPodsFor(clientset, options.namespace, args[0])
 			if err != nil {
 				return err
 			}
 
-			defer portforward.Stop()
+			resultChan := make(chan metricsResult)
+			for i := range pods {
+				go func(pod corev1.Pod) {
+					bytes, err := getMetrics(config, clientset, pod, verbose)
 
-			go func() {
-				err := portforward.Run()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
-					os.Exit(1)
+					resultChan <- metricsResult{
+						pod:     pod.GetName(),
+						metrics: bytes,
+						err:     err,
+					}
+
+				}(pods[i])
+			}
+
+			results := []metricsResult{}
+			timer := time.NewTimer(30 * time.Second)
+			timedOut := false
+
+			for {
+				select {
+				case result := <-resultChan:
+					results = append(results, result)
+				case <-timer.C:
+					timedOut = true
 				}
-			}()
-
-			<-portforward.Ready()
-
-			metricsURL := portforward.URLFor("/metrics")
-			resp, err := http.Get(metricsURL)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-			bytes, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
+				if len(results) == len(pods) || timedOut {
+					break
+				}
 			}
 
-			fmt.Printf("%s", bytes)
+			sort.Sort(byResult(results))
+			for i, result := range results {
+				fmt.Printf("#\n# POD %s (%d of %d)\n#\n", result.pod, i+1, len(results))
+				if result.err == nil {
+					fmt.Printf("%s", result.metrics)
+				} else {
+					fmt.Printf("# ERROR %s\n", result.err)
+				}
+			}
 
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of pod")
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of resource")
 
 	return cmd
+}
+
+func getMetrics(
+	config *rest.Config,
+	clientset kubernetes.Interface,
+	pod corev1.Pod,
+	emitLogs bool,
+) ([]byte, error) {
+	portforward, err := k8s.NewProxyMetricsForward(config, clientset, pod, emitLogs)
+	if err != nil {
+		return nil, err
+	}
+
+	defer portforward.Stop()
+
+	go func() {
+		err := portforward.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+			portforward.Stop()
+		}
+	}()
+
+	<-portforward.Ready()
+
+	metricsURL := portforward.URLFor("/metrics")
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+// getPodsFor takes a resource string, queries the Kubernetes API, and returns a
+// list of pods belonging to that resource.
+// This could move into `pkg/k8s` if becomes more generally useful.
+func getPodsFor(clientset kubernetes.Interface, namespace string, resource string) ([]corev1.Pod, error) {
+	// TODO: BuildResource parses a resource string (which we need), but returns
+	// objects in Public API protobuf form for submission to the Public API
+	// (which we don't need). Refactor this API to strictly support parsing
+	// resource strings.
+	res, err := util.BuildResource(namespace, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.GetName() == "" {
+		return nil, errors.New("no resource name provided")
+	}
+
+	// special case if a single pod was specified
+	if res.GetType() == k8s.Pod {
+		pod, err := clientset.CoreV1().Pods(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return []corev1.Pod{*pod}, nil
+	}
+
+	var matchLabels map[string]string
+	switch res.GetType() {
+	case k8s.DaemonSet:
+		ds, err := clientset.AppsV1().DaemonSets(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = ds.Spec.Selector.MatchLabels
+
+	case k8s.Deployment:
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = deployment.Spec.Selector.MatchLabels
+
+	case k8s.Job:
+		job, err := clientset.BatchV1().Jobs(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = job.Spec.Selector.MatchLabels
+
+	case k8s.ReplicaSet:
+		rs, err := clientset.AppsV1().ReplicaSets(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = rs.Spec.Selector.MatchLabels
+
+	case k8s.ReplicationController:
+		rc, err := clientset.CoreV1().ReplicationControllers(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = rc.Spec.Selector
+
+	case k8s.StatefulSet:
+		ss, err := clientset.AppsV1().StatefulSets(namespace).Get(res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		matchLabels = ss.Spec.Selector.MatchLabels
+
+	default:
+		return nil, fmt.Errorf("unsupported resource type: %s", res.GetType())
+	}
+
+	podList, err := clientset.
+		CoreV1().
+		Pods(namespace).
+		List(
+			metav1.ListOptions{
+				LabelSelector: labels.Set(matchLabels).AsSelector().String(),
+			},
+		)
+	if err != nil {
+		return nil, err
+	}
+
+	return podList.Items, nil
 }

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+)
+
+type metricsOptions struct {
+	namespace string
+	pod       string
+}
+
+func newMetricsOptions() *metricsOptions {
+	return &metricsOptions{
+		namespace: "default",
+		pod:       "",
+	}
+}
+
+func newCmdMetrics() *cobra.Command {
+	options := newMetricsOptions()
+
+	cmd := &cobra.Command{
+		Use:   "metrics [flags] (POD)",
+		Short: "Fetch metrics from a specific Linkerd proxy",
+		Long: `Fetch metrics from a specific Linkerd proxy.
+
+  This command initiates a port-forward to a given pod, and queries the /metrics
+  endpoint on the Linkerd proxy running in that pod.`,
+		Example: `  # Get metrics from pod-foo-bar in the default namespace.
+  linkerd metrics pod-foo-bar
+
+  # Get metrics from the linkerd-controller pod in the linkerd namespace.
+  linkerd metrics -n linkerd $(
+    kubectl --namespace linkerd get pod \
+      --selector linkerd.io/control-plane-component=controller \
+      --output jsonpath='{.items[*].metadata.name}'
+  )`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := k8s.GetConfig(kubeconfigPath, kubeContext)
+			if err != nil {
+				return err
+			}
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return err
+			}
+
+			portforward, err := k8s.NewProxyMetricsForward(
+				config,
+				clientset,
+				options.namespace,
+				args[0],
+				verbose,
+			)
+			if err != nil {
+				return err
+			}
+
+			defer portforward.Stop()
+
+			go func() {
+				err := portforward.Run()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+					os.Exit(1)
+				}
+			}()
+
+			<-portforward.Ready()
+
+			metricsURL := portforward.URLFor("/metrics")
+			resp, err := http.Get(metricsURL)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			bytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s", string(bytes))
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of pod")
+
+	return cmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -106,6 +106,7 @@ func init() {
 	RootCmd.AddCommand(newCmdInstallCNIPlugin())
 	RootCmd.AddCommand(newCmdInstallSP())
 	RootCmd.AddCommand(newCmdLogs())
+	RootCmd.AddCommand(newCmdMetrics())
 	RootCmd.AddCommand(newCmdProfile())
 	RootCmd.AddCommand(newCmdRoutes())
 	RootCmd.AddCommand(newCmdStat())

--- a/pkg/healthcheck/sidecar.go
+++ b/pkg/healthcheck/sidecar.go
@@ -3,6 +3,7 @@ package healthcheck
 import (
 	"strings"
 
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -14,7 +15,7 @@ func HasExistingSidecars(podSpec *corev1.PodSpec) bool {
 			strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
 			strings.HasPrefix(container.Image, "gcr.io/heptio-images/contour:") ||
 			strings.HasPrefix(container.Image, "docker.io/envoyproxy/envoy-alpine:") ||
-			container.Name == "linkerd-proxy" ||
+			container.Name == k8s.ProxyContainerName ||
 			container.Name == "istio-proxy" ||
 			container.Name == "contour" ||
 			container.Name == "envoy" {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -407,11 +407,11 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch, identity k8s.TLSIdentity
 		},
 		Ports: []v1.ContainerPort{
 			{
-				Name:          "linkerd-proxy",
+				Name:          k8s.ProxyPortName,
 				ContainerPort: int32(conf.proxyConfig.GetInboundPort().GetPort()),
 			},
 			{
-				Name:          "linkerd-metrics",
+				Name:          k8s.ProxyMetricsPortName,
 				ContainerPort: int32(conf.proxyConfig.GetMetricsPort().GetPort()),
 			},
 		},

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -102,6 +102,12 @@ const (
 	// ProxyContainerName is the name assigned to the injected proxy container.
 	ProxyContainerName = "linkerd-proxy"
 
+	// ProxyPortName is the name of the Linkerd Proxy's proxy port
+	ProxyPortName = "linkerd-proxy"
+
+	// ProxyMetricsPortName is the name of the Linkerd Proxy's metrics port
+	ProxyMetricsPortName = "linkerd-metrics"
+
 	// ProxyInjectorWebhookConfig is the name of the mutating webhook
 	// configuration resource of the proxy-injector webhook.
 	ProxyInjectorWebhookConfig = "linkerd-proxy-injector-webhook-config"

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -71,7 +71,6 @@ func NewProxyMetricsForward(
 
 	var port corev1.ContainerPort
 	for _, p := range container.Ports {
-		// TODO: make a constant
 		if p.Name == ProxyMetricsPortName {
 			port = p
 			break

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -79,7 +79,10 @@ spec:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: NewProxyMetricsForward returns expected result", i), func(t *testing.T) {
-			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
+			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err)
+			}
 			pod, err := k8sClient.CoreV1().Pods(test.ns).Get(test.name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
@@ -148,8 +151,11 @@ status:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: NewPortForward returns expected result", i), func(t *testing.T) {
-			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
-			_, err := NewPortForward(&rest.Config{}, k8sClient, test.ns, test.deployName, 0, 0, false)
+			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error %s", err)
+			}
+			_, err = NewPortForward(&rest.Config{}, k8sClient, test.ns, test.deployName, 0, 0, false)
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -1,0 +1,195 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestNewProxyMetricsForward(t *testing.T) {
+	// TODO: test successful cases by mocking out `clientset.CoreV1().RESTClient()`
+	tests := []struct {
+		ns         string
+		name       string
+		k8sConfigs []string
+		err        error
+	}{
+		{
+			"pod-ns",
+			"pod-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-ns
+status:
+  phase: Running
+spec:
+  containers:
+  - name: linkerd-proxy
+    ports:
+    - name: bad-port
+      port: 123`,
+			},
+			errors.New("no linkerd-metrics port found for container pod-name/linkerd-proxy"),
+		},
+		{
+			"pod-ns",
+			"pod-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-ns
+status:
+  phase: Running
+spec:
+  containers:
+  - name: bad-container
+    ports:
+    - name: linkerd-metrics
+      port: 123`,
+			},
+			errors.New("no linkerd-proxy container found for pod pod-name"),
+		},
+		{
+			"bad-ns",
+			"pod-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-ns
+status:
+  phase: Running
+spec:
+  containers:
+  - name: linkerd-proxy
+    ports:
+    - name: linkerd-metrics
+      port: 123`,
+			},
+			errors.New("no running pods found for pod-name"),
+		},
+		{
+			"pod-ns",
+			"bad-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-ns
+status:
+  phase: Running
+spec:
+  containers:
+  - name: linkerd-proxy
+    ports:
+    - name: linkerd-metrics
+      port: 123`,
+			},
+			errors.New("no running pods found for bad-name"),
+		},
+		{
+			"pod-ns",
+			"pod-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+  namespace: pod-ns
+status:
+  phase: Stopped
+spec:
+  containers:
+  - name: linkerd-proxy
+    ports:
+    - name: linkerd-metrics
+      port: 123`,
+			},
+			errors.New("no running pods found for pod-name"),
+		},
+	}
+
+	for i, test := range tests {
+		test := test // pin
+		t.Run(fmt.Sprintf("%d: NewProxyMetricsForward returns expected result", i), func(t *testing.T) {
+			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
+			_, err := NewProxyMetricsForward(&rest.Config{}, k8sClient, test.ns, test.name, false)
+			if err != nil || test.err != nil {
+				if (err == nil && test.err != nil) ||
+					(err != nil && test.err == nil) ||
+					(err.Error() != test.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", test.err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewPortForward(t *testing.T) {
+	// TODO: test successful cases by mocking out `clientset.CoreV1().RESTClient()`
+	tests := []struct {
+		ns         string
+		deployName string
+		k8sConfigs []string
+		err        error
+	}{
+		{
+			"pod-ns",
+			"deploy-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-name
+  namespace: pod-ns
+status:
+  phase: Running`,
+			},
+			errors.New("no running pods found for deploy-name"),
+		},
+		{
+			"pod-ns",
+			"deploy-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: deploy-name-foo-bar
+  namespace: bad-ns
+status:
+  phase: Running`,
+			},
+			errors.New("no running pods found for deploy-name"),
+		},
+		{
+			"pod-ns",
+			"deploy-name",
+			[]string{`apiVersion: v1
+kind: Pod
+metadata:
+  name: deploy-name-foo-bar
+  namespace: pod-ns
+status:
+  phase: Stopped`,
+			},
+			errors.New("no running pods found for deploy-name"),
+		},
+	}
+
+	for i, test := range tests {
+		test := test // pin
+		t.Run(fmt.Sprintf("%d: NewPortForward returns expected result", i), func(t *testing.T) {
+			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
+			_, err := NewPortForward(&rest.Config{}, k8sClient, test.ns, test.deployName, 0, 0, false)
+			if err != nil || test.err != nil {
+				if (err == nil && test.err != nil) ||
+					(err != nil && test.err == nil) ||
+					(err.Error() != test.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", test.err, err)
+				}
+			}
+		})
+	}
+}

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -234,7 +234,17 @@ func (h *KubernetesHelper) ParseNamespacedResource(resource string) (string, str
 // tests can use for access to the given deployment. Note that the port-forward
 // remains running for the duration of the test.
 func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) (string, error) {
-	pf, err := k8s.NewPortForward("", "", namespace, deployName, 0, remotePort, false)
+	config, err := k8s.GetConfig("", "")
+	if err != nil {
+		return "", err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	pf, err := k8s.NewPortForward(config, clientset, namespace, deployName, 0, remotePort, false)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It's sometimes helpful to spotcheck proxy metrics from a specific pod,
but doing so with kubectl requires a few steps.

Introduce a new `linkerd metrics` command. When given a pod name and
namespace, returns a dump of the proxy's /metrics endpoint.

Also modify the k8s.portforward module to accept initialized k8s config
and client objects, to enable testing.

Fixes #2350.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

### Example outputs

```bash
$ bin/go-run cli metrics -n linkerd linkerd-controller-7ffbddccb-cp8v6
# HELP request_total Total count of HTTP requests.
# TYPE request_total counter
request_total{direction="inbound",tls="disabled"} 11541
```

```bash
$ bin/go-run cli metrics -h
Fetch metrics from a specific Linkerd proxy.

  This command initiates a port-forward to a given pod, and queries the /metrics
  endpoint on the Linkerd proxy running in that pod.

Usage:
  linkerd metrics [flags] (POD)

Examples:
  # Get metrics from pod-foo-bar in the default namespace.
  linkerd metrics pod-foo-bar

  # Get metrics from the linkerd-controller pod in the linkerd namespace.
  linkerd metrics -n linkerd $(
    kubectl --namespace linkerd get pod \
      --selector linkerd.io/control-plane-component=controller \
      --output jsonpath='{.items[*].metadata.name}'
  )

Flags:
  -h, --help               help for metrics
  -n, --namespace string   Namespace of pod (default "default")
```