### PR TITLE
Fix service profiles quoted filename download issue (#2473)

### DIFF
--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -78,7 +78,7 @@ func (h *handler) handleProfileDownload(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	dispositionHeaderVal := fmt.Sprintf("attachment; filename='%s-profile.yml'", service)
+	dispositionHeaderVal := fmt.Sprintf("attachment; filename=%s-profile.yml", service)
 
 	w.Header().Set("Content-Type", "text/yaml")
 	w.Header().Set("Content-Disposition", dispositionHeaderVal)

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -95,7 +95,7 @@ func TestHandleConfigDownload(t *testing.T) {
 			"text/yaml",
 		},
 		"Content-Disposition": []string{
-			"attachment; filename='authors-profile.yml'",
+			"attachment; filename=authors-profile.yml",
 		},
 	}
 	if !reflect.DeepEqual(recorder.Header(), header) {


### PR DESCRIPTION
Fixes #2473

Generating and downloading a ServiceProfile from the /routes page in the dashboard yield a filename wrapped in quotes ('test-profile.yml' rather than test-profile.yml). This PR fixes this issue.

Signed-off-by: Gaurav Kumar <gaurav.kumar9825@gmail.com>

cc @siggy 