### PR TITLE
Fix TopRoutes tables not being sorted correctly

### DIFF
--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -144,7 +144,7 @@ const processStatTable = table => {
   return _orderBy(rows, r => r.name);
 };
 
-export const DefaultRoute = "[default]";
+export const DefaultRoute = "[DEFAULT]";
 export const processTopRoutesResults = rows => {
   return _map(rows, row => ({
     route: row.route || DefaultRoute,


### PR DESCRIPTION
Some time ago, I fixed sorting on these tables so that the default route (`[default]`) was sorted to the bottom. The name was changed to `[DEFAULT]` causing that sort to no longer put the default route at the bottom. Fix this.

Before:
<img width="1192" alt="screen shot 2019-03-07 at 5 11 29 pm" src="https://user-images.githubusercontent.com/549258/53989459-67dd3f80-40fc-11e9-9d2f-370027a5751c.png">


After:
<img width="1153" alt="screen shot 2019-03-07 at 5 11 42 pm" src="https://user-images.githubusercontent.com/549258/53989466-6b70c680-40fc-11e9-8aae-70558670be47.png">
