### PR TITLE
Generate .gitcookies during ci to fix rate-limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
           - target
           - vendor
           - "$HOME/.cache"
+      before_install:
+        - echo $GITCOOKIE_SH | base64 -d | bash
       install:
         - ./bin/dep ensure -vendor-only -v
         - ./bin/dep status -v
@@ -127,6 +129,9 @@ jobs:
           - vendor
           - "$HOME/google-cloud-sdk/"
           - "$HOME/.cache"
+
+      before_install:
+        - echo $GITCOOKIE_SH | base64 -d | bash
 
       install:
         - ./bin/dep ensure -vendor-only -v


### PR DESCRIPTION
The ci job pulls Go code from googlesource.com, among other places.
These requests were regularly failing due to rate-limiting.

Introduce a script, from go.googlesource.com, to generate a .gitcookies
file. That script is stored in a `$GITCOOKIE_SH` environment variable in
ci, which is base64 decoded and executed during ci.

More info:
https://github.com/golang/go/issues/12933#issuecomment-199429151

Signed-off-by: Andrew Seigner <siggy@buoyant.io>