### PR TITLE
If HA, set the webhooks failure policy to 'Fail'

### DIFF
--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -10,4 +10,6 @@ metadata:
   name: {{.Namespace}}
   annotations:
     {{.ProxyInjectAnnotation}}: {{.ProxyInjectDisabled}}
+  labels:
+    {{.LinkerdNamespaceLabel}}: "true"
 {{end -}}

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -64,12 +64,17 @@ metadata:
     {{ .ControllerComponentLabel }}: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: {{ .LinkerdNamespaceLabel }}
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProxyInjector.CrtPEM }}
+  failurePolicy: {{.WebhookFailurePolicy}}
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -74,7 +74,7 @@ webhooks:
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProxyInjector.CrtPEM }}
-  failurePolicy: {{.WebhookFailurePolicy}}
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -64,7 +64,7 @@ webhooks:
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProfileValidator.CrtPEM }}
-  failurePolicy: {{.WebhookFailurePolicy}}
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -64,6 +64,7 @@ webhooks:
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProfileValidator.CrtPEM }}
+  failurePolicy: {{.WebhookFailurePolicy}}
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -54,7 +54,6 @@ type (
 		ProxyInjectAnnotation    string
 		ProxyInjectDisabled      string
 		LinkerdNamespaceLabel    string
-		WebhookFailurePolicy     string
 		ControllerUID            int64
 		EnableH2Upgrade          bool
 		NoInitContainer          bool
@@ -383,18 +382,9 @@ func (options *installOptions) validateAndBuild(stage string, flags *pflag.FlagS
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
-	options.setWebhookFailurePolicy(values)
-
 	values.stage = stage
 
 	return values, configs, nil
-}
-
-func (options *installOptions) setWebhookFailurePolicy(values *installValues) {
-	values.WebhookFailurePolicy = "Ignore"
-	if options.highAvailability {
-		values.WebhookFailurePolicy = "Fail"
-	}
 }
 
 // recordableFlagSet returns flags usable during install or upgrade.

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -53,6 +53,8 @@ type (
 		ProxyContainerName       string
 		ProxyInjectAnnotation    string
 		ProxyInjectDisabled      string
+		LinkerdNamespaceLabel    string
+		WebhookFailurePolicy     string
 		ControllerUID            int64
 		EnableH2Upgrade          bool
 		NoInitContainer          bool
@@ -381,9 +383,18 @@ func (options *installOptions) validateAndBuild(stage string, flags *pflag.FlagS
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
+	options.setWebhookFailurePolicy(values)
+
 	values.stage = stage
 
 	return values, configs, nil
+}
+
+func (options *installOptions) setWebhookFailurePolicy(values *installValues) {
+	values.WebhookFailurePolicy = "Ignore"
+	if options.highAvailability {
+		values.WebhookFailurePolicy = "Fail"
+	}
 }
 
 // recordableFlagSet returns flags usable during install or upgrade.
@@ -548,13 +559,14 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		PrometheusImage: prometheusImage,
 		ImagePullPolicy: options.imagePullPolicy,
 
-		// Kubernetes labels/annotations/resourcse:
+		// Kubernetes labels/annotations/resources:
 		CreatedByAnnotation:      k8s.CreatedByAnnotation,
 		CliVersion:               k8s.CreatedByAnnotationValue(),
 		ControllerComponentLabel: k8s.ControllerComponentLabel,
 		ProxyContainerName:       k8s.ProxyContainerName,
 		ProxyInjectAnnotation:    k8s.ProxyInjectAnnotation,
 		ProxyInjectDisabled:      k8s.ProxyInjectDisabled,
+		LinkerdNamespaceLabel:    k8s.LinkerdNamespaceLabel,
 
 		// Controller configuration:
 		Namespace:          controlPlaneNamespace,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -49,6 +49,8 @@ func TestRender(t *testing.T) {
 		ProxyContainerName:       "ProxyContainerName",
 		ProxyInjectAnnotation:    "ProxyInjectAnnotation",
 		ProxyInjectDisabled:      "ProxyInjectDisabled",
+		LinkerdNamespaceLabel:    "LinkerdNamespaceLabel",
+		WebhookFailurePolicy:     "WebhookFailurePolicy",
 		ControllerUID:            2103,
 		EnableH2Upgrade:          true,
 		NoInitContainer:          false,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -50,7 +50,6 @@ func TestRender(t *testing.T) {
 		ProxyInjectAnnotation:    "ProxyInjectAnnotation",
 		ProxyInjectDisabled:      "ProxyInjectDisabled",
 		LinkerdNamespaceLabel:    "LinkerdNamespaceLabel",
-		WebhookFailurePolicy:     "WebhookFailurePolicy",
 		ControllerUID:            2103,
 		EnableH2Upgrade:          true,
 		NoInitContainer:          false,

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -316,7 +316,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -387,7 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -316,7 +316,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -387,7 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -316,7 +316,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -387,7 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -9,6 +9,8 @@ metadata:
   name: Namespace
   annotations:
     ProxyInjectAnnotation: ProxyInjectDisabled
+  labels:
+    LinkerdNamespaceLabel: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     ControllerComponentLabel: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: LinkerdNamespaceLabel
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: Namespace
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: WebhookFailurePolicy
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: Namespace
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: WebhookFailurePolicy
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -316,7 +316,7 @@ webhooks:
       namespace: Namespace
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: WebhookFailurePolicy
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -387,7 +387,7 @@ webhooks:
       namespace: Namespace
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: WebhookFailurePolicy
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -316,7 +316,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -387,7 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Ignore
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -9,6 +9,8 @@ metadata:
   name: linkerd
   annotations:
     linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -304,12 +306,17 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
+  namespaceSelector:
+    matchExpressions:
+    - key: linkerd.io/is-control-plane
+      operator: DoesNotExist
   clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: [""]
@@ -380,6 +387,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
+  failurePolicy: Fail
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -258,6 +258,8 @@ func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Inter
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
+	options.setWebhookFailurePolicy(values)
+
 	values.stage = stage
 
 	return values, configs, nil

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -258,8 +258,6 @@ func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Inter
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
-	options.setWebhookFailurePolicy(values)
-
 	values.stage = stage
 
 	return values, configs, nil

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -22,6 +22,10 @@ const (
 	// Prefix is the prefix common to all labels and annotations injected by Linkerd
 	Prefix = "linkerd.io"
 
+	// LinkerdNamespaceLabel is a label that helps identifying the namespaces
+	// that contain a Linkerd control plane
+	LinkerdNamespaceLabel = Prefix + "/is-control-plane"
+
 	// ControllerComponentLabel identifies this object as a component of Linkerd's
 	// control plane (e.g. web, controller).
 	ControllerComponentLabel = Prefix + "/control-plane-component"


### PR DESCRIPTION
I'm adding to the linkerd namespace a new label
`linkerd.io/is-control-plane: true` that is used in the webhook configs'
selector to skip the proxy injector for this namespace. This avoids
running into the timing issues described in #2852.

Fixes #2852