### PR TITLE
Add debug container annotation

### DIFF
--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       annotations:
+        config.linkerd.io/debug: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -435,6 +435,7 @@ func (conf *ResourceConfig) injectPodSpec(patch *Patch) {
 
 		if debugEnabled {
 			log.Infof("inject debug container")
+			conf.WithDebugSidecar()
 			patch.addContainer(conf.debugSidecar)
 		}
 	}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -158,6 +158,10 @@ const (
 	// ProxyDisableTapAnnotation can be used to disable tap on the injected proxy.
 	ProxyDisableTapAnnotation = ProxyConfigAnnotationsPrefix + "/disable-tap"
 
+	// ProxyEnableDebugAnnotation is set to true if the debug container is
+	// injected.
+	ProxyEnableDebugAnnotation = ProxyConfigAnnotationsPrefix + "/debug"
+
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.
 	IdentityModeDefault = "default"


### PR DESCRIPTION
This  PR adds a new `config.linkerd.io/debug` annotation. When added to the pod's metadata, the proxy injector will inject the debug container into the workload's containers list. This ensures that `linkerd inject --enable-debug-sidecar` works in an auto-inject setup.

The reason why this new annotation is needed it's because when using `linkerd install`, the `pkg/inject` library will only inject Linkerd annotations into the workload YAML. So even though the [`conf.debugSidecar` field is set by the CLI](https://github.com/linkerd/linkerd2/blob/bd4c2788fa19f31b0fb2f32254ac6fd52c737565/cli/cmd/inject.go#L138-L140), the `inject.injectPodSpec()` function is never called. Once the workload YAML got picked up by the proxy injector, `conf.debugSidecar` is already nil, since it's a different, new `conf` object.

Fixes #2840 

Signed-off-by: Ivan Sim <ivan@buoyant.io>