### PR TITLE
Support the config.linkerd.io/pod-weight annotation

### DIFF
--- a/controller/api/destination/endpoint_listener.go
+++ b/controller/api/destination/endpoint_listener.go
@@ -204,18 +204,20 @@ func (l *endpointListener) NoEndpoints(exists bool) {
 }
 
 func (l *endpointListener) toWeightedAddr(address *updateAddress) *pb.WeightedAddr {
-	labels, hint, tlsIdentity := l.getAddrMetadata(address.pod)
+	weight, labels, hint, tlsIdentity := l.getAddrMetadata(address.pod)
 
 	return &pb.WeightedAddr{
 		Addr:         address.address,
-		Weight:       addr.DefaultWeight,
+		Weight:       weight,
 		MetricLabels: labels,
 		TlsIdentity:  tlsIdentity,
 		ProtocolHint: hint,
 	}
 }
 
-func (l *endpointListener) getAddrMetadata(pod *corev1.Pod) (map[string]string, *pb.ProtocolHint, *pb.TlsIdentity) {
+func (l *endpointListener) getAddrMetadata(pod *corev1.Pod) (uint32, map[string]string, *pb.ProtocolHint, *pb.TlsIdentity) {
+	weight := pkgK8s.GetPodWeight(pod)
+
 	controllerNS := pod.Labels[pkgK8s.ControllerNSLabel]
 	sa, ns := pkgK8s.GetServiceAccountAndNS(pod)
 	ok, on := l.ownerKindAndName(pod)
@@ -252,5 +254,5 @@ func (l *endpointListener) getAddrMetadata(pod *corev1.Pod) (map[string]string, 
 		}
 	}
 
-	return labels, hint, identity
+	return weight, labels, hint, identity
 }

--- a/controller/api/destination/endpoint_listener_test.go
+++ b/controller/api/destination/endpoint_listener_test.go
@@ -7,7 +7,6 @@ import (
 
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	"github.com/linkerd/linkerd2-proxy-api/go/net"
-	pkgAddr "github.com/linkerd/linkerd2/pkg/addr"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -424,7 +423,7 @@ func TestUpdateAddress(t *testing.T) {
 func checkAddress(t *testing.T, addr *pb.WeightedAddr, expectedAddress *net.TcpAddress) {
 	actualAddress := addr.Addr
 	actualWeight := addr.Weight
-	expectedWeight := uint32(pkgAddr.DefaultWeight)
+	expectedWeight := uint32(10000)
 
 	if !reflect.DeepEqual(actualAddress, expectedAddress) || actualWeight != expectedWeight {
 		t.Fatalf("Expected added address to be [%+v] and weight to be [%d], but it was [%+v] and [%d]", expectedAddress, expectedWeight, actualAddress, actualWeight)

--- a/pkg/addr/addr.go
+++ b/pkg/addr/addr.go
@@ -9,10 +9,6 @@ import (
 	"github.com/linkerd/linkerd2/controller/gen/public"
 )
 
-// DefaultWeight is the default address weight sent by the Destination service
-// to the Linkerd proxies.
-const DefaultWeight = 1
-
 // PublicAddressToString formats a Public API TCPAddress as a string.
 func PublicAddressToString(addr *public.TcpAddress) string {
 	octects := decodeIPToOctets(addr.GetIp().GetIpv4())

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -43,3 +43,31 @@ func TestGetPodLabels(t *testing.T) {
 		}
 	})
 }
+
+func TestGetPodWeight(t *testing.T) {
+	t.Run("Maps annotations to weights", func(t *testing.T) {
+		type testCase struct {
+			s string
+			n uint32
+		}
+
+		for _, tc := range []testCase{
+			{s: "1m", n: 10},
+			{s: "10m", n: 100},
+			{s: "200m", n: 2000},
+			{s: "1", n: 10000},
+			{s: "", n: 10000},
+		} {
+			pod := &corev1.Pod{}
+			if tc.s != "" {
+				pod.ObjectMeta.Annotations = map[string]string{
+					ProxyPodWeightAnnotation: tc.s,
+				}
+			}
+
+			if w := GetPodWeight(pod); w != tc.n {
+				t.Errorf("Unexpected weight for '%s': %d; expected %d", tc.s, w, tc.n)
+			}
+		}
+	})
+}


### PR DESCRIPTION
The `pod-weight` annotation can be used to configure the proxy's load
balancer for endpoint weighting.