### PR TITLE
Switch UUID implementation

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -11,7 +11,7 @@ RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION) && \
     echo "$version" >version.txt)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 ENV CGO_ENABLED=0 GOOS=linux
 COPY pkg/flags pkg/flags

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -592,14 +592,6 @@
   version = "v1.5.2"
 
 [[projects]]
-  digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  pruneopts = ""
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
   name = "github.com/sergi/go-diff"
   packages = ["diffmatchpatch"]
@@ -1260,6 +1252,7 @@
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/golang/protobuf/ptypes",
     "github.com/golang/protobuf/ptypes/duration",
+    "github.com/google/uuid",
     "github.com/gorilla/websocket",
     "github.com/grpc-ecosystem/go-grpc-prometheus",
     "github.com/julienschmidt/httprouter",
@@ -1277,7 +1270,6 @@
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/common/model",
-    "github.com/satori/go.uuid",
     "github.com/sergi/go-diff/diffmatchpatch",
     "github.com/shurcooL/vfsgen",
     "github.com/sirupsen/logrus",

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -11,13 +11,13 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/google/uuid"
 	"github.com/linkerd/linkerd2/cli/static"
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/linkerd/linkerd2/pkg/version"
-	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -189,7 +189,11 @@ func newInstallOptionsWithDefaults() *installOptions {
 		identityOptions: newInstallIdentityOptionsWithDefaults(),
 
 		generateUUID: func() string {
-			return uuid.NewV4().String()
+			id, err := uuid.NewRandom()
+			if err != nil {
+				log.Fatalf("Could not generate UUID: %s", err)
+			}
+			return id.String()
 		},
 	}
 }

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:3f016933 as golang
+FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
The UUID implementation we use to generate install IDs is technically
not random enough for secure uses, which ours is not. To prevent
security scanners like SNYK from flagging this false-positive, let's
just switch to the other UUID implementation (Already in our
dependencies).