### PR TITLE
Generate the debug container spec in the shared library

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -136,7 +136,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 
 	if rt.enableDebugSidecar {
-		conf = conf.WithDebugSidecar()
+		conf.AppendPodAnnotation(k8s.ProxyEnableDebugAnnotation, "true")
 	}
 
 	report, err := conf.ParseMetaAndYAML(bytes)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -112,7 +112,6 @@ type ResourceConfig struct {
 	proxyOutboundCapacity  map[string]uint
 	ownerRetriever         OwnerRetrieverFunc
 	origin                 Origin
-	debugSidecar           *corev1.Container
 
 	workload struct {
 		obj      runtime.Object

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -473,10 +473,9 @@ func TestInjectPodSpec(t *testing.T) {
 	conf.pod.spec = &corev1.PodSpec{}
 
 	t.Run("debug container", func(t *testing.T) {
-		conf.pod.meta.Annotations[k8s.ProxyEnableDebugAnnotation] = "true"
-		conf.WithDebugSidecar()
-
 		patch := NewPatch("Deployment")
+		conf.AppendPodAnnotation(k8s.ProxyEnableDebugAnnotation, "true")
+		conf.injectPodAnnotations(patch)
 		conf.injectPodSpec(patch)
 
 		passed := false


### PR DESCRIPTION
This commit refactors the changes introduced by #2842 where the debug container spec is created in the `cli` and `pkg` packages. This change follows the existing pattern of annotating the YAML in the CLI code, and injecting the sidecar spec in the shared library.

Test cases:
```
$ curl https://run.linkerd.io/emojivoto.yml | bin/linkerd inject --enable-debug-sidecar --manual -|k apply -f -

$ curl https://run.linkerd.io/emojivoto.yml | bin/linkerd inject --enable-debug-sidecar -|k apply -f -
```
Expect debug container to be injected.

Signed-off-by: Ivan Sim <ivan@buoyant.io>