### PR TITLE
Fix BaseTable ignoring sorting order

### DIFF
--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -16,7 +16,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import _find from 'lodash/find';
 import _get from 'lodash/get';
-import _isEmpty from 'lodash/isEmpty';
 import _isNil from 'lodash/isNil';
 import _orderBy from 'lodash/orderBy';
 import classNames from 'classnames';
@@ -90,10 +89,6 @@ class BaseTable extends React.Component {
   generateRows = (tableRows, tableColumns, order, orderBy, filterBy) => {
     let rows = tableRows;
     let col = _find(tableColumns, d => d.dataIndex === orderBy);
-    let {defaultOrderBy} = this.props;
-    if (_isEmpty(orderBy) && !_isEmpty(defaultOrderBy)) {
-      orderBy = defaultOrderBy;
-    }
 
     if (orderBy && col.sorter) {
       rows = _orderBy(rows, row => col.sorter(row), order);

--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -16,8 +16,9 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import _find from 'lodash/find';
 import _get from 'lodash/get';
+import _isEmpty from 'lodash/isEmpty';
 import _isNil from 'lodash/isNil';
-import _sortBy from 'lodash/sortBy';
+import _orderBy from 'lodash/orderBy';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -89,8 +90,13 @@ class BaseTable extends React.Component {
   generateRows = (tableRows, tableColumns, order, orderBy, filterBy) => {
     let rows = tableRows;
     let col = _find(tableColumns, d => d.dataIndex === orderBy);
+    let {defaultOrderBy} = this.props;
+    if (_isEmpty(orderBy) && !_isEmpty(defaultOrderBy)) {
+      orderBy = defaultOrderBy;
+    }
+
     if (orderBy && col.sorter) {
-      rows = _sortBy(rows, row => col.sorter(row));
+      rows = _orderBy(rows, row => col.sorter(row), order);
     }
     if (filterBy) {
       let columnsToFilter = tableColumns.filter(col => col.filter);
@@ -102,7 +108,8 @@ class BaseTable extends React.Component {
       });
       rows = filteredRows;
     }
-    return order === 'desc' ? rows.reverse() : rows;
+
+    return rows;
   }
 
   renderHeaderCell = (col, order, orderBy) => {


### PR DESCRIPTION
I noticed that the tables weren't maintaining sort order, and were completely ignoring the `defaultOrderBy` BaseTable prop. This branch fixes sorting and incorporates `defaultOrderBy` if provided.

Before:
Look at the tables, for example in the Service Mesh page, the meshed resource table, or in Top Routes. 
Note that both these tables have a default sort order, but do not appear sorted.

![Screen Shot 2019-06-11 at 10 47 45 AM](https://user-images.githubusercontent.com/549258/59296427-d6212900-8c3a-11e9-9f74-318c368f5ecf.png)
![Screen Shot 2019-06-11 at 10 47 49 AM](https://user-images.githubusercontent.com/549258/59296428-d6212900-8c3a-11e9-8c95-550d689994c6.png)


After:
These tables should be sorted by their default order.
![Screen Shot 2019-06-11 at 11 14 30 AM](https://user-images.githubusercontent.com/549258/59296436-d91c1980-8c3a-11e9-8b8f-b074187678c3.png)
![Screen Shot 2019-06-11 at 11 14 34 AM](https://user-images.githubusercontent.com/549258/59296437-d9b4b000-8c3a-11e9-8aeb-2117807ec2b3.png)
