### PR TITLE
Ensure log level is lowercase (#2823)

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -559,7 +560,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		ControllerUID:      options.controllerUID,
 		EnableH2Upgrade:    !options.disableH2Upgrade,
 		NoInitContainer:    options.noInitContainer,
-		PrometheusLogLevel: toPromLogLevel(options.controllerLogLevel),
+		PrometheusLogLevel: toPromLogLevel(strings.ToLower(options.controllerLogLevel)),
 
 		Configs: configJSONs{
 			Global:  globalJSON,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/gen/config"
+	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 )
 
@@ -156,6 +157,27 @@ func TestValidate(t *testing.T) {
 		}
 		if err.Error() != expected {
 			t.Fatalf("Expected error string\"%s\", got \"%s\"", expected, err)
+		}
+	})
+
+	t.Run("Ensure log level input is converted to lower case before passing to prometheus", func(t *testing.T) {
+		underTest := testInstallOptions()
+		underTest.controllerLogLevel = "DEBUG"
+		expected := "debug"
+
+		testValues := new(pb.All)
+		testValues.Global = new(pb.Global)
+		testValues.Proxy = new(pb.Proxy)
+		testValues.Install = new(pb.Install)
+
+		actual, err := underTest.buildValuesWithoutIdentity(testValues)
+
+		if err != nil {
+			t.Fatalf("Unexpected error ocured %s", err)
+		}
+
+		if actual.PrometheusLogLevel != expected {
+			t.Fatalf("Expected error string\"%s\", got \"%s\"", expected, actual.PrometheusLogLevel)
 		}
 	})
 


### PR DESCRIPTION
linkerd accepts correct log level in upper case and they are then passed
into prometheus which only allows lowecase log level with error

Error parsing commandline arguments: unrecognized log level "DEBUG"

More strict validation

Updated the unit tests

Fixes #2823