### PR TITLE
Promote the shared injection check to the CLI and webhook

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -119,7 +119,7 @@ func uninjectAndInject(inputs []io.Reader, errWriter, outWriter io.Writer, trans
 }
 
 func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Report, error) {
-	conf := inject.NewResourceConfig(rt.configs)
+	conf := inject.NewResourceConfig(rt.configs, inject.OriginCLI)
 	if len(rt.proxyOutboundCapacity) > 0 {
 		conf = conf.WithProxyOutboundCapacity(rt.proxyOutboundCapacity)
 	}
@@ -156,11 +156,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	if patchJSON == nil {
 		return bytes, reports, nil
 	}
-	// TODO: refactor GetPatch() for it to return just one report item
-	if len(reports) > 0 {
-		r := reports[0]
-		log.Infof("patch generated for: %s", r.ResName())
-	}
+	log.Infof("patch generated for: %s", report.ResName())
 	log.Debugf("patch: %s", patchJSON)
 	patch, err := jsonpatch.DecodePatch(patchJSON)
 	if err != nil {

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -123,13 +123,15 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	if len(rt.proxyOutboundCapacity) > 0 {
 		conf = conf.WithProxyOutboundCapacity(rt.proxyOutboundCapacity)
 	}
-	nonEmpty, err := conf.ParseMeta(bytes)
+
+	report, err := conf.ParseMetaAndYAML(bytes)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !nonEmpty {
-		r := inject.Report{UnsupportedResource: true}
-		return bytes, []inject.Report{r}, nil
+	reports := []inject.Report{*report}
+
+	if !report.Injectable() {
+		return bytes, reports, nil
 	}
 
 	conf.AppendPodAnnotations(map[string]string{
@@ -139,7 +141,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		conf.AppendPodAnnotations(rt.overrideAnnotations)
 	}
 
-	p, reports, err := conf.GetPatch(bytes, inject.ShouldInjectCLI)
+	p, err := conf.GetPatch(bytes)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -63,7 +63,7 @@ sub-folders, or coming from stdin.`,
 }
 
 func (rt resourceTransformerUninject) transform(bytes []byte) ([]byte, []inject.Report, error) {
-	conf := inject.NewResourceConfig(rt.configs)
+	conf := inject.NewResourceConfig(rt.configs, inject.OriginWebhook)
 
 	report, err := conf.ParseMetaAndYAML(bytes)
 	if err != nil {

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -65,7 +65,7 @@ sub-folders, or coming from stdin.`,
 func (rt resourceTransformerUninject) transform(bytes []byte) ([]byte, []inject.Report, error) {
 	conf := inject.NewResourceConfig(rt.configs)
 
-	report, err := conf.ParseMetaAndYaml(bytes)
+	report, err := conf.ParseMetaAndYAML(bytes)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +91,7 @@ func (resourceTransformerUninject) generateReport(reports []inject.Report, outpu
 	output.Write([]byte("\n"))
 
 	for _, r := range reports {
-		if r.Sidecar {
+		if r.Uninjected.Proxy || r.Uninjected.ProxyInit {
 			output.Write([]byte(fmt.Sprintf("%s \"%s\" uninjected\n", r.Kind, r.Name)))
 		} else {
 			if r.Kind != "" {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -105,7 +105,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	nsAnnotations := namespace.GetAnnotations()
 
 	configs := &pb.All{Global: globalConfig, Proxy: proxyConfig}
-	resourceConfig := inject.NewResourceConfig(configs).
+	resourceConfig := inject.NewResourceConfig(configs, inject.OriginWebhook).
 		WithOwnerRetriever(w.ownerRetriever(request.Namespace)).
 		WithNsAnnotations(nsAnnotations).
 		WithKind(request.Kind.Kind)
@@ -121,7 +121,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	}
 
 	if !report.Injectable() {
-		log.Infof("skipped %s ", report.ResName())
+		log.Infof("skipped %s", report.ResName())
 		return admissionResponse, nil
 	}
 

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -125,7 +125,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 		return admissionResponse, nil
 	}
 
-	conf.AppendPodAnnotations(map[string]string{
+	resourceConfig.AppendPodAnnotations(map[string]string{
 		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
 	})
 	p, err := resourceConfig.GetPatch(request.Object.Raw)

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -113,7 +113,7 @@ func (w *Webhook) inject(request *admissionv1beta1.AdmissionRequest) (*admission
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("received %s ", report.ResName())
+	log.Infof("received %s", report.ResName())
 
 	admissionResponse := &admissionv1beta1.AdmissionResponse{
 		UID:     request.UID,

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -41,12 +41,12 @@ var (
 
 func confNsEnabled() *inject.ResourceConfig {
 	return inject.
-		NewResourceConfig(configs).
+		NewResourceConfig(configs, inject.OriginWebhook).
 		WithNsAnnotations(map[string]string{pkgK8s.ProxyInjectAnnotation: pkgK8s.ProxyInjectEnabled})
 }
 
 func confNsDisabled() *inject.ResourceConfig {
-	return inject.NewResourceConfig(configs).WithNsAnnotations(map[string]string{})
+	return inject.NewResourceConfig(configs, inject.OriginWebhook).WithNsAnnotations(map[string]string{})
 }
 
 func TestGetPatch(t *testing.T) {

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -80,28 +80,10 @@ func TestGetPatch(t *testing.T) {
 				expected: true,
 			},
 			{
-				filename: "deployment-inject-disabled.yaml",
-				ns:       nsEnabled,
-				conf:     confNsEnabled(),
-				expected: false,
-			},
-			{
-				filename: "deployment-inject-empty.yaml",
-				ns:       nsDisabled,
-				conf:     confNsDisabled(),
-				expected: false,
-			},
-			{
 				filename: "deployment-inject-enabled.yaml",
 				ns:       nsDisabled,
 				conf:     confNsDisabled(),
 				expected: true,
-			},
-			{
-				filename: "deployment-inject-disabled.yaml",
-				ns:       nsDisabled,
-				conf:     confNsDisabled(),
-				expected: false,
 			},
 		}
 
@@ -115,7 +97,12 @@ func TestGetPatch(t *testing.T) {
 
 				fakeReq := getFakeReq(deployment)
 				fullConf := testCase.conf.WithKind(fakeReq.Kind.Kind)
-				p, _, err := fullConf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
+				_, err = fullConf.ParseMetaAndYAML(fakeReq.Object.Raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				p, err := fullConf.GetPatch(fakeReq.Object.Raw)
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -142,7 +129,7 @@ func TestGetPatch(t *testing.T) {
 
 		fakeReq := getFakeReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		p, _, err := conf.GetPatch(fakeReq.Object.Raw, inject.ShouldInjectWebhook)
+		p, err := conf.GetPatch(fakeReq.Object.Raw)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -61,18 +61,6 @@ const (
 
 	identityAPIPort     = 8080
 	identityDisabledMsg = "Identity is not yet available"
-
-	// OriginCLI is the value of the ResourceConfig's 'origin' field if the input
-	// YAML comes from the CLI
-	OriginCLI Origin = iota
-
-	// OriginWebhook is the value of the ResourceConfig's 'origin' field if the input
-	// YAML comes from the CLI
-	OriginWebhook
-
-	// OriginUnknown is the value of the ResourceConfig's 'origin' field if the
-	// input YAML comes from an unknown source
-	OriginUnknown
 )
 
 var injectableKinds = []string{
@@ -88,6 +76,20 @@ var injectableKinds = []string{
 // Origin defines where the input YAML comes from. Refer the ResourceConfig's
 // 'origin' field
 type Origin int
+
+const (
+	// OriginCLI is the value of the ResourceConfig's 'origin' field if the input
+	// YAML comes from the CLI
+	OriginCLI Origin = iota
+
+	// OriginWebhook is the value of the ResourceConfig's 'origin' field if the input
+	// YAML comes from the CLI
+	OriginWebhook
+
+	// OriginUnknown is the value of the ResourceConfig's 'origin' field if the
+	// input YAML comes from an unknown source
+	OriginUnknown
+)
 
 // OwnerRetrieverFunc is a function that returns a pod's owner reference
 // kind and name
@@ -167,14 +169,6 @@ func (conf *ResourceConfig) AppendPodAnnotations(annotations map[string]string) 
 	for annotation, value := range annotations {
 		conf.pod.annotations[annotation] = value
 	}
-}
-
-// CreatedByCLI returns true if the pod is annotated with linkerd.io/created-by: linkerd/cli
-func (conf *ResourceConfig) CreatedByCLI() bool {
-	if conf.pod.annotations == nil {
-		return false
-	}
-	return strings.Contains(conf.pod.annotations[k8s.CreatedByAnnotation], "")
 }
 
 // YamlMarshalObj returns the yaml for the workload in conf

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -160,14 +160,7 @@ func (conf *ResourceConfig) ParseMetaAndYAML(bytes []byte) (*Report, error) {
 		return nil, err
 	}
 
-	r := newReport(conf)
-	if conf.pod.meta != nil && conf.pod.spec != nil {
-		r.update(conf)
-	} else {
-		r.UnsupportedResource = true
-	}
-
-	return &r, nil
+	return newReport(conf), nil
 }
 
 // GetPatch returns the JSON patch containing the proxy and init containers specs, if any
@@ -446,7 +439,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
 	// We key off of any container image in the pod. Ideally we would instead key
 	// off of something at the top-level of the PodSpec, but there is nothing
 	// easily identifiable at that level.
-	// Currently this will bet set on any proxy that gets injected into a Prometheus pod,
+	// Currently this will be set on any proxy that gets injected into a Prometheus pod,
 	// not just the one in Linkerd's Control Plane.
 	for _, container := range conf.pod.spec.Containers {
 		if capacity, ok := conf.proxyOutboundCapacity[container.Image]; ok {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -350,7 +350,8 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		}
 
 	default:
-		// other resources like namespace, secret, config map etc.
+		// unmarshal the metadata of other resource kinds like namespace, secret,
+		// config map etc. to be used in the report struct
 		if err := yaml.Unmarshal(bytes, &conf.workload); err != nil {
 			return err
 		}

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -226,7 +226,7 @@ func TestConfigAccessors(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resourceConfig := NewResourceConfig(configs).WithKind("Deployment")
+			resourceConfig := NewResourceConfig(configs, OriginUnknown).WithKind("Deployment")
 			if err := resourceConfig.parse(data); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -41,8 +41,8 @@ type expectedProxyConfigs struct {
 
 func TestConfigAccessors(t *testing.T) {
 	// this test uses an annotated deployment and a proxyConfig object to verify
-	// all the proxy config accessors. The first test run ensures that the
-	// accessors picks up the pod-level config annotations. The second test run
+	// all the proxy config accessors. The first test suite ensures that the
+	// accessors picks up the pod-level config annotations. The second test suite
 	// ensures that the defaults in the config map is used.
 
 	proxyConfig := &config.Proxy{
@@ -66,7 +66,6 @@ func TestConfigAccessors(t *testing.T) {
 	}
 	globalConfig := &config.Global{LinkerdNamespace: "linkerd"}
 	configs := &config.All{Global: globalConfig, Proxy: proxyConfig}
-	resourceConfig := NewResourceConfig(configs).WithKind("Deployment")
 
 	var testCases = []struct {
 		id       string
@@ -227,7 +226,8 @@ func TestConfigAccessors(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if _, err := resourceConfig.ParseMetaAndYaml(data); err != nil {
+			resourceConfig := NewResourceConfig(configs).WithKind("Deployment")
+			if err := resourceConfig.parse(data); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -85,7 +85,7 @@ func checkUDPPorts(t *v1.PodSpec) bool {
 }
 
 func (r *Report) disableByAnnotation(conf *ResourceConfig) bool {
-	// truth table of the effects of the inject annotation:
+	// truth table of the effects of the inject annotation on the webhook:
 	//
 	// namespace | pod      | inject?  | return
 	// --------- | -------- | -------- | ------

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -35,7 +35,7 @@ type Report struct {
 // from conf
 func newReport(conf *ResourceConfig) *Report {
 	var name string
-	if m := conf.workload.meta; m != nil {
+	if m := conf.workload.Meta; m != nil {
 		name = m.Name
 	} else if m := conf.pod.meta; m != nil {
 		name = m.Name

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -85,22 +85,22 @@ func checkUDPPorts(t *v1.PodSpec) bool {
 }
 
 func (r *Report) disableByAnnotation(conf *ResourceConfig) bool {
-	// truth table of the effects of the inject annotation on the webhook:
+	// truth table of the effects of the inject annotation:
 	//
-	// namespace | pod      | inject?  | return
-	// --------- | -------- | -------- | ------
-	// enabled   | enabled  | yes      | false
-	// enabled   | ""       | yes      | false
-	// enabled   | disabled | no       | true
-	// disabled  | enabled  | yes      | false
-	// ""        | enabled  | yes      | false
-	// disabled  | disabled | no       | true
-	// ""        | disabled | no       | true
-	// disabled  | ""       | no       | true
-	// ""        | ""       | no       | true
-	//
-	// for CLI, only the 'disabled' annotation is taken into consideration
-	// for its opt-out effect
+	// origin  | namespace | pod      | inject?  | return
+	// ------- | --------- | -------- | -------- | ------
+	// webhook | enabled   | enabled  | yes      | false
+	// webhook | enabled   | ""       | yes      | false
+	// webhook | enabled   | disabled | no       | true
+	// webhook | disabled  | enabled  | yes      | false
+	// webhook | ""        | enabled  | yes      | false
+	// webhook | disabled  | disabled | no       | true
+	// webhook | ""        | disabled | no       | true
+	// webhook | disabled  | ""       | no       | true
+	// webhook | ""        | ""       | no       | true
+	// cli     | n/a       | enabled  | yes      | false
+	// cli     | n/a       | ""       | yes      | false
+	// cli     | n/a       | disabled | no       | true
 
 	podAnnotation := conf.pod.meta.Annotations[k8s.ProxyInjectAnnotation]
 	nsAnnotation := conf.nsAnnotations[k8s.ProxyInjectAnnotation]

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -15,17 +15,25 @@ func TestInjectable(t *testing.T) {
 		podMeta             *metav1.ObjectMeta
 		nsAnnotations       map[string]string
 		unsupportedResource bool
-		expected            bool
+		injectable          bool
 	}{
 		{
-			podSpec:  &corev1.PodSpec{HostNetwork: false},
-			podMeta:  &metav1.ObjectMeta{},
-			expected: true,
+			podSpec: &corev1.PodSpec{HostNetwork: false},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			injectable: true,
 		},
 		{
-			podSpec:  &corev1.PodSpec{HostNetwork: true},
-			podMeta:  &metav1.ObjectMeta{},
-			expected: false,
+			podSpec: &corev1.PodSpec{HostNetwork: true},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			injectable: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -36,8 +44,12 @@ func TestInjectable(t *testing.T) {
 					},
 				},
 			},
-			podMeta:  &metav1.ObjectMeta{},
-			expected: false,
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			injectable: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -48,80 +60,22 @@ func TestInjectable(t *testing.T) {
 					},
 				},
 			},
-			podMeta:  &metav1.ObjectMeta{},
-			expected: false,
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			injectable: false,
 		},
 		{
 			unsupportedResource: true,
 			podSpec:             &corev1.PodSpec{},
-			podMeta:             &metav1.ObjectMeta{},
-			expected:            false,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
 			podMeta: &metav1.ObjectMeta{
 				Annotations: map[string]string{
 					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
 				},
 			},
-			expected: true,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
-			podMeta: &metav1.ObjectMeta{
-				Annotations: map[string]string{
-					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
-				},
-			},
-			expected: false,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
-			podMeta: &metav1.ObjectMeta{
-				Annotations: map[string]string{
-					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
-				},
-			},
-			nsAnnotations: map[string]string{
-				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
-			},
-			expected: true,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
-			podMeta: &metav1.ObjectMeta{
-				Annotations: map[string]string{
-					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
-				},
-			},
-			nsAnnotations: map[string]string{
-				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
-			},
-			expected: false,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
-			podMeta: &metav1.ObjectMeta{
-				Annotations: map[string]string{
-					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
-				},
-			},
-			nsAnnotations: map[string]string{
-				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
-			},
-			expected: false,
-		},
-		{
-			podSpec: &corev1.PodSpec{},
-			podMeta: &metav1.ObjectMeta{
-				Annotations: map[string]string{
-					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
-				},
-			},
-			nsAnnotations: map[string]string{
-				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
-			},
-			expected: true,
+			injectable: false,
 		},
 	}
 
@@ -134,10 +88,112 @@ func TestInjectable(t *testing.T) {
 			resourceConfig.pod.meta = testCase.podMeta
 
 			report := newReport(resourceConfig)
-			report.update(resourceConfig)
 			report.UnsupportedResource = testCase.unsupportedResource
 
-			if actual := report.Injectable(); testCase.expected != actual {
+			if actual := report.Injectable(); testCase.injectable != actual {
+				t.Errorf("Expected %t. Actual %t", testCase.injectable, actual)
+			}
+		})
+	}
+}
+
+func TestDisableByAnnotation(t *testing.T) {
+	var testCases = []struct {
+		podMeta       *metav1.ObjectMeta
+		nsAnnotations map[string]string
+		expected      bool
+	}{
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			expected: false,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+			},
+			expected: false,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+			},
+			expected: false,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+			},
+			expected: false,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+			},
+			expected: true,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+			},
+			expected: true,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			nsAnnotations: map[string]string{},
+			expected:      true,
+		},
+		{
+			podMeta: &metav1.ObjectMeta{},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+			},
+			expected: true,
+		},
+		{
+			podMeta:       &metav1.ObjectMeta{},
+			nsAnnotations: map[string]string{},
+			expected:      true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("test case #%d", i), func(t *testing.T) {
+			resourceConfig := &ResourceConfig{}
+			resourceConfig.WithNsAnnotations(testCase.nsAnnotations)
+			resourceConfig.pod.meta = testCase.podMeta
+
+			report := newReport(resourceConfig)
+			if actual := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
 				t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 			}
 		})

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -129,6 +129,7 @@ func TestInjectable(t *testing.T) {
 		testCase := testCase
 		t.Run(fmt.Sprintf("test case #%d", i), func(t *testing.T) {
 			resourceConfig := &ResourceConfig{}
+			resourceConfig.WithNsAnnotations(testCase.nsAnnotations)
 			resourceConfig.pod.spec = testCase.podSpec
 			resourceConfig.pod.meta = testCase.podMeta
 

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -1,0 +1,144 @@
+package inject
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInjectable(t *testing.T) {
+	var testCases = []struct {
+		podSpec             *corev1.PodSpec
+		podMeta             *metav1.ObjectMeta
+		nsAnnotations       map[string]string
+		unsupportedResource bool
+		expected            bool
+	}{
+		{
+			podSpec:  &corev1.PodSpec{HostNetwork: false},
+			podMeta:  &metav1.ObjectMeta{},
+			expected: true,
+		},
+		{
+			podSpec:  &corev1.PodSpec{HostNetwork: true},
+			podMeta:  &metav1.ObjectMeta{},
+			expected: false,
+		},
+		{
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  k8s.ProxyContainerName,
+						Image: "gcr.io/linkerd-io/proxy:",
+					},
+				},
+			},
+			podMeta:  &metav1.ObjectMeta{},
+			expected: false,
+		},
+		{
+			podSpec: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:  k8s.InitContainerName,
+						Image: "gcr.io/linkerd-io/proxy-init:",
+					},
+				},
+			},
+			podMeta:  &metav1.ObjectMeta{},
+			expected: false,
+		},
+		{
+			unsupportedResource: true,
+			podSpec:             &corev1.PodSpec{},
+			podMeta:             &metav1.ObjectMeta{},
+			expected:            false,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			expected: true,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			expected: false,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+			},
+			expected: true,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+			},
+			expected: false,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectDisabled,
+			},
+			expected: false,
+		},
+		{
+			podSpec: &corev1.PodSpec{},
+			podMeta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+				},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+			},
+			expected: true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+		t.Run(fmt.Sprintf("test case #%d", i), func(t *testing.T) {
+			resourceConfig := &ResourceConfig{}
+			resourceConfig.pod.spec = testCase.podSpec
+			resourceConfig.pod.meta = testCase.podMeta
+
+			report := newReport(resourceConfig)
+			report.update(resourceConfig)
+			report.UnsupportedResource = testCase.unsupportedResource
+
+			if actual := report.Injectable(); testCase.expected != actual {
+				t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -21,7 +21,7 @@ func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
 		uninjectObjectMeta(conf.workload.meta)
 	}
 
-	uninjectObjectMeta(conf.pod.Meta)
+	uninjectObjectMeta(conf.pod.meta)
 	return conf.YamlMarshalObj()
 }
 
@@ -34,7 +34,7 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 		if container.Name != k8s.InitContainerName {
 			initContainers = append(initContainers, container)
 		} else {
-			report.Sidecar = true
+			report.Uninjected.ProxyInit = true
 		}
 	}
 	t.InitContainers = initContainers
@@ -43,6 +43,8 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 	for _, container := range t.Containers {
 		if container.Name != k8s.ProxyContainerName {
 			containers = append(containers, container)
+		} else {
+			report.Uninjected.Proxy = true
 		}
 	}
 	t.Containers = containers

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -17,8 +17,8 @@ func (conf *ResourceConfig) Uninject(report *Report) ([]byte, error) {
 
 	conf.uninjectPodSpec(report)
 
-	if conf.workload.meta != nil {
-		uninjectObjectMeta(conf.workload.meta)
+	if conf.workload.Meta != nil {
+		uninjectObjectMeta(conf.workload.Meta)
 	}
 
 	uninjectObjectMeta(conf.pod.meta)

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -214,7 +214,7 @@ const (
 // CreatedByAnnotationValue returns the value associated with
 // CreatedByAnnotation.
 func CreatedByAnnotationValue() string {
-	return fmt.Sprintf("linkerd/cli %s", version.Version)
+	return fmt.Sprintf("%s %s", "linkerd/cli", version.Version)
 }
 
 // GetServiceAccountAndNS returns the pod's serviceaccount and namespace.

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -214,7 +214,7 @@ const (
 // CreatedByAnnotationValue returns the value associated with
 // CreatedByAnnotation.
 func CreatedByAnnotationValue() string {
-	return fmt.Sprintf("%s %s", "linkerd/cli", version.Version)
+	return fmt.Sprintf("linkerd/cli %s", version.Version)
 }
 
 // GetServiceAccountAndNS returns the pod's serviceaccount and namespace.


### PR DESCRIPTION
This PR refactors the `shouldInject` logic by promoting it from the shared `pkg/inject` library to the CLI and webhook.

Performing this check earlier helps to separate the specialized logic to the CLI and webhook. Subsequent modification to this check to support configs override of existing meshed workloads will be confined to the relevant component.

This PR addresses point 1 to 3 of our [previous discussion on configs override in 2500](https://github.com/linkerd/linkerd2/pull/2500#issuecomment-474182920).

Signed-off-by: Ivan Sim <ivan@buoyant.io>