### PR TITLE
Restructure inject resource config struct

### DIFF
--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -25,11 +25,11 @@ type Report struct {
 // from conf
 func newReport(conf *ResourceConfig) Report {
 	var name string
-	if m := conf.podMeta.ObjectMeta; m != nil {
+	if m := conf.pod.Meta; m != nil {
 		name = m.Name
 	}
 	return Report{
-		Kind: strings.ToLower(conf.meta.Kind),
+		Kind: strings.ToLower(conf.workload.metaType.Kind),
 		Name: name,
 	}
 }
@@ -47,10 +47,10 @@ func (r Report) Injectable() bool {
 
 // update updates the report for the provided resource conf.
 func (r *Report) update(conf *ResourceConfig) {
-	r.InjectDisabled = conf.podMeta.ObjectMeta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
-	r.HostNetwork = conf.podSpec.HostNetwork
-	r.Sidecar = healthcheck.HasExistingSidecars(conf.podSpec)
-	r.UDP = checkUDPPorts(conf.podSpec)
+	r.InjectDisabled = conf.pod.Meta.GetAnnotations()[k8s.ProxyInjectAnnotation] == k8s.ProxyInjectDisabled
+	r.HostNetwork = conf.pod.spec.HostNetwork
+	r.Sidecar = healthcheck.HasExistingSidecars(conf.pod.spec)
+	r.UDP = checkUDPPorts(conf.pod.spec)
 }
 
 func checkUDPPorts(t *v1.PodSpec) bool {

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -11,24 +11,24 @@ import (
 // Uninject removes from the workload in conf the init and proxy containers,
 // the TLS volumes and the extra annotations/labels that were added
 func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
-	if conf.podSpec == nil {
+	if conf.pod.spec == nil {
 		return nil, nil
 	}
 
 	conf.uninjectPodSpec(report)
 
-	if conf.workLoadMeta != nil {
-		uninjectObjectMeta(conf.workLoadMeta)
+	if conf.workload.meta != nil {
+		uninjectObjectMeta(conf.workload.meta)
 	}
 
-	uninjectObjectMeta(conf.podMeta.ObjectMeta)
+	uninjectObjectMeta(conf.pod.Meta)
 	return conf.YamlMarshalObj()
 }
 
 // Given a PodSpec, update the PodSpec in place with the sidecar
 // and init-container uninjected
 func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
-	t := conf.podSpec
+	t := conf.pod.spec
 	initContainers := []v1.Container{}
 	for _, container := range t.InitContainers {
 		if container.Name != k8s.InitContainerName {


### PR DESCRIPTION
This PR separates out the restructuring work done in #2500, where the `ResourceConfig` struct is restructured better encapsulate and separate a parent resource related fields from those of a pod.

Signed-off-by: Ivan Sim <ivan@buoyant.io>