### PR TITLE
Add more known log errors to integration tests

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -70,17 +70,18 @@ var (
 		`.* linkerd-web-.*-.* linkerd-proxy WARN trust_dns_proto::xfer::dns_exchange failed to associate send_message response to the sender`,
 
 		// prometheus scrape failures of control-plane
-		`.* linkerd-prometheus-.*-.* linkerd-proxy ERR! proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: .*:999(4|5|6|7|8)\)`,
+		`.* linkerd-prometheus-.*-.* linkerd-proxy ERR! proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: .*:(3000|999(4|5|6|7|8))\)`,
 		`.* linkerd-prometheus-.*-.* linkerd-proxy ERR! proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: operation timed out after 300ms`,
 
 		// single namespace warnings
 		`.*-single-namespace linkerd-controller-.*-.* (destination|public-api|tap) time=".*" level=warning msg="Not authorized for cluster-wide access, limiting access to \\".*-single-namespace\\" namespace"`,
 		`.*-single-namespace linkerd-controller-.*-.* (destination|public-api|tap) time=".*" level=warning msg="ServiceProfiles not available"`,
 
-		`.*-tls linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*-tls\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
+		`.* linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
 		`.*-tls linkerd-web-.*-.* linkerd-proxy ERR! linkerd-destination\..*-tls\.svc\.cluster\.local:8086 rustls::session TLS alert received: Message {`,
 		`.*-tls linkerd-controller-.*-.* linkerd-proxy ERR! .*:9090 rustls::session TLS alert received: Message {`,
 		`.*-tls linkerd-web-.*-.* linkerd-proxy WARN linkerd-destination\..*-tls\.svc\.cluster\.local:8086 linkerd2_proxy::proxy::reconnect connect error to Config { addr: Name\(NameAddr { name: "linkerd-destination\..*-tls\.svc\.cluster\.local", port: 8086 }\), tls_server_identity: Some\("linkerd-controller\.deployment\..*-tls\.linkerd-managed\..*-tls.svc.cluster.local"\), tls_config: Some\(ClientConfig\) }: received fatal alert: AccessDenied`,
+		`.*-tls linkerd-controller-.*-.* linkerd-proxy WARN .*:9090 linkerd2_proxy::proxy::reconnect connect error to Config { target: Target { addr: V4\(.*:9090\), tls: Some\(ConnectionConfig { server_identity: "linkerd-prometheus\.deployment\..*-tls.linkerd-managed\..*-tls\.svc\.cluster\.local", config: ClientConfig }\) }, settings: Http2, _p: \(\) }: received fatal alert: AccessDenied`,
 	}, "|"))
 )
 


### PR DESCRIPTION
Also temporarily enable integration tests in ci to verify.

Relates to #2414, #2452

Signed-off-by: Andrew Seigner <siggy@buoyant.io>