### PR TITLE
testutil: Only store k8s context in KubernetesHelper struct

### DIFF
--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -17,7 +17,6 @@ import (
 
 // TestHelper provides helpers for running the linkerd integration tests.
 type TestHelper struct {
-	k8sContext string
 	linkerd    string
 	version    string
 	namespace  string
@@ -71,7 +70,6 @@ func NewTestHelper() *TestHelper {
 	}
 
 	testHelper := &TestHelper{
-		k8sContext: *k8sContext,
 		linkerd:    *linkerd,
 		namespace:  ns,
 		autoInject: *autoInject,
@@ -83,7 +81,7 @@ func NewTestHelper() *TestHelper {
 	}
 	testHelper.version = strings.TrimSpace(version)
 
-	kubernetesHelper, err := NewKubernetesHelper(testHelper.k8sContext, testHelper.RetryFor)
+	kubernetesHelper, err := NewKubernetesHelper(*k8sContext, testHelper.RetryFor)
 	if err != nil {
 		exit(1, "error creating kubernetes helper: "+err.Error())
 	}


### PR DESCRIPTION
This is a super small follow-up to #2592, which added support for running our integration tests using a non-default Kubernetes context. Both the `TestHelper` struct and the `KubernetesHelper` struct were updated to include a `k8sContext` field, but since `TestHelper` embeds `KubernetesHelper`, it doesn't need to have its own copy of the field. In this PR I'm removing the field from `TestHelper`, so that all Kubernetes configuration is tied directly to the `KubernetesHelper` struct.