### PR TITLE
Introduce script to test multiple cloud providers

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -244,6 +244,17 @@ This script assumes you have a working Kubernetes cluster set up on each Cloud
 provider, and that Kubernetes contexts are configured via environment
 variables.
 
+For example:
+```bash
+export AKS=my-aks-cluster
+export DO=do-nyc1-my-cluster
+export EKS=arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+export GKE=gke_my-project_us-east1-b_my-cluster
+```
+
+For more information on configuring access to multiple clusters, see:
+https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#define-clusters-users-and-contexts
+
 ```bash
 bin/test-clouds `pwd`/bin/linkerd
 ```

--- a/TEST.md
+++ b/TEST.md
@@ -230,3 +230,26 @@ cd proxy-init/integration_test
 eval $(minikube docker-env)
 ./run_tests.sh
 ```
+
+# Test against multiple cloud providers
+
+The [`bin/test-clouds`](bin/test-clouds) script runs the integration tests
+against 4 cloud providers:
+- Amazon (EKS)
+- DigitalOcean (DO)
+- Google (GKE)
+- Microsoft (AKS)
+
+This script assumes you have a working Kubernetes cluster set up on each Cloud
+provider, and that Kubernetes contexts are configured via environment
+variables.
+
+```bash
+bin/test-clouds `pwd`/bin/linkerd
+```
+
+To cleanup all integration tests:
+
+```bash
+bin/test-clouds-cleanup
+```

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -3,26 +3,27 @@
 set -eu
 
 linkerd_namespace=${1:-l5d-integration}
+k8s_context=${2:-""}
 
 if [ -z "$linkerd_namespace" ]; then
-    echo "usage: $(basename "$0") <namespace>" >&2
+    echo "usage: $(basename "$0") <namespace> [k8s-context]">&2
     exit 64
 fi
 
-echo "cleaning up namespace [${linkerd_namespace}] and associated test namespaces"
+echo "cleaning up namespace [${linkerd_namespace}] in k8s-context [${k8s_context}] and associated test namespaces"
 
-if ! namespaces=$(kubectl get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
+if ! namespaces=$(kubectl --context=$k8s_context get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
   echo "no namespaces found for [$linkerd_namespace]" >&2
 fi
 
-if ! clusterrolebindings=$(kubectl get clusterrolebindings -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
   echo "no clusterrolebindings found for [$linkerd_namespace]" >&2
 fi
 
-if ! clusterroles=$(kubectl get clusterroles -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
   echo "no clusterroles found for [$linkerd_namespace]" >&2
 fi
 
 if [[ $namespaces || $clusterrolebindings || $clusterroles ]]; then
-  kubectl delete --wait=false $namespaces $clusterrolebindings $clusterroles
+  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles
 fi

--- a/bin/test-clouds
+++ b/bin/test-clouds
@@ -8,10 +8,19 @@
 # - Microsoft (AKS)
 #
 # This script assumes you have a working Kubernetes cluster set up on each Cloud
-# provider, and that Kubernetes contexts are configured via environment
-# variables.
+# provider, and that Kubernetes contexts are configured via the environment
+# variables $AKS $DO $EKS $GKE.
+#
+# For example:
+# export AKS=my-aks-cluster
+# export DO=do-nyc1-my-cluster
+# export EKS=arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+# export GKE=gke_my-project_us-east1-b_my-cluster
+#
+# For more information on configuring access to multiple clusters, see:
+# https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#define-clusters-users-and-contexts
 
-set -eu
+set -e
 
 # TODO: share this with test-run
 function check_linkerd_binary(){
@@ -32,6 +41,18 @@ function check_linkerd_binary(){
     fi
     printf "[ok]\\n"
 }
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $(basename "$0") /path/to/linkerd" >&2
+    exit 64
+fi
+
+for CLUSTER in AKS DO EKS GKE; do
+    if [ -z "${!CLUSTER}" ]; then
+        echo "\$$CLUSTER not set" >&2
+        exit 64
+    fi
+done
 
 linkerd_path=$1
 check_linkerd_binary

--- a/bin/test-clouds
+++ b/bin/test-clouds
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# Run integration tests on 4 cloud providers:
+# - Amazon (EKS)
+# - DigitalOcean (DO)
+# - Google (GKE)
+# - Microsoft (AKS)
+#
+# This script assumes you have a working Kubernetes cluster set up on each Cloud
+# provider, and that Kubernetes contexts are configured via environment
+# variables.
+
+set -eu
+
+# TODO: share this with test-run
+function check_linkerd_binary(){
+    printf "Checking the linkerd binary..."
+    if [[ "$linkerd_path" != /* ]]; then
+        printf "\\n[%s] is not an absolute path\\n" "$linkerd_path"
+        exit 1
+    fi
+    if [ ! -x "$linkerd_path" ]; then
+        printf "\\n[%s] does not exist or is not executable\\n" "$linkerd_path"
+        exit 1
+    fi
+    exit_code=0
+    "$linkerd_path" version --client > /dev/null 2>&1 || exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        printf "\\nFailed to run linkerd version command\\n"
+        exit $exit_code
+    fi
+    printf "[ok]\\n"
+}
+
+linkerd_path=$1
+check_linkerd_binary
+
+printf "\nKicking off tests for:\n- $AKS\n- $DO\n- $EKS\n- $GKE\n\n"
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+for CLUSTER in $AKS $DO $EKS $GKE; do
+    bin/test-run $linkerd_path l5d-integration-cloud $CLUSTER | while IFS= read -r line; do printf '[%s] %s\n' "$CLUSTER" "$line"; done &
+done
+
+wait
+
+# TODO propagate error code

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -11,7 +11,14 @@
 # provider, and that Kubernetes contexts are configured via environment
 # variables.
 
-set -eu
+set -e
+
+for CLUSTER in AKS DO EKS GKE; do
+  if [ -z "${!CLUSTER}" ]; then
+    echo "\$$CLUSTER not set" >&2
+    exit 64
+  fi
+done
 
 for CLUSTER in $AKS $DO $EKS $GKE
 do

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#
+# Cleans up integration tests from 4 cloud providers:
+# - Amazon (EKS)
+# - DigitalOcean (DO)
+# - Google (GKE)
+# - Microsoft (AKS)
+#
+# This script assumes you have a working Kubernetes cluster set up on each Cloud
+# provider, and that Kubernetes contexts are configured via environment
+# variables.
+
+set -eu
+
+for CLUSTER in $AKS $DO $EKS $GKE
+do
+  printf "\n$CLUSTER\n"
+  bin/test-cleanup l5d-integration-cloud $CLUSTER
+done

--- a/bin/test-run
+++ b/bin/test-run
@@ -22,7 +22,7 @@ function check_linkerd_binary(){
 function check_if_k8s_reachable(){
     printf "Checking if there is a Kubernetes cluster available..."
     exit_code=0
-    kubectl --request-timeout=5s get ns > /dev/null 2>&1 || exit_code=$?
+    kubectl --context=$k8s_context --request-timeout=5s get ns > /dev/null 2>&1 || exit_code=$?
     if [ $exit_code -ne 0 ]; then
         printf "\\nFailed to connect to Kubernetes cluster\\n"
         exit $exit_code
@@ -32,27 +32,28 @@ function check_if_k8s_reachable(){
 
 function run_test(){
     printf "Running test [%s] %s\\n" "$(basename "$1")" "$2"
-    go test -v "$1" -linkerd "$linkerd_path" -linkerd-namespace "$linkerd_namespace" -integration-tests "$2"
+    go test -v "$1" --linkerd="$linkerd_path" --linkerd-namespace="$linkerd_namespace" --k8s-context="$k8s_context" --integration-tests "$2"
 }
 
 linkerd_path=$1
 
 if [ -z "$linkerd_path" ]; then
-    echo "usage: $(basename "$0") /path/to/linkerd [namespace]" >&2
+    echo "usage: $(basename "$0") /path/to/linkerd [namespace] [k8s-context]" >&2
     exit 64
 fi
-
-check_linkerd_binary
-check_if_k8s_reachable
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 test_directory="$bindir/../test"
 linkerd_version=$($linkerd_path version --client --short)
 linkerd_namespace=${2:-l5d-integration}
+k8s_context=${3:-""}
+
+check_linkerd_binary
+check_if_k8s_reachable
 
 printf "==================RUNNING ALL TESTS==================\\n"
 
-printf "Testing Linkerd version [%s] namespace [%s]\\n" "$linkerd_version" "$linkerd_namespace"
+printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linkerd_version" "$linkerd_namespace" "$k8s_context"
 
 exit_code=0
 

--- a/testutil/doc.go
+++ b/testutil/doc.go
@@ -30,9 +30,11 @@ TestMain function. For example:
 Calling NewTestHelper adds the following command line flags:
 
 	-linkerd string
-			path to the linkerd binary to test
+		path to the linkerd binary to test
 	-linkerd-namespace string
-			the namespace where linkerd is installed (default "linkerd")
+		the namespace where linkerd is installed (default "linkerd")
+	-k8s-context string
+		the kubernetes context associated with the test cluster (default "")
 	-integration-tests
 		must be provided to run the integration tests
 

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -130,7 +130,7 @@ func (h *TestHelper) LinkerdRun(arg ...string) (string, string, error) {
 // --linkerd-namespace flag, and provides a string at Stdin.
 func (h *TestHelper) PipeToLinkerdRun(stdin string, arg ...string) (string, string, error) {
 	withParams := append(arg, "--linkerd-namespace", h.namespace, "--context="+h.k8sContext)
-	return h.combinedOutput(h.linkerd, withParams...)
+	return h.combinedOutput(stdin, h.linkerd, withParams...)
 }
 
 // LinkerdRunStream initiates a linkerd command appended with the

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -130,7 +130,7 @@ func (h *TestHelper) LinkerdRun(arg ...string) (string, string, error) {
 // --linkerd-namespace flag, and provides a string at Stdin.
 func (h *TestHelper) PipeToLinkerdRun(stdin string, arg ...string) (string, string, error) {
 	withParams := append(arg, "--linkerd-namespace", h.namespace, "--context="+h.k8sContext)
-	return h.CombinedOutput(h.linkerd, withParams...)
+	return h.combinedOutput(h.linkerd, withParams...)
 }
 
 // LinkerdRunStream initiates a linkerd command appended with the


### PR DESCRIPTION
Introduce a `bin/test-clouds` and cleanup script, to run integration
tests against 4 cloud providers.

Also modify the integration tests to accept a `--context` param to
specify the Kubernetes context to run the tests against.

Fixes #2516

Signed-off-by: Andrew Seigner <siggy@buoyant.io>