### PR TITLE
Convert CLI inject proxy options to annotations

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -341,8 +341,8 @@ func (options *injectOptions) overrideConfigs(configs *config.All, overrideAnnot
 		overrideAnnotations[k8s.ProxyLogLevelAnnotation] = options.proxyLogLevel
 	}
 
+	configs.Proxy.DisableExternalProfiles = options.disableExternalProfiles
 	if options.disableExternalProfiles {
-		configs.Proxy.DisableExternalProfiles = true
 		overrideAnnotations[k8s.ProxyDisableExternalProfilesAnnotation] = "true"
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -318,10 +318,19 @@ func (options *injectOptions) overrideConfigs(configs *config.All, overrideAnnot
 		overrideAnnotations[k8s.ProxyOutboundPortAnnotation] = parsePort(configs.Proxy.OutboundPort)
 	}
 
-	if options.dockerRegistry != "" {
-		configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
-		configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
+	if options.proxyImage != "" {
+		configs.Proxy.ProxyImage.ImageName = options.proxyImage
+		if options.dockerRegistry != "" {
+			configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
+		}
 		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
+	}
+
+	if options.initImage != "" {
+		configs.Proxy.ProxyInitImage.ImageName = options.initImage
+		if options.dockerRegistry != "" {
+			configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
+		}
 		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -297,6 +297,10 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 // the overrideAnnotations map keeps track of which configs are overridden, by
 // storing the corresponding annotations and values.
 func (options *injectOptions) overrideConfigs(configs *config.All, overrideAnnotations map[string]string) {
+	if options.linkerdVersion != "" {
+		configs.Global.Version = options.linkerdVersion
+	}
+
 	if len(options.ignoreInboundPorts) > 0 {
 		configs.Proxy.IgnoreInboundPorts = toPorts(options.ignoreInboundPorts)
 		overrideAnnotations[k8s.ProxyIgnoreInboundPortsAnnotation] = parsePorts(configs.Proxy.IgnoreInboundPorts)

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -39,8 +39,12 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 
 	output := new(bytes.Buffer)
 	report := new(bytes.Buffer)
+	transformer := &resourceTransformerInject{
+		configs:             tc.testInjectConfig,
+		overrideAnnotations: map[string]string{},
+	}
 
-	if exitCode := uninjectAndInject([]io.Reader{read}, report, output, tc.testInjectConfig); exitCode != 0 {
+	if exitCode := uninjectAndInject([]io.Reader{read}, report, output, transformer); exitCode != 0 {
 		t.Errorf("Unexpected error injecting YAML: %v\n", report)
 	}
 	diffTestdata(t, tc.goldenFileName, output.String())
@@ -211,7 +215,8 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, testConfig)
+	transformer := &resourceTransformerInject{configs: testConfig}
+	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, transformer)
 	if exitCode != tc.exitCode {
 		t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
 	}
@@ -268,8 +273,8 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	configs := testInstallConfig()
-	if exitCode := runInjectCmd(in, errBuf, actual, configs); exitCode != 0 {
+	transformer := &resourceTransformerInject{configs: testInstallConfig()}
+	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}
 	diffTestdata(t, tc.expectedFile, actual.String())
@@ -286,8 +291,8 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	configs := testInstallConfig()
-	if exitCode := runInjectCmd(in, errBuf, actual, configs); exitCode != 0 {
+	transformer := &resourceTransformerInject{configs: testInstallConfig()}
+	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}
 

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -122,6 +122,9 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 		return admissionResponse, nil
 	}
 
+	conf.AppendPodAnnotations(map[string]string{
+		k8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
+	})
 	p, reports, err := conf.GetPatch(request.Object.Raw, inject.ShouldInjectWebhook)
 	if err != nil {
 		return nil, err
@@ -130,8 +133,6 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	if p.IsEmpty() {
 		return admissionResponse, nil
 	}
-
-	p.AddPodAnnotation(k8s.CreatedByAnnotation, fmt.Sprintf("linkerd/proxy-injector %s", version.Version))
 
 	patchJSON, err := p.Marshal()
 	if err != nil {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -131,7 +131,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 		return admissionResponse, nil
 	}
 
-	p.AddCreatedByPodAnnotation(fmt.Sprintf("linkerd/proxy-injector %s", version.Version))
+	p.AddPodAnnotation(k8s.CreatedByAnnotation, fmt.Sprintf("linkerd/proxy-injector %s", version.Version))
 
 	patchJSON, err := p.Marshal()
 	if err != nil {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -123,7 +123,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	}
 
 	conf.AppendPodAnnotations(map[string]string{
-		k8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
+		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
 	})
 	p, reports, err := conf.GetPatch(request.Object.Raw, inject.ShouldInjectWebhook)
 	if err != nil {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -623,14 +623,11 @@ func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
 
 	for k, v := range conf.pod.annotations {
 		patch.addPodAnnotation(k, v)
-	}
 
-	// append any additional pod annotations to the pod's meta.
-	// for e.g., annotations that were converted from CLI inject options.
-	for annotation, value := range conf.pod.annotations {
-		conf.pod.Meta.Annotations[annotation] = value
+		// append any additional pod annotations to the pod's meta.
+		// for e.g., annotations that were converted from CLI inject options.
+		conf.pod.Meta.Annotations[k] = v
 	}
-
 }
 
 func (conf *ResourceConfig) getOverride(annotation string) string {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -566,7 +566,7 @@ func (conf *ResourceConfig) injectProxyInit(patch *Patch, saVolumeMount *v1.Volu
 		Image:                    conf.taggedProxyInitImage(),
 		ImagePullPolicy:          conf.proxyInitImagePullPolicy(),
 		TerminationMessagePolicy: v1.TerminationMessageFallbackToLogsOnError,
-		Args: conf.proxyInitArgs(),
+		Args:                     conf.proxyInitArgs(),
 		SecurityContext: &v1.SecurityContext{
 			Capabilities: &v1.Capabilities{
 				Add: []v1.Capability{v1.Capability("NET_ADMIN")},

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -820,11 +820,16 @@ func (conf *ResourceConfig) proxyLivenessProbe() *v1.Probe {
 }
 
 func (conf *ResourceConfig) proxyDestinationProfileSuffixes() string {
-	if overrides := conf.getOverride(k8s.ProxyDisableExternalProfilesAnnotation); overrides != "" {
-		disableExternalProfiles, err := strconv.ParseBool(overrides)
-		if err == nil && disableExternalProfiles {
-			return internalProfileSuffix
+	disableExternalProfiles := conf.configs.GetProxy().GetDisableExternalProfiles()
+	if override := conf.getOverride(k8s.ProxyDisableExternalProfilesAnnotation); override != "" {
+		value, err := strconv.ParseBool(override)
+		if err == nil {
+			disableExternalProfiles = value
 		}
+	}
+
+	if disableExternalProfiles {
+		return internalProfileSuffix
 	}
 
 	return defaultProfileSuffix

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -591,12 +591,12 @@ func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
 	if len(conf.pod.Meta.Annotations) == 0 {
 		patch.addPodAnnotationsRoot()
 	}
-	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, conf.configs.GetGlobal().GetVersion())
+	patch.AddPodAnnotation(k8s.ProxyVersionAnnotation, conf.configs.GetGlobal().GetVersion())
 
 	if conf.configs.GetGlobal().GetIdentityContext() != nil {
-		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDefault)
+		patch.AddPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDefault)
 	} else {
-		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDisabled)
+		patch.AddPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDisabled)
 	}
 
 	if len(conf.pod.labels) > 0 {

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -121,18 +120,14 @@ func (p *Patch) addPodAnnotationsRoot() {
 	})
 }
 
-func (p *Patch) addPodAnnotation(key, value string) {
+// AddPodAnnotation creates an 'add' JSON patch operation structure to append
+// the given annotation and value.
+func (p *Patch) AddPodAnnotation(key, value string) {
 	p.patchOps = append(p.patchOps, &patchOp{
 		Op:    "add",
 		Path:  p.patchPathPodAnnotations + "/" + escapeKey(key),
 		Value: value,
 	})
-}
-
-// AddCreatedByPodAnnotation tags the pod so that we can tell apart injections
-// from the CLI and the webhook
-func (p *Patch) AddCreatedByPodAnnotation(s string) {
-	p.addPodAnnotation(k8s.CreatedByAnnotation, s)
 }
 
 // IsEmpty returns true if the patch doesn't contain any operations

--- a/pkg/inject/patch.go
+++ b/pkg/inject/patch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -120,9 +121,7 @@ func (p *Patch) addPodAnnotationsRoot() {
 	})
 }
 
-// AddPodAnnotation creates an 'add' JSON patch operation structure to append
-// the given annotation and value.
-func (p *Patch) AddPodAnnotation(key, value string) {
+func (p *Patch) addPodAnnotation(key, value string) {
 	p.patchOps = append(p.patchOps, &patchOp{
 		Op:    "add",
 		Path:  p.patchPathPodAnnotations + "/" + escapeKey(key),

--- a/pkg/inject/patch_test.go
+++ b/pkg/inject/patch_test.go
@@ -40,7 +40,7 @@ func TestPatch(t *testing.T) {
 	actual.addVolumeRoot()
 	actual.addVolume(secrets)
 	actual.addPodLabel(k8sPkg.ControllerNSLabel, controllerNamespace)
-	actual.AddPodAnnotation(k8sPkg.CreatedByAnnotation, createdBy)
+	actual.addPodAnnotation(k8sPkg.CreatedByAnnotation, createdBy)
 
 	expected := NewPatch(k8sPkg.Deployment)
 	expected.patchOps = []*patchOp{

--- a/pkg/inject/patch_test.go
+++ b/pkg/inject/patch_test.go
@@ -40,7 +40,7 @@ func TestPatch(t *testing.T) {
 	actual.addVolumeRoot()
 	actual.addVolume(secrets)
 	actual.addPodLabel(k8sPkg.ControllerNSLabel, controllerNamespace)
-	actual.addPodAnnotation(k8sPkg.CreatedByAnnotation, createdBy)
+	actual.AddPodAnnotation(k8sPkg.CreatedByAnnotation, createdBy)
 
 	expected := NewPatch(k8sPkg.Deployment)
 	expected.patchOps = []*patchOp{


### PR DESCRIPTION
The PR introduces code to convert CLI inject proxy options into config annotations. The annotations ensure that these configs are persisted in subsequent resource updates. 

Fixes #2447 

Signed-off-by: Ivan Sim <ivan@buoyant.io>
