### PR TITLE
Add the ability to inject a debug sidecar 

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,0 +1,8 @@
+FROM gcr.io/linkerd-io/base:2019-02-19.01
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tcpdump \
+    iproute2 \
+    lsof \
+    tshark && \
+    rm -rf /var/lib/apt/lists/*
+ENTRYPOINT [ "tshark", "-i", "any" ]

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -13,6 +13,7 @@ $bindir/docker-build-controller
 $bindir/docker-build-web
 $bindir/docker-build-proxy-init
 $bindir/docker-build-cni-plugin
+$bindir/docker-build-debug
 if [ -z "${LINKERD_LOCAL_BUILD_CLI:-}" ]; then
     $bindir/docker-build-cli-bin
 else

--- a/bin/docker-build-debug
+++ b/bin/docker-build-debug
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    exit 64
+fi
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rootdir="$( cd $bindir/.. && pwd )"
+
+. $bindir/_docker.sh
+. $bindir/_tag.sh
+
+dockerfile=$rootdir/Dockerfile-debug
+
+(
+    "$bindir"/docker-build-base
+) >/dev/null
+
+tag="$(head_root_tag)"
+
+docker_build debug $tag $dockerfile

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -16,7 +16,7 @@ docker_image() {
 
 tag=$(head_root_tag)
 
-for img in cli-bin cni-plugin controller grafana proxy proxy-init web  ; do
+for img in cli-bin cni-plugin controller debug grafana proxy proxy-init web  ; do
     docker_image "$img" "$tag"
 done
 

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin cni-plugin controller grafana proxy proxy-init web  ; do
+for img in cli-bin cni-plugin controller debug grafana proxy proxy-init web  ; do
     docker_pull "$img" "$tag"
 done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin cni-plugin controller grafana proxy proxy-init web  ; do
+for img in cli-bin cni-plugin controller debug grafana proxy proxy-init web  ; do
     docker_push "$img" "$tag"
 done

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -13,6 +13,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . $bindir/_docker.sh
 
-for img in cli-bin cni-plugin controller grafana proxy proxy-init web  ; do
+for img in cli-bin cni-plugin controller debug grafana proxy proxy-init web  ; do
     docker_retag "$img" "$from" "$to"
 done

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/linkerd/linkerd2/controller/gen/config"
+	cfg "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/inject"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -31,9 +31,10 @@ const (
 )
 
 type resourceTransformerInject struct {
-	configs               *config.All
+	configs               *cfg.All
 	overrideAnnotations   map[string]string
 	proxyOutboundCapacity map[string]uint
+	enableDebugSidecar    bool
 }
 
 func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, transformer *resourceTransformerInject) int {
@@ -83,6 +84,7 @@ sub-folders, or coming from stdin.`,
 			transformer := &resourceTransformerInject{
 				configs:             configs,
 				overrideAnnotations: overrideAnnotations,
+				enableDebugSidecar:  options.enableDebugSidecar,
 			}
 			exitCode := uninjectAndInject(in, stderr, stdout, transformer)
 			os.Exit(exitCode)
@@ -99,6 +101,9 @@ sub-folders, or coming from stdin.`,
 		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
 		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
 	)
+
+	flags.BoolVar(&options.enableDebugSidecar, "enable-debug-sidecar", options.enableDebugSidecar,
+		"Inject a debug sidecar for data plane debugging")
 	cmd.PersistentFlags().AddFlagSet(flags)
 
 	return cmd
@@ -116,6 +121,10 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	conf := inject.NewResourceConfig(rt.configs, inject.OriginCLI)
 	if len(rt.proxyOutboundCapacity) > 0 {
 		conf = conf.WithProxyOutboundCapacity(rt.proxyOutboundCapacity)
+	}
+
+	if rt.enableDebugSidecar {
+		conf = conf.WithDebugSidecar()
 	}
 
 	report, err := conf.ParseMetaAndYAML(bytes)
@@ -271,7 +280,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 	output.Write([]byte("\n"))
 }
 
-func (options *proxyConfigOptions) fetchConfigsOrDefault() (*config.All, error) {
+func (options *proxyConfigOptions) fetchConfigsOrDefault() (*cfg.All, error) {
 	if options.ignoreCluster {
 		if !options.disableIdentity {
 			return nil, errors.New("--disable-identity must be set with --ignore-cluster")
@@ -287,13 +296,16 @@ func (options *proxyConfigOptions) fetchConfigsOrDefault() (*config.All, error) 
 		return nil, err
 	}
 
+	if options.enableDebugSidecar {
+		config.Proxy.EnableDebugSidecar = options.enableDebugSidecar
+	}
 	return config, nil
 }
 
 // overrideConfigs uses command-line overrides to update the provided configs.
 // the overrideAnnotations map keeps track of which configs are overridden, by
 // storing the corresponding annotations and values.
-func (options *proxyConfigOptions) overrideConfigs(configs *config.All, overrideAnnotations map[string]string) {
+func (options *proxyConfigOptions) overrideConfigs(configs *cfg.All, overrideAnnotations map[string]string) {
 	if options.proxyVersion != "" {
 		configs.Proxy.ProxyVersion = options.proxyVersion
 		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = options.proxyVersion
@@ -353,7 +365,7 @@ func (options *proxyConfigOptions) overrideConfigs(configs *config.All, override
 	}
 
 	if options.proxyLogLevel != "" {
-		configs.Proxy.LogLevel = &config.LogLevel{Level: options.proxyLogLevel}
+		configs.Proxy.LogLevel = &cfg.LogLevel{Level: options.proxyLogLevel}
 		overrideAnnotations[k8s.ProxyLogLevelAnnotation] = options.proxyLogLevel
 	}
 
@@ -388,23 +400,23 @@ func (options *proxyConfigOptions) overrideConfigs(configs *config.All, override
 	}
 }
 
-func toPort(p uint) *config.Port {
-	return &config.Port{Port: uint32(p)}
+func toPort(p uint) *cfg.Port {
+	return &cfg.Port{Port: uint32(p)}
 }
 
-func parsePort(port *config.Port) string {
+func parsePort(port *cfg.Port) string {
 	return strconv.FormatUint(uint64(port.GetPort()), 10)
 }
 
-func toPorts(ints []uint) []*config.Port {
-	ports := make([]*config.Port, len(ints))
+func toPorts(ints []uint) []*cfg.Port {
+	ports := make([]*cfg.Port, len(ints))
 	for i, p := range ints {
 		ports[i] = toPort(p)
 	}
 	return ports
 }
 
-func parsePorts(ports []*config.Port) string {
+func parsePorts(ports []*cfg.Port) string {
 	var str string
 	for _, port := range ports {
 		str += parsePort(port) + ","

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -296,9 +296,6 @@ func (options *proxyConfigOptions) fetchConfigsOrDefault() (*cfg.All, error) {
 		return nil, err
 	}
 
-	if options.enableDebugSidecar {
-		config.Proxy.EnableDebugSidecar = options.enableDebugSidecar
-	}
 	return config, nil
 }
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -43,6 +43,7 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, transforme
 
 func newCmdInject() *cobra.Command {
 	options := &proxyConfigOptions{}
+	var enableDebugSidecar bool
 
 	cmd := &cobra.Command{
 		Use:   "inject [flags] CONFIG-FILE",
@@ -60,7 +61,6 @@ sub-folders, or coming from stdin.`,
   # Inject all the resources inside a folder and its sub-folders.
   linkerd inject <folder> | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if len(args) < 1 {
 				return fmt.Errorf("please specify a kubernetes resource file")
 			}
@@ -84,7 +84,7 @@ sub-folders, or coming from stdin.`,
 			transformer := &resourceTransformerInject{
 				configs:             configs,
 				overrideAnnotations: overrideAnnotations,
-				enableDebugSidecar:  options.enableDebugSidecar,
+				enableDebugSidecar:  enableDebugSidecar,
 			}
 			exitCode := uninjectAndInject(in, stderr, stdout, transformer)
 			os.Exit(exitCode)
@@ -102,7 +102,7 @@ sub-folders, or coming from stdin.`,
 		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
 	)
 
-	flags.BoolVar(&options.enableDebugSidecar, "enable-debug-sidecar", options.enableDebugSidecar,
+	flags.BoolVar(&enableDebugSidecar, "enable-debug-sidecar", enableDebugSidecar,
 		"Inject a debug sidecar for data plane debugging")
 	cmd.PersistentFlags().AddFlagSet(flags)
 

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -16,10 +16,11 @@ import (
 )
 
 type testCase struct {
-	inputFileName    string
-	goldenFileName   string
-	reportFileName   string
-	testInjectConfig *config.All
+	inputFileName          string
+	goldenFileName         string
+	reportFileName         string
+	testInjectConfig       *config.All
+	enableDebugSidecarFlag bool
 }
 
 func mkFilename(filename string, verbose bool) string {
@@ -42,6 +43,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	transformer := &resourceTransformerInject{
 		configs:             tc.testInjectConfig,
 		overrideAnnotations: map[string]string{},
+		enableDebugSidecar:  tc.enableDebugSidecarFlag,
 	}
 
 	if exitCode := uninjectAndInject([]io.Reader{read}, report, output, transformer); exitCode != 0 {
@@ -184,6 +186,13 @@ func TestUninjectAndInject(t *testing.T) {
 			goldenFileName:   "inject_emojivoto_deployment_config_overrides.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
 			testInjectConfig: overrideConfig,
+		},
+		{
+			inputFileName:          "inject_emojivoto_deployment.input.yml",
+			goldenFileName:         "inject_emojivoto_deployment_debug.golden.yml",
+			reportFileName:         "inject_emojivoto_deployment.report",
+			testInjectConfig:       defaultConfig,
+			enableDebugSidecarFlag: true,
 		},
 	}
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -1,0 +1,155 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+      creationTimestamp: null
+      labels:
+        app: web-svc
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: web
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - image: gcr.io/linkerd-io/debug:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        name: linkerd-debug
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd2_proxy=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-destination.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-controller.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        resources: {}
+        securityContext:
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:test-inject-control-plane-version
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: false
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+status: {}
+---

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -38,7 +38,7 @@ spec:
         - containerPort: 80
           name: http
         resources: {}
-      - image: gcr.io/linkerd-io/debug:test-inject-proxy-version
+      - image: gcr.io/linkerd-io/debug:test-inject-control-plane-version
         imagePullPolicy: IfNotPresent
         name: linkerd-debug
         resources: {}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -169,6 +169,12 @@ const (
 	// ConfigConfigMapName is the name of the ConfigMap containing the linkerd controller configuration.
 	ConfigConfigMapName = "linkerd-config"
 
+	// DebugSidecarName is the name of the default linkerd debug container
+	DebugSidecarName = "linkerd-debug"
+
+	// DebugSidecarImage is the image name of the default linkerd debug container
+	DebugSidecarImage = "gcr.io/linkerd-io/debug"
+
 	// InitContainerName is the name assigned to the injected init container.
 	InitContainerName = "linkerd-init"
 


### PR DESCRIPTION
The current proxy and control plane containers are stripped down to reduce size. While that's awesome, it makes debugging (especially network level stuff) a little bit of a pain.

This PR first adds a new `debug` docker image to the linkerd2 inject workflow. This image contains pre-installed networking packages that are useful for debugging. This PR also adds the ability for the inject command to add this debugging container as a sidecar alongside a linkerd proxy. By default, the containers `ENTRYPOINT` is `tshark -i any` which exposes TCP traffic flowing to and from the meshed pod. This container also serves as a foundation for users to exec into in order to install and run any additional debugging tools as well.

New output:
```bash
bin/go-run cli inject --enable-debug-sidecar cli/cmd/testdata/inject_emojivoto_deployment.input.yml --ignore-cluster --disable-identity

apiVersion: apps/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  name: web
  namespace: emojivoto
spec:
  replicas: 1
  selector:
    matchLabels:
      app: web-svc
  strategy: {}
  template:
    metadata:
      annotations:
        linkerd.io/created-by: linkerd/cli git-77a64178
        linkerd.io/identity-mode: disabled
        linkerd.io/proxy-version: git-77a64178
      creationTimestamp: null
      labels:
        app: web-svc
        linkerd.io/control-plane-ns: linkerd
        linkerd.io/proxy-deployment: web
    spec:
      containers:
      - env:
        - name: WEB_PORT
          value: "80"
        - name: EMOJISVC_HOST
          value: emoji-svc.emojivoto:8080
        - name: VOTINGSVC_HOST
          value: voting-svc.emojivoto:8080
        - name: INDEX_BUNDLE
          value: dist/index_bundle.js
        image: buoyantio/emojivoto-web:v3
        name: web-svc
        ports:
        - containerPort: 80
          name: http
        resources: {}
      # Debug container
     - image: gcr.io/linkerd-io/debug:git-77a64178
        imagePullPolicy: IfNotPresent
        name: linkerd-debug
        resources: {}
        terminationMessagePolicy: FallbackToLogsOnError
      - env:
        - name: LINKERD2_PROXY_LOG
          value: warn,linkerd2_proxy=info
        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
          value: linkerd-destination.linkerd.svc.cluster.local:8086
        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
          value: 0.0.0.0:4190
        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
          value: 0.0.0.0:4191
        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
          value: 127.0.0.1:4140
        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
          value: 0.0.0.0:4143
        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
          value: svc.cluster.local.
        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
          value: 10000ms
        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
          value: 10000ms
        - name: _pod_ns
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
          value: ns:$(_pod_ns)
        - name: LINKERD2_PROXY_IDENTITY_DISABLED
          value: disabled
        image: gcr.io/linkerd-io/proxy:git-77a64178
        imagePullPolicy: IfNotPresent
        livenessProbe:
          httpGet:
            path: /metrics
            port: 4191
          initialDelaySeconds: 10
        name: linkerd-proxy
        ports:
        - containerPort: 4143
          name: linkerd-proxy
        - containerPort: 4191
          name: linkerd-admin
        readinessProbe:
          httpGet:
            path: /ready
            port: 4191
          initialDelaySeconds: 2
        resources: {}
        securityContext:
          runAsUser: 2102
        terminationMessagePolicy: FallbackToLogsOnError
      initContainers:
      - args:
        - --incoming-proxy-port
        - "4143"
        - --outgoing-proxy-port
        - "4140"
        - --proxy-uid
        - "2102"
        - --inbound-ports-to-ignore
        - 4190,4191
        image: gcr.io/linkerd-io/proxy-init:git-77a64178
        imagePullPolicy: IfNotPresent
        name: linkerd-init
        resources: {}
        securityContext:
          capabilities:
            add:
            - NET_ADMIN
          privileged: false
          runAsNonRoot: false
          runAsUser: 0
        terminationMessagePolicy: FallbackToLogsOnError
status: {}
---

deployment "web" injected
```
 

Fixes #2199 