### PR TITLE
install: Change --ha to set a 100m CPU request

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -430,7 +430,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 
 	if options.highAvailability {
 		defaultConstraints := &resources{
-			CPU:    constraints{Request: "20m"},
+			CPU:    constraints{Request: "100m"},
 			Memory: constraints{Request: "50Mi"},
 		}
 		// Copy constraints to each so that further modification isn't global.
@@ -441,10 +441,10 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		values.TapResources = &*defaultConstraints
 		values.WebResources = &*defaultConstraints
 
-		values.IdentityResources = &resources{
-			CPU:    constraints{Request: "100m"},
-			Memory: constraints{Request: "10Mi"},
-		}
+		// The identity controller maintains no internal state, so it need not request
+		// 50Mi.
+		values.IdentityResources = &*defaultConstraints
+		values.IdentityResources.Memory = "10Mi"
 
 		values.PrometheusResources = &resources{
 			CPU:    constraints{Request: "300m"},

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -426,6 +426,15 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 			Proxy:   proxyJSON,
 			Install: installJSON,
 		},
+
+		DestinationResources:   &resources{},
+		GrafanaResources:       &resources{},
+		IdentityResources:      &resources{},
+		PrometheusResources:    &resources{},
+		ProxyInjectorResources: &resources{},
+		PublicAPIResources:     &resources{},
+		TapResources:           &resources{},
+		WebResources:           &resources{},
 	}
 
 	if options.highAvailability {
@@ -434,16 +443,16 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 			Memory: constraints{Request: "50Mi"},
 		}
 		// Copy constraints to each so that further modification isn't global.
-		values.DestinationResources = &*defaultConstraints
-		values.GrafanaResources = &*defaultConstraints
-		values.ProxyInjectorResources = &*defaultConstraints
-		values.PublicAPIResources = &*defaultConstraints
-		values.TapResources = &*defaultConstraints
-		values.WebResources = &*defaultConstraints
+		*values.DestinationResources = *defaultConstraints
+		*values.GrafanaResources = *defaultConstraints
+		*values.ProxyInjectorResources = *defaultConstraints
+		*values.PublicAPIResources = *defaultConstraints
+		*values.TapResources = *defaultConstraints
+		*values.WebResources = *defaultConstraints
 
 		// The identity controller maintains no internal state, so it need not request
 		// 50Mi.
-		values.IdentityResources = &*defaultConstraints
+		*values.IdentityResources = *defaultConstraints
 		values.IdentityResources.Memory = constraints{Request: "10Mi"}
 
 		values.PrometheusResources = &resources{

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -444,7 +444,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		// The identity controller maintains no internal state, so it need not request
 		// 50Mi.
 		values.IdentityResources = &*defaultConstraints
-		values.IdentityResources.Memory = "10Mi"
+		values.IdentityResources.Memory = constraints{Request: "10Mi"}
 
 		values.PrometheusResources = &resources{
 			CPU:    constraints{Request: "300m"},

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -375,7 +375,7 @@ func (options *installOptions) validate() error {
 		}
 
 		if options.proxyCPURequest == "" {
-			options.proxyCPURequest = "10m"
+			options.proxyCPURequest = "100m"
 		}
 
 		if options.proxyMemoryRequest == "" {
@@ -442,7 +442,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		values.WebResources = &*defaultConstraints
 
 		values.IdentityResources = &resources{
-			CPU:    constraints{Request: "10m"},
+			CPU:    constraints{Request: "100m"},
 			Memory: constraints{Request: "10Mi"},
 		}
 

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -17,7 +17,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"dev-undefined","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy\nLmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE\nAxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0\nxtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364\n6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF\nBQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE\nAiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv\nOLO4Zsk1XrGZHGsmyiEyvYF9lpY=\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null}
   proxy: |
-    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"10m","requestMemory":"20Mi","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true}
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"100m","requestMemory":"20Mi","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true}
   install: |
     {"uuid":"deaab91a-f4ab-448a-b7d1-c832a2fa0a60","cliVersion":"dev-undefined","flags":[{"name":"ha","value":"true"}]}
 ---
@@ -134,7 +134,7 @@ spec:
             port: 9990
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 10Mi
         securityContext:
           runAsUser: 2103
@@ -220,7 +220,7 @@ spec:
           initialDelaySeconds: 2
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 20Mi
         securityContext:
           runAsUser: 2102
@@ -538,7 +538,7 @@ spec:
           initialDelaySeconds: 2
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 20Mi
         securityContext:
           runAsUser: 2102
@@ -849,7 +849,7 @@ spec:
           initialDelaySeconds: 2
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 20Mi
         securityContext:
           runAsUser: 2102
@@ -1078,7 +1078,7 @@ spec:
           initialDelaySeconds: 2
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 20Mi
         securityContext:
           runAsUser: 2102
@@ -1371,7 +1371,7 @@ spec:
           initialDelaySeconds: 2
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 20Mi
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -394,7 +394,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -427,7 +427,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -458,7 +458,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -769,7 +769,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -1285,7 +1285,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 472
         volumeMounts:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -393,8 +393,8 @@ spec:
             port: 9995
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -426,8 +426,8 @@ spec:
             port: 9996
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -457,8 +457,8 @@ spec:
             port: 9998
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -768,8 +768,8 @@ spec:
             port: 9994
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -1284,8 +1284,8 @@ spec:
             port: 3000
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 472
         volumeMounts:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -134,7 +134,7 @@ spec:
             port: 9990
         resources:
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 10Mi
         securityContext:
           runAsUser: 2103

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -394,7 +394,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -427,7 +427,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -458,7 +458,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -769,7 +769,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -1285,7 +1285,7 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 10Mi
+            memory: 50Mi
         securityContext:
           runAsUser: 472
         volumeMounts:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -393,8 +393,8 @@ spec:
             port: 9995
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -426,8 +426,8 @@ spec:
             port: 9996
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
         volumeMounts:
@@ -457,8 +457,8 @@ spec:
             port: 9998
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -768,8 +768,8 @@ spec:
             port: 9994
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 2103
       - env:
@@ -1284,8 +1284,8 @@ spec:
             port: 3000
         resources:
           requests:
-            cpu: 20m
-            memory: 50Mi
+            cpu: 100m
+            memory: 10Mi
         securityContext:
           runAsUser: 472
         volumeMounts:


### PR DESCRIPTION
When the --ha flag is set, we currently set a 10m CPU request, which
correspnds to 1% of a core, which isn't actually enough to keep the
proxy responding to health checks if you have 100 processes on the box.
Let's give ourselves a little more breathing room.

Fixes #2643