### PR TITLE
Define proxy version override annotation

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -302,7 +302,6 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 // storing the corresponding annotations and values.
 func (options *proxyConfigOptions) overrideConfigs(configs *config.All, overrideAnnotations map[string]string) {
 	if options.linkerdVersion != "" {
-		configs.Global.Version = options.linkerdVersion
 		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = options.linkerdVersion
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -303,6 +303,7 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 func (options *proxyConfigOptions) overrideConfigs(configs *config.All, overrideAnnotations map[string]string) {
 	if options.linkerdVersion != "" {
 		configs.Global.Version = options.linkerdVersion
+		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = options.linkerdVersion
 	}
 
 	if len(options.ignoreInboundPorts) > 0 {

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -65,6 +65,9 @@ func TestUninjectAndInject(t *testing.T) {
 	defaultConfig := testInstallConfig()
 	defaultConfig.Global.Version = "testinjectversion"
 
+	overrideConfig := testInstallConfig()
+	overrideConfig.Global.Version = "override"
+
 	proxyResourceConfig := testInstallConfig()
 	proxyResourceConfig.Global.Version = defaultConfig.Global.Version
 	proxyResourceConfig.Proxy.Resource = &config.ResourceRequirements{
@@ -179,7 +182,7 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment_config_overrides.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_config_overrides.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			testInjectConfig: defaultConfig,
+			testInjectConfig: overrideConfig,
 		},
 	}
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         config.linkerd.io/admin-port: "9998"
+        config.linkerd.io/linkerd-version: override
         config.linkerd.io/proxy-cpu-limit: "1"
         config.linkerd.io/proxy-cpu-request: "0.5"
         config.linkerd.io/proxy-memory-limit: 256Mi
@@ -22,7 +23,7 @@ spec:
         config.linkerd.io/skip-outbound-ports: "9999"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: testinjectversion
+        linkerd.io/proxy-version: override
       creationTimestamp: null
       labels:
         app: web-svc
@@ -102,7 +103,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:testinjectversion
+        image: gcr.io/linkerd-io/proxy:override
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -145,7 +146,7 @@ spec:
         - 7777,8888,4190,9998
         - --outbound-ports-to-ignore
         - "9999"
-        image: gcr.io/linkerd-io/proxy-init:testinjectversion
+        image: gcr.io/linkerd-io/proxy-init:override
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         config.linkerd.io/admin-port: "9998"
+        config.linkerd.io/linkerd-version: override
         config.linkerd.io/proxy-cpu-limit: "1"
         config.linkerd.io/proxy-cpu-request: "0.5"
         config.linkerd.io/proxy-memory-limit: 256Mi

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -636,11 +636,11 @@ func (conf *ResourceConfig) getOverride(annotation string) string {
 }
 
 func (conf *ResourceConfig) taggedProxyImage() string {
-	return fmt.Sprintf("%s:%s", conf.proxyImage(), conf.configs.GetGlobal().GetVersion())
+	return fmt.Sprintf("%s:%s", conf.proxyImage(), conf.proxyVersion())
 }
 
 func (conf *ResourceConfig) taggedProxyInitImage() string {
-	return fmt.Sprintf("%s:%s", conf.proxyInitImage(), conf.configs.GetGlobal().GetVersion())
+	return fmt.Sprintf("%s:%s", conf.proxyInitImage(), conf.proxyVersion())
 }
 
 func (conf *ResourceConfig) proxyImage() string {
@@ -655,6 +655,13 @@ func (conf *ResourceConfig) proxyImagePullPolicy() v1.PullPolicy {
 		return v1.PullPolicy(override)
 	}
 	return v1.PullPolicy(conf.configs.GetProxy().GetProxyImage().GetPullPolicy())
+}
+
+func (conf *ResourceConfig) proxyVersion() string {
+	if override := conf.getOverride(k8s.ProxyVersionOverrideAnnotation); override != "" {
+		return override
+	}
+	return conf.configs.GetGlobal().GetVersion()
 }
 
 func (conf *ResourceConfig) proxyControlPort() int32 {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -148,6 +148,9 @@ const (
 	// disableExternalProfilesAnnotation config.
 	ProxyEnableExternalProfilesAnnotation = ProxyConfigAnnotationsPrefix + "/enable-external-profiles"
 
+	// ProxyVersionOverrideAnnotation can be used to override the linkerd-version config.
+	ProxyVersionOverrideAnnotation = ProxyConfigAnnotationsPrefix + "/linkerd-version"
+
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.
 	IdentityModeDefault = "default"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -148,8 +148,8 @@ const (
 	// disableExternalProfilesAnnotation config.
 	ProxyEnableExternalProfilesAnnotation = ProxyConfigAnnotationsPrefix + "/enable-external-profiles"
 
-	// ProxyVersionOverrideAnnotation can be used to override the linkerd-version config.
-	ProxyVersionOverrideAnnotation = ProxyConfigAnnotationsPrefix + "/linkerd-version"
+	// ProxyVersionOverrideAnnotation can be used to override the proxy version config.
+	ProxyVersionOverrideAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-version"
 
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.


### PR DESCRIPTION
This PR adds a new `config.linkerd.io/linkerd-version` annotation to capture overridden proxy version, using `linkerd inject --linkerd-version`. 

Assumption: The `config.linkerd.io/linkerd-version` and `linkerd.io/proxy-version` use the same overridden value.

```diff
$ bin/go-run cli inject isim-tests/nginx/nginx.yaml --linkerd-version=isim-test  > inject-override.yaml
$ bin/go-run cli inject isim-tests/nginx/nginx.yaml  > inject.yaml
$ diff -u inject.yaml inject-override.yaml
--- inject.yaml 2019-03-29 10:25:43.379796632 -0700
+++ inject-override.yaml        2019-03-29 10:25:33.787871270 -0700
@@ -11,9 +11,10 @@
   template:
     metadata:
       annotations:
+        config.linkerd.io/linkerd-version: isim-test
         linkerd.io/created-by: linkerd/cli dev-45aa10dc-isim
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: git-45aa10dc
+        linkerd.io/proxy-version: isim-test
       creationTimestamp: null
       labels:
         app: nginx
@@ -85,7 +86,7 @@
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:git-45aa10dc
+        image: gcr.io/linkerd-io/proxy:isim-test
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -120,7 +121,7 @@
         - "2102"
         - --inbound-ports-to-ignore
         - 4190,4191
-        image: gcr.io/linkerd-io/proxy-init:git-45aa10dc
+        image: gcr.io/linkerd-io/proxy-init:isim-test
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
```

Fixes #2551 #2497 

Signed-off-by: Ivan Sim <ivan@buoyant.io>