### PR TITLE
Prevent container from running tshark immediately

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -5,4 +5,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsof \
     tshark && \
     rm -rf /var/lib/apt/lists/*
-ENTRYPOINT [ "tshark", "-i", "any" ]
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -632,6 +632,7 @@ func (conf *ResourceConfig) injectDebugSidecar() *corev1.Container {
 		ImagePullPolicy:          conf.proxyImagePullPolicy(),
 		Image:                    fmt.Sprintf("%s:%s", k8s.DebugSidecarImage, conf.configs.GetGlobal().GetVersion()),
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Resources:                conf.proxyResourceRequirements(),
 	}
 }
 


### PR DESCRIPTION
This PR is added to in order to prevent what might be a race condition in the `tshark` process for the debug container to avoid the `glib-CRITICAL` message. Another added benefit with this PR is that debug containers no longer floods the KubeAPI Server with logs.

To invoke a tshark from a container, users would need to run:
```bash
kubectl -n emojivoto exec -it voting-58b579f99f-4rdlh -c linkerd-debug -- tshark -i any
```

fixes #2860 