### PR TITLE
Update proxy to fix a connection starvation issue

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-b634c3a}"
+PROXY_VERSION="${PROXY_VERSION:-c96dd3a}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
In https://github.com/linkerd/linkerd2-proxy/pull/233, we fixed an issue
in the proxy where, when the proxy performed TLS discovery (on inbound
connections), detection on a slow or idle connection could block all
other connections from being accepted on the listener.

This would frequently cause liveness probe failures on application
containers, causing pods to go into CrashLoopBackoff.

Fixes #2581 #2585 #2630