### PR TITLE
install: Replace EnableHA with resource values

### DIFF
--- a/chart/templates/_resources.yaml
+++ b/chart/templates/_resources.yaml
@@ -1,0 +1,21 @@
+{{- define "resources" }}
+        resources:
+          {{- if or .CPU.Request .Memory.Request }}
+          requests:
+            {{- with .CPU.Request }}
+            cpu: {{.}}
+            {{- end }}
+            {{- with .Memory.Request }}
+            memory: {{.}}
+            {{- end }}
+          {{- end }}
+          {{- if or .CPU.Limit .Memory.Limit }}
+          limits:
+            {{- with .CPU.Limit }}
+            cpu: {{.}}
+            {{- end }}
+            {{- with .Memory.Limit }}
+            memory: {{.}}
+            {{- end }}
+          {{- end }}
+{{- end }}

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -123,7 +123,7 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
-        {{ with .PublicApiResources -}}
+        {{ with .PublicAPIResources -}}
         {{- template "resources" . }}
         {{ end -}}
         securityContext:

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -123,12 +123,9 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
-        {{- end }}
+        {{ with .PublicApiResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       - name: destination
@@ -158,12 +155,9 @@ spec:
             path: /ready
             port: 9996
           failureThreshold: 7
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
-        {{- end }}
+        {{ with .DestinationResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       - name: tap
@@ -188,12 +182,9 @@ spec:
             path: /ready
             port: 9998
           failureThreshold: 7
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
-        {{- end }}
+        {{ with .TapResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -84,11 +84,8 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
+        {{- with .GrafanaResources }}
+        {{- template "resources" . }}
         {{- end }}
         securityContext:
           runAsUser: 472

--- a/chart/templates/identity.yaml
+++ b/chart/templates/identity.yaml
@@ -115,12 +115,9 @@ spec:
             path: /ready
             port: 9990
           failureThreshold: 7
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 10m
-            memory: 50Mi
-        {{- end }}
+        {{ with .IdentityResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -105,12 +105,9 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 300m
-            memory: 300Mi
-        {{- end }}
+        {{ with .PrometheusResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: 65534
 ---

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -53,14 +53,8 @@ spec:
             port: 9995
           failureThreshold: 7
         {{ with .ProxyInjectorResources -}}
-        resources:
-          requests:
-            {{- with .CPU.Request}}cpu: {{.}}{{end}}
-            {{- with .Memory.Request}}memory: {{.}}{{end}}
-          limits:
-            {{- with .CPU.Limit}}cpu: {{.}}{{end}}
-            {{- with .Memory.Limit}}memory: {{.}}{{end}}
-        {{- end }}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -52,11 +52,14 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
-        {{- if .EnableHA }}
+        {{ with .ProxyInjectorResources -}}
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            {{- with .CPU.Request}}cpu: {{.}}{{end}}
+            {{- with .Memory.Request}}memory: {{.}}{{end}}
+          limits:
+            {{- with .CPU.Limit}}cpu: {{.}}{{end}}
+            {{- with .Memory.Limit}}memory: {{.}}{{end}}
         {{- end }}
         securityContext:
           runAsUser: {{.ControllerUID}}

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -74,12 +74,9 @@ spec:
             path: /ready
             port: 9994
           failureThreshold: 7
-        {{- if .EnableHA }}
-        resources:
-          requests:
-            cpu: 20m
-            memory: 50Mi
-        {{- end }}
+        {{ with .WebResources -}}
+        {{- template "resources" . }}
+        {{ end -}}
         securityContext:
           runAsUser: {{.ControllerUID}}
       serviceAccountName: linkerd-web

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -62,7 +62,7 @@ type (
 		IdentityResources,
 		PrometheusResources,
 		ProxyInjectorResources,
-		PublicApiResources,
+		PublicAPIResources,
 		TapResources,
 		WebResources *resources
 
@@ -365,25 +365,25 @@ func (options *installOptions) validateAndBuild() (*installValues, *pb.All, erro
 
 	if options.highAvailability {
 		defaultConstraints := &resources{
-			CPU:    constraints{Request: "20m", Limit: ""},
-			Memory: constraints{Request: "50Mi", Limit: ""},
+			CPU:    constraints{Request: "20m"},
+			Memory: constraints{Request: "50Mi"},
 		}
 		// Copy constraints to each so that further modification isn't global.
-		values.DestinationResources = defaultConstraints
-		values.GrafanaResources = defaultConstraints
-		values.ProxyInjectorResources = defaultConstraints
-		values.PublicApiResources = defaultConstraints
-		values.TapResources = defaultConstraints
-		values.WebResources = defaultConstraints
+		values.DestinationResources = &*defaultConstraints
+		values.GrafanaResources = &*defaultConstraints
+		values.ProxyInjectorResources = &*defaultConstraints
+		values.PublicAPIResources = &*defaultConstraints
+		values.TapResources = &*defaultConstraints
+		values.WebResources = &*defaultConstraints
 
 		values.IdentityResources = &resources{
-			CPU:    constraints{Request: "10m", Limit: ""},
-			Memory: constraints{Request: "10Mi", Limit: ""},
+			CPU:    constraints{Request: "10m"},
+			Memory: constraints{Request: "10Mi"},
 		}
 
 		values.PrometheusResources = &resources{
-			CPU:    constraints{Request: "300m", Limit: ""},
-			Memory: constraints{Request: "300Mi", Limit: ""},
+			CPU:    constraints{Request: "300m"},
+			Memory: constraints{Request: "300Mi"},
 		}
 	}
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -39,10 +39,10 @@ type (
 		WebImage                 string
 		PrometheusImage          string
 		GrafanaImage             string
-		ControllerReplicas       uint
 		ImagePullPolicy          string
 		UUID                     string
 		CliVersion               string
+		ControllerReplicas       uint
 		ControllerLogLevel       string
 		PrometheusLogLevel       string
 		ControllerComponentLabel string
@@ -51,15 +51,26 @@ type (
 		ProxyAutoInjectEnabled   bool
 		ProxyInjectAnnotation    string
 		ProxyInjectDisabled      string
-		EnableHA                 bool
 		ControllerUID            int64
 		EnableH2Upgrade          bool
 		NoInitContainer          bool
 		GlobalConfig             string
 		ProxyConfig              string
 
+		DestinationResources,
+		GrafanaResources,
+		IdentityResources,
+		PrometheusResources,
+		ProxyInjectorResources,
+		PublicApiResources,
+		TapResources,
+		WebResources *resources
+
 		Identity *installIdentityValues
 	}
+
+	resources   struct{ CPU, Memory constraints }
+	constraints struct{ Request, Limit string }
 
 	installIdentityValues struct {
 		Replicas uint
@@ -126,6 +137,7 @@ const (
 	webTemplateName            = "templates/web.yaml"
 	prometheusTemplateName     = "templates/prometheus.yaml"
 	grafanaTemplateName        = "templates/grafana.yaml"
+	resourcesTemplateName      = "templates/_resources.yaml"
 	serviceprofileTemplateName = "templates/serviceprofile.yaml"
 	proxyInjectorTemplateName  = "templates/proxy_injector.yaml"
 )
@@ -166,11 +178,15 @@ func newInstallOptionsWithDefaults() *installOptions {
 			disableExternalProfiles: false,
 			noInitContainer:         false,
 		},
-		identityOptions: &installIdentityOptions{
-			trustDomain:        defaultIdentityTrustDomain,
-			issuanceLifetime:   defaultIdentityIssuanceLifetime,
-			clockSkewAllowance: defaultIdentityClockSkewAllowance,
-		},
+		identityOptions: newInstallIdentityOptionsWithDefaults(),
+	}
+}
+
+func newInstallIdentityOptionsWithDefaults() *installIdentityOptions {
+	return &installIdentityOptions{
+		trustDomain:        defaultIdentityTrustDomain,
+		issuanceLifetime:   defaultIdentityIssuanceLifetime,
+		clockSkewAllowance: defaultIdentityClockSkewAllowance,
 	}
 }
 
@@ -186,10 +202,14 @@ func newCmdInstall() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return render(values, os.Stdout, configs)
+			return values.render(os.Stdout, configs)
 		},
 	}
 
+	return options.configure(cmd)
+}
+
+func (options *installOptions) configure(cmd *cobra.Command) *cobra.Command {
 	addProxyConfigFlags(cmd, options.proxyConfigOptions)
 	cmd.PersistentFlags().UintVar(
 		&options.controllerReplicas, "controller-replicas", options.controllerReplicas,
@@ -239,7 +259,6 @@ func newCmdInstall() *cobra.Command {
 		&options.identityOptions.issuanceLifetime, "identity-issuance-lifetime", options.identityOptions.issuanceLifetime,
 		"The amount of time for which the Identity issuer should certify identity",
 	)
-
 	return cmd
 }
 
@@ -331,18 +350,41 @@ func (options *installOptions) validateAndBuild() (*installValues, *pb.All, erro
 		// Controller configuration:
 		Namespace:              controlPlaneNamespace,
 		UUID:                   configs.GetGlobal().GetInstallationUuid(),
+		ControllerReplicas:     options.controllerReplicas,
 		ControllerLogLevel:     options.controllerLogLevel,
 		ControllerUID:          options.controllerUID,
-		EnableHA:               options.highAvailability,
 		EnableH2Upgrade:        !options.disableH2Upgrade,
 		NoInitContainer:        options.noInitContainer,
-		ControllerReplicas:     options.controllerReplicas,
 		ProxyAutoInjectEnabled: options.proxyAutoInject,
 		PrometheusLogLevel:     toPromLogLevel(options.controllerLogLevel),
 
 		GlobalConfig: globalConfig,
 		ProxyConfig:  proxyConfig,
 		Identity:     identityValues,
+	}
+
+	if options.highAvailability {
+		defaultConstraints := &resources{
+			CPU:    constraints{Request: "20m", Limit: ""},
+			Memory: constraints{Request: "50Mi", Limit: ""},
+		}
+		// Copy constraints to each so that further modification isn't global.
+		values.DestinationResources = defaultConstraints
+		values.GrafanaResources = defaultConstraints
+		values.ProxyInjectorResources = defaultConstraints
+		values.PublicApiResources = defaultConstraints
+		values.TapResources = defaultConstraints
+		values.WebResources = defaultConstraints
+
+		values.IdentityResources = &resources{
+			CPU:    constraints{Request: "10m", Limit: ""},
+			Memory: constraints{Request: "10Mi", Limit: ""},
+		}
+
+		values.PrometheusResources = &resources{
+			CPU:    constraints{Request: "300m", Limit: ""},
+			Memory: constraints{Request: "300Mi", Limit: ""},
+		}
 	}
 
 	return values, configs, nil
@@ -357,7 +399,7 @@ func toPromLogLevel(level string) string {
 	}
 }
 
-func render(values *installValues, w io.Writer, configs *pb.All) error {
+func (values *installValues) render(w io.Writer, configs *pb.All) error {
 	// Render raw values and create chart config
 	rawValues, err := yaml.Marshal(values)
 	if err != nil {
@@ -369,6 +411,7 @@ func render(values *installValues, w io.Writer, configs *pb.All) error {
 		{Name: chartutil.ChartfileName},
 		{Name: nsTemplateName},
 		{Name: configTemplateName},
+		{Name: resourcesTemplateName},
 		{Name: identityTemplateName},
 		{Name: controllerTemplateName},
 		{Name: serviceprofileTemplateName},

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -27,7 +27,6 @@ func TestRender(t *testing.T) {
 		WebImage:                 "WebImage",
 		PrometheusImage:          "PrometheusImage",
 		GrafanaImage:             "GrafanaImage",
-		ControllerReplicas:       1,
 		ImagePullPolicy:          "ImagePullPolicy",
 		UUID:                     "UUID",
 		CliVersion:               "CliVersion",
@@ -44,6 +43,7 @@ func TestRender(t *testing.T) {
 		NoInitContainer:          false,
 		GlobalConfig:             "GlobalConfig",
 		ProxyConfig:              "ProxyConfig",
+		ControllerReplicas:       1,
 		Identity:                 defaultValues.Identity,
 	}
 
@@ -86,8 +86,8 @@ func TestRender(t *testing.T) {
 			controlPlaneNamespace = tc.configs.GetGlobal().GetLinkerdNamespace()
 
 			var buf bytes.Buffer
-			if err := render(tc.values, &buf, tc.configs); err != nil {
-				t.Fatalf("Unexpected error: %v", err)
+			if err := tc.values.render(&buf, tc.configs); err != nil {
+				t.Fatalf("Failed to render templates: %v", err)
 			}
 			diffTestdata(t, tc.goldenFileName, buf.String())
 		})

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -133,7 +133,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -133,7 +133,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 50Mi
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/web/templates/includes/base.tmpl.html
+++ b/web/templates/includes/base.tmpl.html
@@ -9,10 +9,10 @@
     <meta name="keywords" content="Linkerd">
     <link rel="icon" type="image/png" href="{{.Contents.PathPrefix}}dist/img/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900" rel="stylesheet">
-    {{- template "script-tags" . }}
+    {{ template "script-tags" . }}
   </head>
   <body>
-    {{- template "content" .Contents }}
+    {{ template "content" .Contents }}
   </body>
 </html>
 {{ end }}

--- a/web/templates/includes/base.tmpl.html
+++ b/web/templates/includes/base.tmpl.html
@@ -9,10 +9,10 @@
     <meta name="keywords" content="Linkerd">
     <link rel="icon" type="image/png" href="{{.Contents.PathPrefix}}dist/img/favicon.png">
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900" rel="stylesheet">
-    {{ template "script-tags" . }}
+    {{- template "script-tags" . }}
   </head>
   <body>
-    {{ template "content" .Contents }}
+    {{- template "content" .Contents }}
   </body>
 </html>
 {{ end }}


### PR DESCRIPTION
This change moves resource-templating logic into a dedicated template,
creates new values types to model kubernetes resource constraints, and
changes the `--ha` flag's behavior to create these resource templates
instead of hardcoding the resource constraints in the various templates.

This is in service of https://github.com/linkerd/linkerd2/pull/2564, where
we want to be able to re-use any existing resource constraints.