### PR TITLE
Fixing bin/web test

### DIFF
--- a/web/app/.babelrc
+++ b/web/app/.babelrc
@@ -4,5 +4,5 @@
       "plugins": ["transform-react-remove-prop-types"]
     }
   },
-  "presets": ["react-app"]
+  "presets": ["env", "react-app"]
 }


### PR DESCRIPTION
#2036 removed `env` from the `presets` in the `.babelrc` file, causing Jest to fail if running tests from `bin/web test`. This PR restores it, enabling the script to work again. For context, see [babel-preset-env](https://babeljs.io/docs/en/babel-preset-env) docs.

To test:
From your current branch, run `bin/web test` - should see `Test suite failed to run`
From this branch, run `bin/web test` - should pass