### PR TITLE
Adding bin/dep ensure to web dev steps

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -244,7 +244,7 @@ These commands assume working [Go](https://golang.org) and
 
 #### First time setup
 
-1. Install [Yarn](https://yarnpkg.com) and use it to install dependencies:
+1. Install [Yarn](https://yarnpkg.com) and use it to install JS dependencies:
 
     ```bash
     brew install yarn

--- a/BUILD.md
+++ b/BUILD.md
@@ -251,7 +251,13 @@ These commands assume working [Go](https://golang.org) and
     bin/web setup
     ```
 
-1. Install Linkerd on a Kubernetes cluster.
+2. Fetch the necessary Go dependencies:
+
+    ```bash
+    bin/dep ensure
+    ```
+
+3. Install Linkerd on a Kubernetes cluster.
 
 #### Run web standalone
 


### PR DESCRIPTION
In the `Web` section of `BUILD.md` we don't mention installing the latest Go dependencies, although those are necessary to build the dashboard; the dashboard won't build if there are missing Go packages. Adding this could help with troubleshooting (thanks @adleong)!