### PR TITLE
Update changelog for stable-2.3.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## stable-2.3.2
+
+This stable release fixes a memory leak in the proxy.
+
+To install this release, run: `curl https://run.linkerd.io/install | sh`
+
+**Full release notes**:
+
+* Proxy
+  * Fixed a memory leak that can occur if an HTTP/2 request with a payload
+    ends before the entire payload is sent to the destination
+
 ## edge-19.5.4
 
 * CLI


### PR DESCRIPTION
## stable-2.3.2

This stable release fixes a memory leak in the proxy.

To install this release, run: `curl https://run.linkerd.io/install | sh`

**Full release notes**:

* Proxy
  * Fixed a memory leak that can occur if an HTTP/2 request with a payload
    ends before the entire payload is sent to the destination