### PR TITLE
proxy: update to linkerd/linkerd2-proxy#35df8ab

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -23,7 +23,7 @@ validate_go_deps_tag $dockerfile
 ) >/dev/null
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-790a86a}"
+PROXY_VERSION="${PROXY_VERSION:-35df8ab}"
 
 tag="$(head_root_tag)"
 docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
439fbfed Update to rust-1.35.0 (linkerd/linkerd2-proxy#265)
db26495e Honor `l5d-override-dst` for inbound service profiles (linkerd/linkerd2-proxy#267)
a476e995 metrics: Include the prefix of a Report in log lines (linkerd/linkerd2-proxy#262)
1a52a5e6 discovery: Fall back in MakeService, only on InvalidArgument (linkerd/linkerd2-proxy#268)
35df8ab4 metrics: Classify response errors  (linkerd/linkerd2-proxy#269)