### PR TITLE
Make JSON output of `linkerd edges` consistent

### DIFF
--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -181,7 +181,6 @@ func renderEdgeStats(rows []*pb.Edge, options *edgesOptions) string {
 }
 
 type edgeRow struct {
-	key    string
 	src    string
 	dst    string
 	client string
@@ -207,7 +206,6 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 	edgeRows := []edgeRow{}
 	if len(rows) != 0 {
 		for _, r := range rows {
-			key := r.Src.Name + r.Dst.Name
 			clientID := r.ClientId
 			serverID := r.ServerId
 			msg := r.NoIdentityMsg
@@ -225,7 +223,6 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			}
 
 			row := edgeRow{
-				key:    key,
 				client: clientID,
 				server: serverID,
 				msg:    msg,
@@ -255,7 +252,9 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 
 	// sorting edgeRows by key for alphabetical listing
 	sort.Slice(edgeRows, func(i, j int) bool {
-		return edgeRows[i].key < edgeRows[j].key
+		keyI := edgeRows[i].src + edgeRows[i].dst
+		keyJ := edgeRows[j].src + edgeRows[j].dst
+		return keyI < keyJ
 	})
 
 	switch options.outputFormat {

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -329,17 +329,18 @@ type edgesJSONStats struct {
 	Msg    string `json:"no_tls_reason"`
 }
 
-func printEdgesJSON(edgeTables map[string]*edgeRow, w *tabwriter.Writer) {
+func printEdgesJSON(rows map[string]*edgeRow, w *tabwriter.Writer) {
 	// avoid nil initialization so that if there are not stats it gets marshalled as an empty array vs null
 	entries := []*edgesJSONStats{}
 
-	for _, row := range edgeTables {
+	sortedKeys := sortEdgesKeys(rows)
+	for _, key := range sortedKeys {
 		entry := &edgesJSONStats{
-			Src:    row.src,
-			Dst:    row.dst,
-			Client: row.client,
-			Server: row.server,
-			Msg:    row.msg}
+			Src:    rows[key].src,
+			Dst:    rows[key].dst,
+			Client: rows[key].client,
+			Server: rows[key].server,
+			Msg:    rows[key].msg}
 		entries = append(entries, entry)
 	}
 

--- a/cli/cmd/testdata/edges_one_output.golden
+++ b/cli/cmd/testdata/edges_one_output.golden
@@ -1,4 +1,4 @@
 SRC                         DST                       CLIENT              SERVER             MSG
+vote-bot-7466ffc7f7-5rc4l   web-57b7f9db85-297dw      default.emojivoto   web.emojivoto      -  
 web-57b7f9db85-297dw        emoji-646ddcc5f9-zjgs9    web.emojivoto       emoji.emojivoto    -  
 web-57b7f9db85-297dw        voting-689f845d98-rj6nz   web.emojivoto       voting.emojivoto   -  
-vote-bot-7466ffc7f7-5rc4l   web-57b7f9db85-297dw      default.emojivoto   web.emojivoto      -  

--- a/cli/cmd/testdata/edges_one_output_json.golden
+++ b/cli/cmd/testdata/edges_one_output_json.golden
@@ -1,5 +1,12 @@
 [
   {
+    "src": "vote-bot-7466ffc7f7-5rc4l",
+    "dst": "web-57b7f9db85-297dw",
+    "client_id": "default.emojivoto",
+    "server_id": "web.emojivoto",
+    "no_tls_reason": "-"
+  },
+  {
     "src": "web-57b7f9db85-297dw",
     "dst": "emoji-646ddcc5f9-zjgs9",
     "client_id": "web.emojivoto",
@@ -11,13 +18,6 @@
     "dst": "voting-689f845d98-rj6nz",
     "client_id": "web.emojivoto",
     "server_id": "voting.emojivoto",
-    "no_tls_reason": "-"
-  },
-  {
-    "src": "vote-bot-7466ffc7f7-5rc4l",
-    "dst": "web-57b7f9db85-297dw",
-    "client_id": "default.emojivoto",
-    "server_id": "web.emojivoto",
     "no_tls_reason": "-"
   }
 ]


### PR DESCRIPTION
This PR updates `printEdgesJSON` to iterate over sorted keys instead of iterating over a map. This will make the ordering of the resulting JSON consistent and allow the associated unit test to pass. For reference, look at `printEdgeTable` which also iterates over sorted keys.