### PR TITLE
Validate that data exists for resource type in Prometheus

### DIFF
--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -65,8 +65,12 @@ func (s *grpcServer) getEdges(ctx context.Context, req *pb.EdgesRequest) ([]*pb.
 	labelsOutbound := labels.Merge(promDirectionLabels("outbound"))
 	labelsInbound := labels.Merge(promDirectionLabels("inbound"))
 
-	inboundQuery := fmt.Sprintf(inboundIdentityQuery, labelsInbound, resourceType)
-	outboundQuery := fmt.Sprintf(outboundIdentityQuery, labelsOutbound, resourceType, resourceType)
+	// checking that data for the specified resource type exists
+	labelsOutboundStr := customToString(labelsOutbound, resourceType)
+	labelsInboundStr := customToString(labelsInbound, resourceType)
+
+	outboundQuery := fmt.Sprintf(outboundIdentityQuery, labelsOutboundStr, resourceType, resourceType)
+	inboundQuery := fmt.Sprintf(inboundIdentityQuery, labelsInboundStr, resourceType)
 
 	inboundResult, err := s.queryProm(ctx, inboundQuery)
 	if err != nil {

--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -66,8 +66,8 @@ func (s *grpcServer) getEdges(ctx context.Context, req *pb.EdgesRequest) ([]*pb.
 	labelsInbound := labels.Merge(promDirectionLabels("inbound"))
 
 	// checking that data for the specified resource type exists
-	labelsOutboundStr := customToString(labelsOutbound, resourceType)
-	labelsInboundStr := customToString(labelsInbound, resourceType)
+	labelsOutboundStr := generateLabelStringWithExclusion(labelsOutbound, resourceType)
+	labelsInboundStr := generateLabelStringWithExclusion(labelsInbound, resourceType)
 
 	outboundQuery := fmt.Sprintf(outboundIdentityQuery, labelsOutboundStr, resourceType, resourceType)
 	inboundQuery := fmt.Sprintf(inboundIdentityQuery, labelsInboundStr, resourceType)

--- a/controller/api/public/prometheus.go
+++ b/controller/api/public/prometheus.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 	"time"
 
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
@@ -114,6 +116,20 @@ func promDstQueryLabels(resource *pb.Resource) model.LabelSet {
 	}
 
 	return set
+}
+
+// insert a not-nil check into a LabelSet to verify that data for a specified
+// label name exists. due to the `!=` this must be inserted as a string. the
+// structure of this code is taken from the Prometheus labelset.go library.
+func customToString(l model.LabelSet, labelName string) string {
+	lstrs := make([]string, 0, len(l))
+	for l, v := range l {
+		lstrs = append(lstrs, fmt.Sprintf("%s=%q", l, v))
+	}
+	lstrs = append(lstrs, fmt.Sprintf(`%s!=""`, labelName))
+
+	sort.Strings(lstrs)
+	return fmt.Sprintf("{%s}", strings.Join(lstrs, ", "))
 }
 
 // determine if we should add "namespace=<namespace>" to a named query

--- a/controller/api/public/prometheus.go
+++ b/controller/api/public/prometheus.go
@@ -121,7 +121,7 @@ func promDstQueryLabels(resource *pb.Resource) model.LabelSet {
 // insert a not-nil check into a LabelSet to verify that data for a specified
 // label name exists. due to the `!=` this must be inserted as a string. the
 // structure of this code is taken from the Prometheus labelset.go library.
-func customToString(l model.LabelSet, labelName string) string {
+func generateLabelStringWithExclusion(l model.LabelSet, labelName string) string {
 	lstrs := make([]string, 0, len(l))
 	for l, v := range l {
 		lstrs = append(lstrs, fmt.Sprintf("%s=%q", l, v))


### PR DESCRIPTION
Logic for this PR is credit @rmars who modeled her code on the Prometheus library. 

This PR adds a check to the Prometheus queries for edges, in order to verify that data for a specified label name exists. Previous queries generated: 
```
count(response_total{direction="inbound", namespace="emojivoto"}) by (replicaset, client_id)
count(response_total{direction="outbound", namespace="emojivoto"}) by (replicaset, dst_replicaset, server_id, no_tls_reason)
```
With these queries, if there were no `replicaset` metrics Prometheus would skip that label and return data for the other labels. 

The new queries generated should be:

```
count(response_total{replicaset!="", direction="inbound", namespace="emojivoto"}) by (replicaset, client_id)
count(response_total{replicaset!="", direction="outbound", namespace="emojivoto"}) by (replicaset, dst_replicaset, server_id, no_tls_reason)
```

To check in the CLI, run these steps on `master` and on this branch:
1. Install emojivoto and inject Linkerd
`curl -sL https://run.linkerd.io/emojivoto.yml | linkerd inject - | kubectl apply -f -`

2. Run the public API locally (this should start HTTP server on :8085)
`bin/go-run controller/cmd/public-api -log-level debug`

3. Port forward Prometheus
`kubectl -n linkerd port-forward $(kubectl --namespace=linkerd get po --selector=linkerd.io/control-plane-component=prometheus -o jsonpath='{.items[*].metadata.name}') 9090:9090`

4. Run edges in the terminal, communicating directly with the control plane at :8085
`bin/go-run cli edges rc -n emojivoto --api-addr localhost:8085`

The incorrect response is:
```bash
SRC   DST   CLIENT              SERVER             MSG
            default.emojivoto   web.emojivoto      -
```

The correct response should be:
```bash
No edges found.
```
