### PR TITLE
Re-add pre-install permission checks

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -90,6 +90,7 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 		} else {
 			checks = append(checks, healthcheck.LinkerdPreInstallClusterChecks)
 		}
+		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -90,10 +90,10 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 		} else {
 			checks = append(checks, healthcheck.LinkerdPreInstallClusterChecks)
 		}
-		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}
+		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
 	} else {
 		checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
 		checks = append(checks, healthcheck.LinkerdAPIChecks)

--- a/test/testdata/check.pre.single_namespace.golden
+++ b/test/testdata/check.pre.single_namespace.golden
@@ -14,6 +14,10 @@ pre-kubernetes-single-namespace-setup
 √ can create Roles
 √ can create RoleBindings
 
+pre-kubernetes-capability
+-------------------------
+√ has NET_ADMIN capability
+
 pre-kubernetes-setup
 --------------------
 √ can create ServiceAccounts


### PR DESCRIPTION
This fixes a small issue from #2421, where we inadvertently removed some of the pre-flight RBAC checks.