### PR TITLE
Update Prometheus retention param

### DIFF
--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -90,7 +90,7 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - "--storage.tsdb.path=/data"
-        - "--storage.tsdb.retention=6h"
+        - "--storage.tsdb.retention.time=6h"
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--log.level={{.PrometheusLogLevel}}"
         readinessProbe:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -940,7 +940,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=info
         image: prom/prometheus:v2.7.1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -964,7 +964,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=info
         image: prom/prometheus:v2.7.1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -964,7 +964,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=info
         image: prom/prometheus:v2.7.1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -868,7 +868,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=info
         image: prom/prometheus:v2.7.1

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -870,7 +870,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=info
         image: prom/prometheus:v2.7.1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -837,7 +837,7 @@ spec:
       containers:
       - args:
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention=6h
+        - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=PrometheusLogLevel
         image: PrometheusImage


### PR DESCRIPTION
`storage.tsdb.retention` is deprecated in favor of
`storage.tsdb.retention.time`.

Replace all occurrences.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>