### PR TITLE
Add "Community" menu item to dashboard that displays linkerd.io content

### DIFF
--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -13,6 +13,7 @@ const routeToCrumbTitle = {
   "tap": "Tap",
   "top": "Top",
   "routes": "Top Routes",
+  "community": "Community",
   "debug": "Debug"
 };
 

--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -1,0 +1,20 @@
+import Iframe from 'react-iframe';
+import React from 'react';
+
+function Community() {
+  return (
+    <React.Fragment>
+      <Iframe
+        url="https://linkerd.io/dashboard/"
+        id="myId"
+        className="myClassname"
+        position="inherit"
+        display="block"
+        height="-webkit-fill-available"
+        width="-webkit-fill-available"
+        border="none" />
+    </React.Fragment>
+  );
+}
+
+export default Community;

--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -6,8 +6,6 @@ function Community() {
     <React.Fragment>
       <Iframe
         url="https://linkerd.io/dashboard/"
-        id="myId"
-        className="myClassname"
         position="inherit"
         display="block"
         height="-webkit-fill-available"

--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -1,17 +1,15 @@
 import Iframe from 'react-iframe';
 import React from 'react';
 
-function Community() {
+const Community = () => {
   return (
-    <React.Fragment>
-      <Iframe
-        url="https://linkerd.io/dashboard/"
-        position="inherit"
-        display="block"
-        height="100vh"
-        border="none" />
-    </React.Fragment>
+    <Iframe
+      url="https://linkerd.io/dashboard/"
+      position="inherit"
+      display="block"
+      height="100vh"
+      border="none" />
   );
-}
+};
 
 export default Community;

--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -8,8 +8,7 @@ function Community() {
         url="https://linkerd.io/dashboard/"
         position="inherit"
         display="block"
-        height="-webkit-fill-available"
-        width="-webkit-fill-available"
+        height="100vh"
         border="none" />
     </React.Fragment>
   );

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -34,6 +34,7 @@ import { withStyles } from '@material-ui/core/styles';
 import yellow from '@material-ui/core/colors/yellow';
 
 const jsonFeedUrl = "https://linkerd.io/dashboard/index.json";
+const localStorageKey = "linkerd-updates-last-clicked";
 
 const styles = theme => {
   const drawerWidth = theme.spacing.unit * 31;
@@ -184,7 +185,7 @@ class NavigationBase extends React.Component {
       .then(rsp => rsp.data.date)
       .then(rsp => {
         if (rsp.length > 0) {
-          let lastClicked = localStorage["linkerd-updates-last-clicked"];
+          let lastClicked = localStorage[localStorageKey];
           if (!lastClicked) {
             this.setState({ hideUpdateBadge: false });
           } else {
@@ -207,10 +208,8 @@ class NavigationBase extends React.Component {
 
   handleCommunityClick = () => {
     let lastClicked = new Date();
-    localStorage.setItem("linkerd-updates-last-clicked", lastClicked);
-    if (this.state.hideUpdateBadge === false) {
-      this.setState({ hideUpdateBadge: true });
-    }
+    localStorage.setItem(localStorageKey, lastClicked);
+    this.setState({ hideUpdateBadge: true });
   }
 
   handleDrawerClick = () => {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -27,10 +27,13 @@ import SentimentVerySatisfiedIcon from '@material-ui/icons/SentimentVerySatisfie
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Version from './Version.jsx';
+import _maxBy from 'lodash/maxBy';
 import classNames from 'classnames';
 import { withContext } from './util/AppContext.jsx';
 import { withStyles } from '@material-ui/core/styles';
 import yellow from '@material-ui/core/colors/yellow';
+
+const jsonFeedUrl = "https://linkerd.io/dashboard/index.json";
 
 const styles = theme => {
   const drawerWidth = theme.spacing.unit * 31;
@@ -176,7 +179,6 @@ class NavigationBase extends React.Component {
   }
 
   fetchLatestCommunityUpdate() {
-    let jsonFeedUrl = "https://linkerd.io/dashboard/index.json";
     this.communityUpdatesPromise = fetch(jsonFeedUrl)
       .then(rsp => rsp.json())
       .then(rsp => rsp.data.date)
@@ -186,10 +188,10 @@ class NavigationBase extends React.Component {
           if (!lastClicked) {
             this.setState({ hideUpdateBadge: false });
           } else {
-            lastClicked = new Date(lastClicked);
-            let latestCommunityUpdate = rsp.map(update => new Date(update.date))
-              .sort((a, b) => b - a)[0];
-            if (latestCommunityUpdate > lastClicked) {
+            let lastClickedDateObject = new Date(lastClicked);
+            let latestArticle = _maxBy(rsp, update => update.date);
+            let latestArticleDateObject = new Date(latestArticle);
+            if (latestArticleDateObject > lastClickedDateObject) {
               this.setState({ hideUpdateBadge: false });
             }
           }

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -181,15 +181,16 @@ class NavigationBase extends React.Component {
       .then(rsp => rsp.data.date)
       .then(rsp => {
         if (rsp.length > 0) {
-          let lastUpdated = rsp.map(update => new Date(update.date))
-            .sort((a, b) => b - a);
-          let lastChecked = localStorage["linkerd-updates-last-checked"];
-          if (!lastChecked) {
+          let lastClicked = localStorage["linkerd-updates-last-checked"];
+          if (!lastClicked) {
             localStorage.setItem("linkerd-updates-last-checked", new Date());
             this.setState({ hideUpdateBadge: false });
-          }
-          if (lastUpdated[0] > lastChecked) {
-            this.setState({ hideUpdateBadge: false });
+          } else {
+            let latestCommunityUpdate = rsp.map(update => new Date(update.date))
+              .sort((a, b) => b - a)[0];
+            if (latestCommunityUpdate > lastClicked) {
+              this.setState({ hideUpdateBadge: false });
+            }
           }
         }
       }).catch(this.handleApiError);

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -186,6 +186,7 @@ class NavigationBase extends React.Component {
           if (!lastClicked) {
             this.setState({ hideUpdateBadge: false });
           } else {
+            lastClicked = new Date(lastClicked);
             let latestCommunityUpdate = rsp.map(update => new Date(update.date))
               .sort((a, b) => b - a)[0];
             if (latestCommunityUpdate > lastClicked) {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -30,6 +30,7 @@ import Version from './Version.jsx';
 import classNames from 'classnames';
 import { withContext } from './util/AppContext.jsx';
 import { withStyles } from '@material-ui/core/styles';
+import yellow from '@material-ui/core/colors/yellow';
 
 const styles = theme => {
   const drawerWidth = theme.spacing.unit * 31;
@@ -126,7 +127,7 @@ const styles = theme => {
       paddingRight: "3px",
     },
     badge: {
-      backgroundColor: "#ffeb3b",
+      backgroundColor: yellow[500],
     }
   };
 };
@@ -139,13 +140,13 @@ class NavigationBase extends React.Component {
     this.handleCommunityClick = this.handleCommunityClick.bind(this);
 
     this.state = this.getInitialState();
-    this.state.hideUpdateBadge = true;
   }
 
   getInitialState() {
     return {
       drawerOpen: true,
       helpMenuOpen: false,
+      hideUpdateBadge: true,
       latestVersion: '',
       isLatest: true,
       namespaceFilter: "all"
@@ -181,9 +182,8 @@ class NavigationBase extends React.Component {
       .then(rsp => rsp.data.date)
       .then(rsp => {
         if (rsp.length > 0) {
-          let lastClicked = localStorage["linkerd-updates-last-checked"];
+          let lastClicked = localStorage["linkerd-updates-last-clicked"];
           if (!lastClicked) {
-            localStorage.setItem("linkerd-updates-last-checked", new Date());
             this.setState({ hideUpdateBadge: false });
           } else {
             let latestCommunityUpdate = rsp.map(update => new Date(update.date))
@@ -203,8 +203,8 @@ class NavigationBase extends React.Component {
   }
 
   handleCommunityClick = () => {
-    let lastChecked = new Date();
-    localStorage.setItem("linkerd-updates-last-checked", lastChecked);
+    let lastClicked = new Date();
+    localStorage.setItem("linkerd-updates-last-clicked", lastClicked);
     if (this.state.hideUpdateBadge === false) {
       this.setState({ hideUpdateBadge: true });
     }
@@ -218,35 +218,22 @@ class NavigationBase extends React.Component {
     this.setState(state => ({ helpMenuOpen: !state.helpMenuOpen }));
   }
 
-  menuItem(path, title, icon, isCommunity) {
+  menuItem(path, title, icon, onClick) {
     const { classes, api } = this.props;
     let normalizedPath = this.props.location.pathname.replace(this.props.pathPrefix, "");
     let isCurrentPage = path => path === normalizedPath;
 
-    if (isCommunity) {
-      return (
-        <MenuItem
-          component={Link}
-          onClick={this.handleCommunityClick}
-          to={api.prefixLink(path)}
-          className={classes.navMenuItem}
-          selected={isCurrentPage(path)}>
-          <ListItemIcon>{icon}</ListItemIcon>
-          <ListItemText primary={title} />
-        </MenuItem>
-      );
-    } else {
-      return (
-        <MenuItem
-          component={Link}
-          to={api.prefixLink(path)}
-          className={classes.navMenuItem}
-          selected={isCurrentPage(path)}>
-          <ListItemIcon>{icon}</ListItemIcon>
-          <ListItemText primary={title} />
-        </MenuItem>
-      );
-    }
+    return (
+      <MenuItem
+        component={Link}
+        onClick={onClick}
+        to={api.prefixLink(path)}
+        className={classes.navMenuItem}
+        selected={isCurrentPage(path)}>
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText primary={title} />
+      </MenuItem>
+    );
   }
 
   render() {
@@ -303,8 +290,8 @@ class NavigationBase extends React.Component {
                 classes={{ badge: classes.badge }}
                 invisible={this.state.hideUpdateBadge}
                 badgeContent="1">
-                <SentimentVerySatisfiedIcon fontSize="small" />
-              </Badge>, true
+                <SentimentVerySatisfiedIcon />
+              </Badge>, this.handleCommunityClick
               ) }
             <ListItem component="a" href="https://lists.cncf.io/g/cncf-linkerd-users" target="_blank" className={classes.helpMenuItem}>
               <ListItemIcon><EmailIcon /></ListItemIcon>

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -6,6 +6,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 import ApiHelpers from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
+import Community from './components/Community.jsx';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Debug from './components/Debug.jsx';
 import Namespace from './components/Namespace.jsx';
@@ -114,6 +115,9 @@ let applicationHtml = (
               <Route
                 path={`${pathPrefix}/debug`}
                 render={props => <Navigation {...props} ChildComponent={Debug} />} />
+              <Route
+                path={`${pathPrefix}/community`}
+                render={props => <Navigation {...props} ChildComponent={Community} />} />
               <Route component={NoMatch} />
             </Switch>
           </RouterToUrlQuery>

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -17,6 +17,7 @@
     "prop-types": "15.6.1",
     "react": "16.5.0",
     "react-dom": "16.5.0",
+    "react-iframe": "^1.5.0",
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",
     "react-router-prop-types": "^1.0.4",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -7198,6 +7198,15 @@ prop-types@^15.5.4, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, 
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.x:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 proxy-addr@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
@@ -7394,10 +7403,23 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-iframe@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-iframe/-/react-iframe-1.5.0.tgz#20778988cb2782d32663a4537ef0da704dd2b9b2"
+  integrity sha512-hHPK0Os1iQIGD5YVM4N7DMZB9mcWHm+BmY+pSauuaX+NofilONnWUrVbCbrzy0gW6NkDW1ETAmUqlY4mrE9cxg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.x"
+
 react-is@^16.3.2, react-is@^16.5.2, react-is@^16.6.3, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -110,6 +110,7 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/replicationcontrollers/:replicationcontroller", handler.handleIndex)
 	server.router.GET("/tap", handler.handleIndex)
 	server.router.GET("/top", handler.handleIndex)
+	server.router.GET("/community", handler.handleIndex)
 	server.router.GET("/debug", handler.handleIndex)
 	server.router.GET("/routes", handler.handleIndex)
 	server.router.GET("/profiles/new", handler.handleProfileDownload)


### PR DESCRIPTION
Fulfills #2327.

This PR creates a "Community" menu item on the dashboard sidebar that, when clicked, displays an iFrame of a page on `linkerd.io`. A yellow badge appears on the menu item if there has been an update since the user last clicked the "Community" menu item. This is calculated by comparing a date in the user's `localStorage` to a JSON feed at `linkerd.io/dashboard/index.json`.