### PR TITLE
Fix web init to not check for ServiceProfiles

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -58,7 +58,6 @@ exit_code=0
 
 run_test "$test_directory/install_test.go" || exit_code=$?
 run_test "$test_directory/install_test.go" "-enable-tls" || exit_code=$?
-run_test "$test_directory/install_test.go" "-single-namespace" || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -574,7 +574,7 @@ func TestEndpoints(t *testing.T) {
 
 func TestConfig(t *testing.T) {
 	t.Run("Configs are parsed and returned", func(t *testing.T) {
-		k8sAPI, err := k8s.NewFakeAPI("")
+		k8sAPI, err := k8s.NewFakeAPI()
 		if err != nil {
 			t.Fatalf("NewFakeAPI returned an error: %s", err)
 		}

--- a/web/main.go
+++ b/web/main.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
-	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
-	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/web/srv"
 	log "github.com/sirupsen/logrus"
 )
@@ -28,19 +26,9 @@ func main() {
 	uuid := flag.String("uuid", "", "unique linkerd install id")
 	reload := flag.Bool("reload", true, "reloading set to true or false")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
-	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	flags.ConfigureAndParse()
 
-	k8sClient, err := k8s.NewClientSet(*kubeConfigPath)
-	if err != nil {
-		log.Fatalf("failed to initialize Kubernetes client: %s", err)
-	}
-	serviceProfiles, err := pkgK8s.ServiceProfilesAccess(k8sClient)
-	if err != nil {
-		log.Fatalf("failed to check for ServiceProfiles: %s", err)
-	}
-
-	_, _, err = net.SplitHostPort(*apiAddr) // Verify apiAddr is of the form host:port.
+	_, _, err := net.SplitHostPort(*apiAddr) // Verify apiAddr is of the form host:port.
 	if err != nil {
 		log.Fatalf("failed to parse API server address: %s", *apiAddr)
 	}
@@ -52,7 +40,8 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	server := srv.NewServer(*addr, *grafanaAddr, *templateDir, *staticDir, *uuid, *controllerNamespace, serviceProfiles, *reload, client)
+	// TODO: modify this API to always assume serviceProfiles are available
+	server := srv.NewServer(*addr, *grafanaAddr, *templateDir, *staticDir, *uuid, *controllerNamespace, true, *reload, client)
 
 	go func() {
 		log.Infof("starting HTTP server on %+v", *addr)


### PR DESCRIPTION
linkerd/linkerd2#2428 modified SelfSubjectAccessReview behavior to no
longer paper-over failed ServiceProfile checks, assuming that
ServiceProfiles will be required going forward. There was a lingering
ServiceProfile check in the web's startup that started failing due to
this change, as the web component does not have (and should not need)
ServiceProfile access. The check was originally implemented to inform
the web component whether to expect "single namespace" mode or
ServiceProfile support.

Modify the web's initialization to always expect ServiceProfile support.

Also remove single namespace integration test

Signed-off-by: Andrew Seigner <siggy@buoyant.io>