### PR TITLE
cli: Always display stat tables for all routes

### DIFF
--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -154,10 +154,6 @@ func (s *grpcServer) topRoutesFor(ctx context.Context, req *pb.TopRoutesRequest,
 		}
 	}
 
-	if len(profiles) == 0 {
-		return nil, fmt.Errorf("No ServiceProfiles found for Services of %s/%s", requestedResource.Type, requestedResource.Name)
-	}
-
 	metrics, err := s.getRouteMetrics(ctx, req, profiles, targetResource)
 	if err != nil {
 		return nil, err
@@ -274,10 +270,8 @@ func (s *grpcServer) getRouteMetrics(ctx context.Context, req *pb.TopRoutesReque
 		}
 	}
 
-	err = processRouteMetrics(results, timeWindow, table)
-	if err != nil {
-		return nil, err
-	}
+	processRouteMetrics(results, timeWindow, table)
+
 	return table, nil
 }
 
@@ -311,12 +305,9 @@ func renderLabels(labels model.LabelSet, services []string) string {
 	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
 }
 
-func processRouteMetrics(results []promResult, timeWindow string, table indexedTable) error {
-	samples := 0
+func processRouteMetrics(results []promResult, timeWindow string, table indexedTable) {
 	for _, result := range results {
 		for _, sample := range result.vec {
-			samples++
-
 			route := string(sample.Metric[model.LabelName("rt_route")])
 			dst := string(sample.Metric[model.LabelName("dst")])
 			dst = strings.Split(dst, ":")[0] // Truncate port, if there is one.
@@ -355,6 +346,4 @@ func processRouteMetrics(results []promResult, timeWindow string, table indexedT
 			}
 		}
 	}
-
-	return nil
 }

--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -355,8 +355,6 @@ func processRouteMetrics(results []promResult, timeWindow string, table indexedT
 			}
 		}
 	}
-	if samples == 0 {
-		return errors.New("No samples")
-	}
+
 	return nil
 }

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -787,7 +787,7 @@ func (api *API) GetServiceProfileFor(svc *corev1.Service, clientNs string) *spv1
 		}
 	}
 	// Not found; return default.
-	log.Infof("no Service Profile found for '%s' -- using default", dst)
+	log.Debugf("no Service Profile found for '%s' -- using default", dst)
 	return &spv1alpha1.ServiceProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dst,

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -787,6 +787,7 @@ func (api *API) GetServiceProfileFor(svc *corev1.Service, clientNs string) *spv1
 		}
 	}
 	// Not found; return default.
+	log.Infof("no Service Profile found for '%s' -- using default", dst)
 	return &spv1alpha1.ServiceProfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dst,


### PR DESCRIPTION
## Problem

When an object has no previous route metrics, we do not generate a table for
that object.

The reasoning behind this was for reducing output of the following command:

```
$ linkerd routes deploy --to deploy/foo
```

For each deployment object, if it has no previous traffic to `deploy/foo`, then
a table would not be generated for it.

However, the behavior we see with that indicates there is an error even when a
Service Profile is installed:

```
$ linkerd routes deploy deploy/foo
Error: No Service Profiles found for selected resources
```

## Solution

Always generate a stat table for the queried resource object.

## Validation

I deployed [booksapp](https://github.com/buoyantIO/booksapp) with the `traffic`
deployment removed and Service Profiles installed.

Without the fix, `linkerd routes deploy/webapp` displays an error because there
has been no traffic to `deploy/webapp` without the `traffic` deployment.

With the fix, the following output is generated:

```
ROUTE                       SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
GET /                        webapp     0.00%   0.0rps           0ms           0ms           0ms
GET /authors/{id}            webapp     0.00%   0.0rps           0ms           0ms           0ms
GET /books/{id}              webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /authors                webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /authors/{id}/delete    webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /authors/{id}/edit      webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /books                  webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /books/{id}/delete      webapp     0.00%   0.0rps           0ms           0ms           0ms
POST /books/{id}/edit        webapp     0.00%   0.0rps           0ms           0ms           0ms
[DEFAULT]                    webapp     0.00%   0.0rps           0ms           0ms           0ms
```

Closes #2328

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
