### PR TITLE
Introduce ServiceProfile integration tests

### DIFF
--- a/test/routes/routes_test.go
+++ b/test/routes/routes_test.go
@@ -1,0 +1,78 @@
+package get
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/linkerd/linkerd2/testutil"
+)
+
+//////////////////////
+///   TEST SETUP   ///
+//////////////////////
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+// TestRoutes exercises the "linkerd routes" command, validating the
+// installation and output of ServiceProfiles for both the control-plane and
+// smoke test.
+func TestRoutes(t *testing.T) {
+	// control-plane routes
+	cmd := []string{"routes", "--namespace", TestHelper.GetLinkerdNamespace(), "deploy"}
+	out, _, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		t.Fatalf("Routes command failed\n%s", out)
+	}
+
+	routeStrings := []struct {
+		s string
+		c int
+	}{
+		{"linkerd-controller-api", 9},
+		{"linkerd-destination", 3},
+		{"linkerd-grafana", 12},
+		{"linkerd-identity", 2},
+		{"linkerd-prometheus", 5},
+		{"linkerd-web", 2},
+
+		{"POST /api/v1/ListPods", 1},
+		{"POST /api/v1/", 8},
+		{"POST /io.linkerd.proxy.destination.Destination/Get", 2},
+		{"GET /api/annotations", 1},
+		{"GET /api/", 9},
+		{"GET /public/", 3},
+		{"GET /api/v1/", 3},
+	}
+
+	for _, r := range routeStrings {
+		count := strings.Count(out, r.s)
+		if count != r.c {
+			t.Fatalf("Expected %d occurrences of \"%s\", got %d\n%s", r.c, r.s, count, out)
+		}
+	}
+
+	// smoke test / bb routes
+	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
+	cmd = []string{"routes", "--namespace", prefixedNs, "deploy"}
+	golden := "routes.smoke.golden"
+
+	out, _, err = TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		t.Fatalf("Routes command failed\n%s", out)
+	}
+
+	err = TestHelper.ValidateOutput(out, golden)
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err)
+	}
+}

--- a/test/routes/testdata/routes.smoke.golden
+++ b/test/routes/testdata/routes.smoke.golden
@@ -1,0 +1,9 @@
+==> deployment/smoke-test-gateway <==
+ROUTE                      SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
+[DEFAULT]   smoke-test-gateway-svc     0.00%   0.0rps           0ms           0ms           0ms
+
+==> deployment/smoke-test-terminus <==
+ROUTE                         SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
+[DEFAULT]     smoke-test-terminus-svc     0.00%   0.0rps           0ms           0ms           0ms
+theFunction   smoke-test-terminus-svc     0.00%   0.0rps           0ms           0ms           0ms
+

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -106,9 +106,10 @@ func (h *TestHelper) GetTestNamespace(testName string) string {
 	return h.namespace + "-" + testName
 }
 
-// CombinedOutput executes a shell command and returns the output.
-func (h *TestHelper) CombinedOutput(name string, arg ...string) (string, string, error) {
+// combinedOutput executes a shell command and returns the output.
+func (h *TestHelper) combinedOutput(stdin string, name string, arg ...string) (string, string, error) {
 	command := exec.Command(name, arg...)
+	command.Stdin = strings.NewReader(stdin)
 	var stderr bytes.Buffer
 	command.Stderr = &stderr
 
@@ -119,8 +120,14 @@ func (h *TestHelper) CombinedOutput(name string, arg ...string) (string, string,
 // LinkerdRun executes a linkerd command appended with the --linkerd-namespace
 // flag.
 func (h *TestHelper) LinkerdRun(arg ...string) (string, string, error) {
+	return h.PipeToLinkerdRun("", arg...)
+}
+
+// PipeToLinkerdRun executes a linkerd command appended with the
+// --linkerd-namespace flag, and provides a string at Stdin.
+func (h *TestHelper) PipeToLinkerdRun(stdin string, arg ...string) (string, string, error) {
 	withNamespace := append(arg, "--linkerd-namespace", h.namespace)
-	return h.CombinedOutput(h.linkerd, withNamespace...)
+	return h.combinedOutput(stdin, h.linkerd, withNamespace...)
 }
 
 // LinkerdRunStream initiates a linkerd command appended with the


### PR DESCRIPTION
The existing integration tests were not validating ServiceProfile
functionality.

Introduce ServiceProfile integration tests that do the following:
- install control-plane ServiceProfiles via `linkerd install-sp`
- install smoke-test ServiceProfiles via `linkerd profile --proto`
- validate well-formed ServiceProfiles via `linkerd check`
- validate `linkerd routes` returns expected output

Fixes #2520

Signed-off-by: Andrew Seigner <siggy@buoyant.io>