### PR TITLE
Check the cluster's config for install & inject

### DIFF
--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -46,7 +46,7 @@ spec:
         {{.Values.CreatedByAnnotation}}: {{.Values.CliVersion}}
     spec:
       volumes:
-      - name: {{.Values.GrafanaVolumeName}}
+      - name: data
         emptyDir: {}
       - name: grafana-config
         configMap:
@@ -65,10 +65,10 @@ spec:
           containerPort: 3000
         env:
         - name: GF_PATHS_DATA
-          value: /{{.Values.GrafanaVolumeName}}
+          value: /data
         volumeMounts:
-        - name: {{.Values.GrafanaVolumeName}}
-          mountPath: /{{.Values.GrafanaVolumeName}}
+        - name: data
+          mountPath: /data
         - name: grafana-config
           mountPath: /etc/grafana
           readOnly: true

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: linkerd-prometheus
       volumes:
-      - name: {{.Values.PrometheusVolumeName}}
+      - name: data
         emptyDir: {}
       - name: prometheus-config
         configMap:
@@ -80,15 +80,15 @@ spec:
         - name: admin-http
           containerPort: 9090
         volumeMounts:
-        - name: {{.Values.PrometheusVolumeName}}
-          mountPath: /{{.Values.PrometheusVolumeName}}
+        - name: data
+          mountPath: /data
         - name: prometheus-config
           mountPath: /etc/prometheus
           readOnly: true
         image: {{.Values.PrometheusImage}}
         imagePullPolicy: {{.Values.ImagePullPolicy}}
         args:
-        - "--storage.tsdb.path=/{{.Values.PrometheusVolumeName}}"
+        - "--storage.tsdb.path=/data"
         - "--storage.tsdb.retention=6h"
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--log.level={{.Values.PrometheusLogLevel}}"

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -29,7 +29,7 @@ const (
 )
 
 type injectOptions struct {
-	ignoreCluster, disableIdentity bool
+	disableIdentity bool
 	*proxyConfigOptions
 }
 
@@ -47,8 +47,6 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, conf *conf
 
 func newInjectOptions() *injectOptions {
 	return &injectOptions{
-		ignoreCluster: false,
-
 		// No proxy config overrides.
 		proxyConfigOptions: &proxyConfigOptions{},
 	}
@@ -101,12 +99,8 @@ sub-folders, or coming from stdin.`,
 
 	addProxyConfigFlags(cmd, options.proxyConfigOptions)
 	cmd.PersistentFlags().BoolVar(
-		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
-		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
-	)
-	cmd.PersistentFlags().BoolVar(
 		&options.disableIdentity, "disable-identity", options.disableIdentity,
-		"Disables resources from participating in identity",
+		"Disables resources from participating in TLS identity",
 	)
 
 	return cmd
@@ -275,7 +269,7 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 			return nil, errors.New("--disable-identity must be set with --ignore-cluster")
 		}
 
-		install := defaultInstallOptions()
+		install := newInstallOptionsWithDefaults()
 		return install.configs(nil), nil
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -287,21 +287,26 @@ func (options *injectOptions) overrideConfigs(configs *config.All) {
 	}
 
 	if options.proxyAdminPort != 0 {
-		configs.Proxy.AdminPort = &config.Port{Port: uint32(options.proxyAdminPort)}
+		configs.Proxy.AdminPort = toPort(options.proxyAdminPort)
 	}
 	if options.proxyControlPort != 0 {
-		configs.Proxy.ControlPort = &config.Port{Port: uint32(options.proxyControlPort)}
+		configs.Proxy.ControlPort = toPort(options.proxyControlPort)
 	}
 	if options.proxyInboundPort != 0 {
-		configs.Proxy.InboundPort = &config.Port{Port: uint32(options.proxyInboundPort)}
+		configs.Proxy.InboundPort = toPort(options.proxyInboundPort)
 	}
 	if options.proxyOutboundPort != 0 {
-		configs.Proxy.OutboundPort = &config.Port{Port: uint32(options.proxyOutboundPort)}
+		configs.Proxy.OutboundPort = toPort(options.proxyOutboundPort)
 	}
 
 	if options.dockerRegistry != "" {
 		configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
 		configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
+	}
+
+	if options.imagePullPolicy != "" {
+		configs.Proxy.ProxyImage.PullPolicy = options.imagePullPolicy
+		configs.Proxy.ProxyInitImage.PullPolicy = options.imagePullPolicy
 	}
 
 	if options.proxyUID != 0 {
@@ -330,10 +335,14 @@ func (options *injectOptions) overrideConfigs(configs *config.All) {
 	}
 }
 
+func toPort(p uint) *config.Port {
+	return &config.Port{Port: uint32(p)}
+}
+
 func toPorts(ints []uint) []*config.Port {
 	ports := make([]*config.Port, len(ints))
 	for i, p := range ints {
-		ports[i] = &config.Port{Port: uint32(p)}
+		ports[i] = toPort(p)
 	}
 	return ports
 }

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -17,7 +17,7 @@ type testCase struct {
 	inputFileName    string
 	goldenFileName   string
 	reportFileName   string
-	testInjectConfig configs
+	testInjectConfig *config.All
 }
 
 func mkFilename(filename string, verbose bool) string {
@@ -48,21 +48,21 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 }
 
 func TestUninjectAndInject(t *testing.T) {
-	defaultConfig := newConfig()
-	defaultConfig.global.Version = "testinjectversion"
+	_, defaultConfig, _ := testInstallOptions().validateAndBuild()
+	defaultConfig.Global.Version = "testinjectversion"
 
-	proxyResourceConfig := newConfig()
-	proxyResourceConfig.global.Version = defaultConfig.global.Version
-	proxyResourceConfig.proxy.Resource = &config.ResourceRequirements{
+	_, proxyResourceConfig, _ := testInstallOptions().validateAndBuild()
+	proxyResourceConfig.Global.Version = defaultConfig.Global.Version
+	proxyResourceConfig.Proxy.Resource = &config.ResourceRequirements{
 		RequestCpu:    "110m",
 		RequestMemory: "100Mi",
 		LimitCpu:      "160m",
 		LimitMemory:   "150Mi",
 	}
 
-	noInitContainerConfig := newConfig()
-	noInitContainerConfig.global.Version = defaultConfig.global.Version
-	noInitContainerConfig.global.CniEnabled = true
+	_, noInitContainerConfig, _ := testInstallOptions().validateAndBuild()
+	noInitContainerConfig.Global.Version = defaultConfig.Global.Version
+	noInitContainerConfig.Global.CniEnabled = true
 
 	testCases := []testCase{
 		{
@@ -190,8 +190,8 @@ type injectCmd struct {
 }
 
 func testInjectCmd(t *testing.T, tc injectCmd) {
-	testConfig := newConfig()
-	testConfig.global.Version = "testinjectversion"
+	_, testConfig, _ := testInstallOptions().validateAndBuild()
+	testConfig.Global.Version = "testinjectversion"
 
 	errBuffer := &bytes.Buffer{}
 	outBuffer := &bytes.Buffer{}
@@ -258,8 +258,8 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	conf := injectOptionsToConfigs(newInjectOptions())
-	if exitCode := runInjectCmd(in, errBuf, actual, conf); exitCode != 0 {
+	_, configs, _ := testInstallOptions().validateAndBuild()
+	if exitCode := runInjectCmd(in, errBuf, actual, configs); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}
 	diffTestdata(t, tc.expectedFile, actual.String())
@@ -276,7 +276,8 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	if exitCode := runInjectCmd(in, errBuf, actual, newConfig()); exitCode != 0 {
+	_, configs, _ := testInstallOptions().validateAndBuild()
+	if exitCode := runInjectCmd(in, errBuf, actual, configs); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}
 

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/inject"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,11 +15,6 @@ import (
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
-
-type configs struct {
-	global *config.Global
-	proxy  *config.Proxy
-}
 
 type resourceTransformer interface {
 	transform([]byte) ([]byte, []inject.Report, error)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -17,9 +17,14 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
+	"github.com/linkerd/linkerd2/pkg/version"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/renderutil"
@@ -28,14 +33,12 @@ import (
 )
 
 type (
-	installConfig struct {
+	installValues struct {
 		Namespace                string
 		ControllerImage          string
 		WebImage                 string
 		PrometheusImage          string
-		PrometheusVolumeName     string
 		GrafanaImage             string
-		GrafanaVolumeName        string
 		ControllerReplicas       uint
 		ImagePullPolicy          string
 		UUID                     string
@@ -55,19 +58,19 @@ type (
 		GlobalConfig             string
 		ProxyConfig              string
 
-		Identity *installIdentityConfig
+		Identity *installIdentityValues
 	}
 
-	installIdentityConfig struct {
+	installIdentityValues struct {
 		Replicas uint
 
 		TrustDomain     string
 		TrustAnchorsPEM string
 
-		Issuer *issuerConfig
+		Issuer *issuerValues
 	}
 
-	issuerConfig struct {
+	issuerValues struct {
 		ClockSkewAllowance string
 		IssuanceLifetime   string
 
@@ -90,11 +93,13 @@ type (
 		highAvailability   bool
 		controllerUID      int64
 		disableH2Upgrade   bool
+		ignoreCluster      bool
 		identityOptions    *installIdentityOptions
 		*proxyConfigOptions
 	}
 
 	installIdentityOptions struct {
+		replicas    uint
 		trustDomain string
 
 		issuanceLifetime   time.Duration
@@ -105,6 +110,7 @@ type (
 )
 
 const (
+	prometheusImage                   = "prom/prometheus:v2.7.1"
 	prometheusProxyOutboundCapacity   = 10000
 	defaultControllerReplicas         = 1
 	defaultHAControllerReplicas       = 3
@@ -122,7 +128,7 @@ const (
 	proxyInjectorTemplateName  = "templates/proxy_injector.yaml"
 )
 
-func newInstallOptions() *installOptions {
+func defaultInstallOptions() *installOptions {
 	return &installOptions{
 		controllerReplicas: defaultControllerReplicas,
 		controllerLogLevel: "info",
@@ -130,7 +136,28 @@ func newInstallOptions() *installOptions {
 		highAvailability:   false,
 		controllerUID:      2103,
 		disableH2Upgrade:   false,
-		proxyConfigOptions: newProxyConfigOptions(),
+		ignoreCluster:      false,
+		proxyConfigOptions: &proxyConfigOptions{
+			linkerdVersion:          version.Version,
+			proxyImage:              defaultDockerRegistry + "/proxy",
+			initImage:               defaultDockerRegistry + "/proxy-init",
+			dockerRegistry:          defaultDockerRegistry,
+			imagePullPolicy:         "IfNotPresent",
+			ignoreInboundPorts:      nil,
+			ignoreOutboundPorts:     nil,
+			proxyUID:                2102,
+			proxyLogLevel:           "warn,linkerd2_proxy=info",
+			proxyControlPort:        4190,
+			proxyAdminPort:          4191,
+			proxyInboundPort:        4143,
+			proxyOutboundPort:       4140,
+			proxyCPURequest:         "",
+			proxyMemoryRequest:      "",
+			proxyCPULimit:           "",
+			proxyMemoryLimit:        "",
+			disableExternalProfiles: false,
+			noInitContainer:         false,
+		},
 		identityOptions: &installIdentityOptions{
 			trustDomain:        defaultIdentityTrustDomain,
 			issuanceLifetime:   defaultIdentityIssuanceLifetime,
@@ -140,21 +167,18 @@ func newInstallOptions() *installOptions {
 }
 
 func newCmdInstall() *cobra.Command {
-	options := newInstallOptions()
+	options := defaultInstallOptions()
 
 	cmd := &cobra.Command{
 		Use:   "install [flags]",
 		Short: "Output Kubernetes configs to install Linkerd",
 		Long:  "Output Kubernetes configs to install Linkerd.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO check with a config already exists in the API and fail if it does.
-
-			config, err := validateAndBuildConfig(options)
+			values, configs, err := options.validateAndBuild()
 			if err != nil {
 				return err
 			}
-
-			return render(*config, os.Stdout, options)
+			return render(values, os.Stdout, configs)
 		},
 	}
 
@@ -183,7 +207,10 @@ func newCmdInstall() *cobra.Command {
 		&options.disableH2Upgrade, "disable-h2-upgrade", options.disableH2Upgrade,
 		"Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)",
 	)
-
+	cmd.PersistentFlags().BoolVar(
+		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
+		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
+	)
 	cmd.PersistentFlags().StringVar(
 		&options.identityOptions.trustDomain, "identity-trust-domain", options.identityOptions.trustDomain,
 		"Configures the name suffix used for identities.",
@@ -212,157 +239,118 @@ func newCmdInstall() *cobra.Command {
 	return cmd
 }
 
-func validateAndBuildConfig(options *installOptions) (*installConfig, error) {
-	if err := options.validate(); err != nil {
-		return nil, err
+func (options *installOptions) validate() error {
+	if options.identityOptions == nil {
+		log.Fatal("missing identity options")
 	}
 
-	if options.highAvailability && options.controllerReplicas == defaultControllerReplicas {
-		options.controllerReplicas = defaultHAControllerReplicas
+	if _, err := log.ParseLevel(options.controllerLogLevel); err != nil {
+		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
 	}
 
-	if options.highAvailability && options.proxyCPURequest == "" {
-		options.proxyCPURequest = "10m"
+	if err := options.proxyConfigOptions.validate(); err != nil {
+		return err
 	}
 
-	if options.highAvailability && options.proxyMemoryRequest == "" {
-		options.proxyMemoryRequest = "20Mi"
-	}
-
-	var identity *installIdentityConfig
-	if idopts := options.identityOptions; idopts != nil {
-		trustDomain := idopts.trustDomain
-		if trustDomain == "" {
-			return nil, errors.New("Trust domain must be specified")
+	if !options.ignoreCluster {
+		exists, err := linkerdConfigAlreadyExistsInCluster()
+		if err != nil {
+			return fmt.Errorf("Unable to connect to a Kubernetes cluster to check for configuration. If this expected, use the --ignore-cluster flag.")
 		}
-		issuerName := fmt.Sprintf("identity.%s.%s", controlPlaneNamespace, trustDomain)
-
-		identityReplicas := uint(1)
-		if options.highAvailability {
-			identityReplicas = 3
-		}
-
-		// Load signing material from options...
-		if idopts.trustPEMFile != "" || idopts.crtPEMFile != "" || idopts.keyPEMFile != "" {
-			if idopts.trustPEMFile == "" {
-				return nil, errors.New("a trust anchors file must be specified if other credentials are provided")
-			}
-			if idopts.crtPEMFile == "" {
-				return nil, errors.New("a certificate file must be specified if other credentials are provided")
-			}
-			if idopts.keyPEMFile == "" {
-				return nil, errors.New("a private key file must be specified if other credentials are provided")
-			}
-
-			// Validate credentials...
-			creds, err := tls.ReadPEMCreds(idopts.keyPEMFile, idopts.crtPEMFile)
-			if err != nil {
-				return nil, err
-			}
-
-			trustb, err := ioutil.ReadFile(idopts.trustPEMFile)
-			if err != nil {
-				return nil, err
-			}
-			trustAnchorsPEM := string(trustb)
-			roots, err := tls.DecodePEMCertPool(trustAnchorsPEM)
-			if err != nil {
-				return nil, err
-			}
-
-			issuerName := "" // TODO restrict issuer name?
-			if err := creds.Verify(roots, issuerName); err != nil {
-				return nil, fmt.Errorf("Credentials cannot be validated: %s", err)
-			}
-
-			identity = &installIdentityConfig{
-				Replicas:        identityReplicas,
-				TrustDomain:     idopts.trustDomain,
-				TrustAnchorsPEM: trustAnchorsPEM,
-				Issuer: &issuerConfig{
-					ClockSkewAllowance:  idopts.clockSkewAllowance.String(),
-					IssuanceLifetime:    idopts.issuanceLifetime.String(),
-					CrtExpiryAnnotation: k8s.IdentityIssuerExpiryAnnotation,
-
-					KeyPEM:    creds.EncodePrivateKeyPEM(),
-					CrtPEM:    creds.EncodeCertificatePEM(),
-					CrtExpiry: creds.Crt.Certificate.NotAfter,
-				},
-			}
-		} else {
-			// Generate new signing material...
-
-			root, err := tls.GenerateRootCAWithDefaults(issuerName)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to create root certificate for identity: %s", err)
-			}
-
-			identity = &installIdentityConfig{
-				Replicas:        identityReplicas,
-				TrustDomain:     trustDomain,
-				TrustAnchorsPEM: root.Cred.Crt.EncodeCertificatePEM(),
-				Issuer: &issuerConfig{
-					ClockSkewAllowance:  idopts.clockSkewAllowance.String(),
-					IssuanceLifetime:    idopts.issuanceLifetime.String(),
-					CrtExpiryAnnotation: k8s.IdentityIssuerExpiryAnnotation,
-
-					KeyPEM:    root.Cred.EncodePrivateKeyPEM(),
-					CrtPEM:    root.Cred.Crt.EncodeCertificatePEM(),
-					CrtExpiry: root.Cred.Crt.Certificate.NotAfter,
-				},
-			}
+		if exists {
+			return fmt.Errorf("You are already running a control plane. If you would like to ignore its configuration, use the --ignore-cluster flag.")
 		}
 	}
 
-	jsonMarshaler := jsonpb.Marshaler{EmitDefaults: true}
-	globalConfig, err := jsonMarshaler.MarshalToString(globalConfig(options, identity))
-	if err != nil {
-		return nil, err
-	}
-
-	proxyConfig, err := jsonMarshaler.MarshalToString(proxyConfig(options))
-	if err != nil {
-		return nil, err
-	}
-
-	prometheusLogLevel := options.controllerLogLevel
-	if prometheusLogLevel == "panic" || prometheusLogLevel == "fatal" {
-		prometheusLogLevel = "error"
-	}
-
-	return &installConfig{
-		Namespace:                controlPlaneNamespace,
-		ControllerImage:          fmt.Sprintf("%s/controller:%s", options.dockerRegistry, options.linkerdVersion),
-		WebImage:                 fmt.Sprintf("%s/web:%s", options.dockerRegistry, options.linkerdVersion),
-		PrometheusImage:          "prom/prometheus:v2.7.1",
-		PrometheusVolumeName:     "data",
-		GrafanaImage:             fmt.Sprintf("%s/grafana:%s", options.dockerRegistry, options.linkerdVersion),
-		GrafanaVolumeName:        "data",
-		ControllerReplicas:       options.controllerReplicas,
-		ImagePullPolicy:          options.imagePullPolicy,
-		UUID:                     uuid.NewV4().String(),
-		CliVersion:               k8s.CreatedByAnnotationValue(),
-		ControllerLogLevel:       options.controllerLogLevel,
-		PrometheusLogLevel:       prometheusLogLevel,
-		ControllerComponentLabel: k8s.ControllerComponentLabel,
-		ControllerUID:            options.controllerUID,
-		CreatedByAnnotation:      k8s.CreatedByAnnotation,
-		ProxyContainerName:       k8s.ProxyContainerName,
-		ProxyAutoInjectEnabled:   options.proxyAutoInject,
-		ProxyInjectAnnotation:    k8s.ProxyInjectAnnotation,
-		ProxyInjectDisabled:      k8s.ProxyInjectDisabled,
-		EnableHA:                 options.highAvailability,
-		EnableH2Upgrade:          !options.disableH2Upgrade,
-		NoInitContainer:          options.noInitContainer,
-		GlobalConfig:             globalConfig,
-		ProxyConfig:              proxyConfig,
-		Identity:                 identity,
-	}, nil
+	return nil
 }
 
-func render(config installConfig, w io.Writer, options *installOptions) error {
+func (options *installOptions) validateAndBuild() (*installValues, *pb.All, error) {
+	if err := options.validate(); err != nil {
+		return nil, nil, err
+	}
+
+	if options.highAvailability {
+		if options.controllerReplicas == defaultControllerReplicas {
+			options.controllerReplicas = defaultHAControllerReplicas
+		}
+
+		if options.proxyCPURequest == "" {
+			options.proxyCPURequest = "10m"
+		}
+
+		if options.proxyMemoryRequest == "" {
+			options.proxyMemoryRequest = "20Mi"
+		}
+	}
+
+	options.identityOptions.replicas = options.controllerReplicas
+	identityValues, err := options.identityOptions.validateAndBuild()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	configs := options.configs(identityValues.toIdentityContext())
+
+	j := jsonpb.Marshaler{EmitDefaults: true}
+	globalConfig, err := j.MarshalToString(configs.GetGlobal())
+	if err != nil {
+		return nil, nil, err
+	}
+	proxyConfig, err := j.MarshalToString(configs.GetProxy())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := &installValues{
+		// Container images:
+		ControllerImage: fmt.Sprintf("%s/controller:%s", options.dockerRegistry, options.linkerdVersion),
+		WebImage:        fmt.Sprintf("%s/web:%s", options.dockerRegistry, options.linkerdVersion),
+		GrafanaImage:    fmt.Sprintf("%s/grafana:%s", options.dockerRegistry, options.linkerdVersion),
+		PrometheusImage: prometheusImage,
+		ImagePullPolicy: options.imagePullPolicy,
+
+		// Kubernetes labels/annotations/resourcse:
+		CreatedByAnnotation:      k8s.CreatedByAnnotation,
+		CliVersion:               k8s.CreatedByAnnotationValue(),
+		ControllerComponentLabel: k8s.ControllerComponentLabel,
+		ProxyContainerName:       k8s.ProxyContainerName,
+		ProxyInjectAnnotation:    k8s.ProxyInjectAnnotation,
+		ProxyInjectDisabled:      k8s.ProxyInjectDisabled,
+
+		// Controller configuration:
+		Namespace:              controlPlaneNamespace,
+		UUID:                   uuid.NewV4().String(),
+		ControllerLogLevel:     options.controllerLogLevel,
+		ControllerUID:          options.controllerUID,
+		EnableHA:               options.highAvailability,
+		EnableH2Upgrade:        !options.disableH2Upgrade,
+		NoInitContainer:        options.noInitContainer,
+		ControllerReplicas:     options.controllerReplicas,
+		ProxyAutoInjectEnabled: options.proxyAutoInject,
+		PrometheusLogLevel:     toPromLogLevel(options.controllerLogLevel),
+
+		GlobalConfig: globalConfig,
+		ProxyConfig:  proxyConfig,
+		Identity:     identityValues,
+	}
+
+	return values, configs, nil
+}
+
+func toPromLogLevel(level string) (prom string) {
+	switch level {
+	case "panic", "fatal":
+		prom = "error"
+	default:
+		prom = level
+	}
+	return
+}
+
+func render(values *installValues, w io.Writer, configs *pb.All) error {
 	// Render raw values and create chart config
-	rawValues, err := yaml.Marshal(config)
+	rawValues, err := yaml.Marshal(values)
 	if err != nil {
 		return err
 	}
@@ -420,37 +408,17 @@ func render(config installConfig, w io.Writer, options *installOptions) error {
 		}
 	}
 
-	injectOptions := newInjectOptions()
-
-	*injectOptions.proxyConfigOptions = *options.proxyConfigOptions
-
 	// Skip outbound port 443 to enable Kubernetes API access without the proxy.
 	// Once Kubernetes supports sidecar containers, this may be removed, as that
 	// will guarantee the proxy is running prior to control-plane startup.
-	injectOptions.ignoreOutboundPorts = append(injectOptions.ignoreOutboundPorts, 443)
-
-	// TODO: Fetch GlobalConfig and ProxyConfig from the ConfigMap/API
-	pbConfig := injectOptionsToConfigs(injectOptions)
-
-	// injectOptionsToConfigs does NOT set an identity context if none exists,
-	// since it can't be enabled at inject-time if it's not enabled at
-	// install-time.
-	pbConfig.global.IdentityContext = config.Identity.toIdentityContext()
+	configs.Proxy.IgnoreOutboundPorts = append(configs.Proxy.IgnoreOutboundPorts, &config.Port{Port: 443})
 
 	return processYAML(&buf, w, ioutil.Discard, resourceTransformerInject{
-		configs: pbConfig,
+		configs: configs,
 		proxyOutboundCapacity: map[string]uint{
-			config.PrometheusImage: prometheusProxyOutboundCapacity,
+			values.PrometheusImage: prometheusProxyOutboundCapacity,
 		},
 	})
-}
-
-func (options *installOptions) validate() error {
-	if _, err := log.ParseLevel(options.controllerLogLevel); err != nil {
-		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
-	}
-
-	return options.proxyConfigOptions.validate()
 }
 
 func readIntoBytes(filename string) ([]byte, error) {
@@ -466,16 +434,23 @@ func readIntoBytes(filename string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func globalConfig(options *installOptions, id *installIdentityConfig) *pb.Global {
+func (options *installOptions) configs(identity *pb.IdentityContext) *pb.All {
+	return &pb.All{
+		Global: options.globalConfig(identity),
+		Proxy:  options.proxyConfig(),
+	}
+}
+
+func (options *installOptions) globalConfig(identity *pb.IdentityContext) *pb.Global {
 	return &pb.Global{
 		LinkerdNamespace: controlPlaneNamespace,
 		CniEnabled:       options.noInitContainer,
 		Version:          options.linkerdVersion,
-		IdentityContext:  id.toIdentityContext(),
+		IdentityContext:  identity,
 	}
 }
 
-func proxyConfig(options *installOptions) *pb.Proxy {
+func (options *installOptions) proxyConfig() *pb.Proxy {
 	ignoreInboundPorts := []*pb.Port{}
 	for _, port := range options.ignoreInboundPorts {
 		ignoreInboundPorts = append(ignoreInboundPorts, &pb.Port{Port: uint32(port)})
@@ -501,13 +476,13 @@ func proxyConfig(options *installOptions) *pb.Proxy {
 		IgnoreInboundPorts:  ignoreInboundPorts,
 		IgnoreOutboundPorts: ignoreOutboundPorts,
 		InboundPort: &pb.Port{
-			Port: uint32(options.inboundPort),
+			Port: uint32(options.proxyInboundPort),
 		},
 		AdminPort: &config.Port{
 			Port: uint32(options.proxyAdminPort),
 		},
 		OutboundPort: &pb.Port{
-			Port: uint32(options.outboundPort),
+			Port: uint32(options.proxyOutboundPort),
 		},
 		Resource: &pb.ResourceRequirements{
 			RequestCpu:    options.proxyCPURequest,
@@ -523,24 +498,174 @@ func proxyConfig(options *installOptions) *pb.Proxy {
 	}
 }
 
-func (id *installIdentityConfig) toIdentityContext() *pb.IdentityContext {
-	if id == nil {
+// linkerdConfigAlreadyExistsInCluster checks the kubernetes API to determine
+// whether a config exists.
+//
+// This bypasses the public API so that public API errors cannot cause us to
+// misdiagnose a controller error to indicate that no control plane exists.
+//
+// If we cannot determine whether the configuration exists, an error is returned.
+func linkerdConfigAlreadyExistsInCluster() (bool, error) {
+	api, err := k8s.NewAPI(kubeconfigPath, kubeContext)
+	if err != nil {
+		return false, err
+	}
+
+	k, err := kubernetes.NewForConfig(api.Config)
+	if err != nil {
+		return false, err
+	}
+
+	c := k.CoreV1().ConfigMaps(controlPlaneNamespace)
+	if _, err = c.Get(k8s.ConfigConfigMapName, metav1.GetOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (idopts *installIdentityOptions) validate() error {
+	if idopts == nil {
 		return nil
 	}
 
-	il, err := time.ParseDuration(id.Issuer.IssuanceLifetime)
+	if idopts.trustDomain == "" {
+		if errs := validation.IsDNS1123Subdomain(idopts.trustDomain); len(errs) > 0 {
+			return fmt.Errorf("invalid trust domain '%s': %s", idopts.trustDomain, errs[0])
+		}
+	}
+
+	if idopts.trustPEMFile != "" || idopts.crtPEMFile != "" || idopts.keyPEMFile != "" {
+		if idopts.trustPEMFile == "" {
+			return errors.New("a trust anchors file must be specified if other credentials are provided")
+		}
+		if idopts.crtPEMFile == "" {
+			return errors.New("a certificate file must be specified if other credentials are provided")
+		}
+		if idopts.keyPEMFile == "" {
+			return errors.New("a private key file must be specified if other credentials are provided")
+		}
+
+		for _, f := range []string{idopts.trustPEMFile, idopts.crtPEMFile, idopts.keyPEMFile} {
+			stat, err := os.Stat(f)
+			if err != nil {
+				return fmt.Errorf("missing file: %s", err)
+			}
+			if stat.IsDir() {
+				return fmt.Errorf("not a file: %s", f)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (idopts *installIdentityOptions) validateAndBuild() (*installIdentityValues, error) {
+	if idopts == nil {
+		return nil, nil
+	}
+
+	if err := idopts.validate(); err != nil {
+		return nil, err
+	}
+
+	if idopts.trustPEMFile != "" && idopts.crtPEMFile != "" && idopts.keyPEMFile != "" {
+		return idopts.readValues()
+	}
+
+	return idopts.genValues()
+}
+
+func (idopts *installIdentityOptions) issuerName() string {
+	return fmt.Sprintf("identity.%s.%s", controlPlaneNamespace, idopts.trustDomain)
+}
+
+func (idopts *installIdentityOptions) genValues() (*installIdentityValues, error) {
+	root, err := tls.GenerateRootCAWithDefaults(idopts.issuerName())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to generate root certificate for identity: %s", err)
+	}
+
+	return &installIdentityValues{
+		Replicas:        idopts.replicas,
+		TrustDomain:     idopts.trustDomain,
+		TrustAnchorsPEM: root.Cred.Crt.EncodeCertificatePEM(),
+		Issuer: &issuerValues{
+			ClockSkewAllowance:  idopts.clockSkewAllowance.String(),
+			IssuanceLifetime:    idopts.issuanceLifetime.String(),
+			CrtExpiryAnnotation: k8s.IdentityIssuerExpiryAnnotation,
+
+			KeyPEM: root.Cred.EncodePrivateKeyPEM(),
+			CrtPEM: root.Cred.Crt.EncodeCertificatePEM(),
+
+			CrtExpiry: root.Cred.Crt.Certificate.NotAfter,
+		},
+	}, nil
+}
+
+// readValues attempts to read an issuer configuration from disk
+// to produce an `installIdentityValues`.
+//
+// The identity options must have already been validated.
+func (idopts *installIdentityOptions) readValues() (*installIdentityValues, error) {
+	creds, err := tls.ReadPEMCreds(idopts.keyPEMFile, idopts.crtPEMFile)
+	if err != nil {
+		return nil, err
+	}
+
+	trustb, err := ioutil.ReadFile(idopts.trustPEMFile)
+	if err != nil {
+		return nil, err
+	}
+	trustAnchorsPEM := string(trustb)
+	roots, err := tls.DecodePEMCertPool(trustAnchorsPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := creds.Verify(roots, idopts.issuerName()); err != nil {
+		return nil, fmt.Errorf("invalid credentials: %s", err)
+	}
+
+	return &installIdentityValues{
+		Replicas:        idopts.replicas,
+		TrustDomain:     idopts.trustDomain,
+		TrustAnchorsPEM: trustAnchorsPEM,
+		Issuer: &issuerValues{
+			ClockSkewAllowance:  idopts.clockSkewAllowance.String(),
+			IssuanceLifetime:    idopts.issuanceLifetime.String(),
+			CrtExpiryAnnotation: k8s.IdentityIssuerExpiryAnnotation,
+
+			KeyPEM: creds.EncodePrivateKeyPEM(),
+			CrtPEM: creds.EncodeCertificatePEM(),
+
+			CrtExpiry: creds.Crt.Certificate.NotAfter,
+		},
+	}, nil
+}
+
+func (idvals *installIdentityValues) toIdentityContext() *pb.IdentityContext {
+	if idvals == nil {
+		return nil
+	}
+
+	il, err := time.ParseDuration(idvals.Issuer.IssuanceLifetime)
 	if err != nil {
 		il = defaultIdentityIssuanceLifetime
 	}
 
-	csa, err := time.ParseDuration(id.Issuer.ClockSkewAllowance)
+	csa, err := time.ParseDuration(idvals.Issuer.ClockSkewAllowance)
 	if err != nil {
 		csa = defaultIdentityClockSkewAllowance
 	}
 
 	return &pb.IdentityContext{
-		TrustDomain:        id.TrustDomain,
-		TrustAnchorsPem:    id.TrustAnchorsPEM,
+		TrustDomain:        idvals.TrustDomain,
+		TrustAnchorsPem:    idvals.TrustAnchorsPEM,
 		IssuanceLifetime:   ptypes.DurationProto(il),
 		ClockSkewAllowance: ptypes.DurationProto(csa),
 	}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -523,9 +523,9 @@ func linkerdConfigAlreadyExistsInCluster() (bool, error) {
 	if _, err = c.Get(k8s.ConfigConfigMapName, metav1.GetOptions{}); err != nil {
 		if kerrors.IsNotFound(err) {
 			return false, nil
-		} else {
-			return false, err
 		}
+
+		return false, err
 	}
 
 	return true, nil

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -100,7 +100,7 @@ func TestRender(t *testing.T) {
 }
 
 func testInstallOptions() *installOptions {
-	o := defaultInstallOptions()
+	o := newInstallOptionsWithDefaults()
 	o.ignoreCluster = true
 	o.identityOptions.crtPEMFile = filepath.Join("testdata", "crt.pem")
 	o.identityOptions.keyPEMFile = filepath.Join("testdata", "key.pem")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -201,6 +201,8 @@ type proxyConfigOptions struct {
 	proxyMemoryLimit        string
 	disableExternalProfiles bool
 	noInitContainer         bool
+	// ignoreCluster is not validated by validate().
+	ignoreCluster bool
 }
 
 func (options *proxyConfigOptions) validate() error {
@@ -301,4 +303,9 @@ func addProxyConfigFlags(cmd *cobra.Command, options *proxyConfigOptions) {
 
 	cmd.PersistentFlags().MarkDeprecated("proxy-memory", "use --proxy-memory-request instead")
 	cmd.PersistentFlags().MarkDeprecated("proxy-cpu", "use --proxy-cpu-request instead")
+
+	cmd.PersistentFlags().BoolVar(
+		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
+		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
+	)
 }

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -79,7 +79,7 @@ metadata:
   name: linkerd-identity
   namespace: linkerd
 spec:
-  replicas: 3
+  replicas: 2
   strategy: {}
   template:
     metadata:

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -5,23 +5,24 @@ import (
 	"io"
 	"os"
 
+	"github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/inject"
 	"github.com/spf13/cobra"
 )
 
 type resourceTransformerUninject struct {
-	configs
+	configs *config.All
 }
 
 type resourceTransformerUninjectSilent struct {
-	configs
+	configs *config.All
 }
 
-func runUninjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, conf configs) int {
+func runUninjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, conf *config.All) int {
 	return transformInput(inputs, errWriter, outWriter, resourceTransformerUninject{conf})
 }
 
-func runUninjectSilentCmd(inputs []io.Reader, errWriter, outWriter io.Writer, conf configs) int {
+func runUninjectSilentCmd(inputs []io.Reader, errWriter, outWriter io.Writer, conf *config.All) int {
 	return transformInput(inputs, errWriter, outWriter, resourceTransformerUninjectSilent{conf})
 }
 
@@ -52,7 +53,7 @@ sub-folders, or coming from stdin.`,
 				return err
 			}
 
-			exitCode := runUninjectCmd(in, os.Stderr, os.Stdout, configs{})
+			exitCode := runUninjectCmd(in, os.Stderr, os.Stdout, nil)
 			os.Exit(exitCode)
 			return nil
 		},
@@ -62,7 +63,7 @@ sub-folders, or coming from stdin.`,
 }
 
 func (rt resourceTransformerUninject) transform(bytes []byte) ([]byte, []inject.Report, error) {
-	conf := inject.NewResourceConfig(rt.global, rt.proxy)
+	conf := inject.NewResourceConfig(rt.configs)
 
 	report, err := conf.ParseMetaAndYaml(bytes)
 	if err != nil {

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -93,7 +93,7 @@ func TestUninjectYAML(t *testing.T) {
 			output := new(bytes.Buffer)
 			report := new(bytes.Buffer)
 
-			exitCode := runUninjectCmd(read, report, output, configs{nil, nil})
+			exitCode := runUninjectCmd(read, report, output, nil)
 			if exitCode != 0 {
 				t.Errorf("Failed to inject %s\n", tc.inputFileName)
 			}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -3,6 +3,7 @@ package injector
 import (
 	"fmt"
 
+	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/inject"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -102,7 +103,8 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	}
 	nsAnnotations := namespace.GetAnnotations()
 
-	conf := inject.NewResourceConfig(globalConfig, proxyConfig).
+	configs := &pb.All{Global: globalConfig, Proxy: proxyConfig}
+	conf := inject.NewResourceConfig(configs).
 		WithNsAnnotations(nsAnnotations).
 		WithKind(request.Kind.Kind)
 	nonEmpty, err := conf.ParseMeta(request.Object.Raw)

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -15,36 +15,38 @@ import (
 )
 
 var (
-	factory      *fake.Factory
-	globalConfig = &config.Global{
-		LinkerdNamespace: "linkerd",
-		CniEnabled:       false,
-		IdentityContext:  nil,
-	}
-	proxyConfig = &config.Proxy{
-		ProxyImage:              &config.Image{ImageName: "gcr.io/linkerd-io/proxy", PullPolicy: "IfNotPresent"},
-		ProxyInitImage:          &config.Image{ImageName: "gcr.io/linkerd-io/proxy-init", PullPolicy: "IfNotPresent"},
-		ControlPort:             &config.Port{Port: 4190},
-		IgnoreInboundPorts:      nil,
-		IgnoreOutboundPorts:     nil,
-		InboundPort:             &config.Port{Port: 4143},
-		AdminPort:               &config.Port{Port: 4191},
-		OutboundPort:            &config.Port{Port: 4140},
-		Resource:                &config.ResourceRequirements{RequestCpu: "", RequestMemory: "", LimitCpu: "", LimitMemory: ""},
-		ProxyUid:                2102,
-		LogLevel:                &config.LogLevel{Level: "warn,linkerd2_proxy=info"},
-		DisableExternalProfiles: false,
+	factory *fake.Factory
+	configs = &config.All{
+		Global: &config.Global{
+			LinkerdNamespace: "linkerd",
+			CniEnabled:       false,
+			IdentityContext:  nil,
+		},
+		Proxy: &config.Proxy{
+			ProxyImage:              &config.Image{ImageName: "gcr.io/linkerd-io/proxy", PullPolicy: "IfNotPresent"},
+			ProxyInitImage:          &config.Image{ImageName: "gcr.io/linkerd-io/proxy-init", PullPolicy: "IfNotPresent"},
+			ControlPort:             &config.Port{Port: 4190},
+			IgnoreInboundPorts:      nil,
+			IgnoreOutboundPorts:     nil,
+			InboundPort:             &config.Port{Port: 4143},
+			AdminPort:               &config.Port{Port: 4191},
+			OutboundPort:            &config.Port{Port: 4140},
+			Resource:                &config.ResourceRequirements{RequestCpu: "", RequestMemory: "", LimitCpu: "", LimitMemory: ""},
+			ProxyUid:                2102,
+			LogLevel:                &config.LogLevel{Level: "warn,linkerd2_proxy=info"},
+			DisableExternalProfiles: false,
+		},
 	}
 )
 
 func confNsEnabled() *inject.ResourceConfig {
 	return inject.
-		NewResourceConfig(globalConfig, proxyConfig).
+		NewResourceConfig(configs).
 		WithNsAnnotations(map[string]string{k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled})
 }
 
 func confNsDisabled() *inject.ResourceConfig {
-	return inject.NewResourceConfig(globalConfig, proxyConfig).WithNsAnnotations(map[string]string{})
+	return inject.NewResourceConfig(configs).WithNsAnnotations(map[string]string{})
 }
 
 func TestGetPatch(t *testing.T) {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -65,7 +65,8 @@ func TestConfigAccessors(t *testing.T) {
 		DisableExternalProfiles: false,
 	}
 	globalConfig := &config.Global{LinkerdNamespace: "linkerd"}
-	resourceConfig := NewResourceConfig(globalConfig, proxyConfig).WithKind("Deployment")
+	configs := &config.All{Global: globalConfig, Proxy: proxyConfig}
+	resourceConfig := NewResourceConfig(configs).WithKind("Deployment")
 
 	var testCases = []struct {
 		id       string

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -63,7 +63,7 @@ const (
 
 	// IdentityIssuerExpiryAnnotation indicates the time at which this set of identity
 	// issuer credentials will cease to be valid.
-	IdentityIssuerExpiryAnnotation = "linkerd.io/identity-issuer-expiry"
+	IdentityIssuerExpiryAnnotation = Prefix + "/identity-issuer-expiry"
 
 	// ProxyVersionAnnotation indicates the version of the injected data plane
 	// (e.g. v0.1.3).
@@ -159,6 +159,9 @@ const (
 	/*
 	 * Component Names
 	 */
+
+	// ConfigConfigMapName is the name of hte ConfigMap containing the linkerd controller configuration.
+	ConfigConfigMapName = "linkerd-config"
 
 	// InitContainerName is the name assigned to the injected init container.
 	InitContainerName = "linkerd-init"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -160,7 +160,7 @@ const (
 	 * Component Names
 	 */
 
-	// ConfigConfigMapName is the name of hte ConfigMap containing the linkerd controller configuration.
+	// ConfigConfigMapName is the name of the ConfigMap containing the linkerd controller configuration.
 	ConfigConfigMapName = "linkerd-config"
 
 	// InitContainerName is the name assigned to the injected init container.


### PR DESCRIPTION
The introduction of identity in 0626fa37 created new state in the
control plane's configuration that must be considered when re-installing
the control plane or when injecting pods.

This change alters `install` to fail if it would seem to conflict with
an existing installation. This behavior may be disabled with the
`--ignore-cluster` flag.

Furthermore, `inject` now _requires_ that it can fetch a configuration
from the control plane in order to operate. Otherwise the
`--ignore-cluster` and `--disable-identity` flags must be specified.

This change does not actually instrument pods to use identity yet---it
lays the framework for proxy identity without changing the test fixture
output (besides a change to how identity HA is configured).

Fixes #2531