### PR TITLE
proxy: Bump pinned version to f2d907b

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-2064900}"
+PROXY_VERSION="${PROXY_VERSION:-6d3ff68}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-6d3ff68}"
+PROXY_VERSION="${PROXY_VERSION:-f2d907b}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This change picks up:
* Added configuration for overriding the connection backoff
* Added configuration for overriding the HTTP/2 stream or connection window size

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>