### PR TITLE
Edge 19.6.1 release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,21 @@
+## edge-19.5.4
+
+* CLI
+  * Fixed an issue where, when Linkerd is installed with `--ha`, running
+    `linkerd upgrade` without `--ha` will disable the high availability
+    control plane
+  * Added a `--init-image-version` flag to `linkerd inject` to override the
+    injected proxy-init container version
+* Controller
+  * Added multiple replicas for the `proxy-injector` and `sp-validator`
+    controllers when run in high availability mode (thanks to @Pothulapati!)
+* Proxy
+  * Fixed a memory leak that can occur if an HTTP/2 request with a payload
+    ends before the entire payload is sent to the destination
+* Internal
+  * Moved the proxy-init container to a separate `linkerd/proxy-init` Git
+    repository
+
 ## stable-2.3.2
 
 This stable release fixes a memory leak in the proxy.


### PR DESCRIPTION
## edge-19.6.1

* CLI
  * Fixed an issue where, when Linkerd is installed with `--ha`, running
    `linkerd upgrade` without `--ha` will disable the high availability
    control plane
  * Added a `--init-image-version` flag to `linkerd inject` to override the
    injected proxy-init container version
* Controller
  * Added multiple replicas for the `proxy-injector` and `sp-validator`
    controllers when run in high availability mode (thanks to @Pothulapati!)
* Proxy
  * Fixed a memory leak that can occur if an HTTP/2 request with a payload
    ends before the entire payload is sent to the destination
* Internal
  * Moved the proxy-init container to a separate `linkerd/proxy-init` Git
    repository

