### PR TITLE
Add known proxy-injector log warning to tests

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -54,6 +54,7 @@ var (
 	knownControllerErrorsRegex = regexp.MustCompile(strings.Join([]string{
 		`.* linkerd-controller-.*-.* tap time=".*" level=error msg="\[.*\] encountered an error: rpc error: code = Canceled desc = context canceled"`,
 		`.* linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
+		`.* linkerd-proxy-injector-.*-.* proxy-injector time=".*" level=warning msg="failed to retrieve replicaset from indexer, retrying with get request .*-smoke-test/smoke-test-terminus-.*: replicaset\.apps \\"smoke-test-terminus-.*\\" not found"`,
 	}, "|"))
 
 	knownProxyErrorsRegex = regexp.MustCompile(strings.Join([]string{


### PR DESCRIPTION
PR #2737 introduced a warning in the proxy-injector when owner ref
lookups failed due to not having up-to-date ReplicaSet information. That
warning may occur during integration tests, causing a failure.

Add the warning as a known controller log message. The warning will be
printed as a skipped test, allowing the integration tests to pass.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>