### PR TITLE
Specify a default port for the Linkerd dashboard

### DIFF
--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -185,7 +185,7 @@ func (pf *PortForward) URLFor(path string) string {
 // If that port is taken, it binds to a free ephemeral port and returns the
 // port number.
 func getLocalPort() (int, error) {
-	addr := "127.0.0.1:60606"
+	addr := "127.0.0.1:50750"
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		if opError, ok := err.(*net.OpError); ok {


### PR DESCRIPTION
This PR changes the default behavior of `getLocalPort()` in `portforward.go`. Originally, we randomly assigned the port for the dashboard. Now, we specify a default port and check whether it is available. If the default port is unavailable, we resume our original behavior of assigning a random port.

The reason for this change is that the community updates navbar feature in #2476 checks the user's `localStorage` to calculate whether to display an "unread" badge on the dashboard. Since `localStorage` does not persist across ports, each time a user runs the dashboard command, they are on a new port with empty `localStorage`. This would mean the "unread" badge in #2476 would always be displayed, rendering it meaningless.

Note: Although this PR fixes most use cases, if a user is running multiple `linkerd dashboard` instances, they will still have empty `localStorage` on all additional instances after the first.