### PR TITLE
lower the log level of the linkerd-cni output

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -191,7 +191,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 
 		if containsLinkerdProxy && !containsInitContainer {
-			logEntry.Infof("linkerd-cni: setting up iptables firewall")
+			logEntry.Debug("linkerd-cni: setting up iptables firewall")
 			options := cmd.RootOptions{
 				IncomingProxyPort:     conf.ProxyInit.IncomingProxyPort,
 				OutgoingProxyPort:     conf.ProxyInit.OutgoingProxyPort,
@@ -210,27 +210,27 @@ func cmdAdd(args *skel.CmdArgs) error {
 			iptables.ConfigureFirewall(*firewallConfiguration)
 		} else {
 			if containsInitContainer {
-				logEntry.Infof("linkerd-cni: linkerd-init initContainer is present, skipping.")
+				logEntry.Debug("linkerd-cni: linkerd-init initContainer is present, skipping.")
 			} else {
-				logEntry.Infof("linkerd-cni: linkerd-proxy is not present, skipping.")
+				logEntry.Debug("linkerd-cni: linkerd-proxy is not present, skipping.")
 			}
 		}
 	} else {
-		logEntry.Infof("linkerd-cni: no Kubernetes namespace or pod name found, skipping.")
+		logEntry.Debug("linkerd-cni: no Kubernetes namespace or pod name found, skipping.")
 	}
 
-	logrus.Infof("linkerd-cni: plugin is finished")
+	logrus.Debug("linkerd-cni: plugin is finished")
 	if conf.PrevResult != nil {
 		// Pass through the prevResult for the next plugin
 		return types.PrintResult(conf.PrevResult, conf.CNIVersion)
 	}
 
-	logrus.Infof("linkerd-cni: no previous result to pass through, emptying stdout")
+	logrus.Debug("linkerd-cni: no previous result to pass through, emptying stdout")
 	return nil
 }
 
 // cmdDel is called for DELETE requests
 func cmdDel(args *skel.CmdArgs) error {
-	logrus.Info("linkerd-cni: cmdDel not implemented")
+	logrus.Debug("linkerd-cni: cmdDel not implemented")
 	return nil
 }


### PR DESCRIPTION
We are getting reports from our cluster admins that the linkerd-cni is too chatty in the logs on Info level. This PR lowers the log level to Debug for most all of the logging.