### PR TITLE
Fix proxy build to build go-deps and set version

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -13,7 +13,17 @@ rootdir="$( cd $bindir/.. && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
+dockerfile=$rootdir/Dockerfile-proxy
+
+validate_go_deps_tag $dockerfile
+
+(
+    $bindir/docker-build-base
+    $bindir/docker-build-go-deps
+) >/dev/null
+
 # Default to a pinned commit SHA of the proxy.
 PROXY_VERSION="${PROXY_VERSION:-5018026}"
 
-docker_build proxy "$(head_root_tag)" $rootdir/Dockerfile-proxy --build-arg PROXY_VERSION=$PROXY_VERSION
+tag="$(head_root_tag)"
+docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
The `docker-build-proxy` script builds `Dockerfile-proxy`. That
Dockerfile depends on a go-deps image, and takes a `LINKERD_VERSION`
arg. The `docker-build-proxy` script was neither ensuring go-deps had
been built, nor setting `LINKERD_VERSION`. The former resulted in the
build failing if go-deps did not exist. The latter resulted in
`dev-undefined` log messages in the `linkerd-proxy` container.

Fix `docker-build-proxy` to ensure go-deps are built, and also set the
`LINKERD_VERSION`. This brings this script more in-line with the other
`docker-build-*` scripts.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

## Before
```bash
$ linkerd logs -c linkerd-proxy | grep "running version"
linkerd linkerd-sp-validator-5bcbc9857c-klkqg linkerd-proxy time="2019-05-06T17:34:19Z" level=info msg="running version dev-undefined"
linkerd linkerd-prometheus-7f69b4b48-mjx7b linkerd-proxy time="2019-05-06T17:34:16Z" level=info msg="running version dev-undefined"
linkerd linkerd-identity-8478c498fd-gsqkm linkerd-proxy time="2019-05-06T17:34:13Z" level=info msg="running version dev-undefined"
linkerd linkerd-web-6cbb98c7db-59tdn linkerd-proxy time="2019-05-06T17:34:13Z" level=info msg="running version dev-undefined"
linkerd linkerd-controller-6bfb57cb64-bzmr6 linkerd-proxy time="2019-05-06T17:34:15Z" level=info msg="running version dev-undefined"
linkerd linkerd-proxy-injector-687db5f8c4-qk4lc linkerd-proxy time="2019-05-06T17:34:17Z" level=info msg="running version dev-undefined"
linkerd linkerd-grafana-7574796697-77jls linkerd-proxy time="2019-05-06T17:34:15Z" level=info msg="running version dev-undefined"
```

## After

```bash
$ linkerd logs -c linkerd-proxy | grep "running version"
linkerd linkerd-proxy-injector-5f479dd449-zrblk linkerd-proxy time="2019-05-06T17:31:47Z" level=info msg="running version git-70aa7182"
linkerd linkerd-web-6d496f746c-bf2cp linkerd-proxy time="2019-05-06T17:31:44Z" level=info msg="running version git-70aa7182"
linkerd linkerd-controller-7d84544f87-kvmj5 linkerd-proxy time="2019-05-06T17:31:44Z" level=info msg="running version git-70aa7182"
linkerd linkerd-grafana-69c46f96fd-djgtv linkerd-proxy time="2019-05-06T17:31:46Z" level=info msg="running version git-70aa7182"
linkerd linkerd-identity-7589f5f7fc-vbpmk linkerd-proxy time="2019-05-06T17:31:41Z" level=info msg="running version git-70aa7182"
linkerd linkerd-sp-validator-6cfc665c5d-ptp5t linkerd-proxy time="2019-05-06T17:31:50Z" level=info msg="running version git-70aa7182"
linkerd linkerd-prometheus-79cb748697-f8j27 linkerd-proxy time="2019-05-06T17:31:44Z" level=info msg="running version git-70aa7182"
```
