### PR TITLE
proxy-identity: Set a CommonName on CSRs

### DIFF
--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -160,9 +160,12 @@ func checkCSR(csr *x509.CertificateRequest, identity string) error {
 		return fmt.Errorf("CSR name does not match requested identity: csr=%s; req=%s", csr.DNSNames[0], identity)
 	}
 
-	if csr.Subject.CommonName != "" {
-		return errors.New("CommonName must be empty")
+	switch csr.Subject.CommonName {
+	case "", identity:
+	default:
+		return fmt.Errorf("invalid CommonName: %s", csr.Subject.CommonName)
 	}
+
 	if len(csr.EmailAddresses) > 0 {
 		return errors.New("cannot validate email addresses")
 	}

--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"errors"
 	"flag"
 	"fmt"
@@ -120,12 +121,15 @@ func generateAndStoreKey(p string) (key *ecdsa.PrivateKey, err error) {
 }
 
 func generateAndStoreCSR(p, id string, key *ecdsa.PrivateKey) ([]byte, error) {
+	// TODO do proper DNS name validation.
 	if id == "" {
 		return nil, errors.New("a non-empty identity is required")
 	}
 
-	// TODO do proper DNS name validation.
-	csr := x509.CertificateRequest{DNSNames: []string{id}}
+	csr := x509.CertificateRequest{
+		Subject:  pkix.Name{CommonName: id},
+		DNSNames: []string{id},
+	}
 	csrb, err := x509.CreateCertificateRequest(rand.Reader, &csr, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CSR: %s", err)


### PR DESCRIPTION
Some CAs (like AWS) require a CommonName be set on the CSR.

This change modifies proxy-identity to set the identity name as the
CSR's CommonName.

Fixes #2622