### PR TITLE
Handle configs override for meshed workloads

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -117,7 +117,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 
 	p, err := conf.GetPatch()
 	if err != nil {
-		if err == inject.ErrUnsupportedResourceType {
+		if err == inject.ErrUnsupportedResourceKind {
 			report.UnsupportedResource = true
 		}
 		return bytes, []inject.Report{*report}, err

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -90,7 +90,7 @@ func (resourceTransformerUninject) generateReport(reports []inject.Report, outpu
 	output.Write([]byte("\n"))
 
 	for _, r := range reports {
-		if r.Sidecar {
+		if r.Uninjected.Proxy || r.Uninjected.ProxyInit {
 			output.Write([]byte(fmt.Sprintf("%s \"%s\" uninjected\n", r.Kind, r.Name)))
 		} else {
 			if r.Kind != "" {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -110,8 +110,10 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	if _, err := conf.ParseMetaAndYaml(request.Object.Raw); err != nil {
 		return nil, err
 	}
+	log.Infof("received %s", conf)
 
 	if !shouldInject(conf) && !conf.ShouldOverrideConfig() {
+		log.Infof("skipping %s", conf)
 		return &admissionv1beta1.AdmissionResponse{
 			UID:     request.UID,
 			Allowed: true,

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -129,7 +129,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 		return admissionResponse, nil
 	}
 
-	p.AddCreatedByPodAnnotation(fmt.Sprintf("linkerd/proxy-injector %s", version.Version))
+	p.AddCreatedByPodAnnotation(fmt.Sprintf("%s %s", k8s.CreatedByProxyInjector, version.Version))
 
 	// When adding workloads through `kubectl apply` the spec template labels are
 	// automatically copied to the workload's main metadata section.

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -112,7 +112,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	}
 	log.Infof("received %s", conf)
 
-	if !shouldInject(conf) && !conf.ShouldOverrideConfig() {
+	if !shouldInject(conf) {
 		log.Infof("skipping %s", conf)
 		return &admissionv1beta1.AdmissionResponse{
 			UID:     request.UID,

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -81,13 +81,13 @@ func TestGetPatch(t *testing.T) {
 				filename: "deployment-inject-disabled.yaml",
 				ns:       nsEnabled,
 				conf:     confNsEnabled(),
-				expected: false,
+				expected: true,
 			},
 			{
 				filename: "deployment-inject-empty.yaml",
 				ns:       nsDisabled,
 				conf:     confNsDisabled(),
-				expected: false,
+				expected: true,
 			},
 			{
 				filename: "deployment-inject-enabled.yaml",
@@ -99,7 +99,7 @@ func TestGetPatch(t *testing.T) {
 				filename: "deployment-inject-disabled.yaml",
 				ns:       nsDisabled,
 				conf:     confNsDisabled(),
-				expected: false,
+				expected: true,
 			},
 		}
 

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -113,7 +113,8 @@ func TestGetPatch(t *testing.T) {
 
 				fakeReq := getFakeReq(deployment)
 				fullConf := testCase.conf.WithKind(fakeReq.Kind.Kind)
-				p, _, err := fullConf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
+				fullConf.ParseMetaAndYaml(fakeReq.Object.Raw)
+				p, err := fullConf.GetPatch()
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -129,24 +130,6 @@ func TestGetPatch(t *testing.T) {
 					t.Fatalf("Was expecting injection for file '%s'", testCase.filename)
 				}
 			})
-		}
-	})
-
-	t.Run("by checking container spec", func(t *testing.T) {
-		deployment, err := factory.HTTPRequestBody("deployment-with-injected-proxy.yaml")
-		if err != nil {
-			t.Fatalf("Unexpected error: %s", err)
-		}
-
-		fakeReq := getFakeReq(deployment)
-		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		p, _, err := conf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
-		if err != nil {
-			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
-		}
-
-		if !p.IsEmpty() {
-			t.Errorf("Expected empty patch")
 		}
 	})
 }

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -181,8 +181,6 @@ func (conf *ResourceConfig) AddRootLabels(patch *Patch) {
 
 // GetPatch returns the JSON patch containing the proxy and init containers specs, if any
 func (conf *ResourceConfig) GetPatch() (*Patch, error) {
-	log.Infof("received %s", conf)
-
 	// If we don't inject anything into the pod template then output the
 	// original serialization of the original object. Otherwise, output the
 	// serialization of the modified object.

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -162,7 +162,7 @@ func (conf *ResourceConfig) GetPatch(
 	shouldInject func(*ResourceConfig, Report) bool,
 ) (*Patch, []Report, error) {
 	report := newReport(conf)
-	log.Infof("received %s", conf)
+	log.Infof("received %s/%s", conf, report.Name)
 
 	if err := conf.parse(bytes); err != nil {
 		return nil, nil, err
@@ -438,7 +438,7 @@ func (conf *ResourceConfig) setProxyConfigs(identity k8s.TLSIdentity) *v1.Contai
 
 func (conf *ResourceConfig) newProxyContainer(identity k8s.TLSIdentity) *v1.Container {
 	return &v1.Container{
-		Name:                     k8s.ProxyContainerName,
+		Name: k8s.ProxyContainerName,
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		Ports: []v1.ContainerPort{
 			{
@@ -529,7 +529,7 @@ func (conf *ResourceConfig) newProxyInitContainer() *v1.Container {
 	)
 
 	return &v1.Container{
-		Name:                     k8s.InitContainerName,
+		Name: k8s.InitContainerName,
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{
@@ -835,13 +835,16 @@ func ShouldInjectCLI(_ *ResourceConfig, r Report) bool {
 //   linkerd.io/inject annotation set to "disabled"; or
 // - the workload's pod spec has the linkerd.io/inject annotation set to "enabled"
 func ShouldInjectWebhook(conf *ResourceConfig, r Report) bool {
+	log.Info("ShouldInjectWebhook")
 	if !r.Injectable() {
 		return false
 	}
 
+	log.Infof("CLI created-by annotation %s", conf.podMeta.Annotations[k8s.CreatedByAnnotation])
 	if createdBy, exists := conf.podMeta.Annotations[k8s.CreatedByAnnotation]; exists && strings.Contains(createdBy, k8s.CreatedByCLI) {
 		return false
 	}
+	log.Info("Not skipping CLI inject")
 
 	podAnnotation := conf.podMeta.Annotations[k8s.ProxyInjectAnnotation]
 	nsAnnotation := conf.nsAnnotations[k8s.ProxyInjectAnnotation]

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -379,11 +379,10 @@ func TestShouldOverrideAnnotation(t *testing.T) {
 						annotation: annotationValue,
 					},
 				}}
-				resourceConfig = &ResourceConfig{
-					podSpec: podSpec,
-					podMeta: podMeta,
-				}
+				resourceConfig = &ResourceConfig{}
 			)
+			resourceConfig.pod.spec = podSpec
+			resourceConfig.pod.meta = podMeta
 
 			if actual := resourceConfig.ShouldOverrideConfig(); expected != actual {
 				t.Errorf("Expected %t. Actual %t", expected, actual)
@@ -399,11 +398,10 @@ func TestShouldOverrideAnnotation(t *testing.T) {
 					"created-by": annotationValue,
 				},
 			}}
-			resourceConfig = &ResourceConfig{
-				podSpec: podSpec,
-				podMeta: podMeta,
-			}
+			resourceConfig = &ResourceConfig{}
 		)
+		resourceConfig.pod.spec = podSpec
+		resourceConfig.pod.meta = podMeta
 
 		if actual := resourceConfig.ShouldOverrideConfig(); expected != actual {
 			t.Errorf("Expected %t. Actual %t", expected, actual)
@@ -509,17 +507,17 @@ func TestSetProxyConfigs(t *testing.T) {
 			}
 		)
 
-		resourceConfig.podMeta = objMeta{&metav1.ObjectMeta{}}
+		resourceConfig.pod.meta = objMeta{&metav1.ObjectMeta{}}
 
 		t.Run("create a new proxy for an unmeshed workload", func(t *testing.T) {
-			resourceConfig.podSpec = &corev1.PodSpec{}
+			resourceConfig.pod.spec = &corev1.PodSpec{}
 			if actual := resourceConfig.setProxyConfigs(identity); !reflect.DeepEqual(expected, actual) {
 				t.Errorf("Expected %+v\nActual %+v", expected, actual)
 			}
 		})
 
 		t.Run("override existing proxy of a meshed workload", func(t *testing.T) {
-			resourceConfig.podSpec = &corev1.PodSpec{
+			resourceConfig.pod.spec = &corev1.PodSpec{
 				// all the configurable properties in this proxy will be overridden by
 				// defaults in the config map.
 				Containers: []corev1.Container{
@@ -645,17 +643,17 @@ func TestSetProxyInitConfigs(t *testing.T) {
 			}
 		)
 
-		resourceConfig.podMeta = objMeta{&metav1.ObjectMeta{}}
+		resourceConfig.pod.meta = objMeta{&metav1.ObjectMeta{}}
 
 		t.Run("create a new proxy-init for an unmeshed workload", func(t *testing.T) {
-			resourceConfig.podSpec = &corev1.PodSpec{}
+			resourceConfig.pod.spec = &corev1.PodSpec{}
 			if actual := resourceConfig.setProxyInitConfigs(); !reflect.DeepEqual(expected, actual) {
 				t.Errorf("Expected %+v\nActual %+v", expected, actual)
 			}
 		})
 
 		t.Run("override existing proxy-init of a meshed workload", func(t *testing.T) {
-			resourceConfig.podSpec = &corev1.PodSpec{
+			resourceConfig.pod.spec = &corev1.PodSpec{
 				// all the configurable properties will be overridden by defaults in
 				// the config map.
 				Containers: []corev1.Container{
@@ -694,8 +692,8 @@ func TestHasPayload(t *testing.T) {
 
 	resourceConfig := NewResourceConfig(&config.Global{}, &config.Proxy{})
 	for _, testCase := range testCases {
-		resourceConfig.podMeta = testCase.podMeta
-		resourceConfig.podSpec = testCase.podSpec
+		resourceConfig.pod.meta = testCase.podMeta
+		resourceConfig.pod.spec = testCase.podSpec
 		if actual := resourceConfig.HasPayload(); testCase.expected != actual {
 			t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 		}
@@ -772,7 +770,7 @@ func TestInjectEnabled(t *testing.T) {
 	resourceConfig := NewResourceConfig(&config.Global{}, &config.Proxy{})
 	for _, testCase := range testCases {
 		resourceConfig.WithNsAnnotations(testCase.nsAnnotations)
-		resourceConfig.podMeta = testCase.podMeta
+		resourceConfig.pod.meta = testCase.podMeta
 		if actual := resourceConfig.InjectEnabled(); testCase.expected != actual {
 			t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 		}
@@ -791,7 +789,7 @@ func TestPodUsingHostNetwork(t *testing.T) {
 
 	resourceConfig := NewResourceConfig(&config.Global{}, &config.Proxy{})
 	for _, testCase := range testCases {
-		resourceConfig.podSpec = testCase.podSpec
+		resourceConfig.pod.spec = testCase.podSpec
 		if actual := resourceConfig.PodUsingHostNetwork(); testCase.expected != actual {
 			t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 		}
@@ -827,7 +825,7 @@ func TestHasExistingProxy(t *testing.T) {
 
 	resourceConfig := NewResourceConfig(&config.Global{}, &config.Proxy{})
 	for _, testCase := range testCases {
-		resourceConfig.podSpec = testCase.podSpec
+		resourceConfig.pod.spec = testCase.podSpec
 		if actual := resourceConfig.HasExistingProxy(); testCase.expected != actual {
 			t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 		}

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -16,6 +16,7 @@ const (
 // Patch represents a RFC 6902 patch document.
 type Patch struct {
 	patchOps                   []*patchOp
+	patchPathContainerRoot     string
 	patchPathContainer         string
 	patchPathInitContainerRoot string
 	patchPathInitContainer     string
@@ -29,6 +30,7 @@ type Patch struct {
 func NewPatchDeployment() *Patch {
 	return &Patch{
 		patchOps:                   []*patchOp{},
+		patchPathContainerRoot:     "/spec/template/spec/containers",
 		patchPathContainer:         "/spec/template/spec/containers/-",
 		patchPathInitContainerRoot: "/spec/template/spec/initContainers",
 		patchPathInitContainer:     "/spec/template/spec/initContainers/-",
@@ -43,6 +45,7 @@ func NewPatchDeployment() *Patch {
 func NewPatchPod() *Patch {
 	return &Patch{
 		patchOps:                   []*patchOp{},
+		patchPathContainerRoot:     "/spec/containers",
 		patchPathContainer:         "/spec/containers/-",
 		patchPathInitContainerRoot: "/spec/initContainers",
 		patchPathInitContainer:     "/spec/initContainers/-",
@@ -133,7 +136,7 @@ func (p *Patch) addPodAnnotation(key, value string) {
 func (p *Patch) replaceContainer(container *corev1.Container, index int) {
 	p.patchOps = append(p.patchOps, &patchOp{
 		Op:    "replace",
-		Path:  fmt.Sprintf("/spec/template/spec/containers/%d", index),
+		Path:  fmt.Sprintf("%s/%d", p.patchPathContainerRoot, index),
 		Value: container,
 	})
 }
@@ -141,7 +144,7 @@ func (p *Patch) replaceContainer(container *corev1.Container, index int) {
 func (p *Patch) replaceInitContainer(container *corev1.Container, index int) {
 	p.patchOps = append(p.patchOps, &patchOp{
 		Op:    "replace",
-		Path:  fmt.Sprintf("/spec/template/spec/initContainers/%d", index),
+		Path:  fmt.Sprintf("%s/%d", p.patchPathInitContainerRoot, index),
 		Value: container,
 	})
 }

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -2,6 +2,7 @@ package inject
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -129,6 +130,22 @@ func (p *Patch) addPodAnnotation(key, value string) {
 	})
 }
 
+func (p *Patch) replaceContainer(container *corev1.Container, index int) {
+	p.patchOps = append(p.patchOps, &patchOp{
+		Op:    "replace",
+		Path:  fmt.Sprintf("/spec/template/spec/containers/%d", index),
+		Value: container,
+	})
+}
+
+func (p *Patch) replaceInitContainer(container *corev1.Container, index int) {
+	p.patchOps = append(p.patchOps, &patchOp{
+		Op:    "replace",
+		Path:  fmt.Sprintf("/spec/template/spec/initContainers/%d", index),
+		Value: container,
+	})
+}
+
 // AddCreatedByPodAnnotation tags the pod so that we can tell apart injections
 // from the CLI and the webhook
 func (p *Patch) AddCreatedByPodAnnotation(s string) {
@@ -138,6 +155,11 @@ func (p *Patch) AddCreatedByPodAnnotation(s string) {
 // IsEmpty returns true if the patch doesn't contain any operations
 func (p *Patch) IsEmpty() bool {
 	return len(p.patchOps) == 0
+}
+
+// Append appends all tail's patchOps to p.
+func (p *Patch) Append(tail *Patch) {
+	p.patchOps = append(p.patchOps, tail.patchOps...)
 }
 
 // Slashes need to be encoded as ~1 per

--- a/pkg/inject/proxy_patch.go
+++ b/pkg/inject/proxy_patch.go
@@ -1,0 +1,146 @@
+package inject
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	v1 "k8s.io/api/core/v1"
+)
+
+func newProxyPatch(proxy *v1.Container, identity k8s.TLSIdentity, config *ResourceConfig) *Patch {
+	patch := patchKind(config.meta.Kind)
+
+	// Special case if the caller specifies that
+	// LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY be set on the pod.
+	// We key off of any container image in the pod. Ideally we would instead key
+	// off of something at the top-level of the PodSpec, but there is nothing
+	// easily identifiable at that level.
+	// Currently this will bet set on any proxy that gets injected into a Prometheus pod,
+	// not just the one in Linkerd's Control Plane.
+	for _, container := range config.podSpec.Containers {
+		if capacity, ok := config.proxyOutboundCapacity[container.Image]; ok {
+			proxy.Env = append(proxy.Env,
+				v1.EnvVar{
+					Name:  "LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY",
+					Value: fmt.Sprintf("%d", capacity),
+				},
+			)
+			break
+		}
+	}
+
+	if config.globalConfig.GetIdentityContext() != nil {
+		yes := true
+
+		configMapVolume := &v1.Volume{
+			Name: k8s.TLSTrustAnchorVolumeName,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{Name: k8s.TLSTrustAnchorConfigMapName},
+					Optional:             &yes,
+				},
+			},
+		}
+		secretVolume := &v1.Volume{
+			Name: k8s.TLSSecretsVolumeName,
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: identity.ToSecretName(),
+					Optional:   &yes,
+				},
+			},
+		}
+
+		base := "/var/linkerd-io"
+		configMapBase := base + "/trust-anchors"
+		secretBase := base + "/identity"
+		tlsEnvVars := []v1.EnvVar{
+			{Name: "LINKERD2_PROXY_TLS_TRUST_ANCHORS", Value: configMapBase + "/" + k8s.TLSTrustAnchorFileName},
+			{Name: "LINKERD2_PROXY_TLS_CERT", Value: secretBase + "/" + k8s.TLSCertFileName},
+			{Name: "LINKERD2_PROXY_TLS_PRIVATE_KEY", Value: secretBase + "/" + k8s.TLSPrivateKeyFileName},
+			{
+				Name:  "LINKERD2_PROXY_TLS_POD_IDENTITY",
+				Value: identity.ToDNSName(),
+			},
+			{Name: "LINKERD2_PROXY_CONTROLLER_NAMESPACE", Value: config.globalConfig.GetLinkerdNamespace()},
+			{Name: "LINKERD2_PROXY_TLS_CONTROLLER_IDENTITY", Value: identity.ToControllerIdentity().ToDNSName()},
+		}
+
+		proxy.Env = append(proxy.Env, tlsEnvVars...)
+		proxy.VolumeMounts = []v1.VolumeMount{
+			{Name: configMapVolume.Name, MountPath: configMapBase, ReadOnly: true},
+			{Name: secretVolume.Name, MountPath: secretBase, ReadOnly: true},
+		}
+
+		if len(config.podSpec.Volumes) == 0 {
+			patch.addVolumeRoot()
+		}
+		patch.addVolume(configMapVolume)
+		patch.addVolume(secretVolume)
+	}
+
+	patch.addContainer(proxy)
+	return patch
+}
+
+func newProxyInitPatch(proxyInit *v1.Container, config *ResourceConfig) *Patch {
+	patch := patchKind(config.meta.Kind)
+	if len(config.podSpec.InitContainers) == 0 {
+		patch.addInitContainerRoot()
+	}
+
+	patch.addInitContainer(proxyInit)
+	return patch
+}
+
+func newObjectMetaPatch(config *ResourceConfig) *Patch {
+	patch := patchKind(config.meta.Kind)
+	if len(config.podMeta.Annotations) == 0 {
+		patch.addPodAnnotationsRoot()
+	}
+	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, config.globalConfig.GetVersion())
+
+	if config.globalConfig.GetIdentityContext() != nil {
+		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeOptional)
+	} else {
+		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDisabled)
+	}
+
+	for k, v := range config.podLabels {
+		patch.addPodLabel(k, v)
+	}
+
+	return patch
+}
+
+func newOverrideProxyPatch(proxy *v1.Container, conf *ResourceConfig) *Patch {
+	patch := patchKind(conf.meta.Kind)
+	for i, c := range conf.podSpec.Containers {
+		if c.Name == k8s.ProxyContainerName {
+			patch.replaceContainer(proxy, i)
+			break
+		}
+	}
+
+	return patch
+}
+
+func newOverrideProxyInitPatch(proxyInit *v1.Container, conf *ResourceConfig) *Patch {
+	patch := patchKind(conf.meta.Kind)
+	for i, c := range conf.podSpec.InitContainers {
+		if c.Name == k8s.InitContainerName {
+			patch.replaceInitContainer(proxyInit, i)
+			break
+		}
+	}
+
+	return patch
+}
+
+func patchKind(kind string) *Patch {
+	if strings.ToLower(kind) == k8s.Pod {
+		return NewPatchPod()
+	}
+	return NewPatchDeployment()
+}

--- a/pkg/inject/proxy_patch.go
+++ b/pkg/inject/proxy_patch.go
@@ -16,7 +16,7 @@ func newProxyPatch(proxy *v1.Container, identity k8s.TLSIdentity, config *Resour
 	// We key off of any container image in the pod. Ideally we would instead key
 	// off of something at the top-level of the PodSpec, but there is nothing
 	// easily identifiable at that level.
-	// Currently this will bet set on any proxy that gets injected into a Prometheus pod,
+	// Currently this will be set on any proxy that gets injected into a Prometheus pod,
 	// not just the one in Linkerd's Control Plane.
 	for _, container := range config.podSpec.Containers {
 		if capacity, ok := config.proxyOutboundCapacity[container.Image]; ok {

--- a/pkg/inject/proxy_patch_test.go
+++ b/pkg/inject/proxy_patch_test.go
@@ -1,0 +1,255 @@
+package inject
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/linkerd/linkerd2/controller/gen/config"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	k8sResource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestProxyPatch(t *testing.T) {
+	var (
+		resourceKind        = "Pod"
+		controllerNamespace = "linkerd"
+		proxyUID            = int64(8888)
+	)
+
+	t.Run("Non TLS", func(t *testing.T) {
+		var (
+			identity = k8s.TLSIdentity{
+				Name:                "emojivoto",
+				Kind:                resourceKind,
+				Namespace:           "emojivoto",
+				ControllerNamespace: controllerNamespace,
+			}
+
+			globalConfig = &config.Global{
+				LinkerdNamespace: controllerNamespace,
+				Version:          "abcde",
+			}
+
+			container = &corev1.Container{
+				Name:                     k8s.ProxyContainerName,
+				Image:                    "gcr.io/linkerd-io/proxy:abcde",
+				ImagePullPolicy:          "IfNotPresent",
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+				SecurityContext: &corev1.SecurityContext{
+					RunAsUser: &proxyUID,
+				},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"cpu":    k8sResource.MustParse("0.2"),
+						"memory": k8sResource.MustParse("64"),
+					},
+					Limits: corev1.ResourceList{
+						"cpu":    k8sResource.MustParse("1"),
+						"memory": k8sResource.MustParse("128"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{Name: k8s.ProxyPortName, ContainerPort: 6000},
+					{Name: k8s.ProxyMetricsPortName, ContainerPort: 6001},
+				},
+				Env: []corev1.EnvVar{
+					{Name: envVarProxyLog, Value: "info,linkerd2_proxy=debug"},
+					{Name: envVarProxyControlURL, Value: fmt.Sprintf("tcp://linkerd-destination.%s.svc.cluster.local:8086", controllerNamespace)},
+					{Name: envVarProxyControlListener, Value: "tcp://0.0.0.0:9000"},
+					{Name: envVarProxyMetricsListener, Value: "tcp://0.0.0.0:6001"},
+					{Name: envVarProxyOutboundListener, Value: "tcp://127.0.0.1:6002"},
+					{Name: envVarProxyInboundListener, Value: "tcp://0.0.0.0:6000"},
+					{Name: envVarProxyDestinationProfileSuffixes, Value: "."},
+					{Name: envVarProxyPodNamespace, ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+					}},
+					{Name: envVarProxyInboundAcceptKeepAlive, Value: "10000ms"},
+					{Name: envVarProxyOutboundConnectKeepAlive, Value: "10000ms"},
+					{Name: envVarProxyID, Value: identity.ToDNSName()},
+				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/metrics",
+							Port: intstr.IntOrString{
+								IntVal: int32(6001),
+							},
+						},
+					},
+					InitialDelaySeconds: 10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/metrics",
+							Port: intstr.IntOrString{
+								IntVal: int32(6001),
+							},
+						},
+					},
+					InitialDelaySeconds: 10,
+				},
+			}
+		)
+		resourceConfig := NewResourceConfig(globalConfig, &config.Proxy{}).WithKind(resourceKind)
+
+		t.Run("create new proxy", func(t *testing.T) {
+			expected := &Patch{
+				patchPathContainerRoot:     "/spec/containers",
+				patchPathContainer:         "/spec/containers/-",
+				patchPathInitContainerRoot: "/spec/initContainers",
+				patchPathInitContainer:     "/spec/initContainers/-",
+				patchPathVolumeRoot:        "/spec/volumes",
+				patchPathVolume:            "/spec/volumes/-",
+				patchPathPodLabels:         patchPathRootLabels,
+				patchPathPodAnnotations:    "/metadata/annotations",
+				patchOps: []*patchOp{
+					{Op: "add", Path: "/spec/containers/-", Value: container},
+				},
+			}
+
+			// the empty containers list emulates an unmeshed pod
+			resourceConfig.podSpec = &corev1.PodSpec{}
+			if actual := newProxyPatch(container, identity, resourceConfig); !reflect.DeepEqual(expected, actual) {
+				t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
+			}
+		})
+
+		t.Run("override existing proxy", func(t *testing.T) {
+			expected := &Patch{
+				patchPathContainerRoot:     "/spec/containers",
+				patchPathContainer:         "/spec/containers/-",
+				patchPathInitContainerRoot: "/spec/initContainers",
+				patchPathInitContainer:     "/spec/initContainers/-",
+				patchPathVolumeRoot:        "/spec/volumes",
+				patchPathVolume:            "/spec/volumes/-",
+				patchPathPodLabels:         patchPathRootLabels,
+				patchPathPodAnnotations:    "/metadata/annotations",
+				patchOps: []*patchOp{
+					{Op: "replace", Path: "/spec/containers/0", Value: container},
+				},
+			}
+
+			// the non-empty containers list emulates a meshed pod
+			resourceConfig.podSpec = &corev1.PodSpec{
+				Containers: []corev1.Container{*container},
+			}
+			if actual := newOverrideProxyPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
+				fmt.Printf("%v\n", actual.patchOps[0])
+				t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
+			}
+		})
+	})
+}
+
+func TestNewProxyInitPatch(t *testing.T) {
+	var (
+		resourceKind   = "Pod"
+		globalConfig   = &config.Global{Version: "abcde"}
+		resourceConfig = NewResourceConfig(globalConfig, &config.Proxy{}).WithKind(resourceKind)
+		nonRoot        = false
+		runAsUser      = int64(0)
+		container      = &corev1.Container{
+			Name:                     k8s.InitContainerName,
+			Image:                    "gcr.io/linkerd-io/proxy-init:abcde",
+			ImagePullPolicy:          "IfNotPresent",
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			Args: []string{
+				"--incoming-proxy-port", "4143",
+				"--outgoing-proxy-port", "4140",
+				"--proxy-uid", "2102",
+			},
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{corev1.Capability("NET_ADMIN")},
+				},
+				Privileged:   &nonRoot,
+				RunAsNonRoot: &nonRoot,
+				RunAsUser:    &runAsUser,
+			},
+		}
+	)
+
+	t.Run("create new proxy-init", func(t *testing.T) {
+		expected := &Patch{
+			patchPathContainerRoot:     "/spec/containers",
+			patchPathContainer:         "/spec/containers/-",
+			patchPathInitContainerRoot: "/spec/initContainers",
+			patchPathInitContainer:     "/spec/initContainers/-",
+			patchPathVolumeRoot:        "/spec/volumes",
+			patchPathVolume:            "/spec/volumes/-",
+			patchPathPodLabels:         patchPathRootLabels,
+			patchPathPodAnnotations:    "/metadata/annotations",
+			patchOps: []*patchOp{
+				{Op: "add", Path: "/spec/initContainers", Value: []*corev1.Container{}},
+				{Op: "add", Path: "/spec/initContainers/-", Value: container},
+			},
+		}
+
+		// the empty init-containers list emulates an unmeshed pod
+		resourceConfig.podSpec = &corev1.PodSpec{}
+		if actual := newProxyInitPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
+		}
+	})
+
+	t.Run("overrides existing proxy-init", func(t *testing.T) {
+		expected := &Patch{
+			patchPathContainerRoot:     "/spec/containers",
+			patchPathContainer:         "/spec/containers/-",
+			patchPathInitContainerRoot: "/spec/initContainers",
+			patchPathInitContainer:     "/spec/initContainers/-",
+			patchPathVolumeRoot:        "/spec/volumes",
+			patchPathVolume:            "/spec/volumes/-",
+			patchPathPodLabels:         patchPathRootLabels,
+			patchPathPodAnnotations:    "/metadata/annotations",
+			patchOps: []*patchOp{
+				{Op: "replace", Path: "/spec/initContainers/0", Value: container},
+			},
+		}
+
+		// the non-empty init-containers list emulates a meshed pod
+		resourceConfig.podSpec = &corev1.PodSpec{
+			InitContainers: []corev1.Container{*container},
+		}
+		if actual := newOverrideProxyInitPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
+		}
+	})
+}
+
+func TestNewObjectMetaPatch(t *testing.T) {
+	var (
+		resourceKind   = "Pod"
+		globalConfig   = &config.Global{Version: "abcde"}
+		resourceConfig = NewResourceConfig(globalConfig, &config.Proxy{}).WithKind(resourceKind)
+	)
+	resourceConfig.podLabels = map[string]string{"app": "nginx"}
+	resourceConfig.podMeta = objMeta{&metav1.ObjectMeta{}}
+
+	t.Run("Non-TLS", func(t *testing.T) {
+		expected := &Patch{
+			patchPathContainerRoot:     "/spec/containers",
+			patchPathContainer:         "/spec/containers/-",
+			patchPathInitContainerRoot: "/spec/initContainers",
+			patchPathInitContainer:     "/spec/initContainers/-",
+			patchPathVolumeRoot:        "/spec/volumes",
+			patchPathVolume:            "/spec/volumes/-",
+			patchPathPodLabels:         patchPathRootLabels,
+			patchPathPodAnnotations:    "/metadata/annotations",
+			patchOps: []*patchOp{
+				{Op: "add", Path: "/metadata/annotations", Value: map[string]string{}},
+				{Op: "add", Path: "/metadata/annotations/linkerd.io~1proxy-version", Value: "abcde"},
+				{Op: "add", Path: "/metadata/annotations/linkerd.io~1identity-mode", Value: "disabled"},
+				{Op: "add", Path: "/metadata/labels/app", Value: "nginx"},
+			},
+		}
+		if actual := newObjectMetaPatch(resourceConfig); !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
+		}
+	})
+}

--- a/pkg/inject/proxy_patch_test.go
+++ b/pkg/inject/proxy_patch_test.go
@@ -113,7 +113,7 @@ func TestProxyPatch(t *testing.T) {
 			}
 
 			// the empty containers list emulates an unmeshed pod
-			resourceConfig.podSpec = &corev1.PodSpec{}
+			resourceConfig.pod.spec = &corev1.PodSpec{}
 			if actual := newProxyPatch(container, identity, resourceConfig); !reflect.DeepEqual(expected, actual) {
 				t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
 			}
@@ -135,7 +135,7 @@ func TestProxyPatch(t *testing.T) {
 			}
 
 			// the non-empty containers list emulates a meshed pod
-			resourceConfig.podSpec = &corev1.PodSpec{
+			resourceConfig.pod.spec = &corev1.PodSpec{
 				Containers: []corev1.Container{*container},
 			}
 			if actual := newOverrideProxyPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
@@ -191,7 +191,7 @@ func TestNewProxyInitPatch(t *testing.T) {
 		}
 
 		// the empty init-containers list emulates an unmeshed pod
-		resourceConfig.podSpec = &corev1.PodSpec{}
+		resourceConfig.pod.spec = &corev1.PodSpec{}
 		if actual := newProxyInitPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
 			t.Errorf("Expected: %+v\nActual: %+v", expected, actual)
 		}
@@ -213,7 +213,7 @@ func TestNewProxyInitPatch(t *testing.T) {
 		}
 
 		// the non-empty init-containers list emulates a meshed pod
-		resourceConfig.podSpec = &corev1.PodSpec{
+		resourceConfig.pod.spec = &corev1.PodSpec{
 			InitContainers: []corev1.Container{*container},
 		}
 		if actual := newOverrideProxyInitPatch(container, resourceConfig); !reflect.DeepEqual(expected, actual) {
@@ -228,8 +228,8 @@ func TestNewObjectMetaPatch(t *testing.T) {
 		globalConfig   = &config.Global{Version: "abcde"}
 		resourceConfig = NewResourceConfig(globalConfig, &config.Proxy{}).WithKind(resourceKind)
 	)
-	resourceConfig.podLabels = map[string]string{"app": "nginx"}
-	resourceConfig.podMeta = objMeta{&metav1.ObjectMeta{}}
+	resourceConfig.pod.labels = map[string]string{"app": "nginx"}
+	resourceConfig.pod.meta = objMeta{&metav1.ObjectMeta{}}
 
 	t.Run("Non-TLS", func(t *testing.T) {
 		expected := &Patch{

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -29,9 +29,9 @@ type Report struct {
 // from conf
 func newReport(conf *ResourceConfig) Report {
 	var name string
-	if conf.workLoadMeta != nil {
-		name = conf.workLoadMeta.Name
-	} else if m := conf.podMeta.ObjectMeta; m != nil {
+	if conf.workload.meta != nil {
+		name = conf.workload.meta.Name
+	} else if m := conf.pod.meta.ObjectMeta; m != nil {
 		name = m.Name
 	}
 
@@ -54,10 +54,10 @@ func (r Report) Injectable() bool {
 
 // update updates the report for the provided resource conf.
 func (r *Report) update(conf *ResourceConfig) {
-	r.InjectDisabled = conf.podMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
-	r.HostNetwork = conf.podSpec.HostNetwork
-	r.Sidecar = healthcheck.HasExistingSidecars(conf.podSpec)
-	r.UDP = checkUDPPorts(conf.podSpec)
+	r.InjectDisabled = conf.pod.meta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
+	r.HostNetwork = conf.pod.spec.HostNetwork
+	r.Sidecar = healthcheck.HasExistingSidecars(conf.pod.spec)
+	r.UDP = checkUDPPorts(conf.pod.spec)
 }
 
 func checkUDPPorts(t *v1.PodSpec) bool {

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -19,15 +19,22 @@ type Report struct {
 	UDP                 bool // true if any port in any container has `protocol: UDP`
 	UnsupportedResource bool
 	InjectDisabled      bool
+	Uninjected          struct {
+		Proxy     bool
+		ProxyInit bool
+	}
 }
 
 // newReport returns a new Report struct, initialized with the Kind and Name
 // from conf
 func newReport(conf *ResourceConfig) Report {
 	var name string
-	if m := conf.podMeta.ObjectMeta; m != nil {
+	if conf.workLoadMeta != nil {
+		name = conf.workLoadMeta.Name
+	} else if m := conf.podMeta.ObjectMeta; m != nil {
 		name = m.Name
 	}
+
 	return Report{
 		Kind: strings.ToLower(conf.meta.Kind),
 		Name: name,

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -34,7 +34,7 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 		if container.Name != k8s.InitContainerName {
 			initContainers = append(initContainers, container)
 		} else {
-			report.Sidecar = true
+			report.Uninjected.ProxyInit = true
 		}
 	}
 	t.InitContainers = initContainers
@@ -43,6 +43,8 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 	for _, container := range t.Containers {
 		if container.Name != k8s.ProxyContainerName {
 			containers = append(containers, container)
+		} else {
+			report.Uninjected.Proxy = true
 		}
 	}
 	t.Containers = containers

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -11,24 +11,24 @@ import (
 // Uninject removes from the workload in conf the init and proxy containers,
 // the TLS volumes and the extra annotations/labels that were added
 func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
-	if conf.podSpec == nil {
+	if conf.pod.spec == nil {
 		return nil, nil
 	}
 
 	conf.uninjectPodSpec(report)
 
-	if conf.workLoadMeta != nil {
-		uninjectObjectMeta(conf.workLoadMeta)
+	if conf.workload.meta != nil {
+		uninjectObjectMeta(conf.workload.meta)
 	}
 
-	uninjectObjectMeta(conf.podMeta.ObjectMeta)
+	uninjectObjectMeta(conf.pod.meta.ObjectMeta)
 	return conf.YamlMarshalObj()
 }
 
 // Given a PodSpec, update the PodSpec in place with the sidecar
 // and init-container uninjected
 func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
-	t := conf.podSpec
+	t := conf.pod.spec
 	initContainers := []v1.Container{}
 	for _, container := range t.InitContainers {
 		if container.Name != k8s.InitContainerName {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -61,6 +61,14 @@ const (
 	// (e.g. linkerd/cli v2.0.0).
 	CreatedByAnnotation = Prefix + "/created-by"
 
+	// CreatedByCLI is used by the CreatedByAnnotation to indicate that the
+	// proxy is injected by the CLI.
+	CreatedByCLI = "linkerd/cli"
+
+	// CreatedByProxyInjector is used by the CreatedByAnnotation to indicate that
+	// the proxy is auto-injected by the proxy injector.
+	CreatedByProxyInjector = "linkerd/proxy-injector"
+
 	// ProxyVersionAnnotation indicates the version of the injected data plane
 	// (e.g. v0.1.3).
 	ProxyVersionAnnotation = Prefix + "/proxy-version"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -224,6 +224,26 @@ var (
 
 	// MountPathProxyConfig is the path at which the global config file is mounted
 	MountPathProxyConfig = MountPathBase + "/config/proxy"
+
+	// ProxyConfigAnnotations is the list of proxy config annotations
+	ProxyConfigAnnotations = []string{
+		ProxyImageAnnotation,
+		ProxyImagePullPolicyAnnotation,
+		ProxyInitImageAnnotation,
+		ProxyControlPortAnnotation,
+		ProxyIgnoreInboundPortsAnnotation,
+		ProxyIgnoreOutboundPortsAnnotation,
+		ProxyInboundPortAnnotation,
+		ProxyMetricsPortAnnotation,
+		ProxyOutboundPortAnnotation,
+		ProxyCPURequestAnnotation,
+		ProxyCPULimitAnnotation,
+		ProxyMemoryRequestAnnotation,
+		ProxyMemoryLimitAnnotation,
+		ProxyUIDAnnotation,
+		ProxyLogLevelAnnotation,
+		ProxyDisableExternalProfilesAnnotation,
+	}
 )
 
 // CreatedByAnnotationValue returns the value associated with


### PR DESCRIPTION
This PR is a different take to handle configs override while updating meshed workloads. 

### Assumptions
The proxy injector is only interested in ~two~ three types of workloads:

* unmeshed workload with the `linkerd.io/inject: enabled` annotation
* meshed workload with the `config.linkerd.io/*` annotations
* NEW: unmeshed workload with the `linkerd.io/inject: enabled` and `config.linkerd.io/*` annotations

Everything else should be a passthrough.

### Implementations
* Introduces a check to verify if a workload should be injected and/or config-overridden, OR if it just needs to be config-overridden. If neither, the rest of the injection process will be skipped.
* Separated out the logic to generate the different patches for unmeshed and meshed workloads.

PS The whole thing probably doesn't work yet and the unit tests are failing. Just thought I will share it to get some early feedback.

Signed-off-by: Ivan Sim <ivan@buoyant.io>