### PR TITLE
Fix 'inject' integration test failure

### DIFF
--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -83,6 +83,8 @@ spec:
           initialDelaySeconds: 2
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 2102
         terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
@@ -106,10 +108,12 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -106,6 +106,8 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 1337
         terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
@@ -131,10 +133,12 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
This PR fixes the integration test failure due to changes in #2911. 

Test result:
```
=== PASS: all tests passed
```

Signed-off-by: Ivan Sim <ivan@buoyant.io>