### PR TITLE
Adding a not-nil check to the Prometheus query for edges

### DIFF
--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -62,8 +62,13 @@ func (s *grpcServer) getEdges(ctx context.Context, req *pb.EdgesRequest) ([]*pb.
 	}
 	resourceType := string(labelNames[1]) // skipping first name which is always namespace
 	labels := promQueryLabels(req.Selector.Resource)
-	labelsOutbound := labels.Merge(promDirectionLabels("outbound"))
-	labelsInbound := labels.Merge(promDirectionLabels("inbound"))
+	labelsOutbound := fmt.Sprint(labels.Merge(promDirectionLabels("outbound")))
+	labelsInbound := fmt.Sprint(labels.Merge(promDirectionLabels("inbound")))
+
+	// checking that data for the selected resource type exists
+	resourceExistsCheck := fmt.Sprintf(`%s!="",`, resourceType)
+	labelsOutbound = labelsOutbound[:1] + resourceExistsCheck + labelsOutbound[1:]
+	labelsInbound = labelsInbound[:1] + resourceExistsCheck + labelsInbound[1:]
 
 	inboundQuery := fmt.Sprintf(inboundIdentityQuery, labelsInbound, resourceType)
 	outboundQuery := fmt.Sprintf(outboundIdentityQuery, labelsOutbound, resourceType, resourceType)


### PR DESCRIPTION
This PR adds a not-nil check to the generated Prometheus query in the API endpoint for `edges`. 

Previously the queries generated were:
```
count(response_total{direction="inbound", namespace="emojivoto"}) by (replicaset, client_id)
count(response_total{direction="outbound", namespace="emojivoto"}) by (replicaset, dst_replicaset, server_id, no_tls_reason)
```

With these queries, if there were no `replicaset` metrics Prometheus would skip that label and return data for the other labels. 

The new queries generated should be:

```
count(response_total{replicaset!="", direction="inbound", namespace="emojivoto"}) by (replicaset, client_id)
count(response_total{replicaset!="", direction="outbound", namespace="emojivoto"}) by (replicaset, dst_replicaset, server_id, no_tls_reason)
```

If there is no `replicaset` data, no data will be returned. This should fix the issue in #2808 where `bin/linkerd edges -n linkerd sts` was returning data when it should have been empty.