### PR TITLE
upgrade: Fix the linkerd version in linkerd-config

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -302,6 +302,7 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 // storing the corresponding annotations and values.
 func (options *proxyConfigOptions) overrideConfigs(configs *config.All, overrideAnnotations map[string]string) {
 	if options.linkerdVersion != "" {
+		configs.Global.Version = options.linkerdVersion
 		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = options.linkerdVersion
 	}
 

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -15,7 +15,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
   global: |
-    {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"edge-19.4.1","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0\neS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz\nMjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j\nYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg\nEMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw\nQDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\nMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW\nYmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj\n+U9K4WlbzA==\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null}
+    {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"TEST-VERSION","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0\neS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz\nMjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j\nYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg\nEMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw\nQDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\nMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW\nYmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj\n+U9K4WlbzA==\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null}
   proxy: |
     {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true}
   install: |
@@ -103,7 +103,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: identity
@@ -114,7 +114,7 @@ spec:
       - args:
         - identity
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:dev-undefined
+        image: gcr.io/linkerd-io/controller:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -198,7 +198,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -235,7 +235,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -355,7 +355,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: controller
@@ -368,7 +368,7 @@ spec:
         - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
         - -controller-namespace=linkerd
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:dev-undefined
+        image: gcr.io/linkerd-io/controller:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -398,7 +398,7 @@ spec:
         - -controller-namespace=linkerd
         - -enable-h2-upgrade=true
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:dev-undefined
+        image: gcr.io/linkerd-io/controller:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -426,7 +426,7 @@ spec:
         - tap
         - -controller-namespace=linkerd
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:dev-undefined
+        image: gcr.io/linkerd-io/controller:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -505,7 +505,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -542,7 +542,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -718,7 +718,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: web
@@ -732,7 +732,7 @@ spec:
         - -uuid=57af298c-58b0-43fc-8d88-3c338789bfbc
         - -controller-namespace=linkerd
         - -log-level=info
-        image: gcr.io/linkerd-io/web:dev-undefined
+        image: gcr.io/linkerd-io/web:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -811,7 +811,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -848,7 +848,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -935,7 +935,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: prometheus
@@ -1035,7 +1035,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1072,7 +1072,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -1230,7 +1230,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: grafana
@@ -1241,7 +1241,7 @@ spec:
       - env:
         - name: GF_PATHS_DATA
           value: /data
-        image: gcr.io/linkerd-io/grafana:dev-undefined
+        image: gcr.io/linkerd-io/grafana:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1323,7 +1323,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1360,7 +1360,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}
@@ -1522,7 +1522,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
-        linkerd.io/proxy-version: edge-19.4.1
+        linkerd.io/proxy-version: TEST-VERSION
       creationTimestamp: null
       labels:
         linkerd.io/control-plane-component: sp-validator
@@ -1534,7 +1534,7 @@ spec:
         - sp-validator
         - -controller-namespace=linkerd
         - -log-level=info
-        image: gcr.io/linkerd-io/controller:dev-undefined
+        image: gcr.io/linkerd-io/controller:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1611,7 +1611,7 @@ spec:
           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-        image: gcr.io/linkerd-io/proxy:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy:TEST-VERSION
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -1648,7 +1648,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:edge-19.4.1
+        image: gcr.io/linkerd-io/proxy-init:TEST-VERSION
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources: {}

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const upgradeVersion = "TEST-VERSION"
+
+func testUpgradeOptions() *upgradeOptions {
+	o := newUpgradeOptionsWithDefaults()
+	o.linkerdVersion = upgradeVersion
+	return o
+}
+
 func TestRenderUpgrade(t *testing.T) {
 	k8sConfigs := []string{`
 kind: ConfigMap
@@ -42,7 +50,7 @@ data:
   key.pem: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUhaaEFWTnNwSlRzMWZ4YmZ4VmptTTJvMTNTOFd4U2VVdTlrNFhZK0NPY3JvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFL2ttK1YrTUl1Rno5Rjk2eWNES2R0MVFYWUJEREZQQkZQaWh2RkNOaTVndVZZNE9VVml6bAp1Z1NZd1pvMTFZaWpQbS90ZjZDZ0hqb09oYXlaUEtzaFpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=`,
 	}
 
-	options := newUpgradeOptionsWithDefaults()
+	options := testUpgradeOptions()
 	flags := options.recordableFlagSet(pflag.ExitOnError)
 
 	clientset, _, err := k8s.NewFakeClientSets(k8sConfigs...)
@@ -53,6 +61,10 @@ data:
 	values, configs, err := options.validateAndBuild(clientset, flags)
 	if err != nil {
 		t.Fatalf("validateAndBuild failed with %s", err)
+	}
+
+	if configs.GetGlobal().GetVersion() != upgradeVersion {
+		t.Errorf("version not upgraded in config")
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
92f15e78a95da15759f7c947f7b147298725a287 incorrectly removed the config
version override when patching a config from options, which caused
upgrade to stop updating the config version.

Fixes #2660