### PR TITLE
Remove readiness probe from sidecar proxies

### DIFF
--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -97,11 +97,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -97,11 +97,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -242,11 +237,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -97,11 +97,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -264,11 +259,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -420,11 +410,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -576,11 +561,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -116,11 +116,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 9998
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 9998
-          initialDelaySeconds: 2
         resources:
           limits:
             cpu: "1"

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -264,11 +259,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -113,11 +113,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -109,11 +109,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -109,11 +109,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 1234
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 1234
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -110,11 +110,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -110,11 +110,6 @@ items:
             name: linkerd-proxy
           - containerPort: 4191
             name: linkerd-admin
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 4191
-            initialDelaySeconds: 2
           resources: {}
           securityContext:
             runAsUser: 2102
@@ -260,11 +255,6 @@ items:
             name: linkerd-proxy
           - containerPort: 4191
             name: linkerd-admin
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 4191
-            initialDelaySeconds: 2
           resources: {}
           securityContext:
             runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -110,11 +110,6 @@ items:
             name: linkerd-proxy
           - containerPort: 4191
             name: linkerd-admin
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 4191
-            initialDelaySeconds: 2
           resources: {}
           securityContext:
             runAsUser: 2102
@@ -260,11 +255,6 @@ items:
             name: linkerd-proxy
           - containerPort: 4191
             name: linkerd-admin
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 4191
-            initialDelaySeconds: 2
           resources: {}
           securityContext:
             runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -91,11 +91,6 @@ spec:
       name: linkerd-proxy
     - containerPort: 4191
       name: linkerd-admin
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: 4191
-      initialDelaySeconds: 2
     resources: {}
     securityContext:
       runAsUser: 2102

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -91,11 +91,6 @@ spec:
       name: linkerd-proxy
     - containerPort: 4191
       name: linkerd-admin
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: 4191
-      initialDelaySeconds: 2
     resources:
       limits:
         cpu: 160m

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -108,11 +108,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -110,11 +110,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -268,11 +263,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -177,11 +177,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -452,11 +447,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -654,11 +644,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -946,11 +931,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1201,11 +1181,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1391,11 +1366,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1605,11 +1575,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -496,11 +496,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -771,11 +766,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -973,11 +963,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1265,11 +1250,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1520,11 +1500,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1710,11 +1685,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1924,11 +1894,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -499,11 +499,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -786,11 +781,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -994,11 +984,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -1292,11 +1277,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -1553,11 +1533,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -1749,11 +1724,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m
@@ -1969,11 +1939,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 100m

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -499,11 +499,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -786,11 +781,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -994,11 +984,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -1292,11 +1277,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -1553,11 +1533,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -1749,11 +1724,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m
@@ -1969,11 +1939,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources:
           requests:
             cpu: 400m

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -496,11 +496,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -741,11 +736,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -913,11 +903,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1175,11 +1160,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1400,11 +1380,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1560,11 +1535,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1744,11 +1714,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -467,11 +467,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -707,11 +702,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -874,11 +864,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1131,11 +1116,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1351,11 +1331,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1506,11 +1481,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1685,11 +1655,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -497,11 +497,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -773,11 +768,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -976,11 +966,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1269,11 +1254,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1525,11 +1505,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1716,11 +1691,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102
@@ -1931,11 +1901,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -142,13 +142,6 @@
         },
         "initialDelaySeconds": 10
       },
-      "readinessProbe": {
-        "httpGet": {
-          "path": "/ready",
-          "port": 4191
-        },
-        "initialDelaySeconds": 2
-      },
       "terminationMessagePolicy": "FallbackToLogsOnError",
       "imagePullPolicy": "IfNotPresent",
       "securityContext": {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -491,8 +491,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
 				Value: "ns:$(_pod_ns)",
 			},
 		},
-		ReadinessProbe: conf.proxyReadinessProbe(),
-		LivenessProbe:  conf.proxyLivenessProbe(),
+		LivenessProbe: conf.proxyLivenessProbe(),
 	}
 
 	// Special case if the caller specifies that
@@ -894,18 +893,6 @@ func (conf *ResourceConfig) proxyUID() int64 {
 	}
 
 	return conf.configs.GetProxy().GetProxyUid()
-}
-
-func (conf *ResourceConfig) proxyReadinessProbe() *corev1.Probe {
-	return &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/ready",
-				Port: intstr.IntOrString{IntVal: conf.proxyAdminPort()},
-			},
-		},
-		InitialDelaySeconds: 2,
-	}
 }
 
 func (conf *ResourceConfig) proxyLivenessProbe() *corev1.Probe {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -32,7 +32,6 @@ type expectedProxyConfigs struct {
 	outboundListenAddr         string
 	proxyUID                   int64
 	livenessProbe              *corev1.Probe
-	readinessProbe             *corev1.Probe
 	destinationProfileSuffixes string
 	initImage                  string
 	initImagePullPolicy        corev1.PullPolicy
@@ -149,15 +148,6 @@ func TestConfigAccessors(t *testing.T) {
 					},
 					InitialDelaySeconds: 10,
 				},
-				readinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
-							Port: intstr.IntOrString{IntVal: int32(5001)},
-						},
-					},
-					InitialDelaySeconds: 2,
-				},
 				destinationProfileSuffixes: "svc.cluster.local.",
 				initImage:                  "gcr.io/linkerd-io/proxy-init",
 				initImagePullPolicy:        corev1.PullPolicy("Always"),
@@ -214,15 +204,6 @@ func TestConfigAccessors(t *testing.T) {
 						},
 					},
 					InitialDelaySeconds: 10,
-				},
-				readinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
-							Port: intstr.IntOrString{IntVal: int32(6001)},
-						},
-					},
-					InitialDelaySeconds: 2,
 				},
 				destinationProfileSuffixes: ".",
 				initImage:                  "gcr.io/linkerd-io/proxy-init",
@@ -376,13 +357,6 @@ func TestConfigAccessors(t *testing.T) {
 			t.Run("proxyLivenessProbe", func(t *testing.T) {
 				expected := testCase.expected.livenessProbe
 				if actual := resourceConfig.proxyLivenessProbe(); !reflect.DeepEqual(expected, actual) {
-					t.Errorf("Expected: %v Actual: %v", expected, actual)
-				}
-			})
-
-			t.Run("proxyReadinessProbe", func(t *testing.T) {
-				expected := testCase.expected.readinessProbe
-				if actual := resourceConfig.proxyReadinessProbe(); !reflect.DeepEqual(expected, actual) {
 					t.Errorf("Expected: %v Actual: %v", expected, actual)
 				}
 			})

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -76,11 +76,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 4191
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 4191
-          initialDelaySeconds: 2
         resources: {}
         securityContext:
           runAsUser: 2102

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -90,11 +90,6 @@ spec:
           name: linkerd-proxy
         - containerPort: 789
           name: linkerd-admin
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 789
-          initialDelaySeconds: 2
         resources:
           limits:
             cpu: 20m


### PR DESCRIPTION
Proxies aren't referred in any service/endpoints resource, so there's
no reason for them to expose a readiness probe.

Also the probes as they're currently declared are usually failing during
install because the main container is usually ready afterwards (e.g.
Prometheus probe takes 30s), which causes warnings events in k8s.

Part of #2713