### PR TITLE
Update integration tests for the identity controller

### DIFF
--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -37,6 +37,7 @@ var (
 		"linkerd-web":        1,
 		"linkerd-prometheus": 1,
 		"linkerd-controller": 1,
+		"linkerd-identity":   1,
 	}
 )
 

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -72,6 +72,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 			args: []string{"stat", "deploy", "-n", TestHelper.GetLinkerdNamespace()},
 			expectedRows: map[string]string{
 				"linkerd-controller": "1/1",
+				"linkerd-identity":   "1/1",
 				"linkerd-grafana":    "1/1",
 				"linkerd-prometheus": "1/1",
 				"linkerd-web":        "1/1",
@@ -104,7 +105,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		{
 			args: []string{"stat", "ns", TestHelper.GetLinkerdNamespace()},
 			expectedRows: map[string]string{
-				TestHelper.GetLinkerdNamespace(): "4/4",
+				TestHelper.GetLinkerdNamespace(): "5/5",
 			},
 		},
 		{


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/2526 added a new controller deployment but did not add it to the integration tests.

This modifies the integration tests to be aware of the identity deployment.