### PR TITLE
proxy: Bump pinned version to 6d10dd6

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-7e55196}"
+PROXY_VERSION="${PROXY_VERSION:-6d10dd6}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This picks up the following:
* [dc00685:](https://github.com/linkerd/linkerd2-proxy/commit/dc00685) Increase inbound router capacity
* [6d10dd6:](https://github.com/linkerd/linkerd2-proxy/commit/6d10dd6) Set `l5d-remote-ip` on inbound requests and outbound responses

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>