### PR TITLE
Add config.linkerd.io/disable-identity annotation

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -193,7 +193,8 @@ type proxyConfigOptions struct {
 	proxyMemoryLimit       string
 	enableExternalProfiles bool
 	// ignoreCluster is not validated by validate().
-	ignoreCluster bool
+	ignoreCluster   bool
+	disableIdentity bool
 }
 
 func (options *proxyConfigOptions) validate() error {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -488,7 +488,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
 		sidecar.VolumeMounts = []v1.VolumeMount{*saVolumeMount}
 	}
 
-	idctx := conf.configs.GetGlobal().GetIdentityContext()
+	idctx := conf.identityContext()
 	if idctx == nil {
 		sidecar.Env = append(sidecar.Env, v1.EnvVar{
 			Name:  envIdentityDisabled,
@@ -608,7 +608,7 @@ func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
 	}
 	patch.addPodAnnotation(k8s.ProxyVersionAnnotation, conf.configs.GetProxy().GetProxyVersion())
 
-	if conf.configs.GetGlobal().GetIdentityContext() != nil {
+	if conf.identityContext() != nil {
 		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDefault)
 	} else {
 		patch.addPodAnnotation(k8s.IdentityModeAnnotation, k8s.IdentityModeDisabled)
@@ -721,6 +721,17 @@ func (conf *ResourceConfig) proxyLogLevel() string {
 	}
 
 	return conf.configs.GetProxy().GetLogLevel().GetLevel()
+}
+
+func (conf *ResourceConfig) identityContext() *config.IdentityContext {
+	if override := conf.getOverride(k8s.ProxyDisableIdentityAnnotation); override != "" {
+		value, err := strconv.ParseBool(override)
+		if err == nil && value {
+			return nil
+		}
+	}
+
+	return conf.configs.GetGlobal().GetIdentityContext()
 }
 
 func (conf *ResourceConfig) proxyResourceRequirements() v1.ResourceRequirements {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -151,6 +151,9 @@ const (
 	// ProxyVersionOverrideAnnotation can be used to override the proxy version config.
 	ProxyVersionOverrideAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-version"
 
+	// ProxyDisableIdentityAnnotation can be used to disable identity on the injected proxy.
+	ProxyDisableIdentityAnnotation = ProxyConfigAnnotationsPrefix + "/disable-identity"
+
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.
 	IdentityModeDefault = "default"

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       annotations:
+        config.linkerd.io/disable-identity: "true"
         config.linkerd.io/init-image: init-image
         config.linkerd.io/proxy-image: proxy-image
         config.linkerd.io/proxy-version: proxy-version

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -13,6 +13,7 @@ spec:
       annotations:
         config.linkerd.io/admin-port: "789"
         config.linkerd.io/control-port: "123"
+        config.linkerd.io/disable-identity: "true"
         config.linkerd.io/enable-external-profiles: "true"
         config.linkerd.io/image-pull-policy: Never
         config.linkerd.io/inbound-port: "678"


### PR DESCRIPTION
First part of #2540

We'll tackle support for `--disable-identity` in `linkerd install` in a separate PR.