### PR TITLE
Bump proxy to 4ed4dcc

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-6d10dd6}"
+PROXY_VERSION="${PROXY_VERSION:-4ed4dcc}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
Picking up the following changes from the linkerd2-proxy repo:

* Update h2, hyper, and tokio dependencies (linkerd/linkerd2-proxy#211)
* main: Consolidate listener configuration (linkerd/linkerd2-proxy#210)
* Refactor Main to build the proxy task inside a lazy future (linkerd/linkerd2-proxy#209)
* Update tower-grpc and tower Error types (linkerd/linkerd2-proxy#208)

Have verified that this passes integration tests.