### PR TITLE
Provide peer Identities via the Destination API

### DIFF
--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -136,6 +136,9 @@ spec:
           containerPort: 8086
         - name: admin-http
           containerPort: 9996
+        volumeMounts:
+        - name: config
+          mountPath: /var/run/linkerd/config
         image: {{.Values.ControllerImage}}
         imagePullPolicy: {{.Values.ImagePullPolicy}}
         args:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -416,6 +416,9 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=linkerd

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -428,6 +428,9 @@ spec:
             memory: 50Mi
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=linkerd

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -428,6 +428,9 @@ spec:
             memory: 50Mi
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=linkerd

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -392,6 +392,9 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=linkerd

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -394,6 +394,9 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=linkerd

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -384,6 +384,9 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/config
+          name: config
       - args:
         - tap
         - -controller-namespace=Namespace

--- a/controller/api/destination/endpoint_listener_test.go
+++ b/controller/api/destination/endpoint_listener_test.go
@@ -70,8 +70,7 @@ func TestEndpointListener(t *testing.T) {
 		listener := newEndpointListener(
 			mockGetServer,
 			defaultOwnerKindAndName,
-			false,
-			"linkerd",
+			false, "linkerd", "",
 		)
 
 		listener.Update(add, remove)
@@ -88,8 +87,7 @@ func TestEndpointListener(t *testing.T) {
 		listener := newEndpointListener(
 			mockGetServer,
 			defaultOwnerKindAndName,
-			false,
-			"linkerd",
+			false, "linkerd", "",
 		)
 
 		listener.Update(add, remove)
@@ -129,8 +127,7 @@ func TestEndpointListener(t *testing.T) {
 		listener := newEndpointListener(
 			mockGetServer,
 			defaultOwnerKindAndName,
-			false,
-			"linkerd",
+			false, "linkerd", "",
 		)
 
 		completed := make(chan bool)
@@ -153,6 +150,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedPodName := pod1.Name
 		expectedNamespace := thisNS
 		expectedReplicationControllerName := "rc-name"
+		expectedServiceAccountName := "serviceaccount-name"
 
 		podForAddedAddress1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -161,6 +159,9 @@ func TestEndpointListener(t *testing.T) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: expectedServiceAccountName,
 			},
 		}
 
@@ -172,8 +173,7 @@ func TestEndpointListener(t *testing.T) {
 		listener := newEndpointListener(
 			mockGetServer,
 			ownerKindAndName,
-			false,
-			"linkerd",
+			false, "linkerd", "",
 		)
 		listener.labels = map[string]string{
 			"service":   expectedServiceName,
@@ -195,6 +195,7 @@ func TestEndpointListener(t *testing.T) {
 		expectedAddedAddress1MetricLabels := map[string]string{
 			"pod":                   expectedPodName,
 			"replicationcontroller": expectedReplicationControllerName,
+			"serviceaccount":        expectedServiceAccountName,
 		}
 		if !reflect.DeepEqual(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels) {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)
@@ -202,19 +203,20 @@ func TestEndpointListener(t *testing.T) {
 	})
 
 	t.Run("Sends TlsIdentity when enabled", func(t *testing.T) {
-		t.Skip("TLS is currently disabled")
 		expectedPodName := pod1.Name
 		expectedPodNamespace := thisNS
 		expectedControllerNamespace := "linkerd-namespace"
 		expectedPodDeployment := podDeployment
-		//expectedTLSIdentity := nil
+		expectedTLSIdentity := &pb.TlsIdentity_DnsLikeIdentity{
+			Name: "this-serviceaccount.this-namespace.serviceaccount.identity.linkerd-namespace.trust.domain",
+		}
 
 		podForAddedAddress1 := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
 				Annotations: map[string]string{
-					pkgK8s.IdentityModeAnnotation: "FIXME",
+					pkgK8s.IdentityModeAnnotation: pkgK8s.IdentityModeDefault,
 				},
 				Labels: map[string]string{
 					pkgK8s.ControllerNSLabel:    expectedControllerNamespace,
@@ -223,6 +225,9 @@ func TestEndpointListener(t *testing.T) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "this-serviceaccount",
 			},
 		}
 
@@ -236,6 +241,7 @@ func TestEndpointListener(t *testing.T) {
 			ownerKindAndName,
 			false,
 			expectedControllerNamespace,
+			"trust.domain",
 		)
 
 		add := []*updateAddress{
@@ -248,14 +254,13 @@ func TestEndpointListener(t *testing.T) {
 			t.Fatalf("Expected [1] address returned, got %v", addrs)
 		}
 
-		// actualTLSIdentity := addrs[0].GetTlsIdentity().GetK8SPodIdentity()
-		// if !reflect.DeepEqual(actualTLSIdentity, expectedTLSIdentity) {
-		// 	t.Fatalf("Expected TlsIdentity to be [%v] but was [%v]", expectedTLSIdentity, actualTLSIdentity)
-		// }
+		actualTLSIdentity := addrs[0].GetTlsIdentity().GetDnsLikeIdentity()
+		if !reflect.DeepEqual(actualTLSIdentity, expectedTLSIdentity) {
+			t.Fatalf("Expected TlsIdentity to be [%v] but was [%v]", expectedTLSIdentity, actualTLSIdentity)
+		}
 	})
 
 	t.Run("Does not send TlsIdentity for other meshes", func(t *testing.T) {
-		t.Skip("TLS is currently disabled")
 		expectedPodName := "pod1"
 		expectedPodNamespace := thisNS
 		expectedControllerNamespace := "other-linkerd-namespace"
@@ -266,7 +271,7 @@ func TestEndpointListener(t *testing.T) {
 				Name:      expectedPodName,
 				Namespace: expectedPodNamespace,
 				Annotations: map[string]string{
-					pkgK8s.IdentityModeAnnotation: "FIXME",
+					pkgK8s.IdentityModeAnnotation: pkgK8s.IdentityModeDefault,
 				},
 				Labels: map[string]string{
 					pkgK8s.ControllerNSLabel:    expectedControllerNamespace,
@@ -288,6 +293,7 @@ func TestEndpointListener(t *testing.T) {
 			ownerKindAndName,
 			false,
 			"linkerd-namespace",
+			"trust.domain",
 		)
 
 		add := []*updateAddress{
@@ -334,7 +340,8 @@ func TestEndpointListener(t *testing.T) {
 			mockGetServer,
 			ownerKindAndName,
 			false,
-			"linkerd",
+			expectedControllerNamespace,
+			"",
 		)
 
 		add := []*updateAddress{

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -157,7 +157,7 @@ func TestEndpoints(t *testing.T) {
 
 	lis := bufconn.Listen(1024 * 1024)
 	gRPCServer, err := NewServer(
-		"fake-addr", "", "controller-ns",
+		"fake-addr", "", "controller-ns", "",
 		false, k8sAPI, nil,
 	)
 	if err != nil {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -213,12 +213,29 @@ func CreatedByAnnotationValue() string {
 	return fmt.Sprintf("linkerd/cli %s", version.Version)
 }
 
+// GetServiceAccountAndNS returns the pod's serviceaccount and namespace.
+func GetServiceAccountAndNS(pod *corev1.Pod) (sa string, ns string) {
+	sa = pod.Spec.ServiceAccountName
+	if sa == "" {
+		sa = "default"
+	}
+
+	ns = pod.GetNamespace()
+	if ns == "" {
+		ns = "default"
+	}
+
+	return
+}
+
 // GetPodLabels returns the set of prometheus owner labels for a given pod
 func GetPodLabels(ownerKind, ownerName string, pod *corev1.Pod) map[string]string {
 	labels := map[string]string{"pod": pod.Name}
 
 	l5dLabel := KindToL5DLabel(ownerKind)
 	labels[l5dLabel] = ownerName
+
+	labels["serviceaccount"], _ = GetServiceAccountAndNS(pod)
 
 	if controllerNS := pod.Labels[ControllerNSLabel]; controllerNS != "" {
 		labels["control_plane_ns"] = controllerNS

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -13,11 +13,15 @@ func TestGetPodLabels(t *testing.T) {
 	t.Run("Maps proxy labels to prometheus labels", func(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-pod",
+				Name:      "test-pod",
+				Namespace: "test-ns",
 				Labels: map[string]string{
 					ControllerNSLabel:                      "linkerd-namespace",
 					appsv1.DefaultDeploymentUniqueLabelKey: "test-pth",
 				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-sa",
 			},
 		}
 
@@ -29,6 +33,7 @@ func TestGetPodLabels(t *testing.T) {
 			"deployment":        "test-deployment",
 			"pod":               "test-pod",
 			"pod_template_hash": "test-pth",
+			"serviceaccount":    "test-sa",
 		}
 
 		podLabels := GetPodLabels(ownerKind, ownerName, pod)

--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -63,14 +63,14 @@ func loadVerifier(pem string) (verify x509.VerifyOptions, err error) {
 // checkEndEntityDir checks that the provided directory path exists and is
 // suitable to write key material to, returning the Key, CSR, and Crt paths.
 //
-// If the directory does not exist or if it has incorrect permissions, we assume
-// that the wrong directory was specified incorrectly, instead of trying to
+// If the directory does not exist, we assume that the wrong directory was
+// specified incorrectly, instead of trying to
 // create or repair the directory. In practice, this directory should be tmpfs
 // so that credentials are not written to disk, so we want to be extra sensitive
 // to an incorrectly specified path.
 //
 // If the key, CSR, and/or Crt paths refer to existing files, it is assumed that
-// multiple instances of this process are running, and an error is returned.
+// the proxy has been restarted and these credentials are NOT recreated.
 func checkEndEntityDir(dir string) (string, string, error) {
 	if dir == "" {
 		return "", "", errors.New("no end entity directory specified")


### PR DESCRIPTION
Provide peer Identities via the Destination API

This change reintroduces identity hinting to the destination service.
The Get endpoint includes identities for pods that are injected with an
identity-mode of "default" and have the same linkerd control plane.

A `serviceaccount` label is now also added to destinatino response
metadata so that it's accessible in prometheus and tap.