### PR TITLE
Removing TLS columns from dashboard

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -10,7 +10,6 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _each from 'lodash/each';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
-import _isNil from 'lodash/isNil';
 import { processedMetricsPropType } from './util/MetricUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
 
@@ -73,13 +72,6 @@ const httpStatColumns = [
     isNumeric: true,
     render: d => metricToFormatter["LATENCY"](d.P99),
     sorter: d => d.P99
-  },
-  {
-    title: "TLS",
-    dataIndex: "tlsRequestPercent",
-    isNumeric: true,
-    render: d => _isNil(d.tlsRequestPercent) || d.tlsRequestPercent.get() === -1 ? "---" : d.tlsRequestPercent.prettyRate(),
-    sorter: d => d.tlsRequestPercent ? d.tlsRequestPercent.get() : -1
   },
 
 ];

--- a/web/app/js/components/MetricsTable.test.js
+++ b/web/app/js/components/MetricsTable.test.js
@@ -25,7 +25,7 @@ describe('Tests for <MetricsTable>', () => {
 
     expect(table).toBeDefined();
     expect(table.props().tableRows).toHaveLength(1);
-    expect(table.props().tableColumns).toHaveLength(10);
+    expect(table.props().tableColumns).toHaveLength(9);
   });
 
   it('if enableFilter is true, user can filter rows by search term', () => {
@@ -72,7 +72,7 @@ describe('Tests for <MetricsTable>', () => {
     const table = component.find("BaseTable");
 
     expect(table).toBeDefined();
-    expect(table.props().tableColumns).toHaveLength(9);
+    expect(table.props().tableColumns).toHaveLength(8);
   });
 
   it('omits the namespace column when showNamespaceColumn is false', () => {
@@ -86,7 +86,7 @@ describe('Tests for <MetricsTable>', () => {
     const table = component.find("BaseTable");
 
     expect(table).toBeDefined();
-    expect(table.props().tableColumns).toHaveLength(9);
+    expect(table.props().tableColumns).toHaveLength(8);
   });
 
   it('omits meshed column for an authority resource', () => {
@@ -96,6 +96,6 @@ describe('Tests for <MetricsTable>', () => {
     const table = component.find("BaseTable");
 
     expect(table).toBeDefined();
-    expect(table.props().tableColumns).toHaveLength(9);
+    expect(table.props().tableColumns).toHaveLength(8);
   });
 });

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -143,7 +143,6 @@ const requestInitSection = d => (
       {itemDisplay("Path", _get(d, "requestInit.http.requestInit.path"))}
       {itemDisplay("Scheme", _get(d, "requestInit.http.requestInit.scheme.registered"))}
       {itemDisplay("Method", _get(d, "requestInit.http.requestInit.method.registered"))}
-      {itemDisplay("TLS", _get(d, "base.tls"))}
     </List>
   </React.Fragment>
 );

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -79,14 +79,6 @@ const getSuccessRate = row => {
   }
 };
 
-const getTlsRequestPercentage = row => {
-  if (_isEmpty(row.stats)) {
-    return null;
-  }
-  let tlsRequests = parseInt(_get(row, ["stats", "tlsRequestCount"], 0), 10);
-  return new Percentage(tlsRequests, getTotalRequests(row));
-};
-
 const getLatency = row => {
   if (_isEmpty(row.stats)) {
     return {};
@@ -130,7 +122,6 @@ const processStatTable = table => {
       successRate: getSuccessRate(row),
       latency: getLatency(row),
       tcp: getTcpStats(row),
-      tlsRequestPercent: getTlsRequestPercentage(row),
       added: runningPodCount > 0 && meshedPodCount > 0,
       pods: {
         totalPods: row.runningPodCount,
@@ -154,7 +145,6 @@ export const processTopRoutesResults = rows => {
     requestRate: getRequestRate(row),
     successRate: getSuccessRate(row),
     latency: getLatency(row),
-    tlsRequestPercent: getTlsRequestPercentage(row),
   }
   ));
 };
@@ -239,7 +229,6 @@ export const emptyMetric = {
   requestRate: null,
   successRate: null,
   latency: null,
-  tlsRequestPercent: null,
   added: false,
   pods: {
     totalPods: null,
@@ -266,7 +255,6 @@ export const metricsPropType = PropTypes.shape({
             latencyMsP50: PropTypes.string,
             latencyMsP95: PropTypes.string,
             latencyMsP99: PropTypes.string,
-            tlsRequestCount: PropTypes.string,
             successCount: PropTypes.string,
           }),
           timeWindow: PropTypes.string,

--- a/web/app/js/components/util/MetricUtils.test.js
+++ b/web/app/js/components/util/MetricUtils.test.js
@@ -27,7 +27,6 @@ describe('MetricUtils', () => {
             writeRate: 73.68333333333334
           },
           totalRequests: 150,
-          tlsRequestPercent: new Percentage(100, 150),
           latency: {
             P50: 1,
             P95: 2,
@@ -39,7 +38,6 @@ describe('MetricUtils', () => {
         }
       ];
       expect(result).toHaveLength(1);
-      expect(result[0].tlsRequestPercent.prettyRate()).toEqual("66.7%");
       expect(result).toEqual(expectedResult);
     });
 

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -147,17 +147,6 @@ export const processTapEvent = jsonString => {
   d.destination.owner = extractPodOwner(d.destinationMeta.labels);
   d.destination.namespace = _get(d, "destinationMeta.labels.namespace", null);
 
-  switch (d.proxyDirection) {
-    case "INBOUND":
-      d.tls = _get(d, "sourceMeta.labels.tls", "");
-      break;
-    case "OUTBOUND":
-      d.tls = _get(d, "destinationMeta.labels.tls", "");
-      break;
-    default:
-      // too old for TLS
-  }
-
   if (_isNil(d.http)) {
     this.setState({ error: "Undefined request type"});
   } else {

--- a/web/app/test/fixtures/deployRollup.json
+++ b/web/app/test/fixtures/deployRollup.json
@@ -16,8 +16,7 @@
                 "latencyMsP50": "1",
                 "latencyMsP95": "2",
                 "latencyMsP99": "7",
-                "successCount": "135",
-                "tlsRequestCount": "100"
+                "successCount": "135"
               },
               "tcpStats": {
                 "openConnections": "221",

--- a/web/app/test/fixtures/emojivotoPods.json
+++ b/web/app/test/fixtures/emojivotoPods.json
@@ -20,8 +20,7 @@
                   "failureCount": "0",
                   "latencyMsP50": "1",
                   "latencyMsP95": "1",
-                  "latencyMsP99": "2",
-                  "tlsRequestCount": "0"
+                  "latencyMsP99": "2"
                 },
                 "errorsByPod": {}
               }
@@ -63,8 +62,7 @@
                   "failureCount": "12",
                   "latencyMsP50": "1",
                   "latencyMsP95": "9",
-                  "latencyMsP99": "10",
-                  "tlsRequestCount": "0"
+                  "latencyMsP99": "10"
                 },
                 "errorsByPod": {}
               }
@@ -95,8 +93,7 @@
                   "failureCount": "12",
                   "latencyMsP50": "2",
                   "latencyMsP95": "3",
-                  "latencyMsP99": "4",
-                  "tlsRequestCount": "0"
+                  "latencyMsP99": "4"
                 },
                 "errorsByPod": {}
               }


### PR DESCRIPTION
This PR closes #2608. It removes the `TLS` columns from the dashboard tables and updates the associated tests.