### PR TITLE
Add identity pod to check, web, and integration tests

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -855,7 +855,7 @@ func getPodStatuses(pods []corev1.Pod) map[string][]corev1.ContainerStatus {
 func validateControlPlanePods(pods []corev1.Pod) error {
 	statuses := getPodStatuses(pods)
 
-	names := []string{"controller", "prometheus", "web", "grafana"}
+	names := []string{"controller", "grafana", "identity", "prometheus", "web"}
 	if _, found := statuses["proxy-injector"]; found {
 		names = append(names, "proxy-injector")
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -377,6 +377,7 @@ func TestValidateControlPlanePods(t *testing.T) {
 		pods := []corev1.Pod{
 			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
 			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-identity-6849948664-27982", corev1.PodRunning, true),
 			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodFailed, false),
 			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
@@ -394,6 +395,7 @@ func TestValidateControlPlanePods(t *testing.T) {
 		pods := []corev1.Pod{
 			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
 			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, false),
+			pod("linkerd-identity-6849948664-27982", corev1.PodRunning, true),
 			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
 			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
@@ -411,6 +413,7 @@ func TestValidateControlPlanePods(t *testing.T) {
 		pods := []corev1.Pod{
 			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
 			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-identity-6849948664-27982", corev1.PodRunning, true),
 			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
 			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 		}
@@ -425,6 +428,7 @@ func TestValidateControlPlanePods(t *testing.T) {
 		pods := []corev1.Pod{
 			pod("linkerd-controller-6f78cbd47-bc557", corev1.PodRunning, true),
 			pod("linkerd-grafana-5b7d796646-hh46d", corev1.PodRunning, true),
+			pod("linkerd-identity-6849948664-27982", corev1.PodRunning, true),
 			pod("linkerd-prometheus-74d6879cd6-bbdk6", corev1.PodRunning, true),
 			pod("linkerd-web-98c9ddbcd-7b5lh", corev1.PodRunning, true),
 			pod("hello-43c25d", corev1.PodRunning, true),

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -33,10 +33,11 @@ var (
 	}
 
 	linkerdPods = map[string]int{
-		"linkerd-grafana":    1,
-		"linkerd-web":        1,
-		"linkerd-prometheus": 1,
 		"linkerd-controller": 1,
+		"linkerd-grafana":    1,
+		"linkerd-identity":   1,
+		"linkerd-prometheus": 1,
+		"linkerd-web":        1,
 	}
 )
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -35,15 +35,17 @@ func TestMain(m *testing.M) {
 var (
 	linkerdSvcs = []string{
 		"linkerd-controller-api",
-		"linkerd-grafana",
-		"linkerd-prometheus",
 		"linkerd-destination",
+		"linkerd-grafana",
+		"linkerd-identity",
+		"linkerd-prometheus",
 		"linkerd-web",
 	}
 
 	linkerdDeployReplicas = map[string]deploySpec{
 		"linkerd-controller": {1, []string{"destination", "public-api", "tap"}},
 		"linkerd-grafana":    {1, []string{}},
+		"linkerd-identity":   {1, []string{"identity"}},
 		"linkerd-prometheus": {1, []string{}},
 		"linkerd-web":        {1, []string{"web"}},
 	}

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -73,6 +73,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 			expectedRows: map[string]string{
 				"linkerd-controller": "1/1",
 				"linkerd-grafana":    "1/1",
+				"linkerd-identity":   "1/1",
 				"linkerd-prometheus": "1/1",
 				"linkerd-web":        "1/1",
 			},
@@ -104,7 +105,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		{
 			args: []string{"stat", "ns", TestHelper.GetLinkerdNamespace()},
 			expectedRows: map[string]string{
-				TestHelper.GetLinkerdNamespace(): "4/4",
+				TestHelper.GetLinkerdNamespace(): "5/5",
 			},
 		},
 		{

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -47,9 +47,10 @@ const getPodClassification = pod => {
 };
 
 const componentsToDeployNames = {
-  "Grafana" : "linkerd-grafana",
-  "Prometheus": "linkerd-prometheus",
   "Destination": "linkerd-controller",
+  "Grafana": "linkerd-grafana",
+  "Identity": "linkerd-identity",
+  "Prometheus": "linkerd-prometheus",
   "Public API": "linkerd-controller",
   "Tap": "linkerd-controller",
   "Web UI": "linkerd-web"


### PR DESCRIPTION
This branch updates our integration tests, `linkerd check`, and the web UI to work with the identity pod that was added in #2526.