### PR TITLE
Allow identity to be disabled during inject on existing cluster

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -294,7 +294,15 @@ func (options *injectOptions) fetchConfigsOrDefault() (*config.All, error) {
 	}
 
 	api := checkPublicAPIClientOrExit()
-	return api.Config(context.Background(), &public.Empty{})
+	config, err := api.Config(context.Background(), &public.Empty{})
+	if err != nil {
+		return nil, err
+	}
+
+	if options.disableIdentity {
+		config.Global.IdentityContext = nil
+	}
+	return config, nil
 }
 
 // overrideConfigs uses command-line overrides to update the provided configs.

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -169,7 +169,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -440,7 +440,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -712,7 +712,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -903,7 +903,7 @@ spec:
         - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
           value: "10000"
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1155,7 +1155,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1360,7 +1360,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1604,7 +1604,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: gcr.io/linkerd-io/proxy:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -122,7 +122,7 @@
         },
         {
           "name": "LINKERD2_PROXY_IDENTITY_DISABLED",
-          "value": "Identity is not yet available"
+          "value": "disabled"
         }
       ],
       "resources": {},

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -60,8 +60,7 @@ const (
 	envIdentityTokenFile    = "LINKERD2_PROXY_IDENTITY_TOKEN_FILE"
 	envIdentityTrustAnchors = "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS"
 
-	identityAPIPort     = 8080
-	identityDisabledMsg = "Identity is not yet available"
+	identityAPIPort = 8080
 )
 
 var injectableKinds = []string{
@@ -492,7 +491,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
 	if idctx == nil {
 		sidecar.Env = append(sidecar.Env, v1.EnvVar{
 			Name:  envIdentityDisabled,
-			Value: identityDisabledMsg,
+			Value: k8s.IdentityModeDisabled,
 		})
 		patch.addContainer(&sidecar)
 		return

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -61,7 +61,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: proxy-image:linkerd-version
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -75,7 +75,7 @@ spec:
         - name: LINKERD2_PROXY_DESTINATION_CONTEXT
           value: ns:$(_pod_ns)
         - name: LINKERD2_PROXY_IDENTITY_DISABLED
-          value: Identity is not yet available
+          value: disabled
         image: proxy-image:linkerd-version
         imagePullPolicy: Never
         livenessProbe:


### PR DESCRIPTION
Currently, during inject, the `--disable-identity` flag only works in conjunction with the `--ignore-cluster` flag. This PR ensures that identity can be disabled via the flag, even without the `--ignore-cluster` flag.

(The changes in this PR doesn't affect auto-inject.)

Tested the diffs between 19.4.3 and this branch:
```
$ diff <(curl -s https://run.linkerd.io/emojivoto.yml | linkerd inject --disable-identity -) <(curl -s https://run.linkerd.io/emojivoto.yml | bin/linkerd inject --disable-identity -)

40,41c40,41
<         linkerd.io/created-by: linkerd/cli edge-19.4.3
<         linkerd.io/identity-mode: default
---
>         linkerd.io/created-by: linkerd/cli git-e467cec0
>         linkerd.io/identity-mode: disabled
86,118c86,87
<         - name: LINKERD2_PROXY_IDENTITY_DIR
<           value: /var/run/linkerd/identity/end-entity
<         - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
<           value: |
<             -----BEGIN CERTIFICATE-----
<             MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
<             eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDExMTYzODAxWhcNMjAwNDEw
<             MTYzODIxWjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
<             YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASH8ewLuOh2bYHPXwq54K5HpBAT
<             gvHuP3t7zGTt4KXgbN3o7q0sUbZhNfduMI7oE4NKZRK9NtWpY7p3t3vH9DmAo0Iw
<             QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
<             MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhALv53LdLrjFel8V9
<             6JPgrT+wT8pMGmGlXzbAA4SePQs8AiBLlZaGqQODELlo+vwDw8SjcYF57K1PDWgt
<             EQUgdIV8Ew==
<             -----END CERTIFICATE-----
<         - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
<           value: /var/run/secrets/kubernetes.io/serviceaccount/token
<         - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
<           value: linkerd-identity.linkerd.svc.cluster.local:8080
<         - name: _pod_sa
<           valueFrom:
<             fieldRef:
<               fieldPath: spec.serviceAccountName
<         - name: _l5d_ns
<           value: linkerd
<         - name: _l5d_trustdomain
<           value: cluster.local
<         - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
<           value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
<           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
<           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
---
>         - name: LINKERD2_PROXY_IDENTITY_DISABLED
>           value: Identity is not yet available
141,143d109
<         volumeMounts:
<         - mountPath: /var/run/linkerd/identity/end-entity
<           name: linkerd-identity-end-entity
167,170d132
<       volumes:
<       - emptyDir:
<           medium: Memory
<         name: linkerd-identity-end-entity
202,203c164,165
<         linkerd.io/created-by: linkerd/cli edge-19.4.3
<         linkerd.io/identity-mode: default
---
>         linkerd.io/created-by: linkerd/cli git-e467cec0
>         linkerd.io/identity-mode: disabled
248,280c210,211
<         - name: LINKERD2_PROXY_IDENTITY_DIR
<           value: /var/run/linkerd/identity/end-entity
<         - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
<           value: |
<             -----BEGIN CERTIFICATE-----
<             MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
<             eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDExMTYzODAxWhcNMjAwNDEw
<             MTYzODIxWjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
<             YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASH8ewLuOh2bYHPXwq54K5HpBAT
<             gvHuP3t7zGTt4KXgbN3o7q0sUbZhNfduMI7oE4NKZRK9NtWpY7p3t3vH9DmAo0Iw
<             QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
<             MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhALv53LdLrjFel8V9
<             6JPgrT+wT8pMGmGlXzbAA4SePQs8AiBLlZaGqQODELlo+vwDw8SjcYF57K1PDWgt
<             EQUgdIV8Ew==
<             -----END CERTIFICATE-----
<         - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
<           value: /var/run/secrets/kubernetes.io/serviceaccount/token
<         - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
<           value: linkerd-identity.linkerd.svc.cluster.local:8080
<         - name: _pod_sa
<           valueFrom:
<             fieldRef:
<               fieldPath: spec.serviceAccountName
<         - name: _l5d_ns
<           value: linkerd
<         - name: _l5d_trustdomain
<           value: cluster.local
<         - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
<           value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
<           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
<           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
---
>         - name: LINKERD2_PROXY_IDENTITY_DISABLED
>           value: Identity is not yet available
303,305d233
<         volumeMounts:
<         - mountPath: /var/run/linkerd/identity/end-entity
<           name: linkerd-identity-end-entity
329,332d256
<       volumes:
<       - emptyDir:
<           medium: Memory
<         name: linkerd-identity-end-entity
364,365c288,289
<         linkerd.io/created-by: linkerd/cli edge-19.4.3
<         linkerd.io/identity-mode: default
---
>         linkerd.io/created-by: linkerd/cli git-e467cec0
>         linkerd.io/identity-mode: disabled
416,448c340,341
<         - name: LINKERD2_PROXY_IDENTITY_DIR
<           value: /var/run/linkerd/identity/end-entity
<         - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
<           value: |
<             -----BEGIN CERTIFICATE-----
<             MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
<             eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDExMTYzODAxWhcNMjAwNDEw
<             MTYzODIxWjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
<             YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASH8ewLuOh2bYHPXwq54K5HpBAT
<             gvHuP3t7zGTt4KXgbN3o7q0sUbZhNfduMI7oE4NKZRK9NtWpY7p3t3vH9DmAo0Iw
<             QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
<             MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhALv53LdLrjFel8V9
<             6JPgrT+wT8pMGmGlXzbAA4SePQs8AiBLlZaGqQODELlo+vwDw8SjcYF57K1PDWgt
<             EQUgdIV8Ew==
<             -----END CERTIFICATE-----
<         - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
<           value: /var/run/secrets/kubernetes.io/serviceaccount/token
<         - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
<           value: linkerd-identity.linkerd.svc.cluster.local:8080
<         - name: _pod_sa
<           valueFrom:
<             fieldRef:
<               fieldPath: spec.serviceAccountName
<         - name: _l5d_ns
<           value: linkerd
<         - name: _l5d_trustdomain
<           value: cluster.local
<         - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
<           value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
<           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
<           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
---
>         - name: LINKERD2_PROXY_IDENTITY_DISABLED
>           value: Identity is not yet available
471,473d363
<         volumeMounts:
<         - mountPath: /var/run/linkerd/identity/end-entity
<           name: linkerd-identity-end-entity
497,500d386
<       volumes:
<       - emptyDir:
<           medium: Memory
<         name: linkerd-identity-end-entity
532,533c418,419
<         linkerd.io/created-by: linkerd/cli edge-19.4.3
<         linkerd.io/identity-mode: default
---
>         linkerd.io/created-by: linkerd/cli git-e467cec0
>         linkerd.io/identity-mode: disabled
577,609c463,464
<         - name: LINKERD2_PROXY_IDENTITY_DIR
<           value: /var/run/linkerd/identity/end-entity
<         - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
<           value: |
<             -----BEGIN CERTIFICATE-----
<             MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
<             eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDExMTYzODAxWhcNMjAwNDEw
<             MTYzODIxWjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
<             YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASH8ewLuOh2bYHPXwq54K5HpBAT
<             gvHuP3t7zGTt4KXgbN3o7q0sUbZhNfduMI7oE4NKZRK9NtWpY7p3t3vH9DmAo0Iw
<             QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
<             MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhALv53LdLrjFel8V9
<             6JPgrT+wT8pMGmGlXzbAA4SePQs8AiBLlZaGqQODELlo+vwDw8SjcYF57K1PDWgt
<             EQUgdIV8Ew==
<             -----END CERTIFICATE-----
<         - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
<           value: /var/run/secrets/kubernetes.io/serviceaccount/token
<         - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
<           value: linkerd-identity.linkerd.svc.cluster.local:8080
<         - name: _pod_sa
<           valueFrom:
<             fieldRef:
<               fieldPath: spec.serviceAccountName
<         - name: _l5d_ns
<           value: linkerd
<         - name: _l5d_trustdomain
<           value: cluster.local
<         - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
<           value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
<           value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
<         - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
<           value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
---
>         - name: LINKERD2_PROXY_IDENTITY_DISABLED
>           value: Identity is not yet available
632,634d486
<         volumeMounts:
<         - mountPath: /var/run/linkerd/identity/end-entity
<           name: linkerd-identity-end-entity
657,660d508
<       volumes:
<       - emptyDir:
<           medium: Memory
<         name: linkerd-identity-end-entity
```

Fixes #2684 

Signed-off-by: Ivan Sim <ivan@buoyant.io>