### PR TITLE
Group Web and Grafana ServiceAccounts with RBAC

### DIFF
--- a/chart/templates/grafana-rbac.yaml
+++ b/chart/templates/grafana-rbac.yaml
@@ -1,0 +1,12 @@
+{{with .Values -}}
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: {{.Namespace}}
+{{- end}}

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -4,12 +4,6 @@
 ### Grafana
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: {{.Namespace}}
----
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/chart/templates/web-rbac.yaml
+++ b/chart/templates/web-rbac.yaml
@@ -1,0 +1,12 @@
+{{with .Values -}}
+---
+###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: {{.Namespace}}
+{{- end}}

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -4,12 +4,6 @@
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: {{.Namespace}}
----
 kind: Service
 apiVersion: v1
 metadata:

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -529,8 +529,10 @@ func (values *installValues) render(w io.Writer, configs *pb.All) error {
 			{Name: "templates/namespace.yaml"},
 			{Name: "templates/identity-rbac.yaml"},
 			{Name: "templates/controller-rbac.yaml"},
+			{Name: "templates/web-rbac.yaml"},
 			{Name: "templates/serviceprofile-crd.yaml"},
 			{Name: "templates/prometheus-rbac.yaml"},
+			{Name: "templates/grafana-rbac.yaml"},
 			{Name: "templates/proxy_injector-rbac.yaml"},
 			{Name: "templates/sp_validator-rbac.yaml"},
 		}...)

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -496,12 +496,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -985,12 +979,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###
@@ -795,12 +815,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1284,12 +1298,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###
@@ -813,12 +833,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1314,12 +1328,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###
@@ -813,12 +833,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1314,12 +1328,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###
@@ -747,12 +767,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1188,12 +1202,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: Namespace
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: Namespace
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: Namespace
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: Namespace
 ---
 ###
@@ -725,12 +745,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: Namespace
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1144,12 +1158,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: Namespace
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -84,6 +84,16 @@ metadata:
   namespace: linkerd
 ---
 ###
+### Web RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: linkerd
+---
+###
 ### Service Profile CRD
 ###
 ---
@@ -218,6 +228,16 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
+  namespace: linkerd
+---
+###
+### Grafana RBAC
+###
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
   namespace: linkerd
 ---
 ###
@@ -797,12 +817,6 @@ status: {}
 ### Web
 ###
 ---
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-web
-  namespace: linkerd
----
 kind: Service
 apiVersion: v1
 metadata:
@@ -1288,12 +1302,6 @@ status: {}
 ###
 ### Grafana
 ###
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: linkerd-grafana
-  namespace: linkerd
 ---
 kind: ConfigMap
 apiVersion: v1


### PR DESCRIPTION
All ServiceAccounts are intended to be grouped together with other RBAC
resources, particularly for `linkerd install config` output. Grafana and
Web ServiceAccounts were still included with their respective
Deployments.

Group Grafana and Web ServiceAccounts with other RBAC resources.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>