### PR TITLE
proxy: Update to linkerd/linkerd2-proxy#ed32e496

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -23,7 +23,7 @@ validate_go_deps_tag $dockerfile
 ) >/dev/null
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-3e0e00c}"
+PROXY_VERSION="${PROXY_VERSION:-ed32e49}"
 
 tag="$(head_root_tag)"
 docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
This changes the proxy's routing behavior so that, when the control plane does not resolve a destination, the proxy forwards request with minimal additional routing logic.

Furthermore, this fixes a bug in the proxy's HPACK codec that could cause requests with very large header values to hang indefinitely.

    b3dcc6e0 Use the proxy's log formatting in tests (linkerd/linkerd2-proxy#258)
    1c91a398 Rewrite the destination client and remove DNS fallback (linkerd/linkerd2-proxy#259)
    ed32e496 Update h2 to v0.1.21 (linkerd/linkerd2-proxy#261)