### PR TITLE
upgrade: Do not require an 'install' config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,18 +52,18 @@ func FromConfigMap(configMap map[string]string) (*pb.All, error) {
 	c := &pb.All{Global: &pb.Global{}, Proxy: &pb.Proxy{}, Install: &pb.Install{}}
 
 	if err := unmarshal(configMap["global"], c.Global); err != nil {
-		return nil, fmt.Errorf("global: %s", err)
+		return nil, fmt.Errorf("invlaid global config: %s", err)
 	}
 
 	if err := unmarshal(configMap["proxy"], c.Proxy); err != nil {
-		return nil, fmt.Errorf("proxy: %s", err)
+		return nil, fmt.Errorf("invalid proxy config: %s", err)
 	}
 
-	// This instal config may not exist when upgrading from previous control plane
+	// This install config may not exist when upgrading from previous control plane
 	// versions.
-	if json := configMap["install"]; json != "" {
+	if json, ok := configMap["install"]; ok {
 		if err := unmarshal(json, c.Install); err != nil {
-			return nil, fmt.Errorf("install: %s", err)
+			return nil, fmt.Errorf("invalid install config: %s", err)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,12 @@ func unmarshalFile(filepath string, msg proto.Message) error {
 }
 
 func unmarshal(json string, msg proto.Message) error {
+	// If a config is missing, then just leave the message as nil and return
+	// without an error.
+	if json == "" {
+		return nil
+	}
+
 	// If we're using older code to read a newer config, blowing up during decoding
 	// is not helpful. We should detect that through other means.
 	u := jsonpb.Unmarshaler{AllowUnknownFields: true}
@@ -59,12 +65,8 @@ func FromConfigMap(configMap map[string]string) (*pb.All, error) {
 		return nil, fmt.Errorf("invalid proxy config: %s", err)
 	}
 
-	// This install config may not exist when upgrading from previous control plane
-	// versions.
-	if json, ok := configMap["install"]; ok {
-		if err := unmarshal(json, c.Install); err != nil {
-			return nil, fmt.Errorf("invalid install config: %s", err)
-		}
+	if err := unmarshal(configMap["install"], c.Install); err != nil {
+		return nil, fmt.Errorf("invalid install config: %s", err)
 	}
 
 	return c, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,8 +59,12 @@ func FromConfigMap(configMap map[string]string) (*pb.All, error) {
 		return nil, fmt.Errorf("proxy: %s", err)
 	}
 
-	if err := unmarshal(configMap["install"], c.Install); err != nil {
-		return nil, fmt.Errorf("install: %s", err)
+	// This instal config may not exist when upgrading from previous control plane
+	// versions.
+	if json := configMap["install"]; json != "" {
+		if err := unmarshal(json, c.Install); err != nil {
+			return nil, fmt.Errorf("install: %s", err)
+		}
 	}
 
 	return c, nil


### PR DESCRIPTION
Previous control plane versions do not provide an 'install' config, so
this field cannot be required.