### PR TITLE
Better handle TCP only resources in the dashboard

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -107,9 +107,10 @@ class Octopus extends React.Component {
 
     // if the resource only has TCP stats, display those instead
     let showTcp = false;
-    if (_isNil(resource.successRate && _isNil(resource.requestRate))) {
+    if (_isNil(resource.successRate) && _isNil(resource.requestRate)) {
       showTcp = true;
     }
+
     return (
       <Grid item key={resource.type + "-" + resource.name} >
         <Card className={type === "neighbor" ? classes.neighborNode : classes.centerNode} title={display}>

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -16,7 +16,6 @@ import _filter from 'lodash/filter';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
-import _isNil from 'lodash/isNil';
 import _merge from 'lodash/merge';
 import _reduce from 'lodash/reduce';
 import { withContext } from './util/AppContext.jsx';

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -183,20 +183,23 @@ export class ResourceDetailBase extends React.Component {
           resourceIsMeshed = _get(this.state.resourceMetrics, '[0].pods.meshedPods') > 0;
         }
 
-        let isTcpOnly = false;
+        let hasHttp = false;
+        let hasTcp = false;
         let metric = resourceMetrics[0];
-        if (!_isEmpty(metric) && !_isEmpty(metric.tcp)) {
-          let { tcp } = metric;
+        if (!_isEmpty(metric)) {
+          hasHttp = !_isEmpty(metric.stats) && metric.totalRequests !== 0;
 
-          if (_isNil(metric.stats) &&
-            (tcp.openConnections > 0 || tcp.readBytes > 0 || tcp.writeBytes > 0)) {
-            isTcpOnly = true;
+          if (!_isEmpty(metric.tcp)) {
+            let { tcp } = metric;
+            hasTcp = tcp.openConnections > 0 || tcp.readBytes > 0 || tcp.writeBytes > 0;
           }
         }
 
+        let isTcpOnly = !hasHttp && hasTcp;
+
         // figure out when the last traffic this resource received was so we can show a no traffic message
         let lastMetricReceivedTime = this.state.lastMetricReceivedTime;
-        if ((!_isEmpty(metric) && metric.totalRequests !== 0) || isTcpOnly) {
+        if (hasHttp || hasTcp) {
           lastMetricReceivedTime = Date.now();
         }
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -184,11 +184,11 @@ export class ResourceDetailBase extends React.Component {
         }
 
         let isTcpOnly = false;
-        let resMetrics = resourceMetrics[0];
-        if (!_isEmpty(resMetrics) && !_isEmpty(resMetrics.tcp)) {
-          let { tcp } = resMetrics;
+        let metric = resourceMetrics[0];
+        if (!_isEmpty(metric) && !_isEmpty(metric.tcp)) {
+          let { tcp } = metric;
 
-          if (_isNil(resMetrics.stats) &&
+          if (_isNil(metric.stats) &&
             (tcp.openConnections > 0 || tcp.readBytes > 0 || tcp.writeBytes > 0)) {
             isTcpOnly = true;
           }
@@ -196,7 +196,7 @@ export class ResourceDetailBase extends React.Component {
 
         // figure out when the last traffic this resource received was so we can show a no traffic message
         let lastMetricReceivedTime = this.state.lastMetricReceivedTime;
-        if ((!_isEmpty(resourceMetrics[0]) && resourceMetrics[0].totalRequests !== 0) || isTcpOnly) {
+        if ((!_isEmpty(metric) && metric.totalRequests !== 0) || isTcpOnly) {
           lastMetricReceivedTime = Date.now();
         }
 

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -17,7 +17,7 @@ export class ResourceListBase extends React.Component {
 
   static propTypes = {
     data: PropTypes.arrayOf(metricsPropType.isRequired).isRequired,
-    error:  apiErrorPropType,
+    error: apiErrorPropType,
     loading: PropTypes.bool.isRequired,
     resource: PropTypes.string.isRequired,
   }
@@ -48,7 +48,14 @@ export class ResourceListBase extends React.Component {
       <React.Fragment>
         <MetricsTable
           resource={this.props.resource}
-          metrics={processedMetrics} />
+          metrics={processedMetrics}
+          title="HTTP metrics" />
+
+        <MetricsTable
+          resource={this.props.resource}
+          isTcpTable={true}
+          metrics={processedMetrics}
+          title="TCP metrics" />
       </React.Fragment>
     );
   }
@@ -68,7 +75,7 @@ export class ResourceListBase extends React.Component {
 
 export default withREST(
   ResourceListBase,
-  ({api, resource}) => [api.fetchMetrics(api.urlsForResource(resource))],
+  ({ api, resource }) => [api.fetchMetrics(api.urlsForResource(resource, '', true))],
   {
     resetProps: ['resource'],
   },

--- a/web/app/js/components/ResourceList.test.jsx
+++ b/web/app/js/components/ResourceList.test.jsx
@@ -25,7 +25,7 @@ describe('Tests for <ResourceListBase>', () => {
     const err = component.find(ErrorBanner);
     expect(err).toHaveLength(1);
     expect(component.find(Spinner)).toHaveLength(0);
-    expect(component.find(MetricsTable)).toHaveLength(1);
+    expect(component.find(MetricsTable)).toHaveLength(2);
     expect(err.props().message.statusText).toEqual(msg);
   });
 
@@ -52,7 +52,7 @@ describe('Tests for <ResourceListBase>', () => {
 
     expect(component.find(ErrorBanner)).toHaveLength(0);
     expect(component.find(Spinner)).toHaveLength(0);
-    expect(component.find(MetricsTable)).toHaveLength(1);
+    expect(component.find(MetricsTable)).toHaveLength(2);
   });
 
   it('renders a metrics table', () => {
@@ -69,9 +69,11 @@ describe('Tests for <ResourceListBase>', () => {
 
     expect(component.find(ErrorBanner)).toHaveLength(0);
     expect(component.find(Spinner)).toHaveLength(0);
-    expect(metrics).toHaveLength(1);
+    expect(metrics).toHaveLength(2);
 
-    expect(metrics.props().resource).toEqual(resource);
-    expect(metrics.props().metrics).toHaveLength(1);
+    expect(metrics.at(0).props().resource).toEqual(resource);
+    expect(metrics.at(1).props().resource).toEqual(resource);
+    expect(metrics.at(0).props().metrics).toHaveLength(1);
+    expect(metrics.at(1).props().metrics).toHaveLength(1);
   });
 });


### PR DESCRIPTION
When a resource only has TCP traffic and no HTTP traffic, the dashboard looks weird in a bunch of places.

This PR:
- updates the main resource card in the Octopus graph to show TCP stats if no HTTP stats are available
- cleans up the resource detail page to show fewer blank tables if the resource only has TCP traffic.

![Screen Shot 2019-03-20 at 3 37 14 PM](https://user-images.githubusercontent.com/549258/54724009-a32d3480-4b26-11e9-8c4c-aae138f03968.png)
![Screen Shot 2019-03-20 at 3 25 09 PM](https://user-images.githubusercontent.com/549258/54724010-a32d3480-4b26-11e9-98c3-490a815368a4.png)

Part of #2223