### PR TITLE
Consolidate k8s APIs

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -9,7 +9,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
 )
 
 // These constants are used by the `show` flag.
@@ -63,12 +62,7 @@ func newCmdDashboard() *cobra.Command {
 			// ensure we can connect to the public API before starting the proxy
 			checkPublicAPIClientOrRetryOrExit(time.Now().Add(options.wait), true)
 
-			config, err := k8s.GetConfig(kubeconfigPath, kubeContext)
-			if err != nil {
-				return err
-			}
-
-			clientset, err := kubernetes.NewForConfig(config)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
 			if err != nil {
 				return err
 			}
@@ -79,8 +73,7 @@ func newCmdDashboard() *cobra.Command {
 			defer signal.Stop(signals)
 
 			portforward, err := k8s.NewPortForward(
-				config,
-				clientset,
+				k8sAPI,
 				controlPlaneNamespace,
 				webDeployment,
 				options.port,

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -20,7 +20,7 @@ import (
 
 //This code replicates most of the functionality in https://github.com/wercker/stern/blob/master/cmd/cli.go
 type logCmdConfig struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 	*stern.Config
 }
 
@@ -117,17 +117,12 @@ func getControlPlaneComponentsAndContainers(pods *corev1.PodList) ([]string, []s
 }
 
 func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext string) (*logCmdConfig, error) {
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	clientset, err := kubernetes.NewForConfig(kubeAPI.Config)
-	if err != nil {
-		return nil, err
-	}
-
-	podList, err := clientset.CoreV1().Pods(controlPlaneNamespace).List(metav1.ListOptions{})
+	podList, err := kubeAPI.CoreV1().Pods(controlPlaneNamespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +135,7 @@ func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext string) (
 	}
 
 	return &logCmdConfig{
-		clientset,
+		kubeAPI,
 		c,
 	}, nil
 }

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -21,7 +21,7 @@ func rawPublicAPIClient() (pb.ApiClient, error) {
 		return public.NewInternalClient(controlPlaneNamespace, apiAddr)
 	}
 
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -65,12 +65,7 @@ install command.`,
 					upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
 				}
 			} else {
-				c, err := k8s.GetConfig(kubeconfigPath, kubeContext)
-				if err != nil {
-					upgradeErrorf("Failed to get kubernetes config: %s", err)
-				}
-
-				k, err = kubernetes.NewForConfig(c)
+				k, err = k8s.NewAPI(kubeconfigPath, kubeContext, 0)
 				if err != nil {
 					upgradeErrorf("Failed to create a kubernetes client: %s", err)
 				}

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // ProxyInit is the configuration for the proxy-init binary
@@ -165,12 +164,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 
 	if namespace != "" && podName != "" {
-		config, err := k8s.GetConfig(conf.Kubernetes.Kubeconfig, "linkerd-cni-context")
-		if err != nil {
-			return err
-		}
-
-		client, err := kubernetes.NewForConfig(config)
+		client, err := k8s.NewAPI(conf.Kubernetes.Kubeconfig, "linkerd-cni-context", 0)
 		if err != nil {
 			return err
 		}

--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	idctl "github.com/linkerd/linkerd2/controller/identity"
-	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/identity"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
@@ -96,7 +96,7 @@ func main() {
 
 	ca := tls.NewCA(*creds, validity)
 
-	k8s, err := k8s.NewClientSet(*kubeConfigPath)
+	k8s, err := k8s.NewAPI(*kubeConfigPath, "", 0)
 	if err != nil {
 		log.Fatalf("Failed to load kubeconfig: %s: %s", *kubeConfigPath, err)
 	}

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -78,7 +78,7 @@ type API struct {
 
 // InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
 func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
-	k8sClient, err := NewClientSet(kubeConfig)
+	k8sClient, err := k8s.NewAPI(kubeConfig, "", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/k8s/clientset.go
+++ b/controller/k8s/clientset.go
@@ -4,23 +4,10 @@ import (
 	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
-	"k8s.io/client-go/kubernetes"
 
 	// Load all the auth plugins for the cloud providers.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
-
-// NewClientSet returns a Kubernetes client for the given configuration.
-func NewClientSet(kubeConfig string) (*kubernetes.Clientset, error) {
-	config, err := k8s.GetConfig(kubeConfig, "")
-	if err != nil {
-		return nil, err
-	}
-
-	wt := config.WrapTransport
-	config.WrapTransport = prometheus.ClientWithTelemetry("k8s", wt)
-	return kubernetes.NewForConfig(config)
-}
 
 // NewSpClientSet returns a Kubernetes ServiceProfile client for the given
 // configuration.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -298,11 +298,11 @@ func TestCheckCanCreate(t *testing.T) {
 		[]CategoryID{},
 		&Options{},
 	)
-	var err error
-	hc.clientset, _, err = k8s.NewFakeClientSets()
+	clientset, _, err := k8s.NewFakeClientSets()
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
+	hc.kubeAPI = &k8s.KubernetesAPI{Interface: clientset}
 	err = hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
 	if err == nil ||
 		err.Error() != exp.Error() {
@@ -340,11 +340,11 @@ spec:
 				&Options{},
 			)
 
-			var err error
-			hc.clientset, _, err = k8s.NewFakeClientSets(test.k8sConfigs...)
+			clientset, _, err := k8s.NewFakeClientSets(test.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
+			hc.kubeAPI = &k8s.KubernetesAPI{Interface: clientset}
 			err = hc.checkNetAdmin()
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -1,16 +1,18 @@
 package k8s
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
+	"github.com/linkerd/linkerd2/pkg/prometheus"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	// Load all the auth plugins for the cloud providers.
@@ -22,6 +24,7 @@ var minAPIVersion = [3]int{1, 10, 0}
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
 type KubernetesAPI struct {
 	*rest.Config
+	kubernetes.Interface
 }
 
 // NewClient returns an http.Client configured with a Transport to connect to
@@ -38,25 +41,8 @@ func (kubeAPI *KubernetesAPI) NewClient() (*http.Client, error) {
 }
 
 // GetVersionInfo returns version.Info for the Kubernetes cluster.
-func (kubeAPI *KubernetesAPI) GetVersionInfo(ctx context.Context, client *http.Client) (*version.Info, error) {
-	rsp, err := kubeAPI.getRequest(ctx, client, "/version")
-	if err != nil {
-		return nil, err
-	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Unexpected Kubernetes API response: %s", rsp.Status)
-	}
-
-	bytes, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var versionInfo version.Info
-	err = json.Unmarshal(bytes, &versionInfo)
-	return &versionInfo, err
+func (kubeAPI *KubernetesAPI) GetVersionInfo() (*version.Info, error) {
+	return kubeAPI.Discovery().ServerVersion()
 }
 
 // CheckVersion validates whether the configured Kubernetes cluster's version is
@@ -77,47 +63,24 @@ func (kubeAPI *KubernetesAPI) CheckVersion(versionInfo *version.Info) error {
 }
 
 // NamespaceExists validates whether a given namespace exists.
-func (kubeAPI *KubernetesAPI) NamespaceExists(ctx context.Context, client *http.Client, namespace string) (bool, error) {
-	rsp, err := kubeAPI.getRequest(ctx, client, "/api/v1/namespaces/"+namespace)
+func (kubeAPI *KubernetesAPI) NamespaceExists(namespace string) (bool, error) {
+	ns, err := kubeAPI.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
-	defer rsp.Body.Close()
 
-	if rsp.StatusCode != http.StatusOK && rsp.StatusCode != http.StatusNotFound {
-		return false, fmt.Errorf("Unexpected Kubernetes API response: %s", rsp.Status)
-	}
-
-	return rsp.StatusCode == http.StatusOK, nil
+	return ns != nil, nil
 }
 
 // GetPodsByNamespace returns all pods in a given namespace
-func (kubeAPI *KubernetesAPI) GetPodsByNamespace(ctx context.Context, client *http.Client, namespace string) ([]corev1.Pod, error) {
-	return kubeAPI.getPods(ctx, client, "/api/v1/namespaces/"+namespace+"/pods")
-}
-
-func (kubeAPI *KubernetesAPI) getPods(ctx context.Context, client *http.Client, path string) ([]corev1.Pod, error) {
-	rsp, err := kubeAPI.getRequest(ctx, client, path)
+func (kubeAPI *KubernetesAPI) GetPodsByNamespace(namespace string) ([]corev1.Pod, error) {
+	podList, err := kubeAPI.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Unexpected Kubernetes API response: %s", rsp.Status)
-	}
-
-	bytes, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var podList corev1.PodList
-	err = json.Unmarshal(bytes, &podList)
-	if err != nil {
-		return nil, err
-	}
-
 	return podList.Items, nil
 }
 
@@ -126,52 +89,35 @@ func (kubeAPI *KubernetesAPI) URLFor(namespace, path string) (*url.URL, error) {
 	return generateKubernetesAPIURLFor(kubeAPI.Host, namespace, path)
 }
 
-func (kubeAPI *KubernetesAPI) getRequest(ctx context.Context, client *http.Client, path string) (*http.Response, error) {
-	endpoint, err := generateKubernetesURL(kubeAPI.Host, path)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", endpoint.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return client.Do(req.WithContext(ctx))
-}
-
 // NewAPI validates a Kubernetes config and returns a client for accessing the
-// configured cluster
-func NewAPI(configPath, kubeContext string) (*KubernetesAPI, error) {
+// configured cluster.
+func NewAPI(configPath, kubeContext string, timeout time.Duration) (*KubernetesAPI, error) {
 	config, err := GetConfig(configPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
 	}
 
-	return &KubernetesAPI{Config: config}, nil
+	// k8s' client-go doesn't support injecting context
+	// https://github.com/kubernetes/kubernetes/issues/46503
+	// but we can set the timeout manually
+	config.Timeout = timeout
+	wt := config.WrapTransport
+	config.WrapTransport = prometheus.ClientWithTelemetry("k8s", wt)
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error configuring Kubernetes API clientset: %v", err)
+	}
+
+	return &KubernetesAPI{
+		Config:    config,
+		Interface: clientset,
+	}, nil
 }
 
 // GetReplicaSets returns all replicasets in a given namespace
-func (kubeAPI *KubernetesAPI) GetReplicaSets(ctx context.Context, client *http.Client, namespace string) ([]v1beta1.ReplicaSet, error) {
-	path := "/apis/extensions/v1beta1/namespaces/" + namespace + "/replicasets"
-	rsp, err := kubeAPI.getRequest(ctx, client, path)
-	if err != nil {
-		return nil, err
-	}
-
-	defer rsp.Body.Close()
-
-	if rsp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Unexpected Kubernetes API response: %s", rsp.Status)
-	}
-
-	bytes, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var replicaSetList v1beta1.ReplicaSetList
-	err = json.Unmarshal(bytes, &replicaSetList)
+func (kubeAPI *KubernetesAPI) GetReplicaSets(namespace string) ([]appsv1.ReplicaSet, error) {
+	replicaSetList, err := kubeAPI.AppsV1().ReplicaSets(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -28,7 +28,7 @@ func TestKubernetesApiUrlFor(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			api, err := NewAPI("testdata/config.test", test.kubeContext)
+			api, err := NewAPI("testdata/config.test", test.kubeContext, 0)
 			if err != nil {
 				t.Fatalf("Unexpected error creating Kubernetes API: %+v", err)
 			}

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 )
 
 func TestNewProxyMetricsForward(t *testing.T) {
@@ -87,7 +86,7 @@ spec:
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
 			}
-			_, err = NewProxyMetricsForward(&rest.Config{}, k8sClient, *pod, false)
+			_, err = NewProxyMetricsForward(&KubernetesAPI{Interface: k8sClient}, *pod, false)
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||
@@ -155,7 +154,7 @@ status:
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
 			}
-			_, err = NewPortForward(&rest.Config{}, k8sClient, test.ns, test.deployName, 0, 0, false)
+			_, err = NewPortForward(&KubernetesAPI{Interface: k8sClient}, test.ns, test.deployName, 0, 0, false)
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -250,17 +250,12 @@ func (h *KubernetesHelper) ParseNamespacedResource(resource string) (string, str
 // tests can use for access to the given deployment. Note that the port-forward
 // remains running for the duration of the test.
 func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) (string, error) {
-	config, err := k8s.GetConfig("", h.k8sContext)
+	k8sAPI, err := k8s.NewAPI("", h.k8sContext, 0)
 	if err != nil {
 		return "", err
 	}
 
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "", err
-	}
-
-	pf, err := k8s.NewPortForward(config, clientset, namespace, deployName, 0, remotePort, false)
+	pf, err := k8s.NewPortForward(k8sAPI, namespace, deployName, 0, remotePort, false)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Numerous codepaths have emerged that create k8s configs, k8s clients,
and make k8s api requests.

This branch consolidates k8s client creation and APIs. The primary
change migrates most codepaths to call `k8s.NewAPI` to instantiate a
`KubernetesAPI` struct from `pkg`. `KubernetesAPI` implements the
`kubernetes.Interface` (clientset) interface, and also persists a
`client-go` `rest.Config`.

Specific list of changes:
- removes manual GET requests from `k8s.KubernetesAPI`, in favor of
  clientsets
- replaces most calls to `k8s.GetConfig`+`kubernetes.NewForConfig` with
  a single `k8s.NewAPI`
- introduces a `timeout` param to `k8s.NewAPI`, currently only used by
  healthchecks
- removes `NewClientSet` in `controller/k8s/clientset.go` in favor of
  `k8s.NewAPI`
- removes `httpClient` and `clientset` from `HealthChecker`, use
  `KubernetesAPI` instead

Signed-off-by: Andrew Seigner <siggy@buoyant.io>