### PR TITLE
add namespace name to MWC

### DIFF
--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -59,7 +59,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-{{ .Namespace }}-proxy-injector-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: proxy-injector
 webhooks:

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -53,7 +53,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-{{ .Namespace }}-sp-validator-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-Namespace-proxy-injector-webhook-config
   labels:
     ControllerComponentLabel: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-Namespace-sp-validator-webhook-config
   labels:
     ControllerComponentLabel: sp-validator
 webhooks:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -299,7 +299,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-proxy-injector-webhook-config
+  name: linkerd-linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -369,7 +369,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-sp-validator-webhook-config
+  name: linkerd-linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:


### PR DESCRIPTION
When installing multiple control planes, the `mutatingwebhookconfiguration` of the first control plane gets overwritten by any subsequent control plane install. This is caused by the fixed name given to the `mutatingwebhookconfiguration` manifest at install time.

This PR adds in the namespace to the manifest so that there is a unique configuration for each control plane.

Fixes #2887 