### PR TITLE
Multi-stage check support

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -40,6 +40,7 @@ func (options *checkOptions) nonConfigFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("non-config-check", pflag.ExitOnError)
 
 	flags.BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled, "When running pre-installation checks (--pre), assume the linkerd-cni plugin is already installed, and a NET_ADMIN check is not needed")
+	flags.StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 	flags.BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
 	flags.BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
 
@@ -51,7 +52,6 @@ func (options *checkOptions) checkFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("check", pflag.ExitOnError)
 
 	flags.StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
-	flags.StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 	flags.DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 
 	return flags

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -12,6 +12,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type checkOptions struct {
@@ -34,12 +35,45 @@ func newCheckOptions() *checkOptions {
 	}
 }
 
+// nonConfigFlagSet specifies flags not allowed with `linkerd check config`
+func (options *checkOptions) nonConfigFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("non-config-check", pflag.ExitOnError)
+
+	flags.BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled, "When running pre-installation checks (--pre), assume the linkerd-cni plugin is already installed, and a NET_ADMIN check is not needed")
+	flags.BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
+	flags.BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
+
+	return flags
+}
+
+// checkFlagSet specifies flags allowed with and without `config`
+func (options *checkOptions) checkFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("check", pflag.ExitOnError)
+
+	flags.StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
+	flags.StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+	flags.DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
+
+	return flags
+}
+
+func (options *checkOptions) validate() error {
+	if options.preInstallOnly && options.dataPlaneOnly {
+		return errors.New("--pre and --proxy flags are mutually exclusive")
+	}
+	return nil
+}
+
 func newCmdCheck() *cobra.Command {
 	options := newCheckOptions()
+	checkFlags := options.checkFlagSet()
+	nonConfigFlags := options.nonConfigFlagSet()
 
 	cmd := &cobra.Command{
-		Use:   "check",
-		Short: "Check the Linkerd installation for potential problems",
+		Use:       fmt.Sprintf("check [%s] [flags]", configStage),
+		Args:      cobra.OnlyValidArgs,
+		ValidArgs: []string{configStage},
+		Short:     "Check the Linkerd installation for potential problems",
 		Long: `Check the Linkerd installation for potential problems.
 
 The check command will perform a series of checks to validate that the linkerd
@@ -52,26 +86,28 @@ non-zero exit code.`,
   # Check that the Linkerd control plane can be installed in the "test" namespace
   linkerd check --pre --linkerd-namespace test
 
+  # Check that "linkerd install config" succeeded
+  linkerd check config
+
   # Check that the Linkerd data plane proxies in the "app" namespace are up and running
   linkerd check --proxy --namespace app`,
-		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return configureAndRunChecks(stdout, options)
+			stage, err := validateArgs(args, nonConfigFlags, nil)
+			if err != nil {
+				return err
+			}
+
+			return configureAndRunChecks(stdout, stage, options)
 		},
 	}
 
-	cmd.Args = cobra.NoArgs
-	cmd.PersistentFlags().StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
-	cmd.PersistentFlags().BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
-	cmd.PersistentFlags().BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
-	cmd.PersistentFlags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
-	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
-	cmd.PersistentFlags().BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled, "When running pre-installation checks (--pre), assume the linkerd-cni plugin is already installed, and a NET_ADMIN check is not needed")
+	cmd.PersistentFlags().AddFlagSet(checkFlags)
+	cmd.PersistentFlags().AddFlagSet(nonConfigFlags)
 
 	return cmd
 }
 
-func configureAndRunChecks(w io.Writer, options *checkOptions) error {
+func configureAndRunChecks(w io.Writer, stage string, options *checkOptions) error {
 	err := options.validate()
 	if err != nil {
 		return fmt.Errorf("Validation error when executing check command: %v", err)
@@ -88,13 +124,17 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}
 	} else {
-		checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
-		checks = append(checks, healthcheck.LinkerdAPIChecks)
+		checks = append(checks, healthcheck.LinkerdConfigChecks)
 
-		if options.dataPlaneOnly {
-			checks = append(checks, healthcheck.LinkerdDataPlaneChecks)
-		} else {
-			checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
+		if stage != configStage {
+			checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
+			checks = append(checks, healthcheck.LinkerdAPIChecks)
+
+			if options.dataPlaneOnly {
+				checks = append(checks, healthcheck.LinkerdDataPlaneChecks)
+			} else {
+				checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
+			}
 		}
 	}
 
@@ -120,13 +160,6 @@ func configureAndRunChecks(w io.Writer, options *checkOptions) error {
 
 	fmt.Fprintf(w, "Status check results are %s\n", okStatus)
 
-	return nil
-}
-
-func (o *checkOptions) validate() error {
-	if o.preInstallOnly && o.dataPlaneOnly {
-		return errors.New("--pre and --proxy flags are mutually exclusive")
-	}
 	return nil
 }
 

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -49,6 +49,7 @@ func newCmdDashboard() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dashboard [flags]",
 		Short: "Open the Linkerd dashboard in a web browser",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.port < 0 {
 				return fmt.Errorf("port must be greater than or equal to zero, was %d", options.port)
@@ -133,7 +134,6 @@ func newCmdDashboard() *cobra.Command {
 		},
 	}
 
-	cmd.Args = cobra.NoArgs
 	// This is identical to what `kubectl proxy --help` reports, `--port 0` indicates a random port.
 	cmd.PersistentFlags().IntVarP(&options.port, "port", "p", options.port, "The local port on which to serve requests (when set to 0, a random port will be used)")
 	cmd.PersistentFlags().StringVar(&options.show, "show", options.show, "Open a dashboard in a browser or show URLs in the CLI (one of: linkerd, grafana, url)")

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -33,12 +33,12 @@ func newCmdVersion() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the client and server version information",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			configureAndRunVersion(options, os.Stdout, os.Stderr, rawPublicAPIClient)
 		},
 	}
 
-	cmd.Args = cobra.NoArgs
 	cmd.PersistentFlags().BoolVar(&options.shortVersion, "short", options.shortVersion, "Print the version number(s) only, with no additional output")
 	cmd.PersistentFlags().BoolVar(&options.onlyClientVersion, "client", options.onlyClientVersion, "Print the client version only")
 

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -733,37 +733,6 @@ metadata:
 	}
 }
 
-func TestCRDExists(t *testing.T) {
-	k8sConfig := `
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: serviceprofiles.linkerd.io
-`
-
-	hc := NewHealthChecker(
-		[]CategoryID{},
-		&Options{},
-	)
-	var err error
-	hc.kubeAPI, err = k8s.NewFakeAPI(k8sConfig)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	hc.addCheckAsCategory("cat1", LinkerdConfigChecks, "control plane CustomResourceDefinitions exist")
-
-	expectedResults := []string{
-		"cat1 control plane CustomResourceDefinitions exist",
-	}
-
-	obs := newObserver()
-	hc.RunChecks(obs.resultFn)
-	if !reflect.DeepEqual(obs.results, expectedResults) {
-		t.Fatalf("Expected results %v, but got %v", expectedResults, obs.results)
-	}
-}
-
 func TestCheckControlPlanePodExistence(t *testing.T) {
 	hc := NewHealthChecker(
 		[]CategoryID{},

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -405,6 +405,181 @@ metadata:
 				"linkerd-config control plane ClusterRoles exist: missing ClusterRoles: linkerd-test-ns-controller, linkerd-test-ns-identity, linkerd-test-ns-prometheus, linkerd-test-ns-proxy-injector, linkerd-test-ns-sp-validator",
 			},
 		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+`,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist: missing ClusterRoleBindings: linkerd-test-ns-controller, linkerd-test-ns-identity, linkerd-test-ns-prometheus, linkerd-test-ns-proxy-injector, linkerd-test-ns-sp-validator",
+			},
+		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-controller
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-identity
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-prometheus
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: test-ns
+`,
+				`
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceprofiles.linkerd.io
+`,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist",
+				"linkerd-config control plane ServiceAccounts exist",
+				"linkerd-config control plane CustomResourceDefinitions exist",
+			},
+		},
 	}
 
 	for i, tc := range testCases {
@@ -439,18 +614,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-65149d37-siggy
-spec:
-  group: linkerd.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: serviceprofiles
-    singular: serviceprofile
-    kind: ServiceProfile
-    shortNames:
-    - sp
 `
 
 	hc := NewHealthChecker(

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -565,6 +565,131 @@ metadata:
   name: linkerd-web
   namespace: test-ns
 `,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist",
+				"linkerd-config control plane ServiceAccounts exist",
+				"linkerd-config control plane CustomResourceDefinitions exist: missing CustomResourceDefinitions: serviceprofiles.linkerd.io",
+			},
+		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-controller
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-identity
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-prometheus
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: test-ns
+`,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -219,15 +219,39 @@ func TestInstallSP(t *testing.T) {
 	}
 }
 
+// TODO: run this after a `linkerd install config`
+func TestCheckConfigPostInstall(t *testing.T) {
+	cmd := []string{"check", "config", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
+	golden := "check.config.golden"
+
+	err := TestHelper.RetryFor(time.Minute, func() error {
+		out, stderr, err := TestHelper.LinkerdRun(cmd...)
+
+		if err != nil {
+			return fmt.Errorf("Check command failed\n%s\n%s", stderr, out)
+		}
+
+		err = TestHelper.ValidateOutput(out, golden)
+		if err != nil {
+			return fmt.Errorf("Received unexpected output\n%s", err.Error())
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestCheckPostInstall(t *testing.T) {
 	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
 	golden := "check.golden"
 
 	err := TestHelper.RetryFor(time.Minute, func() error {
-		out, _, err := TestHelper.LinkerdRun(cmd...)
+		out, stderr, err := TestHelper.LinkerdRun(cmd...)
 
 		if err != nil {
-			return fmt.Errorf("Check command failed\n%s", out)
+			return fmt.Errorf("Check command failed\n%s\n%s", stderr, out)
 		}
 
 		err = TestHelper.ValidateOutput(out, golden)

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -54,7 +54,7 @@ var (
 	knownControllerErrorsRegex = regexp.MustCompile(strings.Join([]string{
 		`.* linkerd-controller-.*-.* tap time=".*" level=error msg="\[.*\] encountered an error: rpc error: code = Canceled desc = context canceled"`,
 		`.* linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
-		`.* linkerd-proxy-injector-.*-.* proxy-injector time=".*" level=warning msg="failed to retrieve replicaset from indexer, retrying with get request .*-smoke-test/smoke-test-terminus-.*: replicaset\.apps \\"smoke-test-terminus-.*\\" not found"`,
+		`.* linkerd-proxy-injector-.*-.* proxy-injector time=".*" level=warning msg="failed to retrieve replicaset from indexer, retrying with get request .*-smoke-test/smoke-test-.*-.*: replicaset\.apps \\"smoke-test-.*-.*\\" not found"`,
 	}, "|"))
 
 	knownProxyErrorsRegex = regexp.MustCompile(strings.Join([]string{

--- a/test/testdata/check.config.golden
+++ b/test/testdata/check.config.golden
@@ -16,30 +16,9 @@ linkerd-config
 √ control plane ServiceAccounts exist
 √ control plane CustomResourceDefinitions exist
 
-linkerd-existence
------------------
-√ control plane components ready
-√ no unschedulable pods
-√ controller pod is running
-√ can initialize the client
-√ can query the control plane API
-
-linkerd-api
------------
-√ control plane pods are ready
-√ control plane self-check
-√ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
-√ no invalid service profiles
-
 linkerd-version
 ---------------
 √ can determine the latest version
 √ cli is up-to-date
-
-control-plane-version
----------------------
-√ control plane is up-to-date
-√ control plane and cli versions match
 
 Status check results are √

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -8,9 +8,16 @@ kubernetes-version
 √ is running the minimum Kubernetes API version
 √ is running the minimum kubectl version
 
+linkerd-config
+--------------
+√ control plane Namespace exists
+√ control plane ClusterRoles exist
+√ control plane ClusterRoleBindings exist
+√ control plane ServiceAccounts exist
+√ control plane CustomResourceDefinitions exist
+
 linkerd-existence
 -----------------
-√ control plane namespace exists
 √ control plane components ready
 √ no unschedulable pods
 √ controller pod is running


### PR DESCRIPTION
Add support for `linkerd check config`. Validates the existence of the
Linkerd Namespace, ClusterRoles, ClusterRoleBindings, ServiceAccounts,
and CustomResourceDefitions.

Part of #2337

Signed-off-by: Andrew Seigner <siggy@buoyant.io>