### PR TITLE
Resync API when informer index returns Not Found

### DIFF
--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -240,7 +240,7 @@ status:
 
 			// TODO: mock out the underlying grpc tap events, rather than waiting an
 			// arbitrary time for request to timeout.
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()
 
 			tapByResourceClient, err := client.TapByResource(ctx, &exp.req)


### PR DESCRIPTION
Fixes #2738 and followup to #2737

When an informer index returns Not Found for a given resource, force an
API resync and try the retrieval one more time.

Also added an API function for retrieving ReplicaSets.

This tested well when retrieving ReplicaSets that were not yet indexed,
in the proxy injector (#2731)

Note: As an alternative I did try to do this in the cache index itself
by replacing the ThreadSafeStore with another Store that would do the
resync inside the Get() method, but I couldn't find a way to replace the
Store, given the private visibility of some of these structs in
go-client. Anyways, it's probably better to do this kind of
customization more explicitly on the calling side.