### PR TITLE
Fix check for empty metrics that always returned false

### DIFF
--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -16,6 +16,7 @@ import _filter from 'lodash/filter';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
+import _isNil from 'lodash/isNil';
 import _merge from 'lodash/merge';
 import _reduce from 'lodash/reduce';
 import { withContext } from './util/AppContext.jsx';
@@ -176,7 +177,6 @@ export class ResourceDetailBase extends React.Component {
           podMetricsForResource = _filter(podMetrics, pod => podBelongsToResource[pod.namespace + "/" + pod.name]);
         }
 
-
         let resourceIsMeshed = true;
         if (!_isEmpty(this.state.resourceMetrics)) {
           resourceIsMeshed = _get(this.state.resourceMetrics, '[0].pods.meshedPods') > 0;
@@ -186,7 +186,7 @@ export class ResourceDetailBase extends React.Component {
         let hasTcp = false;
         let metric = resourceMetrics[0];
         if (!_isEmpty(metric)) {
-          hasHttp = !_isEmpty(metric.stats) && metric.totalRequests !== 0;
+          hasHttp = !_isNil(metric.requestRate) && !_isEmpty(metric.latency);
 
           if (!_isEmpty(metric.tcp)) {
             let { tcp } = metric;


### PR DESCRIPTION
In https://github.com/linkerd/linkerd2/pull/2532 I removed the Tap/Top tables if there was no http traffic, but the check I used depended on a `stats` object being present in the processed metrics (spoiler: it isn't present in the processed metrics). Use a better check for no traffic.
The new check checks for both no requests (so nil request rate) and also no latency (in the case that the service is http but receiving no traffic).

Fixes #2641