### PR TITLE
Integration test for the 'upgrade' command

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -35,6 +35,28 @@ function run_test(){
     go test -v "$1" --linkerd="$linkerd_path" --linkerd-namespace="$linkerd_namespace" --k8s-context="$k8s_context" --integration-tests "$2"
 }
 
+function install_edge() {
+  tmp=$(mktemp -d -t l5dbin.XXX)
+  trap "rm -rf $tmp" EXIT
+
+  curl -s https://run.linkerd.io/install-edge | HOME=$tmp sh
+
+  local linkerd_path=$tmp/.linkerd2/bin/linkerd
+  $linkerd_path install --proxy-auto-inject --linkerd-namespace="$linkerd_namespace" | kubectl apply -f - > /dev/null 2>&1
+  $linkerd_path check --linkerd-namespace="$linkerd_namespace" > /dev/null 2>&1
+}
+
+function run_upgrade_test() {
+  local linkerd_namespace="$linkerd_namespace"-upgrade
+  local edge_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "edge-[0-9]*.[0-9]*.[0-9]*")
+
+  printf "Installing release [%s] namespace [%s]\n" "$edge_version" "$linkerd_namespace"
+  install_edge
+
+  printf "Upgrading release [%s] to [%s]\n" "$edge_version" "$linkerd_version"
+  run_test "$test_directory/install_test.go" "--upgrade-from-version=$edge_version" "--linkerd-namespace=$linkerd_namespace" || exit_code=$?
+}
+
 linkerd_path=$1
 
 if [ -z "$linkerd_path" ]; then
@@ -58,7 +80,8 @@ printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linke
 exit_code=0
 
 run_test "$test_directory/install_test.go" || exit_code=$?
-run_test "$test_directory/install_test.go" "--proxy-auto-inject" || exit_code=$?
+
+run_upgrade_test
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" || exit_code=$?
 done

--- a/bin/test-run
+++ b/bin/test-run
@@ -31,30 +31,36 @@ function check_if_k8s_reachable(){
 }
 
 function run_test(){
-    printf "Running test [%s] %s\\n" "$(basename "$1")" "$2"
-    go test -v "$1" --linkerd="$linkerd_path" --linkerd-namespace="$linkerd_namespace" --k8s-context="$k8s_context" --integration-tests "$2"
+    filename="$1"
+    shift
+
+    printf "Running test [%s] %s\\n" "$(basename "$filename")" "$@"
+    go test -v "$filename" --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
 }
 
+# Install the latest edge release.
+# $1 - namespace to use for the edge release
 function install_edge() {
-  tmp=$(mktemp -d -t l5dbin.XXX)
-  trap "rm -rf $tmp" EXIT
+    tmp=$(mktemp -d -t l5dbin.XXX)
+    trap "rm -rf $tmp" EXIT
 
-  curl -s https://run.linkerd.io/install-edge | HOME=$tmp sh
+    curl -s https://run.linkerd.io/install-edge | HOME=$tmp sh > /dev/null 2>&1
 
-  local linkerd_path=$tmp/.linkerd2/bin/linkerd
-  $linkerd_path install --proxy-auto-inject --linkerd-namespace="$linkerd_namespace" | kubectl apply -f - > /dev/null 2>&1
-  $linkerd_path check --linkerd-namespace="$linkerd_namespace" > /dev/null 2>&1
+    local linkerd_path=$tmp/.linkerd2/bin/linkerd
+    local edge_namespace=${1}
+    $linkerd_path install --linkerd-namespace="$edge_namespace" | kubectl apply -f - > /dev/null 2>&1
+    $linkerd_path check --linkerd-namespace="$edge_namespace" > /dev/null 2>&1
 }
 
 function run_upgrade_test() {
-  local linkerd_namespace="$linkerd_namespace"-upgrade
-  local edge_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "edge-[0-9]*.[0-9]*.[0-9]*")
+    local edge_namespace="$linkerd_namespace"-upgrade
+    local edge_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "edge-[0-9]*.[0-9]*.[0-9]*")
 
-  printf "Installing release [%s] namespace [%s]\n" "$edge_version" "$linkerd_namespace"
-  install_edge
+    printf "Installing release [%s] namespace [%s]\n" "$edge_version" "$edge_namespace"
+    install_edge $edge_namespace
 
-  printf "Upgrading release [%s] to [%s]\n" "$edge_version" "$linkerd_version"
-  run_test "$test_directory/install_test.go" "--upgrade-from-version=$edge_version" "--linkerd-namespace=$linkerd_namespace" || exit_code=$?
+    printf "Upgrading release [%s] to [%s]\n" "$edge_version" "$linkerd_version"
+    run_test "$test_directory/install_test.go" --upgrade-from-version=$edge_version --linkerd-namespace=$edge_namespace --proxy-auto-inject || exit_code=$?
 }
 
 linkerd_path=$1
@@ -79,11 +85,10 @@ printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linke
 
 exit_code=0
 
-run_test "$test_directory/install_test.go" || exit_code=$?
-
+run_test "$test_directory/install_test.go" --linkerd-namespace=${linkerd_namespace} || exit_code=$?
 run_upgrade_test
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
-    run_test "$test" || exit_code=$?
+    run_test "$test" --linkerd-namespace=${linkerd_namespace} || exit_code=$?
 done
 
 if [ $exit_code -eq 0 ]; then

--- a/bin/test-run
+++ b/bin/test-run
@@ -47,13 +47,16 @@ function install_edge() {
     curl -s https://run.linkerd.io/install-edge | HOME=$tmp sh > /dev/null 2>&1
 
     local linkerd_path=$tmp/.linkerd2/bin/linkerd
-    local edge_namespace=${1}
+    local edge_namespace="$1"
     $linkerd_path install --linkerd-namespace="$edge_namespace" | kubectl apply -f - > /dev/null 2>&1
     $linkerd_path check --linkerd-namespace="$edge_namespace" > /dev/null 2>&1
 }
 
+# Run the upgrade test by upgrading the most-recent edge release to the HEAD of
+# this branch.
+# $1 - namespace to use for the edge release
 function run_upgrade_test() {
-    local edge_namespace="$linkerd_namespace"-upgrade
+    local edge_namespace="$1"
     local edge_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "edge-[0-9]*.[0-9]*.[0-9]*")
 
     printf "Installing release [%s] namespace [%s]\n" "$edge_version" "$edge_namespace"
@@ -85,10 +88,10 @@ printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linke
 
 exit_code=0
 
-run_test "$test_directory/install_test.go" --linkerd-namespace=${linkerd_namespace} || exit_code=$?
-run_upgrade_test
+run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace || exit_code=$?
+run_upgrade_test "$linkerd_namespace"-upgrade
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
-    run_test "$test" --linkerd-namespace=${linkerd_namespace} || exit_code=$?
+    run_test "$test" --linkerd-namespace=$linkerd_namespace || exit_code=$?
 done
 
 if [ $exit_code -eq 0 ]; then

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -83,8 +83,8 @@ var (
 
 func TestVersionPreInstall(t *testing.T) {
 	version := "unavailable"
-	if TestHelper.UpgradeFrom() != "" {
-		version = TestHelper.UpgradeFrom()
+	if TestHelper.UpgradeFromVersion() != "" {
+		version = TestHelper.UpgradeFromVersion()
 	}
 
 	err := TestHelper.CheckVersion(version)
@@ -94,7 +94,7 @@ func TestVersionPreInstall(t *testing.T) {
 }
 
 func TestCheckPreInstall(t *testing.T) {
-	if TestHelper.UpgradeFrom() != "" {
+	if TestHelper.UpgradeFromVersion() != "" {
 		t.Skip("Skipping pre-install check for upgrade test")
 	}
 
@@ -121,8 +121,11 @@ func TestInstallOrUpgrade(t *testing.T) {
 		}
 	)
 
-	if TestHelper.UpgradeFrom() != "" {
+	if TestHelper.UpgradeFromVersion() != "" {
 		cmd = "upgrade"
+	}
+
+	if TestHelper.AutoInject() {
 		args = append(args, "--proxy-auto-inject")
 		linkerdDeployReplicas["linkerd-proxy-injector"] = deploySpec{1, []string{"proxy-injector"}}
 	}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -60,6 +60,7 @@ var (
 		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::app::errors unexpected error: an IO error occurred: Connection reset by peer \(os error 104\)`,
 		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: 127\.0\.0\.1:.*\)`,
 		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: .*\)`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: operation timed out after 1s`,
 		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy WARN \[ *\d+.\d+s\] .* linkerd2_proxy::proxy::reconnect connect error to ControlAddr .*`,
 
 		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] admin={server=metrics listen=0\.0\.0\.0:4191 remote=.*} linkerd2_proxy::control::serve_http error serving metrics: Error { kind: Shutdown, .* }`,
@@ -81,13 +82,22 @@ var (
 // Later tests depend on the success of earlier tests
 
 func TestVersionPreInstall(t *testing.T) {
-	err := TestHelper.CheckVersion("unavailable")
+	version := "unavailable"
+	if TestHelper.UpgradeFrom() != "" {
+		version = TestHelper.UpgradeFrom()
+	}
+
+	err := TestHelper.CheckVersion(version)
 	if err != nil {
 		t.Fatalf("Version command failed\n%s", err.Error())
 	}
 }
 
 func TestCheckPreInstall(t *testing.T) {
+	if TestHelper.UpgradeFrom() != "" {
+		t.Skip("Skipping pre-install check for upgrade test")
+	}
+
 	cmd := []string{"check", "--pre", "--expected-version", TestHelper.GetVersion()}
 	golden := "check.pre.golden"
 	out, _, err := TestHelper.LinkerdRun(cmd...)
@@ -101,18 +111,24 @@ func TestCheckPreInstall(t *testing.T) {
 	}
 }
 
-func TestInstall(t *testing.T) {
-	cmd := []string{"install",
-		"--controller-log-level", "debug",
-		"--proxy-log-level", "warn,linkerd2_proxy=debug",
-		"--linkerd-version", TestHelper.GetVersion(),
-	}
-	if TestHelper.AutoInject() {
-		cmd = append(cmd, []string{"--proxy-auto-inject"}...)
+func TestInstallOrUpgrade(t *testing.T) {
+	var (
+		cmd  = "install"
+		args = []string{
+			"--controller-log-level", "debug",
+			"--proxy-log-level", "warn,linkerd2_proxy=debug",
+			"--linkerd-version", TestHelper.GetVersion(),
+		}
+	)
+
+	if TestHelper.UpgradeFrom() != "" {
+		cmd = "upgrade"
+		args = append(args, "--proxy-auto-inject")
 		linkerdDeployReplicas["linkerd-proxy-injector"] = deploySpec{1, []string{"proxy-injector"}}
 	}
 
-	out, _, err := TestHelper.LinkerdRun(cmd...)
+	exec := append([]string{cmd}, args...)
+	out, _, err := TestHelper.LinkerdRun(exec...)
 	if err != nil {
 		t.Fatalf("linkerd install command failed\n%s", out)
 	}

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -21,7 +21,7 @@ type TestHelper struct {
 	version            string
 	namespace          string
 	autoInject         bool
-	upgradeFromversion string
+	upgradeFromVersion string
 	httpClient         http.Client
 	KubernetesHelper
 }
@@ -66,16 +66,11 @@ func NewTestHelper() *TestHelper {
 		log.SetLevel(log.PanicLevel)
 	}
 
-	ns := *namespace
-	if *autoInject {
-		ns += "-auto-inject"
-	}
-
 	testHelper := &TestHelper{
 		linkerd:            *linkerd,
-		namespace:          ns,
+		namespace:          *namespace,
 		autoInject:         *autoInject,
-		upgradeFromversion: *upgradeFromVersion,
+		upgradeFromVersion: *upgradeFromVersion,
 	}
 
 	version, _, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -122,9 +117,9 @@ func (h *TestHelper) AutoInject() bool {
 	return h.autoInject
 }
 
-// UpgradeFrom returns the base version of the upgrade test.
-func (h *TestHelper) UpgradeFrom() string {
-	return h.upgradeFromversion
+// UpgradeFromVersion returns the base version of the upgrade test.
+func (h *TestHelper) UpgradeFromVersion() string {
+	return h.upgradeFromVersion
 }
 
 // LinkerdRun executes a linkerd command appended with the --linkerd-namespace

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -17,11 +17,12 @@ import (
 
 // TestHelper provides helpers for running the linkerd integration tests.
 type TestHelper struct {
-	linkerd    string
-	version    string
-	namespace  string
-	autoInject bool
-	httpClient http.Client
+	linkerd            string
+	version            string
+	namespace          string
+	autoInject         bool
+	upgradeFromversion string
+	httpClient         http.Client
 	KubernetesHelper
 }
 
@@ -37,6 +38,7 @@ func NewTestHelper() *TestHelper {
 	linkerd := flag.String("linkerd", "", "path to the linkerd binary to test")
 	namespace := flag.String("linkerd-namespace", "l5d-integration", "the namespace where linkerd is installed")
 	autoInject := flag.Bool("proxy-auto-inject", false, "enable proxy sidecar auto-injection in tests")
+	upgradeFromVersion := flag.String("upgrade-from-version", "", "when specified, the upgrade test uses it as the base version of the upgrade")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
 	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	flag.Parse()
@@ -70,9 +72,10 @@ func NewTestHelper() *TestHelper {
 	}
 
 	testHelper := &TestHelper{
-		linkerd:    *linkerd,
-		namespace:  ns,
-		autoInject: *autoInject,
+		linkerd:            *linkerd,
+		namespace:          ns,
+		autoInject:         *autoInject,
+		upgradeFromversion: *upgradeFromVersion,
 	}
 
 	version, _, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -117,6 +120,11 @@ func (h *TestHelper) GetTestNamespace(testName string) string {
 // test.
 func (h *TestHelper) AutoInject() bool {
 	return h.autoInject
+}
+
+// UpgradeFrom returns the base version of the upgrade test.
+func (h *TestHelper) UpgradeFrom() string {
+	return h.upgradeFromversion
 }
 
 // LinkerdRun executes a linkerd command appended with the --linkerd-namespace


### PR DESCRIPTION
The extra steps to download and install an edge release increases the test duration by less than a minute, on my machine:

This branch:
```
=== PASS: all tests passed
bin/test-run `pwd`/bin/linkerd  33.16s user 4.85s system 9% cpu 6:33.27 total
```

`master`:
```
=== PASS: all tests passed
bin/test-run `pwd`/bin/linkerd  35.64s user 5.46s system 11% cpu 5:52.69 total
```

Fixes #2669 

Signed-off-by: Ivan Sim <ivan@buoyant.io>