### PR TITLE
Fixed controller panic due to dup listener #2553

### DIFF
--- a/controller/api/destination/fallback_profile_listener.go
+++ b/controller/api/destination/fallback_profile_listener.go
@@ -39,12 +39,12 @@ func newFallbackProfileListener(listener profileUpdateListener) (profileUpdateLi
 	}
 
 	primary := primaryProfileListener{
-		fallbackChildListener{
+		fallbackChildListener: fallbackChildListener{
 			parent: &fallback,
 		},
 	}
 	backup := backupProfileListener{
-		fallbackChildListener{
+		fallbackChildListener: fallbackChildListener{
 			parent: &fallback,
 		},
 	}

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -71,6 +71,7 @@ func NewServer(
 
 	go func() {
 		<-done
+		log.Info("stopping k8s name resolver")
 		resolver.stop()
 	}()
 
@@ -216,7 +217,7 @@ func buildResolver(
 
 	k8sResolver := newK8sResolver(k8sDNSZoneLabels, newEndpointsWatcher(k8sAPI), newProfileWatcher(k8sAPI))
 
-	log.Infof("Built k8s name resolver")
+	log.Infof("built k8s name resolver")
 
 	return k8sResolver, nil
 }


### PR DESCRIPTION
Fixes (or at least provides a workaround) for #2553.

~~There is something weird happening in the primary/backup listener logic, it seems like both listeners are the same. Because of this, ranging over and then stopping the listeners causes a closed channel (from the first duplicate) to be closed again in the second duplicate. This causes the panic.~~

~~I've added a TODO in the newFallbackProfileListener() func, might be good for someone more experienced (maybe original author @adleong) to see if my observations are correct.~~

EDIT: nevermind, I was confused for a bit. The problem was with both the primary and backup listener having a pointer to the same parent `fallbackProfileListener`, which had `.Stop()` called on it for both the primary and backup. Since `.Stop()` closes a channel, this resulted in closing that channel twice, which caused the panic.

Signed-off-by: Sebastiaan Tammer <sebastiaantammer@gmail.com>