### PR TITLE
Fix Service Profile CRD check to handle k8s errors

### DIFF
--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -53,17 +53,15 @@ func ResourceAuthz(
 // ServiceProfilesAccess checks whether the ServiceProfile CRD is installed
 // on the cluster and the client is authorized to access ServiceProfiles.
 func ServiceProfilesAccess(k8sClient kubernetes.Interface) error {
-	res, err := k8sClient.Discovery().ServerResources()
+	res, err := k8sClient.Discovery().ServerResourcesForGroupVersion(ServiceProfileAPIVersion)
 	if err != nil {
 		return err
 	}
 
-	for _, r := range res {
-		if r.GroupVersion == ServiceProfileAPIVersion {
-			for _, apiRes := range r.APIResources {
-				if apiRes.Kind == ServiceProfileKind {
-					return ResourceAuthz(k8sClient, "", "list", "linkerd.io", "", "serviceprofiles", "")
-				}
+	if res.GroupVersion == ServiceProfileAPIVersion {
+		for _, apiRes := range res.APIResources {
+			if apiRes.Kind == ServiceProfileKind {
+				return ResourceAuthz(k8sClient, "", "list", "linkerd.io", "", "serviceprofiles", "")
 			}
 		}
 	}

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -56,5 +57,39 @@ subjects:
 				}
 			}
 		})
+	}
+}
+
+func TestServiceProfilesAccess(t *testing.T) {
+	fakeResources := []string{`
+kind: APIResourceList
+apiVersion: v1
+groupVersion: linkerd.io/v1alpha1
+resources:
+- name: serviceprofiles
+  singularName: serviceprofile
+  namespaced: true
+  kind: ServiceProfile
+  verbs:
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - create
+  - update
+  - watch
+  shortNames:
+  - sp`}
+
+	api, err := NewFakeAPI(fakeResources...)
+	if err != nil {
+		t.Fatalf("NewFakeAPI error: %s", err)
+	}
+
+	err = ServiceProfilesAccess(api)
+	// RBAC SSAR request failed, but the Discovery lookup succeeded
+	if !reflect.DeepEqual(err, errors.New("not authorized to access serviceprofiles.linkerd.io")) {
+		t.Fatalf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
`ServiceProfilesAccess()`, called by control plane components at
startup, would fail if it encountered an `ErrGroupDiscoveryFailed` from
a GroupVersion request. This error is mostly innocuous, as it returns an
error if any GroupVersion fails. `ServiceProfilesAccess()` only needs to
validate ServiceProfiles are available.

Modify `ServiceProfilesAccess()` to specifically request the
ServiceProfile GroupVersion. Also add Discovery object
(`APIResourceList`) support to `NewFakeClientSets`.

Fixes #2780

Signed-off-by: Andrew Seigner <siggy@buoyant.io>