### PR TITLE
Add profiling endpoint for all control-plane components

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -48,6 +48,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		pprof.Profile(w, req)
 	case fmt.Sprintf("%strace", debugPathPrefix):
 		pprof.Trace(w, req)
+	case fmt.Sprintf("%ssymbol", debugPathPrefix):
+		pprof.Symbol(w, req)
 	default:
 		if strings.HasPrefix(req.URL.Path, "/debug/pprof/") {
 			pprof.Index(w, req)

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -1,8 +1,10 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -32,6 +34,7 @@ func StartServer(addr string) {
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	debugPathPrefix := "/debug/pprof/"
 	switch req.URL.Path {
 	case "/metrics":
 		h.promHandler.ServeHTTP(w, req)
@@ -39,12 +42,18 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		h.servePing(w)
 	case "/ready":
 		h.serveReady(w)
-	case "/debug/pprof/", "/debug/pprof":
-		pprof.Index(w, req)
-	case "/debug/pprof/profile/":
+	case fmt.Sprintf("%scmdline", debugPathPrefix):
+		pprof.Cmdline(w, req)
+	case fmt.Sprintf("%sprofile", debugPathPrefix):
 		pprof.Profile(w, req)
+	case fmt.Sprintf("%strace", debugPathPrefix):
+		pprof.Trace(w, req)
 	default:
-		http.NotFound(w, req)
+		if strings.HasPrefix(req.URL.Path, "/debug/pprof/") {
+			pprof.Index(w, req)
+		} else {
+			http.NotFound(w, req)
+		}
 	}
 }
 

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -38,6 +39,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		h.servePing(w)
 	case "/ready":
 		h.serveReady(w)
+	case "/debug/pprof/", "/debug/pprof":
+		pprof.Index(w, req)
+	case "/debug/pprof/profile/":
+		pprof.Profile(w, req)
 	default:
 		http.NotFound(w, req)
 	}


### PR DESCRIPTION
To better assist debugging efforts in the control plane, it would be good to expose profiling information (e.g. CPU and memory usage, number of goroutines) for each control plane component. Since the control plane is built in Go, we can take advantage of Go's [pprof](https://golang.org/pkg/net/http/pprof/) package to expose internal state of a control plane binary on an HTTP endpoint. 

The endpoint is reachable through the admin server at `/debug/pprof/`. and exposes the following diagnostics:
```html
Profile Descriptions:

allocs: A sampling of all past memory allocations
block: Stack traces that led to blocking on synchronization primitives
cmdline: The command line invocation of the current program
goroutine: Stack traces of all current goroutines
heap: A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
mutex: Stack traces of holders of contended mutexes
profile: CPU profile. You can specify the duration in the seconds GET parameter. After you get the profile file, use the go tool pprof command to investigate the profile.
threadcreate: Stack traces that led to the creation of new OS threads
trace: A trace of execution of the current program. You can specify the duration in the seconds GET parameter. After you get the trace file, use the go tool trace command to investigate the trace.
```

You can use `go tool pprof` to get information from a particular component. For example, to get memory for specific go objects, you could run the commands listed below.

```curl
$ bin/linkerd install | kubectl apply -f -

kubectl -n linkerd port-forward linkerd-identity-6889458f-hcbgg 9990

go tool pprof -seconds 5 -pdf http://localhost:9990/debug/pprof/allocs

Fetching profile over HTTP from http://localhost:9990/debug/pprof/allocs?seconds=5
Please wait... (5s)
Saved profile in /Users/dennis/pprof/pprof.identity.alloc_objects.alloc_space.inuse_objects.inuse_space.002.pb.gz
Generating report in profile003.pdf
```

Fixes #2634