### PR TITLE
Introduce pre-install healthcheck for clock skew

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/profiles"
+	"github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,6 +103,14 @@ const (
 // point to. Each check adds its own `hintAnchor` to specify a location on the
 // page.
 const HintBaseURL = "https://linkerd.io/checks/#"
+
+// AllowedClockSkew sets the allowed skew in clock synchronization
+// between the system running inject command and the node(s), being
+// based on assumed node's heartbeat interval (<= 60 seconds) plus default TLS
+// clock skew allowance.
+//
+// TODO: Make this default value overridiable, e.g. by CLI flag
+const AllowedClockSkew = (60 * time.Second) + tls.DefaultClockSkewAllowance
 
 var (
 	retryWindow    = 5 * time.Second
@@ -324,6 +333,13 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
 						return hc.checkCanCreate(hc.ControlPlaneNamespace, "", "v1", "configmaps")
+					},
+				},
+				{
+					description: "no clock skew detected",
+					hintAnchor:  "pre-k8s-clock-skew",
+					check: func(context.Context) error {
+						return hc.checkClockSkew()
 					},
 				},
 			},
@@ -986,6 +1002,43 @@ func (hc *HealthChecker) checkNetAdmin() error {
 	}
 
 	return fmt.Errorf("found %d PodSecurityPolicies, but none provide NET_ADMIN", len(pspList.Items))
+}
+
+func (hc *HealthChecker) checkClockSkew() error {
+	if hc.kubeAPI == nil {
+		// we should never get here
+		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
+	}
+
+	var clockSkewNodes []string
+
+	nodeList, err := hc.kubeAPI.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodeList.Items {
+		for _, condition := range node.Status.Conditions {
+			// we want to check only KubeletReady condition and only execute if the node is ready
+			if condition.Type == "Ready" && condition.Status == "True" {
+				ts := condition.LastHeartbeatTime.Time
+				if (time.Now().Sub(ts) > AllowedClockSkew) || (time.Now().Sub(ts) < -AllowedClockSkew) {
+					clockSkewNodes = append(clockSkewNodes, node.Name)
+				}
+			}
+		}
+	}
+
+	errMsg := ""
+	if len(clockSkewNodes) > 0 {
+		errMsg = fmt.Sprintf("Clock skew detected for node(s): %s", strings.Join(clockSkewNodes, ", "))
+	}
+
+	if errMsg != "" {
+		return fmt.Errorf(errMsg)
+	}
+
+	return nil
 }
 
 func (hc *HealthChecker) validateServiceProfiles() error {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1022,7 +1022,7 @@ func (hc *HealthChecker) checkClockSkew() error {
 			// we want to check only KubeletReady condition and only execute if the node is ready
 			if condition.Type == "Ready" && condition.Status == "True" {
 				ts := condition.LastHeartbeatTime.Time
-				if (time.Now().Sub(ts) > AllowedClockSkew) || (time.Now().Sub(ts) < -AllowedClockSkew) {
+				if (time.Since(ts) > AllowedClockSkew) || (time.Since(ts) < -AllowedClockSkew) {
 					clockSkewNodes = append(clockSkewNodes, node.Name)
 				}
 			}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -335,6 +335,57 @@ func TestCheckCanCreate(t *testing.T) {
 	}
 }
 
+func TestCheckClockSkew(t *testing.T) {
+	tests := []struct {
+		k8sConfigs []string
+		err        error
+	}{
+		{
+			[]string{},
+			nil,
+		},
+		{
+			[]string{`apiVersion: v1
+kind: Node
+metadata:
+  name: test-node
+status:
+  conditions:
+  - lastHeartbeatTime: "2000-01-01T01:00:00Z"
+    status: "True"
+    type: Ready`,
+			},
+			fmt.Errorf("Clock skew detected for node(s): test-node"),
+		},
+	}
+
+	for i, test := range tests {
+		test := test // pin
+		t.Run(fmt.Sprintf("%d: returns expected clock skew check result", i), func(t *testing.T) {
+			hc := NewHealthChecker(
+				[]CategoryID{},
+				&Options{},
+			)
+
+			var err error
+			hc.kubeAPI, err = k8s.NewFakeAPI(test.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			err = hc.checkClockSkew()
+			if err != nil || test.err != nil {
+				if (err == nil && test.err != nil) ||
+					(err != nil && test.err == nil) ||
+					(err.Error() != test.err.Error()) {
+					t.Fatalf("Unexpected error (Expected: %s, Got: %s)", test.err, err)
+				}
+			}
+		})
+	}
+
+}
+
 func TestCheckNetAdmin(t *testing.T) {
 	tests := []struct {
 		k8sConfigs []string

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -355,7 +355,7 @@ status:
     status: "True"
     type: Ready`,
 			},
-			fmt.Errorf("Clock skew detected for node(s): test-node"),
+			fmt.Errorf("clock skew detected for node(s): test-node"),
 		},
 	}
 

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -19,6 +19,7 @@ pre-kubernetes-setup
 √ can create Services
 √ can create Deployments
 √ can create ConfigMaps
+√ no clock skew detected
 
 pre-kubernetes-capability
 -------------------------


### PR DESCRIPTION
**Subject**
Introduce pre-install healthcheck for clock skew

**Problem**
Recently, a user has reported a failed Linkerd install, which was manifesting itself as an error when verifying certificate in linkerd-identity pod. After investigation, the user discover that the issue was caused by clock skew between his system and the Kubernetes node (Minikube in this case). The problem in this scenario is that the user is not aware of the clock skew, as this problem manifests itself as a different issue (i.e. invalid / expired certificate).

**Solution**
To alleviate the issue, an additional pre-install healthcheck for clock skew was suggested. This PR implements such a healthcheck in following way:
- It queries the Kubernetes API for node status(es) and takes the last heartbeat timestamp received from the node as the determining value
- It compares the timestamp with system time of machine running the pre-install check
- If these two time values differ by more than 70 seconds (60 seconds for the presumed maximal interval for node heartbeat + currently 10 second clock skew as allowed by default by TLS package) for any node, fail the check and return names of the failing nodes

For details please follow the thread in the issue comments

**Validation**
This change has been tested with 1) Minikube v1.0.0 node running in VM and 2) local test cluster composed of 2 nodes (running Kuberenets v1.13; the system times have been manipulated to test different scenarios)

Fixes #2762

Signed-off-by: Matej Gera <matejgera@gmail.com>