### PR TITLE
Introduce multi-stage upgrade

### DIFF
--- a/chart/templates/prometheus-rbac.yaml
+++ b/chart/templates/prometheus-rbac.yaml
@@ -4,12 +4,6 @@
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: {{.Namespace}}
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -29,6 +23,12 @@ roleRef:
   name: linkerd-{{.Namespace}}-prometheus
 subjects:
 - kind: ServiceAccount
+  name: linkerd-prometheus
+  namespace: {{.Namespace}}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-prometheus
   namespace: {{.Namespace}}
 {{- end}}

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -4,12 +4,6 @@
 ### Proxy Injector RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -41,4 +35,10 @@ roleRef:
   kind: ClusterRole
   name: linkerd-{{.Namespace}}-proxy-injector
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: {{.Namespace}}
 {{end -}}

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -4,12 +4,6 @@
 ### Service Profile Validator RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-sp-validator
-  namespace: {{.Namespace}}
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -35,4 +29,10 @@ roleRef:
   kind: ClusterRole
   name: linkerd-{{.Namespace}}-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: {{.Namespace}}
 {{end -}}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -914,7 +914,12 @@ func validateArgs(args []string, flags *pflag.FlagSet, additionalFlags *pflag.Fl
 		invalidFlags := make([]string, 0)
 		combinedFlags.VisitAll(func(f *pflag.Flag) {
 			if f.Changed {
-				invalidFlags = append(invalidFlags, f.Name)
+				switch f.Name {
+				case "ignore-cluster":
+					// allow `linkerd install config --ignore-cluster`
+				default:
+					invalidFlags = append(invalidFlags, f.Name)
+				}
 			}
 		})
 		if len(invalidFlags) > 0 {

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -896,7 +896,7 @@ func (idvals *installIdentityValues) toIdentityContext() *pb.IdentityContext {
 	}
 }
 
-func validateArgs(args []string, flags *pflag.FlagSet, installOnlyFlags *pflag.FlagSet) (string, error) {
+func validateArgs(args []string, flags *pflag.FlagSet, additionalFlags *pflag.FlagSet) (string, error) {
 	if len(args) > 1 {
 		return "", fmt.Errorf("only zero or one argument permitted, received: %s", args)
 	} else if len(args) == 0 {
@@ -909,7 +909,7 @@ func validateArgs(args []string, flags *pflag.FlagSet, installOnlyFlags *pflag.F
 	if stage == configStage {
 		combinedFlags := pflag.NewFlagSet("combined-flags", pflag.ExitOnError)
 		combinedFlags.AddFlagSet(flags)
-		combinedFlags.AddFlagSet(installOnlyFlags)
+		combinedFlags.AddFlagSet(additionalFlags)
 
 		invalidFlags := make([]string, 0)
 		combinedFlags.VisitAll(func(f *pflag.Flag) {

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,4 +291,10 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: Namespace
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: Namespace
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: Namespace
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-Namespace-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: Namespace
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-Namespace-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: Namespace
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -192,12 +192,6 @@ spec:
 ### Prometheus RBAC
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-prometheus
-  namespace: linkerd
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -220,15 +214,15 @@ subjects:
   name: linkerd-prometheus
   namespace: linkerd
 ---
-###
-### Proxy Injector RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-proxy-injector
+  name: linkerd-prometheus
   namespace: linkerd
+---
+###
+### Proxy Injector RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,15 +256,15 @@ roleRef:
   name: linkerd-linkerd-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
-###
-### Service Profile Validator RBAC
-###
----
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-sp-validator
+  name: linkerd-proxy-injector
   namespace: linkerd
+---
+###
+### Service Profile Validator RBAC
+###
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -297,6 +291,12 @@ roleRef:
   kind: ClusterRole
   name: linkerd-linkerd-sp-validator
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	okMessage   = "You're on your way to upgrading Linkerd!\nVisit this URL for further instructions: https://linkerd.io/upgrade/#nextsteps\n"
-	failMessage = "For troubleshooting help, visit: https://linkerd.io/upgrade/#troubleshooting\n"
+	okMessage           = "You're on your way to upgrading Linkerd!"
+	controlPlaneMessage = "Don't forget to run `linkerd upgrade control-plane`!"
+	visitMessage        = "Visit this URL for further instructions: https://linkerd.io/upgrade/#nextsteps"
+	failMessage         = "For troubleshooting help, visit: https://linkerd.io/upgrade/#troubleshooting\n"
 )
 
 type upgradeOptions struct {
@@ -117,6 +119,10 @@ install command.`,
 			buf.WriteTo(os.Stdout)
 
 			fmt.Fprintf(os.Stderr, "\n%s %s\n", okStatus, okMessage)
+			if stage == configStage {
+				fmt.Fprintf(os.Stderr, "%s\n", controlPlaneMessage)
+			}
+			fmt.Fprintf(os.Stderr, "%s\n\n", visitMessage)
 
 			return nil
 		},

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -87,7 +87,7 @@ data:
 				t.Fatalf("Error mocking k8s client: %s", err)
 			}
 
-			values, configs, err := options.validateAndBuild(clientset, flags)
+			values, configs, err := options.validateAndBuild("", clientset, flags)
 			if !reflect.DeepEqual(err, tc.err) {
 				t.Fatalf("Expected \"%s\", got \"%s\"", tc.err, err)
 			} else if err == nil {
@@ -134,7 +134,7 @@ data:
 		t.Fatalf("Error mocking k8s client: %s", err)
 	}
 
-	values, configs, err := options.validateAndBuild(clientset, flags)
+	values, configs, err := options.validateAndBuild("", clientset, flags)
 	if err != nil {
 		t.Fatalf("validateAndBuild failed with %s", err)
 	}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -124,6 +124,21 @@ func TestInstallOrUpgrade(t *testing.T) {
 
 	if TestHelper.UpgradeFromVersion() != "" {
 		cmd = "upgrade"
+
+		// test 2-stage install during upgrade
+		out, _, err := TestHelper.LinkerdRun(cmd, "config")
+		if err != nil {
+			t.Fatalf("linkerd upgrade config command failed\n%s", out)
+		}
+
+		// apply stage 1
+		out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
+		if err != nil {
+			t.Fatalf("kubectl apply command failed\n%s", out)
+		}
+
+		// prepare for stage 2
+		args = append([]string{"control-plane"}, args...)
 	}
 
 	exec := append([]string{cmd}, args...)


### PR DESCRIPTION
`linkerd install` supports a 2-stage install process, `linkerd upgrade`
did not.

Add 2-stage support for `linkerd upgrade`. Also exercise multi-stage
functionality during upgrade integration tests.

Part of #2337

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

Depends on #2719