### PR TITLE
Have `NewFakeClientSets()` not swallow errors when parsing YAML

### DIFF
--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -6,7 +6,10 @@ import (
 
 // NewFakeAPI provides a mock Kubernetes API for testing.
 func NewFakeAPI(namespace string, configs ...string) (*API, error) {
-	clientSet, spClientSet := k8s.NewFakeClientSets(configs...)
+	clientSet, spClientSet, err := k8s.NewFakeClientSets(configs...)
+	if err != nil {
+		return nil, err
+	}
 
 	return NewAPI(
 		clientSet,

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -298,8 +298,12 @@ func TestCheckCanCreate(t *testing.T) {
 		[]CategoryID{},
 		&Options{},
 	)
-	hc.clientset, _ = k8s.NewFakeClientSets()
-	err := hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
+	var err error
+	hc.clientset, _, err = k8s.NewFakeClientSets()
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	err = hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
 	if err == nil ||
 		err.Error() != exp.Error() {
 		t.Fatalf("Unexpected error (Expected: %s, Got: %s)", exp, err)
@@ -336,8 +340,12 @@ spec:
 				&Options{},
 			)
 
-			hc.clientset, _ = k8s.NewFakeClientSets(test.k8sConfigs...)
-			err := hc.checkNetAdmin()
+			var err error
+			hc.clientset, _, err = k8s.NewFakeClientSets(test.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			err = hc.checkNetAdmin()
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -46,7 +46,10 @@ subjects:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: returns expected authorization", i), func(t *testing.T) {
-			k8sClient, _ := NewFakeClientSets(test.k8sConfigs...)
+			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
 			allowed, reason, err := ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments", "")
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||

--- a/pkg/k8s/test_helper.go
+++ b/pkg/k8s/test_helper.go
@@ -13,13 +13,13 @@ import (
 )
 
 // NewFakeClientSets provides a mock Kubernetes ClientSet for testing.
-func NewFakeClientSets(configs ...string) (kubernetes.Interface, spclient.Interface) {
+func NewFakeClientSets(configs ...string) (kubernetes.Interface, spclient.Interface, error) {
 	objs := []runtime.Object{}
 	spObjs := []runtime.Object{}
 	for _, config := range configs {
 		obj, err := ToRuntimeObject(config)
 		if err != nil {
-			return nil, nil
+			return nil, nil, err
 		}
 		if strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind) == ServiceProfile {
 			spObjs = append(spObjs, obj)
@@ -28,7 +28,7 @@ func NewFakeClientSets(configs ...string) (kubernetes.Interface, spclient.Interf
 		}
 	}
 
-	return fake.NewSimpleClientset(objs...), spfake.NewSimpleClientset(spObjs...)
+	return fake.NewSimpleClientset(objs...), spfake.NewSimpleClientset(spObjs...), nil
 }
 
 // ToRuntimeObject deserializes Kubernetes YAML into a Runtime Object


### PR DESCRIPTION
This helps catching bad YAMLs in test resources.