### PR TITLE
WIP: Refactor public api client.go to more easily add separate clients

### DIFF
--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -26,7 +26,7 @@ func rawPublicAPIClient() (pb.ApiClient, error) {
 		return nil, err
 	}
 
-	return public.NewExternalClient(controlPlaneNamespace, kubeAPI)
+	return public.NewExternalPublicAPIClient(controlPlaneNamespace, kubeAPI)
 }
 
 // checkPublicAPIClientOrExit builds a new public API client and executes default status

--- a/controller/api/api.go
+++ b/controller/api/api.go
@@ -1,0 +1,8 @@
+package api
+
+const (
+	apiVersion    = "v1"
+	ApiPrefix     = "api/" + apiVersion + "/" // Must be relative (without a leading slash).
+	ApiPort       = 8085
+	ApiDeployment = "linkerd-controller"
+)

--- a/controller/api/destination/client.go
+++ b/controller/api/destination/client.go
@@ -1,0 +1,107 @@
+package destination
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
+	"github.com/linkerd/linkerd2/controller/api"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// NewClient creates a client for the control plane Destination API that
+// implements the Destination service.
+func NewClient(addr string) (pb.DestinationClient, *grpc.ClientConn, error) {
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pb.NewDestinationClient(conn), conn, nil
+}
+
+type grpcOverHTTPClient struct {
+	serverURL             *url.URL
+	httpClient            *http.Client
+	controlPlaneNamespace string
+}
+
+func (c *grpcOverHTTPClient) Get(ctx context.Context, req *pb.GetDestination, _ ...grpc.CallOption) (pb.Destination_GetClient, error) {
+	url := api.EndpointNameToPublicAPIURL(c.serverURL, "Get")
+	httpRsp, err := api.HTTPPost(ctx, c.httpClient, url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := api.CheckIfResponseHasError(httpRsp); err != nil {
+		httpRsp.Body.Close()
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.Debug("Closing response body after context marked as done")
+		httpRsp.Body.Close()
+	}()
+
+	return &destinationClient{api.StreamClient{Ctx: ctx, Reader: bufio.NewReader(httpRsp.Body)}}, nil
+}
+
+func (c *grpcOverHTTPClient) GetProfile(ctx context.Context, _ *pb.GetDestination, _ ...grpc.CallOption) (pb.Destination_GetProfileClient, error) {
+	// Not implemented through this client. The proxies use the gRPC server directly instead.
+	return nil, errors.New("Not implemented")
+}
+
+func newClient(apiURL *url.URL, httpClientToUse *http.Client, controlPlaneNamespace string) (pb.DestinationClient, error) {
+	if !apiURL.IsAbs() {
+		return nil, fmt.Errorf("server URL must be absolute, was [%s]", apiURL.String())
+	}
+
+	serverURL := apiURL.ResolveReference(&url.URL{Path: api.ApiPrefix})
+
+	log.Debugf("Expecting Destination API to be served over [%s]", serverURL)
+
+	return &grpcOverHTTPClient{
+		serverURL:             serverURL,
+		httpClient:            httpClientToUse,
+		controlPlaneNamespace: controlPlaneNamespace,
+	}, nil
+}
+
+type destinationClient struct {
+	api.StreamClient
+}
+
+func (c destinationClient) Recv() (*pb.Update, error) {
+	var msg pb.Update
+	err := api.FromByteStreamToProtocolBuffers(c.Reader, &msg)
+	return &msg, err
+}
+
+// NewExternalDestinationAPIClient creates a new Destination API client intended to run from
+// outside a Kubernetes cluster.
+func NewExternalDestinationAPIClient(controlPlaneNamespace string, kubeAPI *k8s.KubernetesAPI) (pb.DestinationClient, error) {
+	portforward, err := k8s.NewPortForward(
+		kubeAPI,
+		controlPlaneNamespace,
+		api.ApiDeployment,
+		0,
+		api.ApiPort,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+	apiURL, httpClientToUse, err := portforward.Init(controlPlaneNamespace, kubeAPI)
+	if err != nil {
+		return nil, err
+	}
+
+	return newClient(apiURL, httpClientToUse, controlPlaneNamespace)
+}

--- a/controller/api/proto_over_http.go
+++ b/controller/api/proto_over_http.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	ErrorHeader              = "linkerd-error"
+	NumBytesForMessageLength = 4
+)
+
+func deserializePayloadFromReader(reader *bufio.Reader) ([]byte, error) {
+	messageLengthAsBytes := make([]byte, NumBytesForMessageLength)
+	_, err := io.ReadFull(reader, messageLengthAsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error while reading message length: %v", err)
+	}
+	messageLength := int(binary.LittleEndian.Uint32(messageLengthAsBytes))
+
+	messageContentsAsBytes := make([]byte, messageLength)
+	_, err = io.ReadFull(reader, messageContentsAsBytes)
+	if err != nil {
+		return nil, fmt.Errorf("error while reading bytes from message: %v", err)
+	}
+
+	return messageContentsAsBytes, nil
+}
+
+func CheckIfResponseHasError(rsp *http.Response) error {
+	errorMsg := rsp.Header.Get(ErrorHeader)
+
+	if errorMsg != "" {
+		reader := bufio.NewReader(rsp.Body)
+		var apiError pb.ApiError
+
+		err := FromByteStreamToProtocolBuffers(reader, &apiError)
+		if err != nil {
+			return fmt.Errorf("Response has %s header [%s], but response body didn't contain protobuf error: %v", ErrorHeader, errorMsg, err)
+		}
+
+		return errors.New(apiError.Error)
+	}
+
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Unexpected API response: %s", rsp.Status)
+	}
+
+	return nil
+}
+
+// HTTPPost marshals a protobuf message and posts it to the url using the httpClient
+func HTTPPost(ctx context.Context, httpClient *http.Client, url *url.URL, req proto.Message) (*http.Response, error) {
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest(
+		http.MethodPost,
+		url.String(),
+		bytes.NewReader(reqBytes),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp, err := httpClient.Do(httpReq.WithContext(ctx))
+	if err != nil {
+		log.Debugf("Error invoking [%s]: %v", url.String(), err)
+	} else {
+		log.Debugf("Response from [%s] had headers: %v", url.String(), rsp.Header)
+	}
+
+	return rsp, err
+}
+
+// FromByteStreamToProtocolBuffers deserializes the payload from the reader and unmarshalls it into out
+func FromByteStreamToProtocolBuffers(byteStreamContainingMessage *bufio.Reader, out proto.Message) error {
+	messageAsBytes, err := deserializePayloadFromReader(byteStreamContainingMessage)
+	if err != nil {
+		return fmt.Errorf("error reading byte stream header: %v", err)
+	}
+
+	err = proto.Unmarshal(messageAsBytes, out)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling array of [%d] bytes error: %v", len(messageAsBytes), err)
+	}
+
+	return nil
+}
+
+// EndpointNameToPublicAPIURL returns the full URL for endpoint, using
+// serverURL as a base
+func EndpointNameToPublicAPIURL(serverURL *url.URL, endpoint string) *url.URL {
+	return serverURL.ResolveReference(&url.URL{Path: endpoint})
+}

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -331,6 +331,7 @@ func newMockGrpcServer(exp expectedStatRPC) (*mockProm, *grpcServer, error) {
 		mockProm,
 		nil,
 		nil,
+		nil,
 		k8sAPI,
 		"linkerd",
 		[]string{},

--- a/controller/api/stream_client.go
+++ b/controller/api/stream_client.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"bufio"
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// StreamClient is the base struct to be used for gRPC clients
+// using a streaming connection
+type StreamClient struct {
+	Ctx    context.Context
+	Reader *bufio.Reader
+}
+
+// Satisfy the ClientStream interface
+func (c StreamClient) Header() (metadata.MD, error) { return nil, nil }
+func (c StreamClient) Trailer() metadata.MD         { return nil }
+func (c StreamClient) CloseSend() error             { return nil }
+func (c StreamClient) Context() context.Context     { return c.Ctx }
+func (c StreamClient) SendMsg(interface{}) error    { return nil }
+func (c StreamClient) RecvMsg(interface{}) error    { return nil }

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/linkerd/linkerd2/controller/api/destination"
 	"github.com/linkerd/linkerd2/controller/api/discovery"
 	"github.com/linkerd/linkerd2/controller/api/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -44,6 +45,12 @@ func main() {
 	}
 	defer discoveryConn.Close()
 
+	destinationClient, destinationConn, err := destination.NewClient(":8086")
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	defer destinationConn.Close()
+
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath,
 		k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
@@ -62,6 +69,7 @@ func main() {
 		prometheusClient,
 		tapClient,
 		discoveryClient,
+		destinationClient,
 		k8sAPI,
 		*controllerNamespace,
 		strings.Split(*ignoredNamespaces, ","),


### PR DESCRIPTION
The plan for #2885 is to have `linkerd endpoints` hit the
`Destination.Get` gRPC endpoint. Given this will probably be leveraged
from the dashboard as well, it made sense to do like with the other
endpoints and serve it through the public api http server and from there
forward to the Destination service.

The easy way would have been to just add the Destination endpoints into
/controller/api/public/client.go and complete the plumbing.

But I wanted to experiment using a separate new client
/controller/api/destination/client.go to try keeping things separate.

This implied extracting out of /controller/api/public some things that I
moved up one level into /controller/api to be reused by any client under
that directory.

Now both the public API and the Destination clients use a new
`portforward.Init()` method that captures the common logic for building
the port-forwarding, and then each client builds a separate
`grpcOverHTTPClient` struct that only implements the methods relevant to
each client.

I also created /controller/api/stream_client.go with the struct and
common methods needed for our gRPC streaming endpoints: Tap and
Destination.Get.

On the gRPC server side of things, one could make a similar refactoring
to avoid grouping together all the endpoints, but I skipped that for
this PR, and just did the normal plumbing.

/cli/cmd/endpoints.go changed `requestEndpointsFromAPI()` just to be
able to test the new Destination endpoint for a particular emoji
authority (you can test with just `linkerd endpoints`). No processing of
the output has been done yet.

Let me know what you think. Was this too much?