### PR TITLE
Modifying Contribution Guidelines for PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ Do you have an improvement?
 2. We will try to respond to your issue promptly.
 3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 4. Submit a pull request against this repo's `master` branch.
+    - Include instructions on how to test your changes.
+    - If you are making a change to the user interface (UI), include a
+      screenshot of the UI before and after your changes.
 5. Your branch may be merged once all configured checks pass, including:
     - The branch has passed tests in CI.
     - A review from appropriate maintainers (see [MAINTAINERS.md](MAINTAINERS.md) and [GOVERNANCE.md](GOVERNANCE.md))


### PR DESCRIPTION
This PR modifies the Linkerd2 Contribution Guidelines. It adds a request that PRs include instructions on how to test changes, and to include a screenshot if there is a UI change.