### PR TITLE
proxy: Upgrade the proxy for tower updates

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -14,6 +14,6 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_tag.sh
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-c96dd3a}"
+PROXY_VERSION="${PROXY_VERSION:-61db2e7}"
 
 docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
commit 61db2e77a247f7b0235b67581f60e8a92f8543cb
Author: Sean McArthur <sean@seanmonstar.com>
Date:   Tue Apr 23 17:20:43 2019 -0700

    Replace linkerd2-stack with tower-layer (#236)

    Signed-off-by: Sean McArthur <sean@buoyant.io>

commit 2d6c7145cadf709832f3507bcefdaee509ebde81
Author: Sean McArthur <sean@seanmonstar.com>
Date:   Thu Apr 18 12:40:48 2019 -0700

    Add load shedding when over max-in-flight requests. (#225)

    Also adds configuration for inbound and outbound max-in-flight requests.

    Signed-off-by: Sean McArthur <sean@buoyant.io>

commit f4b5cd0b4a25d7d942e018b42af1157ae2e7dbb0
Author: Oliver Gould <ver@buoyant.io>
Date:   Wed Apr 17 13:53:49 2019 -0700

    Upgrade tower (#232)

    This avails the proxy of newer load balancer features, an updated buffer
    implementation, etc.

    The new buffer implementation requires that we implement TypedExecutor
    for our logging executor; and more error types have been made dynamic.