### PR TITLE
New `linkerd inject` default and advanced modes

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -97,7 +97,7 @@ sub-folders, or coming from stdin.`,
 	flags := options.flagSet(pflag.ExitOnError)
 	flags.BoolVar(
 		&advancedOption, "advanced", advancedOption,
-		"Add the proxy container in the ouput (as opposed to just adding the annotations for the auto-injector to do it) (default false)",
+		"Include the proxy sidecar container spec in the YAML output (the auto-injector won't pick it up, so config annotations aren't supported) (default false)",
 	)
 	flags.BoolVar(
 		&options.disableIdentity, "disable-identity", options.disableIdentity,

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -44,7 +44,7 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, transforme
 
 func newCmdInject() *cobra.Command {
 	options := &proxyConfigOptions{}
-	var advancedOption, enableDebugSidecar bool
+	var manualOption, enableDebugSidecar bool
 
 	cmd := &cobra.Command{
 		Use:   "inject [flags] CONFIG-FILE",
@@ -83,7 +83,7 @@ sub-folders, or coming from stdin.`,
 			options.overrideConfigs(configs, overrideAnnotations)
 
 			transformer := &resourceTransformerInject{
-				injectProxy:         advancedOption,
+				injectProxy:         manualOption,
 				configs:             configs,
 				overrideAnnotations: overrideAnnotations,
 				enableDebugSidecar:  enableDebugSidecar,
@@ -96,7 +96,7 @@ sub-folders, or coming from stdin.`,
 
 	flags := options.flagSet(pflag.ExitOnError)
 	flags.BoolVar(
-		&advancedOption, "advanced", advancedOption,
+		&manualOption, "manual", manualOption,
 		"Include the proxy sidecar container spec in the YAML output (the auto-injector won't pick it up, so config annotations aren't supported) (default false)",
 	)
 	flags.BoolVar(

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -41,6 +41,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	output := new(bytes.Buffer)
 	report := new(bytes.Buffer)
 	transformer := &resourceTransformerInject{
+		injectProxy:         true,
 		configs:             tc.testInjectConfig,
 		overrideAnnotations: map[string]string{},
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
@@ -228,7 +229,10 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	transformer := &resourceTransformerInject{configs: testConfig}
+	transformer := &resourceTransformerInject{
+		injectProxy: true,
+		configs:     testConfig,
+	}
 	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, transformer)
 	if exitCode != tc.exitCode {
 		t.Fatalf("Expected exit code to be %d but got: %d", tc.exitCode, exitCode)
@@ -286,7 +290,10 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	transformer := &resourceTransformerInject{configs: testInstallConfig()}
+	transformer := &resourceTransformerInject{
+		injectProxy: true,
+		configs:     testInstallConfig(),
+	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}
@@ -304,7 +311,10 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
-	transformer := &resourceTransformerInject{configs: testInstallConfig()}
+	transformer := &resourceTransformerInject{
+		injectProxy: true,
+		configs:     testInstallConfig(),
+	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
 	}

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/gen/config"
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 )
 
 type testCase struct {
@@ -20,6 +21,7 @@ type testCase struct {
 	goldenFileName         string
 	reportFileName         string
 	testInjectConfig       *config.All
+	overrideAnnotations    map[string]string
 	enableDebugSidecarFlag bool
 }
 
@@ -43,7 +45,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	transformer := &resourceTransformerInject{
 		injectProxy:         true,
 		configs:             tc.testInjectConfig,
-		overrideAnnotations: map[string]string{},
+		overrideAnnotations: tc.overrideAnnotations,
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
 	}
 
@@ -91,6 +93,15 @@ func TestUninjectAndInject(t *testing.T) {
 			goldenFileName:   "inject_emojivoto_deployment.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
 			testInjectConfig: defaultConfig,
+		},
+		{
+			inputFileName:    "inject_emojivoto_deployment.input.yml",
+			goldenFileName:   "inject_emojivoto_deployment_overridden.golden.yml",
+			reportFileName:   "inject_emojivoto_deployment.report",
+			testInjectConfig: defaultConfig,
+			overrideAnnotations: map[string]string{
+				k8s.ProxyAdminPortAnnotation: "1234",
+			},
 		},
 		{
 			inputFileName:    "inject_emojivoto_list.input.yml",

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -232,6 +232,7 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:          "inject_emojivoto_deployment.input.yml",
 			goldenFileName:         "inject_emojivoto_deployment_debug.golden.yml",
 			reportFileName:         "inject_emojivoto_deployment.report",
+			injectProxy:            true,
 			testInjectConfig:       defaultConfig,
 			enableDebugSidecarFlag: true,
 		},

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -20,6 +20,7 @@ type testCase struct {
 	inputFileName          string
 	goldenFileName         string
 	reportFileName         string
+	injectProxy            bool
 	testInjectConfig       *config.All
 	overrideAnnotations    map[string]string
 	enableDebugSidecarFlag bool
@@ -43,7 +44,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	output := new(bytes.Buffer)
 	report := new(bytes.Buffer)
 	transformer := &resourceTransformerInject{
-		injectProxy:         true,
+		injectProxy:         tc.injectProxy,
 		configs:             tc.testInjectConfig,
 		overrideAnnotations: tc.overrideAnnotations,
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
@@ -92,12 +93,24 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
+		},
+		{
+			inputFileName:    "inject_emojivoto_deployment.input.yml",
+			goldenFileName:   "inject_emojivoto_deployment_overridden_noinject.golden.yml",
+			reportFileName:   "inject_emojivoto_deployment.report",
+			injectProxy:      false,
+			testInjectConfig: defaultConfig,
+			overrideAnnotations: map[string]string{
+				k8s.ProxyAdminPortAnnotation: "1234",
+			},
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_overridden.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.ProxyAdminPortAnnotation: "1234",
@@ -107,96 +120,112 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_list.input.yml",
 			goldenFileName:   "inject_emojivoto_list.golden.yml",
 			reportFileName:   "inject_emojivoto_list.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_false.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_false.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_false.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_true.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_injectDisabled.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_injectDisabled.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_injectDisabled.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_controller_name.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_controller_name.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_controller_name.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_statefulset.input.yml",
 			goldenFileName:   "inject_emojivoto_statefulset.golden.yml",
 			reportFileName:   "inject_emojivoto_statefulset.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod.input.yml",
 			goldenFileName:   "inject_emojivoto_pod.golden.yml",
 			reportFileName:   "inject_emojivoto_pod.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod_with_requests.input.yml",
 			goldenFileName:   "inject_emojivoto_pod_with_requests.golden.yml",
 			reportFileName:   "inject_emojivoto_pod_with_requests.report",
+			injectProxy:      true,
 			testInjectConfig: proxyResourceConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_udp.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_udp.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_udp.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_already_injected.input.yml",
 			goldenFileName:   "inject_emojivoto_already_injected.golden.yml",
 			reportFileName:   "inject_emojivoto_already_injected.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_istio.input.yml",
 			goldenFileName:   "inject_emojivoto_istio.input.yml",
 			reportFileName:   "inject_emojivoto_istio.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_contour.input.yml",
 			goldenFileName:   "inject_contour.input.yml",
 			reportFileName:   "inject_contour.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_empty_resources.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_list_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_list_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_list_empty_resources.report",
+			injectProxy:      true,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_no_init_container.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
+			injectProxy:      true,
 			testInjectConfig: noInitContainerConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_config_overrides.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_config_overrides.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
+			injectProxy:      true,
 			testInjectConfig: overrideConfig,
 		},
 		{

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -576,7 +576,8 @@ func (values *installValues) render(w io.Writer, configs *pb.All) error {
 	configs.Proxy.IgnoreOutboundPorts = append(configs.Proxy.IgnoreOutboundPorts, &pb.Port{Port: 443})
 
 	return processYAML(&buf, w, ioutil.Discard, resourceTransformerInject{
-		configs: configs,
+		injectProxy: true,
+		configs:     configs,
 		proxyOutboundCapacity: map[string]uint{
 			values.PrometheusImage: prometheusProxyOutboundCapacity,
 		},

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -1,0 +1,151 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/admin-port: "1234"
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+      creationTimestamp: null
+      labels:
+        app: web-svc
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: web
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-destination.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:1234
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 1234
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 1234
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 1234
+          initialDelaySeconds: 2
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,1234
+        image: gcr.io/linkerd-io/proxy-init:test-inject-control-plane-version
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/admin-port: "1234"
+        linkerd.io/inject: enabled
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+status: {}
+---

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -61,7 +61,7 @@ func Inject(api *k8s.API,
 	resourceConfig.AppendPodAnnotations(map[string]string{
 		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
 	})
-	p, err := resourceConfig.GetPatch(request.Object.Raw)
+	p, err := resourceConfig.GetPatch(request.Object.Raw, true)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -119,7 +119,7 @@ func TestGetPatch(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				p, err := fullConf.GetPatch(fakeReq.Object.Raw)
+				p, err := fullConf.GetPatch(fakeReq.Object.Raw, true)
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -153,7 +153,7 @@ func TestGetPatch(t *testing.T) {
 
 		fakeReq := getFakeReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		p, err := conf.GetPatch(fakeReq.Object.Raw)
+		p, err := conf.GetPatch(fakeReq.Object.Raw, true)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -209,14 +209,11 @@ func (conf *ResourceConfig) ParseMetaAndYAML(bytes []byte) (*Report, error) {
 func (conf *ResourceConfig) GetPatch(bytes []byte, injectProxy bool) (*Patch, error) {
 	patch := NewPatch(conf.workload.metaType.Kind)
 	if conf.pod.spec != nil {
-		if len(conf.pod.meta.Annotations) == 0 {
-			patch.addPodAnnotationsRoot()
-		}
+		conf.injectPodAnnotations(patch)
 		if injectProxy {
 			conf.injectObjectMeta(patch)
 			conf.injectPodSpec(patch)
 		}
-		conf.injectPodAnnotations(patch)
 	}
 
 	return patch, nil
@@ -650,6 +647,10 @@ func (conf *ResourceConfig) injectObjectMeta(patch *Patch) {
 }
 
 func (conf *ResourceConfig) injectPodAnnotations(patch *Patch) {
+	if len(conf.pod.meta.Annotations) == 0 {
+		patch.addPodAnnotationsRoot()
+	}
+
 	for _, k := range sortedKeys(conf.pod.annotations) {
 		patch.addPodAnnotation(k, conf.pod.annotations[k])
 

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 
 func TestInject(t *testing.T) {
 	cmd := []string{"inject",
+		"--advanced",
 		"--linkerd-namespace=fake-ns",
 		"--disable-identity",
 		"--ignore-cluster",
@@ -51,6 +52,7 @@ func TestInject(t *testing.T) {
 func TestInjectParams(t *testing.T) {
 	// TODO: test config.linkerd.io/proxy-version
 	cmd := []string{"inject",
+		"--advanced",
 		"--linkerd-namespace=fake-ns",
 		"--disable-identity",
 		"--ignore-cluster",

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 
 func TestInject(t *testing.T) {
 	cmd := []string{"inject",
-		"--advanced",
+		"--manual",
 		"--linkerd-namespace=fake-ns",
 		"--disable-identity",
 		"--ignore-cluster",
@@ -52,7 +52,7 @@ func TestInject(t *testing.T) {
 func TestInjectParams(t *testing.T) {
 	// TODO: test config.linkerd.io/proxy-version
 	cmd := []string{"inject",
-		"--advanced",
+		"--manual",
 		"--linkerd-namespace=fake-ns",
 		"--disable-identity",
 		"--ignore-cluster",

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -280,7 +280,7 @@ func TestInject(t *testing.T) {
 			t.Fatalf("failed to create %s namespace with auto inject enabled: %s", prefixedNs, err)
 		}
 	} else {
-		cmd := []string{"inject", "--advanced", "testdata/smoke_test.yaml"}
+		cmd := []string{"inject", "--manual", "testdata/smoke_test.yaml"}
 
 		var injectReport string
 		out, injectReport, err = TestHelper.LinkerdRun(cmd...)

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -280,7 +280,7 @@ func TestInject(t *testing.T) {
 			t.Fatalf("failed to create %s namespace with auto inject enabled: %s", prefixedNs, err)
 		}
 	} else {
-		cmd := []string{"inject", "testdata/smoke_test.yaml"}
+		cmd := []string{"inject", "--advanced", "testdata/smoke_test.yaml"}
 
 		var injectReport string
 		out, injectReport, err = TestHelper.LinkerdRun(cmd...)

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 func TestServiceProfiles(t *testing.T) {
 
 	testNamespace := TestHelper.GetTestNamespace("serviceprofile-test")
-	out, stderr, err := TestHelper.LinkerdRun("inject", "--advanced", "testdata/tap_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
 	}
@@ -140,7 +140,7 @@ func TestServiceProfileMetrics(t *testing.T) {
 		)
 
 		t.Run(tc, func(t *testing.T) {
-			out, stderr, err := TestHelper.LinkerdRun("inject", "--advanced", testYAML)
+			out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", testYAML)
 			if err != nil {
 				t.Errorf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
 			}

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -33,7 +33,7 @@ func TestMain(m *testing.M) {
 func TestServiceProfiles(t *testing.T) {
 
 	testNamespace := TestHelper.GetTestNamespace("serviceprofile-test")
-	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/tap_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--advanced", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
 	}
@@ -140,7 +140,7 @@ func TestServiceProfileMetrics(t *testing.T) {
 		)
 
 		t.Run(tc, func(t *testing.T) {
-			out, stderr, err := TestHelper.LinkerdRun("inject", testYAML)
+			out, stderr, err := TestHelper.LinkerdRun("inject", "--advanced", testYAML)
 			if err != nil {
 				t.Errorf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
 			}

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -78,7 +78,7 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "--advanced", "testdata/tap_application.yaml")
+	out, _, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s", out)
 	}

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -78,7 +78,7 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "testdata/tap_application.yaml")
+	out, _, err := TestHelper.LinkerdRun("inject", "--advanced", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s", out)
 	}


### PR DESCRIPTION
Fixes #2710 and #2711 (made more sense to tackle both at once)

This changes the default behavior of `linkerd inject` to not inject the
proxy but just the `linkerd.io/inject: enabled` annotation for the
auto-injector to pick it up (regardless of any namespace annotation).

A new `--advanced` mode was added, which behaves as before, injecting
the proxy in the command output.

The unit tests are running with `--advanced` to avoid any changes in the
fixtures.

I still need to add a new test for non-advanced mode and fix the
integration tests.