### PR TITLE
Create proxy-injector RBAC resources before deployment (fixes #2694)

### DIFF
--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -11,6 +11,38 @@ metadata:
   name: linkerd-proxy-injector
   namespace: {{.Namespace}}
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Namespace}}-proxy-injector
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["create", "get", "delete"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Namespace}}-proxy-injector
+subjects:
+- kind: ServiceAccount
+  name: linkerd-proxy-injector
+  namespace: {{.Namespace}}
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: linkerd-{{.Namespace}}-proxy-injector
+  apiGroup: rbac.authorization.k8s.io
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -66,38 +98,6 @@ spec:
       - name: config
         configMap:
           name: linkerd-config
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-{{.Namespace}}-proxy-injector
-rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "get", "delete"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
-  verbs: ["list", "get", "watch"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-{{.Namespace}}-proxy-injector
-subjects:
-- kind: ServiceAccount
-  name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
-  apiGroup: ""
-roleRef:
-  kind: ClusterRole
-  name: linkerd-{{.Namespace}}-proxy-injector
-  apiGroup: rbac.authorization.k8s.io
 ---
 kind: Service
 apiVersion: v1

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -5,6 +5,12 @@
 ### Proxy Injector
 ###
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: {{.Namespace}}
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -60,12 +66,6 @@ spec:
       - name: config
         configMap:
           name: linkerd-config
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -1333,6 +1333,12 @@ data:
 ### Proxy Injector
 ###
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: linkerd
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1479,12 +1485,6 @@ spec:
           medium: Memory
         name: linkerd-identity-end-entity
 status: {}
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: linkerd
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_no_init_container_auto_inject.golden
+++ b/cli/cmd/testdata/install_no_init_container_auto_inject.golden
@@ -1339,6 +1339,38 @@ metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-proxy-injector
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["create", "get", "delete"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-proxy-injector
+subjects:
+- kind: ServiceAccount
+  name: linkerd-proxy-injector
+  namespace: linkerd
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: linkerd-linkerd-proxy-injector
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1485,38 +1517,6 @@ spec:
           medium: Memory
         name: linkerd-identity-end-entity
 status: {}
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-linkerd-proxy-injector
-rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "get", "delete"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
-  verbs: ["list", "get", "watch"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-linkerd-proxy-injector
-subjects:
-- kind: ServiceAccount
-  name: linkerd-proxy-injector
-  namespace: linkerd
-  apiGroup: ""
-roleRef:
-  kind: ClusterRole
-  name: linkerd-linkerd-proxy-injector
-  apiGroup: rbac.authorization.k8s.io
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1278,6 +1278,12 @@ data:
 ### Proxy Injector
 ###
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: Namespace
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1413,12 +1419,6 @@ spec:
           name: linkerd-config
         name: config
 status: {}
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: Namespace
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1284,6 +1284,38 @@ metadata:
   name: linkerd-proxy-injector
   namespace: Namespace
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-Namespace-proxy-injector
+rules:
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["create", "get", "delete"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-Namespace-proxy-injector
+subjects:
+- kind: ServiceAccount
+  name: linkerd-proxy-injector
+  namespace: Namespace
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: linkerd-Namespace-proxy-injector
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1419,38 +1451,6 @@ spec:
           name: linkerd-config
         name: config
 status: {}
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
-  verbs: ["create", "get", "delete"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list", "get", "watch"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
-  verbs: ["list", "get", "watch"]
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: linkerd-Namespace-proxy-injector
-subjects:
-- kind: ServiceAccount
-  name: linkerd-proxy-injector
-  namespace: Namespace
-  apiGroup: ""
-roleRef:
-  kind: ClusterRole
-  name: linkerd-Namespace-proxy-injector
-  apiGroup: rbac.authorization.k8s.io
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
Problem
The serviceaccount for the proxy-injector is created after the deployment, which has a dependency on it.

Solution
Create the serviceaccount, clusterRole, and clusterRoleBinding before the deployment.

Validation
Unittests passing locally.

Fixes #2694