### PR TITLE
Release notes for Edge-19.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,9 @@
   * Fixed pod creation failure when a `ResourceQuota` exists by adding a default
     resource spec for the proxy-init init container
 * Proxy
-  * Replaced fixed reconnect backoff with exponential one (thanks,
+  * Replaced the fixed reconnect backoff with an exponential one (thanks,
     @zaharidichev!)
-  * Support endpoint weights
-  * Fixed an issue where load balancers can become stuck by removing buffers
-    from endpoint stacks
+  * Fixed an issue where load balancers can become stuck
 * Internal
   * Fixed integration tests by adding known proxy-injector log warning to tests
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+## edge-19.5.1
+
+* CLI
+  * Added a `linkerd check config` command for verifying that
+    `linkerd install config` was successful
+  * Improved the help documentation of `linkerd install` to clarify flag usage
+  * Added support for private Kubernetes clusters by changing the CLI to connect
+    to the control plane using a port-forward (thanks, @jackprice!)
+* Controller
+  * Fixed pod creation failure when a `ResourceQuota` exists by adding a default
+    resource spec for the proxy-init init container
+* Proxy
+  * Replaced fixed reconnect backoff with exponential one (thanks,
+    @zaharidichev!)
+  * Support endpoint weights
+  * Fixed an issue where load balancers can become stuck by removing buffers
+    from endpoint stacks
+* Internal
+  * Fixed integration tests by adding known proxy-injector log warning to tests
+
 ## edge-19.4.5
 
 **Significant Update**


### PR DESCRIPTION
* CLI
  * Added a `linkerd check config` command for verifying that
    `linkerd install config` was successful
  * Improved the help documentation of `linkerd install` to clarify flag usage
  * Added support for private Kubernetes clusters by changing the CLI to connect
    to the control plane using a port-forward (thanks, @jackprice!)
* Controller
  * Fixed pod creation failure when a `ResourceQuota` exists by adding a default
    resource spec for the proxy-init init container
* Proxy
  * Replaced the fixed reconnect backoff with an exponential one (thanks,
    @zaharidichev!)
  * Fixed an issue where load balancers can become stuck
* Internal
  * Fixed integration tests by adding known proxy-injector log warning to tests

Signed-off-by: Alex Leong <alex@buoyant.io>