### PR TITLE
Fix `linkerd check --proxy` with default ns param

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -505,6 +505,10 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-data-plane-exists",
 					fatal:       true,
 					check: func(context.Context) error {
+						if hc.DataPlaneNamespace == "" {
+							// when checking proxies in all namespaces, this check is a no-op
+							return nil
+						}
 						return hc.CheckNamespace(hc.DataPlaneNamespace, true)
 					},
 				},
@@ -579,7 +583,7 @@ func (hc *HealthChecker) allCategories() []category {
 
 // Add adds an arbitrary checker. This should only be used for testing. For
 // production code, pass in the desired set of checks when calling
-// NewHeathChecker.
+// NewHealthChecker.
 func (hc *HealthChecker) Add(categoryID CategoryID, description string, hintAnchor string, check func(context.Context) error) {
 	hc.addCategory(
 		category{


### PR DESCRIPTION
The `linkerd check --proxy` command checks for proxies in all
namespaces, if the `--namespace` flag is not set. PR #2747 modified the
behavior of `KubernetesAPI.NamespaceExists`. Previously it would succeed
if given an emptry string for a namespace. Now it fails with a
`resource name may not be empty` error (for k8s server `v1.10.11`), or a
not found error (for our fake test client).

Modify the data plane proxy namespace check to return success if the
namespace is not set.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>