### PR TITLE
cli: Consolidate the public API clients

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -61,7 +61,7 @@ func newCmdDashboard() *cobra.Command {
 			}
 
 			// ensure we can connect to the public API before starting the proxy
-			validatedPublicAPIClient(time.Now().Add(options.wait), true)
+			checkPublicAPIClientOrRetryOrExit(time.Now().Add(options.wait), true)
 
 			config, err := k8s.GetConfig(kubeconfigPath, kubeContext)
 			if err != nil {

--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -74,7 +74,7 @@ requests.`,
 				return err
 			}
 
-			endpoints, err := requestEndpointsFromAPI(cliPublicAPIClient())
+			endpoints, err := requestEndpointsFromAPI(checkPublicAPIClientOrExit())
 			if err != nil {
 				return fmt.Errorf("Endpoints API error: %s", err)
 			}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -55,7 +55,7 @@ Only pod resources (aka pods, po) are supported.`,
 				return fmt.Errorf("invalid resource type %s, valid types: %s", friendlyName, k8s.Pod)
 			}
 
-			podNames, err := getPods(cliPublicAPIClient(), options)
+			podNames, err := getPods(checkPublicAPIClientOrExit(), options)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -103,7 +103,7 @@ func newCmdProfile() *cobra.Command {
 			} else if options.openAPI != "" {
 				return profiles.RenderOpenAPI(options.openAPI, options.namespace, options.name, os.Stdout)
 			} else if options.tap != "" {
-				return profiles.RenderTapOutputProfile(cliPublicAPIClient(), options.tap, options.namespace, options.name, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
+				return profiles.RenderTapOutputProfile(checkPublicAPIClientOrExit(), options.tap, options.namespace, options.name, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
 			} else if options.proto != "" {
 				return profiles.RenderProto(options.proto, options.namespace, options.name, os.Stdout)
 			}

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/linkerd/linkerd2/controller/api/public"
+	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+)
+
+// rawPublicAPIClient creates a raw public API client with no validation.
+func rawPublicAPIClient() (pb.ApiClient, error) {
+	if apiAddr != "" {
+		return public.NewInternalClient(controlPlaneNamespace, apiAddr)
+	}
+
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return public.NewExternalClient(controlPlaneNamespace, kubeAPI)
+}
+
+// checkPublicAPIClientOrExit builds a new public API client and executes default status
+// checks to determine if the client can successfully perform cli commands. If the
+// checks fail, then CLI will print an error and exit.
+func checkPublicAPIClientOrExit() public.APIClient {
+	return checkPublicAPIClientOrRetryOrExit(time.Time{}, false)
+}
+
+// checkPublicAPIClientWithDeadlineOrExit builds a new public API client and executes status
+// checks to determine if the client can successfully connect to the API. If the
+// checks fail, then CLI will print an error and exit. If the retryDeadline
+// param is specified, then the CLI will print a message to stderr and retry.
+func checkPublicAPIClientOrRetryOrExit(retryDeadline time.Time, apiChecks bool) public.APIClient {
+	checks := []healthcheck.CategoryID{
+		healthcheck.KubernetesAPIChecks,
+		healthcheck.LinkerdControlPlaneExistenceChecks,
+	}
+
+	if apiChecks {
+		checks = append(checks, healthcheck.LinkerdAPIChecks)
+	}
+
+	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
+		ControlPlaneNamespace: controlPlaneNamespace,
+		KubeConfig:            kubeconfigPath,
+		KubeContext:           kubeContext,
+		APIAddr:               apiAddr,
+		RetryDeadline:         retryDeadline,
+	})
+
+	exitOnError := func(result *healthcheck.CheckResult) {
+		if result.Retry {
+			fmt.Fprintln(os.Stderr, "Waiting for control plane to become available")
+			return
+		}
+
+		if result.Err != nil && !result.Warning {
+			var msg string
+			switch result.Category {
+			case healthcheck.KubernetesAPIChecks:
+				msg = "Cannot connect to Kubernetes"
+			case healthcheck.LinkerdControlPlaneExistenceChecks:
+				msg = "Cannot find Linkerd"
+			case healthcheck.LinkerdAPIChecks:
+				msg = "Cannot connect to Linkerd"
+			}
+			fmt.Fprintf(os.Stderr, "%s: %s\n", msg, result.Err)
+
+			checkCmd := "linkerd check"
+			if controlPlaneNamespace != defaultNamespace {
+				checkCmd += fmt.Sprintf(" --linkerd-namespace %s", controlPlaneNamespace)
+			}
+			fmt.Fprintf(os.Stderr, "Validate the install with: %s\n", checkCmd)
+
+			os.Exit(1)
+		}
+	}
+
+	hc.RunChecks(exitOnError)
+	return hc.PublicAPIClient()
+}

--- a/cli/cmd/routes.go
+++ b/cli/cmd/routes.go
@@ -60,7 +60,7 @@ This command will only display traffic which is sent to a service that has a Ser
 				return fmt.Errorf("error creating metrics request while making routes request: %v", err)
 			}
 
-			output, err := requestRouteStatsFromAPI(cliPublicAPIClient(), req, options)
+			output, err := requestRouteStatsFromAPI(checkPublicAPIClientOrExit(), req, options)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -128,7 +128,7 @@ If no resource name is specified, displays stats about all resources of the spec
 
 			// The gRPC client is concurrency-safe, so we can reuse it in all the following goroutines
 			// https://github.com/grpc/grpc-go/issues/682
-			client := cliPublicAPIClient()
+			client := checkPublicAPIClientOrExit()
 			c := make(chan indexedResults, len(reqs))
 			for num, req := range reqs {
 				go func(num int, req *pb.StatSummaryRequest) {

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -112,7 +112,7 @@ func newCmdTap() *cobra.Command {
 				return fmt.Errorf("output format \"%s\" not recognized", options.output)
 			}
 
-			return requestTapByResourceFromAPI(os.Stdout, cliPublicAPIClient(), req, wide)
+			return requestTapByResourceFromAPI(os.Stdout, checkPublicAPIClientOrExit(), req, wide)
 		},
 	}
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -337,7 +337,7 @@ func newCmdTop() *cobra.Command {
 				return err
 			}
 
-			return getTrafficByResourceFromAPI(cliPublicAPIClient(), req, table)
+			return getTrafficByResourceFromAPI(checkPublicAPIClientOrExit(), req, table)
 		},
 	}
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -7,10 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/linkerd/linkerd2/controller/api/public"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
-	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +34,7 @@ func newCmdVersion() *cobra.Command {
 		Use:   "version",
 		Short: "Print the client and server version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			configureAndRunVersion(options, os.Stdout, os.Stderr, newVersionClient)
+			configureAndRunVersion(options, os.Stdout, os.Stderr, rawPublicAPIClient)
 		},
 	}
 
@@ -79,16 +77,4 @@ func configureAndRunVersion(
 			fmt.Fprintf(stdout, "Server version: %s\n", serverVersion)
 		}
 	}
-}
-
-// This client does not do any validation
-func newVersionClient() (pb.ApiClient, error) {
-	if apiAddr != "" {
-		return public.NewInternalClient(controlPlaneNamespace, apiAddr)
-	}
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext)
-	if err != nil {
-		return nil, err
-	}
-	return public.NewExternalClient(controlPlaneNamespace, kubeAPI)
 }


### PR DESCRIPTION
Currently, cli/cmd/root.go provides a couple of utilities for building
clients to Linkerd's Public API; however these utilities are infallible,
execute health checks, etc.

There are a class of API clients---for instance, when an inject command
wants to acquire configuration from the API---where these checks are
undesirable. The version CLI built such a client, for example.

This change consolidates the various utilities into a single file.
Furthermore, I have renamed these utilities to hopefully be clearer in
terms of how they differ.