### PR TITLE
Implement fallback logic for owner ref lookups

### DIFF
--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -329,23 +329,27 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 // references from the Kubernetes API. The kind is represented as the Kubernetes
 // singular resource type (e.g. deployment, daemonset, job, etc.)
 func (api *API) GetOwnerKindAndName(pod *corev1.Pod) (string, string) {
-	if len(pod.GetOwnerReferences()) != 1 {
-		log.Debugf("unexpected owner reference count (%d): %+v", len(pod.GetOwnerReferences()), pod.GetOwnerReferences())
+	ownerRefs := pod.GetOwnerReferences()
+	if len(ownerRefs) == 0 {
+		// pod without a parent
+		return "pod", pod.Name
+	} else if len(ownerRefs) > 1 {
+		log.Debugf("unexpected owner reference count (%d): %+v", len(ownerRefs), ownerRefs)
 		return "pod", pod.Name
 	}
 
-	parent := pod.GetOwnerReferences()[0]
+	parent := ownerRefs[0]
 	if parent.Kind == "ReplicaSet" {
 		rs, err := api.RS().Lister().ReplicaSets(pod.Namespace).Get(parent.Name)
 		if err != nil {
-			log.Errorf("failed to retrieve replicaset from indexer %s/%s: %s", pod.Namespace, parent.Name, err)
+			log.Warnf("failed to retrieve replicaset from indexer, retrying with get request %s/%s: %s", pod.Namespace, parent.Name, err)
 
 			// try again with a get request
 			rs, err = api.Client.AppsV1beta2().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
 			if err != nil {
 				log.Errorf("failed to get replicaset from k8s %s/%s: %s", pod.Namespace, parent.Name, err)
 			} else {
-				log.Infof("successfully recovered replicaset via k8s get request: %s/%s", pod.Namespace, parent.Name)
+				log.Debugf("successfully recovered replicaset via k8s get request: %s/%s", pod.Namespace, parent.Name)
 			}
 		}
 		if err != nil || len(rs.GetOwnerReferences()) != 1 {


### PR DESCRIPTION
The proxy-injector retrieves owner information when injecting pods. For
pods created via deployments, this requires a Pod -> ReplicaSet ->
Deployment lookup. There is a race condition where the injection happens
before the k8s informer client has indexed the new ReplicaSet.

If a ReplicaSet informer lookup initially fails, retry one time via a
get request. Also introduce logging to record the failure/retry, and
tests to validate `GetOwnerKindAndName` works with and without informer
indexing.

Fixes #2731

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

## Log of failure/retry

```bash
kubectl -n linkerd logs -f deploy/linkerd-proxy-injector proxy-injector
...
time="2019-04-23T06:26:30Z" level=info msg="received admission review request bb27118b-6590-11e9-a508-025000000001"
time="2019-04-23T06:26:30Z" level=error msg="failed to retrieve replicaset from indexer emojivoto-enabled/vote-bot-dc4bd6984: replicaset.apps \"vote-bot-dc4bd6984\" not found"
time="2019-04-23T06:26:30Z" level=info msg="successfully recovered replicaset via k8s get request: emojivoto-enabled/vote-bot-dc4bd6984"
time="2019-04-23T06:26:30Z" level=info msg="received pod/vote-bot-dc4bd6984-"
time="2019-04-23T06:26:30Z" level=info msg="patch generated for: pod/vote-bot-dc4bd6984-"
```