### PR TITLE
Don't use spinner in cli when run without a tty

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -11,7 +11,7 @@ RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION) && \
     echo "$version" >version.txt)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 ENV CGO_ENABLED=0 GOOS=linux
 COPY pkg/flags pkg/flags

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -450,12 +450,12 @@
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:3140e04675a6a91d2a20ea9d10bdadf6072085502e6def6768361260aee4b967"
+  digest = "1:d0600e4cf07697303f37130791b2ce4577367931416bea8ec4f601bde3f7c5bf"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = ""
-  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
-  version = "v0.0.4"
+  revision = "c2a7a6ca930a4cd0bc33a3f298eb71960732a3a7"
+  version = "v0.0.7"
 
 [[projects]]
   digest = "1:81e673df85e765593a863f67cba4544cf40e8919590f04d67664940786c2b61a"
@@ -1261,6 +1261,7 @@
     "github.com/linkerd/linkerd2-proxy-api/go/identity",
     "github.com/linkerd/linkerd2-proxy-api/go/net",
     "github.com/linkerd/linkerd2-proxy-api/go/tap",
+    "github.com/mattn/go-isatty",
     "github.com/mattn/go-runewidth",
     "github.com/nsf/termbox-go",
     "github.com/pkg/browser",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,6 +44,10 @@ required = [
   revision = "5cf08d0ac778f0d708570fe143e3f82fdb9f9007"
 
 [[constraint]]
+  name = "github.com/mattn/go-isatty"
+  version = "v0.0.7"
+
+[[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "v1.0.3"
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -148,8 +149,10 @@ func runChecks(w io.Writer, hc *healthcheck.HealthChecker) bool {
 
 		spin.Stop()
 		if result.Retry {
-			spin.Suffix = fmt.Sprintf(" %s -- %s", result.Description, result.Err)
-			spin.Color("bold")
+			if isatty.IsTerminal(os.Stdout.Fd()) {
+				spin.Suffix = fmt.Sprintf(" %s -- %s", result.Description, result.Err)
+				spin.Color("bold") // this calls spin.Restart()
+			}
 			return
 		}
 

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:44063d94 as golang
+FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
In some non-tty environments, the `linkerd check` spinner can render
unexpected control characters.

Disable the spinner when run without a tty.

Fixes #2700

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![check-tty](https://user-images.githubusercontent.com/236915/56322739-bbd93c00-611e-11e9-92e1-7c6a0a0606b6.gif)
