### PR TITLE
Added controller component labels to webhook configurations

### DIFF
--- a/controller/proxy-injector/tmpl/mutating_webhook_configuration.go
+++ b/controller/proxy-injector/tmpl/mutating_webhook_configuration.go
@@ -7,6 +7,8 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .WebhookConfigName }}
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   clientConfig:

--- a/controller/sp-validator/tmpl/validating_webhook_configuration.go
+++ b/controller/sp-validator/tmpl/validating_webhook_configuration.go
@@ -7,6 +7,8 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .WebhookConfigName }}
+  labels:
+    linkerd.io/control-plane-component: sp-validator
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:


### PR DESCRIPTION
Fixes #2602 

This adds the `linkerd.io/control-plane-component` label to the proxy-injector and sp-validator webhook Congurations.

The following query would work after this
`kubectl get MutatingWebhookConfigurations,ValidatingWebhookConfigurations  -l 'linkerd.io/control-plane-component in (proxy-injector,sp-validator)'`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>