### PR TITLE
Update tap integration test to account for always-on mTLS

### DIFF
--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -27,6 +27,7 @@ type tapEvent struct {
 	path       string
 	httpStatus string
 	grpcStatus string
+	tls        string
 	lineCount  int
 }
 
@@ -37,6 +38,7 @@ var (
 		path:       "/buoyantio.bb.TheService/theFunction",
 		httpStatus: "200",
 		grpcStatus: "OK",
+		tls:        "true",
 		lineCount:  3,
 	}
 
@@ -46,6 +48,7 @@ var (
 		path:       "/buoyantio.bb.TheService/theFunction",
 		httpStatus: "200",
 		grpcStatus: "Unknown",
+		tls:        "true",
 		lineCount:  3,
 	}
 
@@ -55,6 +58,7 @@ var (
 		path:       "/",
 		httpStatus: "200",
 		grpcStatus: "",
+		tls:        "true",
 		lineCount:  3,
 	}
 
@@ -64,6 +68,7 @@ var (
 		path:       "/",
 		httpStatus: "500",
 		grpcStatus: "",
+		tls:        "true",
 		lineCount:  3,
 	}
 )
@@ -191,6 +196,7 @@ func tap(target string, arg ...string) ([]*tapEvent, error) {
 			tapEventByID[fields["id"]] = obj
 		}
 		obj.lineCount++
+		obj.tls = fields["tls"]
 
 		switch fields["type"] {
 		case "req":


### PR DESCRIPTION
Out of all the integration tests (egress, get, stat, tap and
install_test) only in stat and tap do meshed (proxy-to-proxy) connections take
place, which we can test are 100% TLS.

For stat, #2537 already added such check for connections with the
Prometheus pod (connections to other pods are not meshed, apparently).

This PR adds such check for tap.

Fixes #2519