### PR TITLE
Cluster DNS domain check provided.

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -79,6 +79,7 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.KubernetesVersionChecks,
 		healthcheck.LinkerdVersionChecks,
+		healthcheck.ClusterDNSDomainChecks,
 	}
 
 	if options.preInstallOnly {


### PR DESCRIPTION
Fixes #1741 

Cluster DNS domain checker checks if every node in the cluster has clusterDomain set to 'cluster.local'.