### PR TITLE
Define multi-stage commands as subcommands

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -50,16 +50,59 @@ func (options *upgradeOptions) upgradeOnlyFlagSet() *pflag.FlagSet {
 	return flags
 }
 
+// newCmdUpgradeConfig is a subcommand for `linkerd upgrade config`
+func newCmdUpgradeConfig(options *upgradeOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Output Kubernetes cluster-wide resources to upgrade an existing Linkerd",
+		Long: `Output Kubernetes cluster-wide resources to upgrade an existing Linkerd.
+
+Note that this command should be followed by "linkerd upgrade control-plane".`,
+		Example: `  # Default upgrade.
+  linkerd upgrade config | kubectl apply -f -`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return upgradeRunE(options, configStage, nil)
+		},
+	}
+
+	return cmd
+}
+
+// newCmdUpgradeControlPlane is a subcommand for `linkerd upgrade control-plane`
+func newCmdUpgradeControlPlane(options *upgradeOptions) *cobra.Command {
+	flags := options.recordableFlagSet()
+
+	cmd := &cobra.Command{
+		Use:   "control-plane [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Output Kubernetes control plane resources to upgrade an existing Linkerd",
+		Long: `Output Kubernetes control plane resources to upgrade an existing Linkerd.
+
+Note that the default flag values for this command come from the Linkerd control
+plane. The default values displayed in the Flags section below only apply to the
+install command. It should be run after "linkerd upgrade config".`,
+		Example: `  # Default upgrade.
+  linkerd upgrade control-plane | kubectl apply -f -`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return upgradeRunE(options, controlPlaneStage, flags)
+		},
+	}
+
+	cmd.PersistentFlags().AddFlagSet(flags)
+
+	return cmd
+}
+
 func newCmdUpgrade() *cobra.Command {
 	options := newUpgradeOptionsWithDefaults()
 	flags := options.recordableFlagSet()
 	upgradeOnlyFlags := options.upgradeOnlyFlagSet()
 
 	cmd := &cobra.Command{
-		Use:       fmt.Sprintf("upgrade [%s|%s] [flags]", configStage, controlPlaneStage),
-		Args:      cobra.OnlyValidArgs,
-		ValidArgs: []string{configStage, controlPlaneStage},
-		Short:     "Output Kubernetes configs to upgrade an existing Linkerd control plane",
+		Use:   "upgrade [flags]",
+		Args:  cobra.NoArgs,
+		Short: "Output Kubernetes configs to upgrade an existing Linkerd control plane",
 		Long: `Output Kubernetes configs to upgrade an existing Linkerd control plane.
 
 Note that the default flag values for this command come from the Linkerd control
@@ -70,67 +113,67 @@ install command.`,
   linkerd upgrade | kubectl apply -f -
 
   # Similar to install, upgrade may also be broken up into two stages, by user
-  # privilege.
-  # First stage requires cluster-level privileges.
-  linkerd upgrade config | kubectl apply -f -
-  # Second stage requires namespace-level privileges.
-  linkerd upgrade control-plane | kubectl apply -f -`,
+  # privilege.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if options.ignoreCluster {
-				panic("ignore cluster must be unset") // Programmer error.
-			}
-
-			stage, err := validateArgs(args, flags, upgradeOnlyFlags)
-			if err != nil {
-				return err
-			}
-
-			// We need a Kubernetes client to fetch configs and issuer secrets.
-			var k kubernetes.Interface
-			if options.manifests != "" {
-				readers, err := read(options.manifests)
-				if err != nil {
-					upgradeErrorf("Failed to parse manifests from %s: %s", options.manifests, err)
-				}
-
-				k, err = k8s.NewFakeAPIFromManifests(readers)
-				if err != nil {
-					upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
-				}
-			} else {
-				k, err = k8s.NewAPI(kubeconfigPath, kubeContext, 0)
-				if err != nil {
-					upgradeErrorf("Failed to create a kubernetes client: %s", err)
-				}
-			}
-
-			values, configs, err := options.validateAndBuild(stage, k, flags)
-			if err != nil {
-				upgradeErrorf("Failed to build upgrade configuration: %s", err)
-			}
-
-			// rendering to a buffer and printing full contents of buffer after
-			// render is complete, to ensure that okStatus prints separately
-			var buf bytes.Buffer
-			if err = values.render(&buf, configs); err != nil {
-				upgradeErrorf("Could not render upgrade configuration: %s", err)
-			}
-
-			buf.WriteTo(os.Stdout)
-
-			fmt.Fprintf(os.Stderr, "\n%s %s\n", okStatus, okMessage)
-			if stage == configStage {
-				fmt.Fprintf(os.Stderr, "%s\n", controlPlaneMessage)
-			}
-			fmt.Fprintf(os.Stderr, "%s\n\n", visitMessage)
-
-			return nil
+			return upgradeRunE(options, "", flags)
 		},
 	}
 
-	cmd.PersistentFlags().AddFlagSet(flags)
+	cmd.Flags().AddFlagSet(flags)
 	cmd.PersistentFlags().AddFlagSet(upgradeOnlyFlags)
+
+	cmd.AddCommand(newCmdUpgradeConfig(options))
+	cmd.AddCommand(newCmdUpgradeControlPlane(options))
+
 	return cmd
+}
+
+func upgradeRunE(options *upgradeOptions, stage string, flags *pflag.FlagSet) error {
+	if options.ignoreCluster {
+		panic("ignore cluster must be unset") // Programmer error.
+	}
+
+	// We need a Kubernetes client to fetch configs and issuer secrets.
+	var k kubernetes.Interface
+	var err error
+	if options.manifests != "" {
+		readers, err := read(options.manifests)
+		if err != nil {
+			upgradeErrorf("Failed to parse manifests from %s: %s", options.manifests, err)
+		}
+
+		k, err = k8s.NewFakeAPIFromManifests(readers)
+		if err != nil {
+			upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
+		}
+	} else {
+		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+		if err != nil {
+			upgradeErrorf("Failed to create a kubernetes client: %s", err)
+		}
+	}
+
+	values, configs, err := options.validateAndBuild(stage, k, flags)
+	if err != nil {
+		upgradeErrorf("Failed to build upgrade configuration: %s", err)
+	}
+
+	// rendering to a buffer and printing full contents of buffer after
+	// render is complete, to ensure that okStatus prints separately
+	var buf bytes.Buffer
+	if err = values.render(&buf, configs); err != nil {
+		upgradeErrorf("Could not render upgrade configuration: %s", err)
+	}
+
+	buf.WriteTo(os.Stdout)
+
+	fmt.Fprintf(os.Stderr, "\n%s %s\n", okStatus, okMessage)
+	if stage == configStage {
+		fmt.Fprintf(os.Stderr, "%s\n", controlPlaneMessage)
+	}
+	fmt.Fprintf(os.Stderr, "%s\n\n", visitMessage)
+
+	return nil
 }
 
 func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Interface, flags *pflag.FlagSet) (*installValues, *pb.All, error) {


### PR DESCRIPTION
The multi-stage args used by install, upgrade, and check were
implemented as positional arguments to their respective parent commands.
This made the help documentation unclear, and the code ambiguous as to
which flags corresponded to which stage.

Define `config` and `control-plane` stages as subcommands. The help
menus now explicitly state flags supported.

Fixes #2729

Signed-off-by: Andrew Seigner <siggy@buoyant.io>