### PR TITLE
upgrade: Generate an Identity config if missing

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -262,6 +262,7 @@ func (options *installOptions) validateAndBuild(flags *pflag.FlagSet) (*installV
 }
 
 // recordableFlagSet returns flags usable during install or upgrade.
+//nolint:unparam
 func (options *installOptions) recordableFlagSet(e pflag.ErrorHandling) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("install", e)
 

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -143,7 +143,7 @@ func setOptionsFromInstall(flags *pflag.FlagSet, install *pb.Install) {
 	}
 }
 func (options *upgradeOptions) overrideConfigs(configs *pb.All, overrideAnnotations map[string]string) {
-	options.proxyConfigOptions.overrideConfigs(configs, overrideAnnotations)
+	options.installOptions.overrideConfigs(configs, overrideAnnotations)
 
 	if options.proxyAutoInject {
 		configs.GetGlobal().AutoInjectContext = &pb.AutoInjectContext{}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -142,6 +142,13 @@ func setOptionsFromInstall(flags *pflag.FlagSet, install *pb.Install) {
 		}
 	}
 }
+func (options *upgradeOptions) overrideConfigs(configs *pb.All, overrideAnnotations map[string]string) {
+	options.proxyConfigOptions.overrideConfigs(configs, overrideAnnotations)
+
+	if options.proxyAutoInject {
+		configs.GetGlobal().AutoInjectContext = &pb.AutoInjectContext{}
+	}
+}
 
 func (options *upgradeOptions) newK8s() (kubernetes.Interface, error) {
 	if options.ignoreCluster {

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -76,7 +76,7 @@ data:
 	diffTestdata(t, "upgrade_default.golden", buf.String())
 }
 
-func TestUpgradeFromNonIdentityConfig(t *testing.T) {
+func TestUpgradeFromOldConfig(t *testing.T) {
 	k8sConfigs := []string{`
 kind: ConfigMap
 apiVersion: v1
@@ -98,6 +98,7 @@ data:
 	}
 
 	options := newUpgradeOptionsWithDefaults()
+	options.proxyAutoInject = true
 	flags := options.recordableFlagSet(pflag.ExitOnError)
 
 	clientset, _, err := k8s.NewFakeClientSets(k8sConfigs...)
@@ -121,6 +122,9 @@ data:
 	if configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem() == "" {
 		t.Errorf("identity config not generated")
 	}
+	if configs.GetGlobal().GetAutoInjectContext() == nil {
+		t.Errorf("autoinject config not generated")
+	}
 
 	global := pb.Global{}
 	if err := json.Unmarshal([]byte(values.Configs.Global), &global); err != nil {
@@ -128,5 +132,8 @@ data:
 	}
 	if configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem() == "" {
 		t.Errorf("identity config not serialized")
+	}
+	if configs.GetGlobal().GetAutoInjectContext() == nil {
+		t.Errorf("autoinject config not serialized")
 	}
 }

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
+	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/pflag"
 )
@@ -114,9 +116,17 @@ data:
 		values.Identity.Issuer == nil ||
 		values.Identity.Issuer.CrtPEM == "" ||
 		values.Identity.Issuer.KeyPEM == "" {
-		t.Fatalf("issuer values not generated")
+		t.Errorf("issuer values not generated")
 	}
 	if configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem() == "" {
-		t.Fatalf("issuer config not generated")
+		t.Errorf("identity config not generated")
+	}
+
+	global := pb.Global{}
+	if err := json.Unmarshal([]byte(values.Configs.Global), &global); err != nil {
+		t.Fatalf("Could not unmarshal global config: %s", err)
+	}
+	if configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem() == "" {
+		t.Errorf("identity config not serialized")
 	}
 }


### PR DESCRIPTION
When upgrading from an older cluster that has a Linkerd config but no
identity, we need to generate an identity context so that the cluster is
configured properly.

Fixes #2650