### PR TITLE
Remove proxy injector's -no-init-container flag

### DIFF
--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -35,7 +35,6 @@ spec:
         - "proxy-injector"
         - "-controller-namespace={{.Namespace}}"
         - "-log-level={{.ControllerLogLevel}}"
-        - "-no-init-container={{.NoInitContainer}}"
         ports:
         - name: proxy-injector
           containerPort: 8443

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -1361,7 +1361,6 @@ spec:
         - proxy-injector
         - -controller-namespace=linkerd
         - -log-level=info
-        - -no-init-container=true
         image: gcr.io/linkerd-io/controller:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1306,7 +1306,6 @@ spec:
         - proxy-injector
         - -controller-namespace=Namespace
         - -log-level=ControllerLogLevel
-        - -no-init-container=false
         image: ControllerImage
         imagePullPolicy: ImagePullPolicy
         livenessProbe:

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -20,7 +20,6 @@ func main() {
 	kubeconfig := flag.String("kubeconfig", "", "path to kubeconfig")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	webhookServiceName := flag.String("webhook-service", "linkerd-proxy-injector.linkerd.io", "name of the admission webhook")
-	noInitContainer := flag.Bool("no-init-container", false, "whether to use an init container or the linkerd-cni plugin")
 	flags.ConfigureAndParse()
 
 	stop := make(chan os.Signal, 1)
@@ -48,7 +47,7 @@ func main() {
 	}
 	log.Infof("created mutating webhook configuration: %s", mwc.ObjectMeta.SelfLink)
 
-	s, err := injector.NewWebhookServer(k8sAPI, *addr, *controllerNamespace, *noInitContainer, rootCA)
+	s, err := injector.NewWebhookServer(k8sAPI, *addr, *controllerNamespace, rootCA)
 	if err != nil {
 		log.Fatalf("failed to initialize the webhook server: %s", err)
 	}

--- a/controller/proxy-injector/fake/factory.go
+++ b/controller/proxy-injector/fake/factory.go
@@ -14,7 +14,6 @@ import (
 const (
 	DefaultControllerNamespace = "linkerd"
 	DefaultNamespace           = "default"
-	DefaultNoInitContainer     = false
 )
 
 // Factory is a factory that can convert in-file YAML content into Kubernetes

--- a/controller/proxy-injector/server.go
+++ b/controller/proxy-injector/server.go
@@ -21,7 +21,7 @@ type WebhookServer struct {
 }
 
 // NewWebhookServer returns a new instance of the WebhookServer.
-func NewWebhookServer(api *k8s.API, addr, controllerNamespace string, noInitContainer bool, rootCA *pkgTls.CA) (*WebhookServer, error) {
+func NewWebhookServer(api *k8s.API, addr, controllerNamespace string, rootCA *pkgTls.CA) (*WebhookServer, error) {
 	c, err := tlsConfig(rootCA, controllerNamespace)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func NewWebhookServer(api *k8s.API, addr, controllerNamespace string, noInitCont
 		TLSConfig: c,
 	}
 
-	webhook, err := NewWebhook(api, controllerNamespace, noInitContainer)
+	webhook, err := NewWebhook(api, controllerNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/server_test.go
+++ b/controller/proxy-injector/server_test.go
@@ -26,7 +26,7 @@ func init() {
 		panic(err)
 	}
 
-	webhook, err := NewWebhook(k8sAPI, fake.DefaultControllerNamespace, false)
+	webhook, err := NewWebhook(k8sAPI, fake.DefaultControllerNamespace)
 	if err != nil {
 		panic(err)
 	}
@@ -82,7 +82,7 @@ func TestNewWebhookServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
-	server, err := NewWebhookServer(k8sAPI, addr, fake.DefaultControllerNamespace, false, rootCA)
+	server, err := NewWebhookServer(k8sAPI, addr, fake.DefaultControllerNamespace, rootCA)
 	if err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -25,11 +25,10 @@ type Webhook struct {
 	k8sAPI              *k8s.API
 	deserializer        runtime.Decoder
 	controllerNamespace string
-	noInitContainer     bool
 }
 
 // NewWebhook returns a new instance of Webhook.
-func NewWebhook(api *k8s.API, controllerNamespace string, noInitContainer bool) (*Webhook, error) {
+func NewWebhook(api *k8s.API, controllerNamespace string) (*Webhook, error) {
 	var (
 		scheme = runtime.NewScheme()
 		codecs = serializer.NewCodecFactory(scheme)
@@ -39,7 +38,6 @@ func NewWebhook(api *k8s.API, controllerNamespace string, noInitContainer bool) 
 		k8sAPI:              api,
 		deserializer:        codecs.UniversalDeserializer(),
 		controllerNamespace: controllerNamespace,
-		noInitContainer:     noInitContainer,
 	}, nil
 }
 


### PR DESCRIPTION
In the process of reviewing linkerd/linkerd2#2573, I realized that the proxy injector no longer needs to be explicitly configured via a command line flag when linkerd-cni is enabled, since it now reads that information from the global config map. This PR removes the flag.