### PR TITLE
Release notes for edge-19.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
   * Added a dispatch timeout that bounds the amount of time a request can be
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
-    to the Destination service
+    queries to the Destination service
 * Internal
   * Fixed potentially flaky assertions in the service profile integration tests
   * Fixed the `docker-build-proxy` script not building the `go-deps` image

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,12 +7,13 @@
   * Fixed control plane components failing on startup when the Kubernetes API
     returns an `ErrGroupDiscoveryFailed`
 * Proxy
-  * Added a dispatch timeout that bounds the amount of time a request can be
+  * Added a dispatch timeout that limits the amount of time a request can be
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
     queries to the Destination service
 * Internal
-  * Fixed potentially flaky assertions in the service profile integration tests
+  * Fixed potential for spurious failures in the service profile integration
+    tests
   * Fixed the `docker-build-proxy` script not building the `go-deps` image
   * Added a proxy integration test asserting that TLS connections are refused
     when the proxy's identity has not yet been certified by the control plane

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+## edge-19.5.2
+
+* CLI
+  * Fixed `linkerd check` and `linkerd dashboard` failing when any control plane
+    pod is not ready, even when multiple replicas exist (as in HA mode)
+* Controller
+  * Fixed control plane components failing on startup when the Kubernetes API
+    returns an `ErrGroupDiscoveryFailed`
+* Proxy
+  * Added a dispatch timeout that bounds the amount of time a request can be
+    buffered in the proxy
+  * Removed the limit on the number of concurrently active service discovery
+    to the Destination service
+* Internal
+  * Fixed potentially flaky assertions in the service profile integration tests
+  * Fixed the `docker-build-proxy` script not building the `go-deps` image
+  * Added a proxy integration test asserting that TLS connections are refused
+    when the proxy's identity has not yet been certified by the control plane
+    (thanks @zaharidichev!)
+
 ## edge-19.5.1
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,13 +11,9 @@
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
     queries to the Destination service
-* Internal
-  * Fixed potential for spurious failures in the service profile integration
-    tests
-  * Fixed the `docker-build-proxy` script not building the `go-deps` image
-  * Added a proxy integration test asserting that TLS connections are refused
-    when the proxy's identity has not yet been certified by the control plane
-    (thanks @zaharidichev!)
+
+Special thanks to @zaharidichev for adding end to end tests for proxies with
+TLS!
 
 ## edge-19.5.1
 


### PR DESCRIPTION
* CLI
  * Fixed `linkerd check` and `linkerd dashboard` failing when any control plane
    pod is not ready, even when multiple replicas exist (as in HA mode)
* Controller
  * Fixed control plane components failing on startup when the Kubernetes API
    returns an `ErrGroupDiscoveryFailed`
* Proxy
  * Added a dispatch timeout that limits the amount of time a request can be
    buffered in the proxy
  * Removed the limit on the number of concurrently active service discovery
    queries to the Destination service

Special thanks to @zaharidichev for adding end to end tests for proxies with
TLS!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>