### PR TITLE
Allow web server to load without install config

### DIFF
--- a/web/main.go
+++ b/web/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	installConfig, err := config.Install(pkgK8s.MountPathInstallConfig)
 	if err != nil {
-		log.Fatalf("failed to take global config %v", err)
+		log.Warnf("failed to load uuid from install config: %s", err)
 	}
 	uuid := installConfig.GetUuid()
 


### PR DESCRIPTION
#2603 updated the web server to load the install UUID from the linkerd-config ConfigMap, but that unfortunately makes it impossible to run the web server locally, when the ConfigMap isn't present. This branch updates the web server to simply warn when the ConfigMap is unavailable, allowing it to still run without a UUID.