### PR TITLE
Use correct resource names for authz checks

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -275,56 +275,56 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "can create Namespaces",
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate("", "", "v1", "Namespace")
+						return hc.checkCanCreate("", "", "v1", "namespaces")
 					},
 				},
 				{
 					description: "can create ClusterRoles",
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRole")
+						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "clusterroles")
 					},
 				},
 				{
 					description: "can create ClusterRoleBindings",
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "ClusterRoleBinding")
+						return hc.checkCanCreate("", "rbac.authorization.k8s.io", "v1beta1", "clusterrolebindings")
 					},
 				},
 				{
 					description: "can create CustomResourceDefinitions",
 					hintAnchor:  "pre-k8s-cluster-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate("", "apiextensions.k8s.io", "v1beta1", "CustomResourceDefinition")
+						return hc.checkCanCreate("", "apiextensions.k8s.io", "v1beta1", "customresourcedefinitions")
 					},
 				},
 				{
 					description: "can create ServiceAccounts",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "ServiceAccount")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "serviceaccounts")
 					},
 				},
 				{
 					description: "can create Services",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "Service")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "services")
 					},
 				},
 				{
 					description: "can create Deployments",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "extensions", "v1beta1", "Deployments")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "extensions", "v1beta1", "deployments")
 					},
 				},
 				{
 					description: "can create ConfigMaps",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "ConfigMap")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "configmaps")
 					},
 				},
 			},
@@ -789,7 +789,7 @@ func (hc *HealthChecker) checkNetAdmin() error {
 			"use",
 			"policy",
 			"v1beta1",
-			"PodSecurityPolicy",
+			"podsecuritypolicies",
 			psp.GetName(),
 		)
 		if err == nil {


### PR DESCRIPTION
The `linkerd check` command was using TitleCase resource names (e.g.
"ConfigMaps") for SelfSubjectAccessReview requests. These were not
valid, they were only passing because SSARs requests return `allowed`
for unknown resource types unless explicitly restricted.

Modify the `linkerd check` authorization requests to use the correct
resource names.

Steps to reproduce:
- default AKS cluster
- running inside a pod

```bash
$ kubectl proxy
```

Fails:

```bash
$ curl -k -v -XPOST -d'{"kind":"SelfSubjectAccessReview","apiVersion":"authorization.k8s.io/v1","spec":{"resourceAttributes":{"namespace":"default","verb":"create","version":"v1","resource":
"Namespace"}}}'  -H "Accept: application/json, */*" -H "Content-Type: application/json" http://127.0.0.1:8001/apis/authorization.k8s.io/v1/selfsubjectaccessreviews

...

{
  "kind": "SelfSubjectAccessReview",
  "apiVersion": "authorization.k8s.io/v1",
  "metadata": {
    "creationTimestamp": null
  },
  "spec": {
    "resourceAttributes": {
      "namespace": "default",
      "verb": "create",
      "version": "v1",
      "resource": "Namespace"
    }
  },
  "status": {
    "allowed": false
  }
}
```

Works:

```bash
curl -k -v -XPOST -d'{"kind":"SelfSubjectAccessReview","apiVersion":"authorization.k8s.io/v1","spec":{"resourceAttributes":{"namespace":"default","verb":"create","version":"v1","resource":
"namespaces"}}}'  -H "Accept: application/json, */*" -H "Content-Type: application/json" http://127.0.0.1:8001/apis/authorization.k8s.io/v1/selfsubjectaccessreviews

...

{
  "kind": "SelfSubjectAccessReview",
  "apiVersion": "authorization.k8s.io/v1",
  "metadata": {
    "creationTimestamp": null
  },
  "spec": {
    "resourceAttributes": {
      "namespace": "default",
      "verb": "create",
      "version": "v1",
      "resource": "namespaces"
    }
  },
  "status": {
    "allowed": true,
    "reason": "RBAC: allowed by ClusterRoleBinding \"docker-build\" of ClusterRole \"docker-build\" to ServiceAccount \"docker-build/docker-build\""
  }
}
```

Signed-off-by: Andrew Seigner <siggy@buoyant.io>