### PR TITLE
Add --disable-identity flag to `linkerd install` and `linkerd upgrade`

### DIFF
--- a/chart/templates/identity-rbac.yaml
+++ b/chart/templates/identity-rbac.yaml
@@ -1,5 +1,5 @@
 {{with .Values -}}
-{{if .Identity -}}
+{{if and (not .DisableIdentity) (.Identity) -}}
 ---
 ###
 ### Identity Controller Service RBAC

--- a/chart/templates/identity.yaml
+++ b/chart/templates/identity.yaml
@@ -1,5 +1,5 @@
 {{with .Values -}}
-{{if .Identity -}}
+{{if and (not .DisableIdentity) (.Identity) -}}
 ---
 ###
 ### Identity Controller Service

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -44,6 +44,7 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, transforme
 
 func newCmdInject() *cobra.Command {
 	options := &proxyConfigOptions{}
+	disableIdentityFlag := options.disableIdentityFlagSet()
 	var manualOption, enableDebugSidecar bool
 
 	cmd := &cobra.Command{
@@ -100,10 +101,6 @@ sub-folders, or coming from stdin.`,
 		"Include the proxy sidecar container spec in the YAML output (the auto-injector won't pick it up, so config annotations aren't supported) (default false)",
 	)
 	flags.BoolVar(
-		&options.disableIdentity, "disable-identity", options.disableIdentity,
-		"Disables resources from participating in TLS identity",
-	)
-	flags.BoolVar(
 		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
 		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
 	)
@@ -111,6 +108,7 @@ sub-folders, or coming from stdin.`,
 	flags.BoolVar(&enableDebugSidecar, "enable-debug-sidecar", enableDebugSidecar,
 		"Inject a debug sidecar for data plane debugging")
 	cmd.PersistentFlags().AddFlagSet(flags)
+	cmd.PersistentFlags().AddFlagSet(disableIdentityFlag)
 
 	return cmd
 }

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -44,7 +44,6 @@ func runInjectCmd(inputs []io.Reader, errWriter, outWriter io.Writer, transforme
 
 func newCmdInject() *cobra.Command {
 	options := &proxyConfigOptions{}
-	disableIdentityFlag := options.disableIdentityFlagSet()
 	var manualOption, enableDebugSidecar bool
 
 	cmd := &cobra.Command{
@@ -104,11 +103,12 @@ sub-folders, or coming from stdin.`,
 		&options.ignoreCluster, "ignore-cluster", options.ignoreCluster,
 		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)",
 	)
-
 	flags.BoolVar(&enableDebugSidecar, "enable-debug-sidecar", enableDebugSidecar,
 		"Inject a debug sidecar for data plane debugging")
+
+	options.addDisableIdentityFlag(flags)
+
 	cmd.PersistentFlags().AddFlagSet(flags)
-	cmd.PersistentFlags().AddFlagSet(disableIdentityFlag)
 
 	return cmd
 }

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -208,7 +208,7 @@ func newCmdInstall() *cobra.Command {
 	// the configuration in validateAndBuild.
 	flags := options.recordableFlagSet()
 	installOnlyFlags := options.installOnlyFlagSet()
-	disableIdentityFlag := options.proxyConfigOptions.disableIdentityFlagSet()
+	disableIdentityFlag := options.disableIdentityFlagSet()
 
 	cmd := &cobra.Command{
 		Use:       fmt.Sprintf("install [%s|%s] [flags]", configStage, controlPlaneStage),
@@ -555,13 +555,7 @@ func (values *installValues) render(w io.Writer, configs *pb.All) error {
 		files = append(files, []*chartutil.BufferedFile{
 			{Name: "templates/_resources.yaml"},
 			{Name: "templates/config.yaml"},
-		}...)
-		if !values.DisableIdentity {
-			files = append(files, &chartutil.BufferedFile{
-				Name: "templates/identity.yaml",
-			})
-		}
-		files = append(files, []*chartutil.BufferedFile{
+			{Name: "templates/identity.yaml"},
 			{Name: "templates/controller.yaml"},
 			{Name: "templates/web.yaml"},
 			{Name: "templates/prometheus.yaml"},

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -292,8 +292,6 @@ func (options *proxyConfigOptions) flagSet(e pflag.ErrorHandling) *pflag.FlagSet
 	return flags
 }
 
-func (options *proxyConfigOptions) disableIdentityFlagSet() *pflag.FlagSet {
-	flags := pflag.NewFlagSet("disable-identity", pflag.ExitOnError)
+func (options *proxyConfigOptions) addDisableIdentityFlag(flags *pflag.FlagSet) {
 	flags.BoolVar(&options.disableIdentity, "disable-identity", options.disableIdentity, "Disables resources from participating in TLS identity")
-	return flags
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -291,3 +291,9 @@ func (options *proxyConfigOptions) flagSet(e pflag.ErrorHandling) *pflag.FlagSet
 
 	return flags
 }
+
+func (options *proxyConfigOptions) disableIdentityFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("disable-identity", pflag.ExitOnError)
+	flags.BoolVar(&options.disableIdentity, "disable-identity", options.disableIdentity, "Disables resources from participating in TLS identity")
+	return flags
+}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -866,10 +866,13 @@ func getPodStatuses(pods []corev1.Pod) map[string][]corev1.ContainerStatus {
 func validateControlPlanePods(pods []corev1.Pod) error {
 	statuses := getPodStatuses(pods)
 
-	names := []string{"controller", "grafana", "identity", "prometheus", "sp-validator", "web"}
+	names := []string{"controller", "grafana", "prometheus", "sp-validator", "web"}
 	// TODO: deprecate this when we drop support for checking pre-default proxy-injector control-planes
 	if _, found := statuses["proxy-injector"]; found {
 		names = append(names, "proxy-injector")
+	}
+	if _, found := statuses["identity"]; found {
+		names = append(names, "identity")
 	}
 
 	for _, name := range names {


### PR DESCRIPTION
In #2717 we implemented `--disable-identity` in `linkerd inject`, adding the annotation `config.linkerd.io/disable-identity: true` which made the proxy injector to not set up identity for the injected proxy.

This PR expands that by enabling `--disable-identity` in `linkerd install [config|control-plane]` and `linkerd upgrade [config|control-plane]`.

Using that flag has these effects:
- The `linkerd-identity` pod is not installed
- All injected pods (including the CP pods) won't use identity (they'll all have the annotation`linkerd.io/identity-mode: disabled`)

Re: second part of #2540