### PR TITLE
Quiet inject logging

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -128,7 +128,8 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	if patchJSON == nil {
 		return bytes, reports, nil
 	}
-	log.Infof("patch generated: %s", patchJSON)
+	log.Infof("patch generated for: %s", conf)
+	log.Debugf("patch: %s", patchJSON)
 	patch, err := jsonpatch.DecodePatch(patchJSON)
 	if err != nil {
 		return nil, nil, err

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -141,7 +141,8 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("patch generated: %s", patchJSON)
+	log.Infof("patch generated for: %s", conf)
+	log.Debugf("patch: %s", patchJSON)
 
 	patchType := admissionv1beta1.PatchTypeJSONPatch
 	admissionResponse.Patch = patchJSON

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -75,6 +75,20 @@ func NewResourceConfig(globalConfig *config.Global, proxyConfig *config.Proxy) *
 	}
 }
 
+// String satisfies the Stringer interface
+func (conf *ResourceConfig) String() string {
+	l := []string{}
+
+	if conf.meta.Kind != "" {
+		l = append(l, conf.meta.Kind)
+	}
+	if conf.workLoadMeta != nil {
+		l = append(l, fmt.Sprintf("%s.%s", conf.workLoadMeta.GetName(), conf.workLoadMeta.GetNamespace()))
+	}
+
+	return strings.Join(l, "/")
+}
+
 // WithKind enriches ResourceConfig with the workload kind
 func (conf *ResourceConfig) WithKind(kind string) *ResourceConfig {
 	conf.meta = metav1.TypeMeta{Kind: kind}


### PR DESCRIPTION
Manual and auto injection was logging the full patch JSON at the `Info`
level.

Modify injection to log the object type and name at the `Info` level,
and the full patch at the `Debug` level.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>