### PR TITLE
Stable 2.3.1 Release Notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## stable-2.3.1
+
 This stable release adds a number of proxy stability improvements.
 
 To install this release, run: `curl https://run.linkerd.io/install | sh`
@@ -6,22 +7,23 @@ To install this release, run: `curl https://run.linkerd.io/install | sh`
 **Special thanks to**: @zaharidichev and @11Takanori!
 
 **Full release notes**:
+
 * Proxy
   * Changed the proxy's routing behavior so that, when the control plane
-    does not resolve a destination, the proxy forwards request with minimal
+    does not resolve a destination, the proxy forwards the request with minimal
     additional routing logic
   * Fixed a bug in the proxy's HPACK codec that could cause requests with
-    very large header values to hang indefinitely.
+    very large header values to hang indefinitely
   * Replaced the fixed reconnect backoff with an exponential one (thanks,
       @zaharidichev!)
   * Fixed an issue where load balancers can become stuck
   * Added a dispatch timeout that limits the amount of time a request can be
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
-    queries to the Destination service
+    queries to the destination service
   * Fix an epoll notification issue that could cause excessive CPU usage
   * Added the ability to disable tap by setting an env var (thanks,
-      @zaharidichev!)
+    @zaharidichev!)
 
 ## edge-19.5.3
 
@@ -54,7 +56,7 @@ To install this release, run: `curl https://run.linkerd.io/install | sh`
   * Added a dispatch timeout that limits the amount of time a request can be
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
-    queries to the Destination service
+    queries to the destination service
 
 Special thanks to @zaharidichev for adding end to end tests for proxies with
 TLS!
@@ -1357,7 +1359,7 @@ formerly hosted at github.com/runconduit/conduit.
   * Update branding to reference Linkerd throughout
   * The CLI is now called `linkerd`
 * Production Readiness
-  * Fix issue with Destination service sending back incomplete pod metadata
+  * Fix issue with destination service sending back incomplete pod metadata
   * Fix high CPU usage during proxy shutdown
   * ClusterRoles are now unique per Linkerd install, allowing multiple instances
     to be installed in the same Kubernetes cluster
@@ -1509,7 +1511,7 @@ Kubernetes-aware observability and debugging.
 * Service Discovery
   * The proxy now uses the [trust-dns] DNS resolver. This fixes a number of DNS
     correctness issues.
-  * The Destination service could sometimes return incorrect, stale, labels for an
+  * The destination service could sometimes return incorrect, stale, labels for an
     endpoint. This has been fixed!
 
 [trust-dns]: https://github.com/bluejekyll/trust-dns

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ To install this release, run: `curl https://run.linkerd.io/install | sh`
 
 **Full release notes**:
 * Proxy
+  * Changed the proxy's routing behavior so that, when the control plane
+    does not resolve a destination, the proxy forwards request with minimal
+    additional routing logic
+  * Fixed a bug in the proxy's HPACK codec that could cause requests with
+    very large header values to hang indefinitely.
   * Replaced the fixed reconnect backoff with an exponential one (thanks,
       @zaharidichev!)
   * Fixed an issue where load balancers can become stuck

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ To install this release, run: `curl https://run.linkerd.io/install | sh`
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery
     queries to the destination service
-  * Fix an epoll notification issue that could cause excessive CPU usage
+  * Fixed an epoll notification issue that could cause excessive CPU usage
   * Added the ability to disable tap by setting an env var (thanks,
     @zaharidichev!)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+## stable-2.3.1
+This stable release adds a number of proxy stability improvements.
+
+To install this release, run: `curl https://run.linkerd.io/install | sh`
+
+**Special thanks to**: @zaharidichev and @11Takanori!
+
+**Full release notes**:
+* Proxy
+  * Replaced the fixed reconnect backoff with an exponential one (thanks,
+      @zaharidichev!)
+  * Fixed an issue where load balancers can become stuck
+  * Added a dispatch timeout that limits the amount of time a request can be
+    buffered in the proxy
+  * Removed the limit on the number of concurrently active service discovery
+    queries to the Destination service
+  * Fix an epoll notification issue that could cause excessive CPU usage
+  * Added the ability to disable tap by setting an env var (thanks,
+      @zaharidichev!)
+
 ## edge-19.5.3
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,8 @@ To install this release, run: `curl https://run.linkerd.io/install | sh`
   * Fixed a bug in the proxy's HPACK codec that could cause requests with
     very large header values to hang indefinitely
   * Replaced the fixed reconnect backoff with an exponential one (thanks,
-      @zaharidichev!)
-  * Fixed an issue where load balancers can become stuck
+    @zaharidichev!)
+  * Fixed an issue where requests could be held indefinitely by the load balancer
   * Added a dispatch timeout that limits the amount of time a request can be
     buffered in the proxy
   * Removed the limit on the number of concurrently active service discovery


### PR DESCRIPTION
This stable release adds a number of proxy stability improvements.

To install this release, run: `curl https://run.linkerd.io/install | sh`

**Special thanks to**: @zaharidichev and @11Takanori!

**Full release notes**:

* Proxy
  * Changed the proxy's routing behavior so that, when the control plane
    does not resolve a destination, the proxy forwards the request with minimal
    additional routing logic
  * Fixed a bug in the proxy's HPACK codec that could cause requests with
    very large header values to hang indefinitely
  * Replaced the fixed reconnect backoff with an exponential one (thanks,
    @zaharidichev!)
  * Fixed an issue where requests could be held indefinitely by the load balancer
  * Added a dispatch timeout that limits the amount of time a request can be
    buffered in the proxy
  * Removed the limit on the number of concurrently active service discovery
    queries to the destination service
  * Fixed an epoll notification issue that could cause excessive CPU usage
  * Added the ability to disable tap by setting an env var (thanks,
    @zaharidichev!)