### PR TITLE
Introduce k8s apiextensions support

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -11,7 +11,7 @@ RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION) && \
     echo "$version" >version.txt)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 ENV CGO_ENABLED=0 GOOS=linux
 COPY pkg/flags pkg/flags

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -907,6 +907,22 @@
   version = "kubernetes-1.13.1"
 
 [[projects]]
+  digest = "1:2133e488e6db5701ef295c39cbc0836855c02af677e8707e539ebf605a4211ca"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = [
+    "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset",
+    "pkg/client/clientset/clientset/fake",
+    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
+  ]
+  pruneopts = ""
+  revision = "0fe22c71c47604641d9aa352c785b7912c200562"
+  version = "kubernetes-1.13.1"
+
+[[projects]]
   digest = "1:66b0292f815d508d11ed5fe94fdeb0bcc5a988703a08e73bf3cb3a415de676cf"
   name = "k8s.io/apimachinery"
   packages = [
@@ -1293,6 +1309,9 @@
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,6 +32,10 @@ required = [
   version = "kubernetes-1.13.1"
 
 [[constraint]]
+  name = "k8s.io/apiextensions-apiserver"
+  version = "kubernetes-1.13.1"
+
+[[constraint]]
   name = "k8s.io/apimachinery"
   version = "kubernetes-1.13.1"
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -93,7 +93,7 @@ install command.`,
 					upgradeErrorf("Failed to parse manifests from %s: %s", options.manifests, err)
 				}
 
-				k, _, err = k8s.NewFakeClientSetsFromManifests(readers)
+				k, err = k8s.NewFakeAPIFromManifests(readers)
 				if err != nil {
 					upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
 				}

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -82,7 +82,7 @@ data:
 			options := testUpgradeOptions()
 			flags := options.recordableFlagSet()
 
-			clientset, _, err := k8s.NewFakeClientSets(tc.k8sConfigs...)
+			clientset, err := k8s.NewFakeAPI(tc.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Error mocking k8s client: %s", err)
 			}
@@ -129,7 +129,7 @@ data:
 	options := testUpgradeOptions()
 	flags := options.recordableFlagSet()
 
-	clientset, _, err := k8s.NewFakeClientSets(k8sConfigs...)
+	clientset, err := k8s.NewFakeAPI(k8sConfigs...)
 	if err != nil {
 		t.Fatalf("Error mocking k8s client: %s", err)
 	}
@@ -231,7 +231,7 @@ data:
 	for i, tc := range testCases {
 		tc := tc // pin
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			clientset, _, err := k8s.NewFakeClientSets(tc.k8sConfigs...)
+			clientset, err := k8s.NewFakeAPI(tc.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY proxy-init proxy-init
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -6,7 +6,7 @@ import (
 
 // NewFakeAPI provides a mock Kubernetes API for testing.
 func NewFakeAPI(configs ...string) (*API, error) {
-	clientSet, spClientSet, err := k8s.NewFakeClientSets(configs...)
+	clientSet, _, spClientSet, err := k8s.NewFakeClientSets(configs...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -298,11 +298,11 @@ func TestCheckCanCreate(t *testing.T) {
 		[]CategoryID{},
 		&Options{},
 	)
-	clientset, _, err := k8s.NewFakeClientSets()
+	var err error
+	hc.kubeAPI, err = k8s.NewFakeAPI()
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	hc.kubeAPI = &k8s.KubernetesAPI{Interface: clientset}
 	err = hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
 	if err == nil ||
 		err.Error() != exp.Error() {
@@ -340,11 +340,12 @@ spec:
 				&Options{},
 			)
 
-			clientset, _, err := k8s.NewFakeClientSets(test.k8sConfigs...)
+			var err error
+			hc.kubeAPI, err = k8s.NewFakeAPI(test.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
-			hc.kubeAPI = &k8s.KubernetesAPI{Interface: clientset}
+
 			err = hc.checkNetAdmin()
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
@@ -469,11 +470,11 @@ func TestValidateDataPlaneNamespace(t *testing.T) {
 					DataPlaneNamespace: tc.ns,
 				},
 			)
-			clientset, _, err := k8s.NewFakeClientSets()
+			var err error
+			hc.kubeAPI, err = k8s.NewFakeAPI()
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
-			hc.kubeAPI = &k8s.KubernetesAPI{Interface: clientset}
 
 			// create a synethic category that only includes the "data plane namespace exists" check
 			dataPlaneNSCat := category{

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -22,9 +23,11 @@ import (
 var minAPIVersion = [3]int{1, 10, 0}
 
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
+// TODO: support spClient
 type KubernetesAPI struct {
 	*rest.Config
 	kubernetes.Interface
+	Apiextensions apiextensionsclient.Interface // for CRDs
 }
 
 // NewAPI validates a Kubernetes config and returns a client for accessing the
@@ -46,10 +49,15 @@ func NewAPI(configPath, kubeContext string, timeout time.Duration) (*KubernetesA
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API clientset: %v", err)
 	}
+	apiextensions, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error configuring Kubernetes API Extensions clientset: %v", err)
+	}
 
 	return &KubernetesAPI{
-		Config:    config,
-		Interface: clientset,
+		Config:        config,
+		Interface:     clientset,
+		Apiextensions: apiextensions,
 	}, nil
 }
 

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -23,7 +23,10 @@ import (
 var minAPIVersion = [3]int{1, 10, 0}
 
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
-// TODO: support spClient
+// TODO: support ServiceProfile ClientSet. A prerequisite is moving the
+// ServiceProfile client code from `./controller` to `./pkg` (#2751). This will
+// also allow making `NewFakeClientSets` private, as KubernetesAPI will support
+// all relevant k8s resources.
 type KubernetesAPI struct {
 	*rest.Config
 	kubernetes.Interface

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -43,7 +43,7 @@ subjects:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: returns expected authorization", i), func(t *testing.T) {
-			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			k8sClient, err := NewFakeAPI(test.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -10,6 +10,9 @@ import (
 	spscheme "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/scheme"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
@@ -19,29 +22,64 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// NewFakeClientSets provides a mock Kubernetes ClientSet.
-func NewFakeClientSets(configs ...string) (kubernetes.Interface, spclient.Interface, error) {
+// NewFakeAPI provides a mock KubernetesAPI backed by hard-coded resources
+func NewFakeAPI(configs ...string) (*KubernetesAPI, error) {
+	client, apiextClient, _, err := NewFakeClientSets(configs...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubernetesAPI{
+		Interface:     client,
+		Apiextensions: apiextClient,
+	}, nil
+}
+
+// NewFakeAPIFromManifests reads from a slice of readers, each representing a
+// manifest or collection of manifests, and returns a mock KubernetesAPI.
+func NewFakeAPIFromManifests(readers []io.Reader) (*KubernetesAPI, error) {
+	client, apiextClient, _, err := newFakeClientSetsFromManifests(readers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KubernetesAPI{
+		Interface:     client,
+		Apiextensions: apiextClient,
+	}, nil
+}
+
+// NewFakeClientSets provides mock Kubernetes ClientSets.
+// TODO: make this private once KubernetesAPI (and NewFakeAPI) supports spClient
+func NewFakeClientSets(configs ...string) (kubernetes.Interface, apiextensionsclient.Interface, spclient.Interface, error) {
 	objs := []runtime.Object{}
+	apiextObjs := []runtime.Object{}
 	spObjs := []runtime.Object{}
 	for _, config := range configs {
 		obj, err := ToRuntimeObject(config)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		if strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind) == ServiceProfile {
+		switch strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind) {
+		case "customresourcedefinition":
+			apiextObjs = append(apiextObjs, obj)
+		case ServiceProfile:
 			spObjs = append(spObjs, obj)
-		} else {
+		default:
 			objs = append(objs, obj)
 		}
 	}
 
-	return fake.NewSimpleClientset(objs...), spfake.NewSimpleClientset(spObjs...), nil
+	return fake.NewSimpleClientset(objs...),
+		apiextensionsfake.NewSimpleClientset(apiextObjs...),
+		spfake.NewSimpleClientset(spObjs...),
+		nil
 }
 
-// NewFakeClientSetsFromManifests reads from a slice of readers, each
+// newFakeClientSetsFromManifests reads from a slice of readers, each
 // representing a manifest or collection of manifests, and returns a mock
 // Kubernetes ClientSet.
-func NewFakeClientSetsFromManifests(readers []io.Reader) (kubernetes.Interface, spclient.Interface, error) {
+func newFakeClientSetsFromManifests(readers []io.Reader) (kubernetes.Interface, apiextensionsclient.Interface, spclient.Interface, error) {
 	configs := []string{}
 
 	for _, reader := range readers {
@@ -55,30 +93,23 @@ func NewFakeClientSetsFromManifests(readers []io.Reader) (kubernetes.Interface, 
 				break
 			}
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 
 			// check for kind
 			var typeMeta metav1.TypeMeta
 			if err := yaml.Unmarshal(bytes, &typeMeta); err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 
 			switch typeMeta.Kind {
 			case "":
 				log.Warnf("Kind missing from YAML, skipping")
 
-			case "CustomResourceDefinition":
-				// TODO: support CRDs:
-				// apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-				// apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-				// apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-				log.Warnf("CRDs not supported, skipping")
-
 			case "List":
 				var sourceList corev1.List
 				if err := yaml.Unmarshal(bytes, &sourceList); err != nil {
-					return nil, nil, err
+					return nil, nil, nil, err
 				}
 				for _, item := range sourceList.Items {
 					configs = append(configs, string(item.Raw))
@@ -95,8 +126,7 @@ func NewFakeClientSetsFromManifests(readers []io.Reader) (kubernetes.Interface, 
 
 // ToRuntimeObject deserializes Kubernetes YAML into a Runtime Object
 func ToRuntimeObject(config string) (runtime.Object, error) {
-	// TODO: support CRDs:
-	// apiextensionsv1beta1.AddToScheme(scheme.Scheme)
+	apiextensionsv1beta1.AddToScheme(scheme.Scheme)
 	spscheme.AddToScheme(scheme.Scheme)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(config), nil, nil)

--- a/pkg/k8s/fake_test.go
+++ b/pkg/k8s/fake_test.go
@@ -7,9 +7,132 @@ import (
 	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestNewFakeAPI(t *testing.T) {
+
+	k8sConfigs := []string{
+		`
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: dep-name
+  namespace: dep-ns
+`, `
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fakecrd.linkerd.io
+spec:
+  group: my-group.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: fakecrds
+    singular: fakecrd
+    kind: FakeCRD
+    shortNames:
+    - fc
+`,
+	}
+
+	api, err := NewFakeAPI(k8sConfigs...)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	deploy, err := api.AppsV1beta2().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1beta2",
+		Kind:    "Deployment",
+	}
+	if !reflect.DeepEqual(deploy.GroupVersionKind(), gvk) {
+		t.Fatalf("Expected: %s Got: %s", gvk, deploy.GroupVersionKind())
+	}
+
+	crd, err := api.Apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().Get("fakecrd.linkerd.io", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	gvk = schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1beta1",
+		Kind:    "CustomResourceDefinition",
+	}
+	if !reflect.DeepEqual(crd.GroupVersionKind(), gvk) {
+		t.Fatalf("Expected: %s Got: %s", gvk, crd.GroupVersionKind())
+	}
+}
+
+func TestNewFakeAPIFromManifests(t *testing.T) {
+	k8sConfigs := []string{
+		`
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: dep-name
+  namespace: dep-ns
+`, `
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fakecrd.linkerd.io
+spec:
+  group: my-group.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: fakecrds
+    singular: fakecrd
+    kind: FakeCRD
+    shortNames:
+    - fc
+`,
+	}
+
+	readers := []io.Reader{}
+	for _, m := range k8sConfigs {
+		readers = append(readers, strings.NewReader(m))
+	}
+
+	api, err := NewFakeAPIFromManifests(readers)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	deploy, err := api.AppsV1beta2().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1beta2",
+		Kind:    "Deployment",
+	}
+	if !reflect.DeepEqual(deploy.GroupVersionKind(), gvk) {
+		t.Fatalf("Expected: %s Got: %s", gvk, deploy.GroupVersionKind())
+	}
+
+	crd, err := api.Apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().Get("fakecrd.linkerd.io", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	gvk = schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1beta1",
+		Kind:    "CustomResourceDefinition",
+	}
+	if !reflect.DeepEqual(crd.GroupVersionKind(), gvk) {
+		t.Fatalf("Expected: %s Got: %s", gvk, crd.GroupVersionKind())
+	}
+}
 
 func TestNewFakeClientSets(t *testing.T) {
 	testCases := []struct {
@@ -52,7 +175,7 @@ spec:
 		tc := tc // pin
 
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			_, _, err := NewFakeClientSets(tc.k8sConfigs...)
+			_, _, _, err := NewFakeClientSets(tc.k8sConfigs...)
 			if !reflect.DeepEqual(err, tc.err) {
 				t.Fatalf("Expected error: %s, Got: %s", tc.err, err)
 			}
@@ -130,7 +253,7 @@ items:
 				readers = append(readers, strings.NewReader(m))
 			}
 
-			_, _, err := NewFakeClientSetsFromManifests(readers)
+			_, _, _, err := newFakeClientSetsFromManifests(readers)
 			if !reflect.DeepEqual(err, tc.err) {
 				t.Fatalf("Expected error: %s, Got: %s", tc.err, err)
 			}
@@ -185,7 +308,8 @@ spec:
 			runtime.NewMissingKindErr("---"),
 		},
 		{
-			`apiVersion: apiextensions.k8s.io/v1beta1
+			`
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: fakecrd.linkerd.io
@@ -199,11 +323,7 @@ spec:
     kind: FakeCRD
     shortNames:
     - fc`,
-			runtime.NewNotRegisteredGVKErrForTarget(
-				"k8s.io/client-go/kubernetes/scheme/register.go:61",
-				schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"},
-				nil,
-			),
+			nil,
 		},
 	}
 

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -78,7 +78,7 @@ spec:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: NewProxyMetricsForward returns expected result", i), func(t *testing.T) {
-			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			k8sClient, err := NewFakeAPI(test.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
 			}
@@ -150,7 +150,7 @@ status:
 	for i, test := range tests {
 		test := test // pin
 		t.Run(fmt.Sprintf("%d: NewPortForward returns expected result", i), func(t *testing.T) {
-			k8sClient, _, err := NewFakeClientSets(test.k8sConfigs...)
+			k8sClient, err := NewFakeAPI(test.k8sConfigs...)
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
 			}

--- a/proxy-init/Dockerfile
+++ b/proxy-init/Dockerfile
@@ -1,5 +1,5 @@
 ## compile proxy-init utility
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY ./proxy-init ./proxy-init
 RUN CGO_ENABLED=0 GOOS=linux go install -v ./proxy-init/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:4120b3aa as golang
+FROM gcr.io/linkerd-io/go-deps:f364cab7 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
CustomResourceDefinition parsing and retrieval is not available via
client-go's `kubernetes.Interface`, but rather via a separate
`k8s.io/apiextensions-apiserver` package.

Introduce support for CustomResourceDefintion object parsing and
retrieval. This change facilitates retrieval of CRDs from the k8s API
server, and also provides CRD resources as mock objects.

Also introduce a `NewFakeAPI` constructor, deprecating
`NewFakeClientSets`. Callers need no longer be concerned with discreet
clientsets (for k8s resources vs. CRDs vs. (eventually)
ServiceProfiles), and can instead use the unified `KubernetesAPI`.

Part of #2337, in service to multi-stage check.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>