### PR TITLE
docker-build: Build the proxy container first

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -9,6 +9,7 @@ fi
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+$bindir/docker-build-proxy
 $bindir/docker-build-controller
 $bindir/docker-build-web
 $bindir/docker-build-proxy-init
@@ -20,4 +21,3 @@ else
     $bindir/build-cli-bin
 fi
 $bindir/docker-build-grafana
-$bindir/docker-build-proxy


### PR DESCRIPTION
When developing on the proxy, it's convenient to build the proxy while
the linkerd2 image is building at a given tag; but because the proxy is
built last, it's difficult to build the proxy at the same tag
simultaneously.

This is made easier by building the proxy first so that the parallel
build can be initiated after this. This shouldn't impact other
development workflows.