### PR TITLE
Known event warnings should hold just the message part, not the reason nor t…

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -85,7 +85,7 @@ var (
 		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
 		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)`,
-		`FailedToUpdateEndpoint linkerd-.* Failed to update endpoint .*-upgrade/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
+		`Failed to update endpoint .*-upgrade/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
 	}, "|"))
 
 	injectionCases = []struct {


### PR DESCRIPTION
…he involved object name

This was causing integration tests to fail sporadically.