### PR TITLE
Add check for unschedulable pods and psp issues (#2465)

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -964,8 +964,8 @@ func validateDataPlanePodReporting(pods []*pb.Pod) error {
 func checkUnschedulablePods(pods []corev1.Pod) error {
 	var podName []string
 	for _, pod := range pods {
-		for _, node := range pod.Status.Conditions {
-			if node.Reason == "Unschedulable" {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Reason == "Unschedulable" {
 				podName = append(podName, pod.Name)
 			}
 		}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -360,7 +360,7 @@ func (hc *HealthChecker) allCategories() []category {
 					check: func(ctx context.Context) error {
 						var err error
 						var controlPlaneReplicaSet []v1beta1.ReplicaSet
-						controlPlaneReplicaSet, err = hc.kubeAPI.GetReplicaSets(ctx, hc.httpClient, hc.ControlPlaneNamespace)
+						controlPlaneReplicaSet, err = hc.kubeAPI.GetReplicaSetByNamespace(ctx, hc.httpClient, hc.ControlPlaneNamespace)
 						if err != nil {
 							return err
 						}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -972,7 +972,7 @@ func checkUnschedulablePods(pods []corev1.Pod) error {
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("%s\n", strings.Join(errors, "\n    "))
+		return fmt.Errorf("%s", strings.Join(errors, "\n    "))
 	}
 
 	return nil
@@ -989,7 +989,7 @@ func checkControlPlaneReplicaSets(rst []v1beta1.ReplicaSet) error {
 	}
 
 	if len(errors) > 0 {
-		return fmt.Errorf("%s\n", strings.Join(errors, "\n   "))
+		return fmt.Errorf("%s", strings.Join(errors, "\n   "))
 	}
 
 	return nil

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -965,17 +965,15 @@ func checkUnschedulablePods(pods []corev1.Pod) error {
 	var podName []string
 	for _, pod := range pods {
 		for _, node := range pod.Status.Conditions {
-			if strings.Contains(node.Message, "Insufficient cpu") || (node.Status == "False" && node.Message == "no nodes available to schedule pods") {
+			if node.Reason == "Unschedulable" {
 				podName = append(podName, pod.Name)
 			}
 		}
 	}
 
 	if len(podName) != 0 {
-		for _, name := range podName {
-			fmt.Println(name)
-		}
-		return fmt.Errorf("No node available for the above pods")
+		pods := strings.Join(podName, ",")
+		return fmt.Errorf("No node available for the pods %s", pods)
 	}
 
 	return nil
@@ -992,10 +990,8 @@ func checkPodSecurityPolicies(rst []v1beta1.ReplicaSet) error {
 	}
 
 	if len(replicaSets) != 0 {
-		for _, name := range replicaSets {
-			fmt.Println(name)
-		}
-		return fmt.Errorf("Invalid pod security policy for the above replicaset")
+		replicasets := strings.Join(replicaSets, ",")
+		return fmt.Errorf("Invalid pod security policy for the replicasets %s", replicasets)
 	}
 
 	return nil

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -360,7 +360,7 @@ func (hc *HealthChecker) allCategories() []category {
 					check: func(ctx context.Context) error {
 						var err error
 						var controlPlaneReplicaSet []v1beta1.ReplicaSet
-						controlPlaneReplicaSet, err = hc.kubeAPI.GetReplicaSetByNamespace(ctx, hc.httpClient, hc.ControlPlaneNamespace)
+						controlPlaneReplicaSet, err = hc.kubeAPI.GetReplicaSets(ctx, hc.httpClient, hc.ControlPlaneNamespace)
 						if err != nil {
 							return err
 						}

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -151,12 +151,9 @@ func NewAPI(configPath, kubeContext string) (*KubernetesAPI, error) {
 	return &KubernetesAPI{Config: config}, nil
 }
 
-// GetReplicaSetByNamespace returns all replicasets in a given namespace
-func (kubeAPI *KubernetesAPI) GetReplicaSetByNamespace(ctx context.Context, client *http.Client, namespace string) ([]v1beta1.ReplicaSet, error) {
-	return kubeAPI.getReplicaSets(ctx, client, "/apis/extensions/v1beta1/namespaces/"+namespace+"/replicasets")
-}
-
-func (kubeAPI *KubernetesAPI) getReplicaSets(ctx context.Context, client *http.Client, path string) ([]v1beta1.ReplicaSet, error) {
+// GetReplicaSets returns all replicasets in a given namespace
+func (kubeAPI *KubernetesAPI) GetReplicaSets(ctx context.Context, client *http.Client, namespace string) ([]v1beta1.ReplicaSet, error) {
+	path := "/apis/extensions/v1beta1/namespaces/" + namespace + "/replicasets"
 	rsp, err := kubeAPI.getRequest(ctx, client, path)
 	if err != nil {
 		return nil, err

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
-
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -11,6 +11,8 @@ kubernetes-version
 linkerd-existence
 -----------------
 √ control plane namespace exists
+√ control plane components ready
+√ no unschedulable pods
 √ controller pod is running
 √ can initialize the client
 √ can query the control plane API

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -11,6 +11,8 @@ kubernetes-version
 linkerd-existence
 -----------------
 √ control plane namespace exists
+√ control plane components ready
+√ no unschedulable pods
 √ controller pod is running
 √ can initialize the client
 √ can query the control plane API


### PR DESCRIPTION
Fixes #2465

On clusters, it is possible for the control plane to be unschedulable due to unavailability or deletion of nodes. Also it also possible for the pods to be unable to start due to pod security policies. This PR adds checks for the above two conditions.
