### PR TITLE
Introduce inject integration tests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -231,7 +231,6 @@ go test ./cli/cmd/... --update
 
 ##### Pretty-printed diffs for templated text
 
-
 When running `go test`, mismatched text is usually displayed as a compact
 diff. If you prefer to see the full text of the mismatch with colorized
 output, you can set the `LINKERD_TEST_PRETTY_DIFF` environment variable or

--- a/cli/cmd/logs_test.go
+++ b/cli/cmd/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/wercker/stern/stern"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -71,7 +72,7 @@ func TestNewSternConfig(t *testing.T) {
 	for _, tt := range flagTestCases {
 		tt := tt // pin
 		components := []string{"grafana", "prometheus", "web", "controller"}
-		containers := []string{"tap", "linkerd-proxy", "destination"}
+		containers := []string{"tap", k8s.ProxyContainerName, "destination"}
 
 		flags := &logsOptions{controlPlaneComponent: tt.testComponent, container: tt.testContainer}
 		config, err := flags.toSternConfig(components, containers)

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// readTesdtata reads a file and returns the contents of that file as a string.
+// readTestdata reads a file and returns the contents of that file as a string.
 func readTestdata(t *testing.T, fileName string) string {
 	file, err := os.Open(filepath.Join("testdata", fileName))
 	if err != nil {
@@ -49,6 +49,7 @@ func writeTestdata(t *testing.T, fileName string, data []byte) {
 	}
 }
 
+// TODO: share this with integration tests
 func diffTestdata(t *testing.T, path, actual string) {
 	expected := readTestdata(t, path)
 	if actual == expected {

--- a/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
@@ -9,12 +9,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-two-replicas-c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-two-replicas-c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090
@@ -36,12 +36,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-one-replica-c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-one-replica-c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -24,7 +24,7 @@ spec:
         - "9090"
         - --response-text
         - c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         name: http-to-grpc-two-replicas-c1
         ports:
         - containerPort: 9090
@@ -35,7 +35,7 @@ spec:
         - "8080"
         - --response-text
         - c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         name: http-to-grpc-two-replicas-c2
         ports:
         - containerPort: 9090
@@ -176,7 +176,7 @@ spec:
         - "9090"
         - --response-text
         - c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         name: http-to-grpc-one-replica-c1
         ports:
         - containerPort: 9090
@@ -187,7 +187,7 @@ spec:
         - "8080"
         - --response-text
         - c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         name: http-to-grpc-one-replica-c2
         ports:
         - containerPort: 9090

--- a/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
@@ -11,12 +11,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-two-replicas-c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-two-replicas-c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090
@@ -33,12 +33,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-one-replica-c1
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-one-replica-c2
-        image: buoyantio/bb:v1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090

--- a/test/egress/testdata/proxy.yaml
+++ b/test/egress/testdata/proxy.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: http-egress-https-post
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
           - "http-egress"
           - "--h1-server-port"
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: http-egress-http-post
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
           - "http-egress"
           - "--h1-server-port"
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: http-egress-https-get
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
           - "http-egress"
           - "--h1-server-port"
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: http-egress-http-get
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
           - "http-egress"
           - "--h1-server-port"
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
       - name: egress-test-not-www-get
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
           - "http-egress"
           - "--h1-server-port"

--- a/test/get/testdata/not_to_be_injected_application.yaml
+++ b/test/get/testdata/not_to_be_injected_application.yaml
@@ -15,12 +15,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-2
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90

--- a/test/get/testdata/to_be_injected_application.yaml
+++ b/test/get/testdata/to_be_injected_application.yaml
@@ -15,12 +15,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-2
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -1,4 +1,4 @@
-package get
+package inject
 
 import (
 	"fmt"
@@ -85,6 +85,8 @@ func TestInjectParams(t *testing.T) {
 	}
 }
 
+// TestAnnotationPermutations assumes a control-plane installed with
+// `--proxy-auto-inject` was installed via `install_test.go`.
 func TestAnnotationPermutations(t *testing.T) {
 	injectYAML, err := testutil.ReadFile("testdata/inject_test.yaml")
 	if err != nil {

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -1,0 +1,282 @@
+package get
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/testutil"
+	"sigs.k8s.io/yaml"
+)
+
+//////////////////////
+///   TEST SETUP   ///
+//////////////////////
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+func TestInject(t *testing.T) {
+	cmd := []string{"inject",
+		"--linkerd-namespace=fake-ns",
+		"--disable-identity",
+		"--ignore-cluster",
+		"--linkerd-version=linkerd-version",
+		"--proxy-image=proxy-image",
+		"--init-image=init-image",
+		"testdata/inject_test.yaml",
+	}
+	out, stderr, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v: %s", stderr, err)
+	}
+
+	err = validateInject(out, "injected_default.golden")
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err.Error())
+	}
+}
+
+func TestInjectParams(t *testing.T) {
+	// TODO: test config.linkerd.io/linkerd-version
+	cmd := []string{"inject",
+		"--linkerd-namespace=fake-ns",
+		"--disable-identity",
+		"--ignore-cluster",
+		"--linkerd-version=linkerd-version",
+		"--proxy-image=proxy-image",
+		"--init-image=init-image",
+		"--image-pull-policy=Never",
+		"--control-port=123",
+		"--skip-inbound-ports=234,345",
+		"--skip-outbound-ports=456,567",
+		"--inbound-port=678",
+		"--admin-port=789",
+		"--outbound-port=890",
+		"--proxy-cpu-request=10m",
+		"--proxy-memory-request=10Mi",
+		"--proxy-cpu-limit=20m",
+		"--proxy-memory-limit=20Mi",
+		"--proxy-uid=1337",
+		"--proxy-log-level=warn",
+		"--enable-external-profiles",
+		"testdata/inject_test.yaml",
+	}
+
+	out, stderr, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v: %s", stderr, err)
+	}
+
+	err = validateInject(out, "injected_params.golden")
+	if err != nil {
+		t.Fatalf("Received unexpected output\n%s", err.Error())
+	}
+}
+
+func TestAnnotationPermutations(t *testing.T) {
+	injectYAML, err := testutil.ReadFile("testdata/inject_test.yaml")
+	if err != nil {
+		t.Fatalf("failed to read inject test file: %s", err)
+	}
+
+	injectNS := "inject-test"
+	deployName := "inject-test-terminus"
+
+	injectAnnotations := []string{"", k8s.ProxyInjectDisabled, k8s.ProxyInjectEnabled}
+
+	// deploy
+	for _, nsAnnotation := range injectAnnotations {
+		nsPrefix := injectNS
+		nsAnnotations := map[string]string{}
+		if nsAnnotation != "" {
+			nsAnnotations[k8s.ProxyInjectAnnotation] = nsAnnotation
+			nsPrefix = fmt.Sprintf("%s-%s", nsPrefix, nsAnnotation)
+		}
+		ns := TestHelper.GetTestNamespace(nsPrefix)
+
+		err = TestHelper.CreateNamespaceIfNotExists(ns, nsAnnotations)
+		if err != nil {
+			t.Fatalf("failed to create %s namespace with annotation %s: %s", ns, nsAnnotation, err)
+		}
+
+		for _, podAnnotation := range injectAnnotations {
+			// patch injectYAML with unique name and pod annotations
+			name := deployName
+			podAnnotations := map[string]string{}
+			if podAnnotation != "" {
+				podAnnotations[k8s.ProxyInjectAnnotation] = podAnnotation
+				name = fmt.Sprintf("%s-%s", name, podAnnotation)
+			}
+
+			patchedYAML, err := patchDeploy(injectYAML, name, podAnnotations)
+			if err != nil {
+				t.Fatalf("failed to patch inject test YAML in namespace %s for deploy/%s: %s", ns, name, err)
+			}
+
+			o, err := TestHelper.Kubectl(patchedYAML, "--namespace", ns, "create", "-f", "-")
+			if err != nil {
+				t.Fatalf("failed to create deploy/%s in namespace %s for  %s: %s", name, ns, err, o)
+			}
+		}
+	}
+
+	containerName := "bb-terminus"
+
+	// check for successful deploy
+	for _, nsAnnotation := range injectAnnotations {
+		nsPrefix := injectNS
+		if nsAnnotation != "" {
+			nsPrefix = fmt.Sprintf("%s-%s", nsPrefix, nsAnnotation)
+		}
+		ns := TestHelper.GetTestNamespace(nsPrefix)
+
+		for _, podAnnotation := range injectAnnotations {
+			name := deployName
+			if podAnnotation != "" {
+				name = fmt.Sprintf("%s-%s", name, podAnnotation)
+			}
+
+			o, err := TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=available", "--timeout=30s", "deploy/"+name)
+			if err != nil {
+				t.Fatalf("failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", name, ns, err, o)
+			}
+
+			pods, err := TestHelper.GetPodsForDeployment(ns, name)
+			if err != nil {
+				t.Fatalf("failed to get pods for namespace %s: %s", ns, err)
+			}
+
+			if len(pods) != 1 {
+				t.Fatalf("expected 1 pod for namespace %s, got %d", ns, len(pods))
+			}
+
+			shouldBeInjected := false
+			switch nsAnnotation {
+			case "", k8s.ProxyInjectDisabled:
+				switch podAnnotation {
+				case k8s.ProxyInjectEnabled:
+					shouldBeInjected = true
+				}
+			case k8s.ProxyInjectEnabled:
+				switch podAnnotation {
+				case "", k8s.ProxyInjectEnabled:
+					shouldBeInjected = true
+				}
+			}
+
+			containers := pods[0].Spec.Containers
+			initContainers := pods[0].Spec.InitContainers
+
+			if shouldBeInjected {
+				if len(containers) != 2 {
+					t.Fatalf("expected 2 containers for pod %s/%s, got %d", ns, pods[0].GetName(), len(containers))
+				}
+				if containers[0].Name != containerName && containers[1].Name != containerName {
+					t.Fatalf("expected bb-terminus container in pod %s/%s, got %+v", ns, pods[0].GetName(), containers[0])
+				}
+				if containers[0].Name != k8s.ProxyContainerName && containers[1].Name != k8s.ProxyContainerName {
+					t.Fatalf("expected %s container in pod %s/%s, got %+v", ns, pods[0].GetName(), k8s.ProxyContainerName, containers[0])
+				}
+				if len(initContainers) != 1 {
+					t.Fatalf("expected 1 init container for pod %s/%s, got %d", ns, pods[0].GetName(), len(initContainers))
+				}
+				if initContainers[0].Name != k8s.InitContainerName {
+					t.Fatalf("expected %s init container in pod %s/%s, got %+v", ns, pods[0].GetName(), k8s.InitContainerName, initContainers[0])
+				}
+			} else {
+				if len(containers) != 1 {
+					t.Fatalf("expected 1 container for pod %s/%s, got %d", ns, pods[0].GetName(), len(containers))
+				}
+				if containers[0].Name != containerName {
+					t.Fatalf("expected bb-terminus container in pod %s/%s, got %s", ns, pods[0].GetName(), containers[0].Name)
+				}
+				if len(initContainers) != 0 {
+					t.Fatalf("expected 0 init containers for pod %s/%s, got %d", ns, pods[0].GetName(), len(initContainers))
+				}
+			}
+		}
+	}
+}
+
+func applyPatch(in string, patchJSON []byte) (string, error) {
+	patch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return "", err
+	}
+	json, err := yaml.YAMLToJSON([]byte(in))
+	if err != nil {
+		return "", err
+	}
+	patched, err := patch.Apply(json)
+	if err != nil {
+		return "", err
+	}
+	return string(patched), nil
+}
+
+func patchDeploy(in string, name string, annotations map[string]string) (string, error) {
+	ops := []string{
+		fmt.Sprintf(`{"op": "replace", "path": "/metadata/name", "value": "%s"}`, name),
+		fmt.Sprintf(`{"op": "replace", "path": "/spec/selector/matchLabels/app", "value": "%s"}`, name),
+		fmt.Sprintf(`{"op": "replace", "path": "/spec/template/metadata/labels/app", "value": "%s"}`, name),
+	}
+
+	if len(annotations) > 0 {
+		ops = append(ops, `{"op": "add", "path": "/spec/template/metadata/annotations", "value": {}}`)
+		for k, v := range annotations {
+			ops = append(ops,
+				fmt.Sprintf(`{"op": "add", "path": "/spec/template/metadata/annotations/%s", "value": "%s"}`, strings.Replace(k, "/", "~1", -1), v),
+			)
+		}
+	}
+
+	patchJSON := []byte(fmt.Sprintf("[%s]", strings.Join(ops, ",")))
+
+	return applyPatch(in, patchJSON)
+}
+
+func removeBuildAnnotations(in string) (string, error) {
+	patchJSON := []byte(`[
+		{"op": "remove", "path": "/spec/template/metadata/annotations/linkerd.io~1created-by"},
+		{"op": "remove", "path": "/spec/template/metadata/annotations/linkerd.io~1proxy-version"}
+	]`)
+
+	return applyPatch(in, patchJSON)
+}
+
+// validateInject is similar to `TestHelper.ValidateOutput`, but it removes the
+// `linkerd.io/created-by` annotation, as that varies from build to build.
+func validateInject(actual, fixtureFile string) error {
+	actualPatched, err := removeBuildAnnotations(actual)
+	if err != nil {
+		return err
+	}
+
+	fixture, err := testutil.ReadFile("testdata/" + fixtureFile)
+	if err != nil {
+		return err
+	}
+	fixturePatched, err := removeBuildAnnotations(fixture)
+	if err != nil {
+		return err
+	}
+
+	if actualPatched != fixturePatched {
+		return fmt.Errorf(
+			"Expected:\n%s\nActual:\n%s", fixturePatched, actualPatched)
+	}
+
+	return nil
+}

--- a/test/inject/testdata/inject_test.yaml
+++ b/test/inject/testdata/inject_test.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: inject-test-terminus
+spec:
+  selector:
+    matchLabels:
+      app: inject-test-terminus
+  template:
+    metadata:
+      labels:
+        app: inject-test-terminus
+    spec:
+      containers:
+      - name: bb-terminus
+        image: buoyantio/bb:v0.0.5
+        args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
+        ports:
+        - containerPort: 9090

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -1,0 +1,110 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: inject-test-terminus
+spec:
+  selector:
+    matchLabels:
+      app: inject-test-terminus
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/init-image: init-image
+        config.linkerd.io/proxy-image: proxy-image
+        config.linkerd.io/proxy-version: linkerd-version
+        linkerd.io/created-by: fake # this gets removed during testing
+        linkerd.io/identity-mode: disabled
+        linkerd.io/proxy-version: fake # this gets removed during testing
+      creationTimestamp: null
+      labels:
+        app: inject-test-terminus
+        linkerd.io/control-plane-ns: fake-ns
+        linkerd.io/proxy-deployment: inject-test-terminus
+    spec:
+      containers:
+      - args:
+        - terminus
+        - --grpc-server-port
+        - "9090"
+        - --response-text
+        - BANANA
+        image: buoyantio/bb:v0.0.5
+        name: bb-terminus
+        ports:
+        - containerPort: 9090
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-destination.fake-ns.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DISABLED
+          value: Identity is not yet available
+        image: proxy-image:linkerd-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: init-image:linkerd-version
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -1,0 +1,132 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: inject-test-terminus
+spec:
+  selector:
+    matchLabels:
+      app: inject-test-terminus
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/admin-port: "789"
+        config.linkerd.io/control-port: "123"
+        config.linkerd.io/enable-external-profiles: "true"
+        config.linkerd.io/image-pull-policy: Never
+        config.linkerd.io/inbound-port: "678"
+        config.linkerd.io/init-image: init-image
+        config.linkerd.io/outbound-port: "890"
+        config.linkerd.io/proxy-cpu-limit: 20m
+        config.linkerd.io/proxy-cpu-request: 10m
+        config.linkerd.io/proxy-image: proxy-image
+        config.linkerd.io/proxy-log-level: warn
+        config.linkerd.io/proxy-memory-limit: 20Mi
+        config.linkerd.io/proxy-memory-request: 10Mi
+        config.linkerd.io/proxy-uid: "1337"
+        config.linkerd.io/proxy-version: linkerd-version
+        config.linkerd.io/skip-inbound-ports: 234,345
+        config.linkerd.io/skip-outbound-ports: 456,567
+        linkerd.io/created-by: fake # this gets removed during testing
+        linkerd.io/identity-mode: disabled
+        linkerd.io/proxy-version: fake # this gets removed during testing
+      creationTimestamp: null
+      labels:
+        app: inject-test-terminus
+        linkerd.io/control-plane-ns: fake-ns
+        linkerd.io/proxy-deployment: inject-test-terminus
+    spec:
+      containers:
+      - args:
+        - terminus
+        - --grpc-server-port
+        - "9090"
+        - --response-text
+        - BANANA
+        image: buoyantio/bb:v0.0.5
+        name: bb-terminus
+        ports:
+        - containerPort: 9090
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-destination.fake-ns.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:123
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:789
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:890
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:678
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: .
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DISABLED
+          value: Identity is not yet available
+        image: proxy-image:linkerd-version
+        imagePullPolicy: Never
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 789
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 678
+          name: linkerd-proxy
+        - containerPort: 789
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 789
+          initialDelaySeconds: 2
+        resources:
+          limits:
+            cpu: 20m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          runAsUser: 1337
+        terminationMessagePolicy: FallbackToLogsOnError
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "678"
+        - --outgoing-proxy-port
+        - "890"
+        - --proxy-uid
+        - "1337"
+        - --inbound-ports-to-ignore
+        - 234,345,123,789
+        - --outbound-ports-to-ignore
+        - 456,567
+        image: init-image:linkerd-version
+        imagePullPolicy: Never
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+status: {}
+---

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -45,7 +45,7 @@ type rowStat struct {
 // requesting, and the test will pass.
 func TestCliStatForLinkerdNamespace(t *testing.T) {
 
-	pods, err := TestHelper.GetPodsForDeployment(TestHelper.GetLinkerdNamespace(), "linkerd-prometheus")
+	pods, err := TestHelper.GetPodNamesForDeployment(TestHelper.GetLinkerdNamespace(), "linkerd-prometheus")
 	if err != nil {
 		t.Fatalf("Failed to get pods for prometheus: %s", err)
 	}
@@ -54,7 +54,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	}
 	prometheusPod := pods[0]
 
-	pods, err = TestHelper.GetPodsForDeployment(TestHelper.GetLinkerdNamespace(), "linkerd-controller")
+	pods, err = TestHelper.GetPodNamesForDeployment(TestHelper.GetLinkerdNamespace(), "linkerd-controller")
 	if err != nil {
 		t.Fatalf("Failed to get pods for controller: %s", err)
 	}

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -126,7 +126,7 @@ func TestCliTap(t *testing.T) {
 
 	t.Run("tap a pod", func(t *testing.T) {
 		deploy := "t3"
-		pods, err := TestHelper.GetPodsForDeployment(prefixedNs, deploy)
+		pods, err := TestHelper.GetPodNamesForDeployment(prefixedNs, deploy)
 		if err != nil {
 			t.Fatalf("Failed to get pods for deployment [%s]\n%s", deploy, err)
 		}

--- a/test/tap/testdata/tap_application.yaml
+++ b/test/tap/testdata/tap_application.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: t1
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: t2
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
       - name: t3
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -136,7 +136,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args:
         - broadcast-channel
         - "--h1-server-port=8080"

--- a/test/testdata/smoke_test.yaml
+++ b/test/testdata/smoke_test.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.1
+        image: buoyantio/bb:v0.0.5
         args: ["point-to-point-channel", "--grpc-downstream-server", "smoke-test-terminus-svc:9090", "--h1-server-port", "8080"]
         ports:
         - containerPort: 8080

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -128,7 +128,7 @@ func (h *TestHelper) LinkerdRun(arg ...string) (string, string, error) {
 // PipeToLinkerdRun executes a linkerd command appended with the
 // --linkerd-namespace flag, and provides a string at Stdin.
 func (h *TestHelper) PipeToLinkerdRun(stdin string, arg ...string) (string, string, error) {
-	withParams := append(arg, "--linkerd-namespace", h.namespace, "--context="+h.k8sContext)
+	withParams := append([]string{"--linkerd-namespace", h.namespace, "--context=" + h.k8sContext}, arg...)
 	return combinedOutput(stdin, h.linkerd, withParams...)
 }
 
@@ -136,7 +136,7 @@ func (h *TestHelper) PipeToLinkerdRun(stdin string, arg ...string) (string, stri
 // --linkerd-namespace flag, and returns a Stream that can be used to read the
 // command's output while it is still executing.
 func (h *TestHelper) LinkerdRunStream(arg ...string) (*Stream, error) {
-	withParams := append(arg, "--linkerd-namespace", h.namespace, "--context="+h.k8sContext)
+	withParams := append([]string{"--linkerd-namespace", h.namespace, "--context=" + h.k8sContext}, arg...)
 	cmd := exec.Command(h.linkerd, withParams...)
 
 	cmdReader, err := cmd.StdoutPipe()


### PR DESCRIPTION
This change introduces integration tests for `linkerd inject`. The tests
perform CLI injection, with and without params, and validates the
output, including annotations.

Also add some known errors in logs to `install_test.go`.

TODO:
- deploy uninjected and injected resources to a default and
  auto-injected cluster
- test creation and update

Part of #2459

Signed-off-by: Andrew Seigner <siggy@buoyant.io>