### PR TITLE
Set MWC and VWC failure policy to 'fail' in HA mode only

### DIFF
--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -71,7 +71,7 @@ webhooks:
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProxyInjector.CrtPEM }}
-  failurePolicy: Fail
+  failurePolicy: {{ .WebhookFailurePolicy }}
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -61,7 +61,7 @@ webhooks:
       namespace: {{ .Namespace }}
       path: "/"
     caBundle: {{ b64enc .ProfileValidator.CrtPEM }}
-  failurePolicy: Fail
+  failurePolicy: {{ .WebhookFailurePolicy }}
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -57,6 +57,7 @@ type (
 		ControllerUID            int64
 		EnableH2Upgrade          bool
 		NoInitContainer          bool
+		WebhookFailurePolicy     string
 
 		Configs configJSONs
 
@@ -565,14 +566,15 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		LinkerdNamespaceLabel:    k8s.LinkerdNamespaceLabel,
 
 		// Controller configuration:
-		Namespace:          controlPlaneNamespace,
-		UUID:               configs.GetInstall().GetUuid(),
-		ControllerReplicas: options.controllerReplicas,
-		ControllerLogLevel: options.controllerLogLevel,
-		ControllerUID:      options.controllerUID,
-		EnableH2Upgrade:    !options.disableH2Upgrade,
-		NoInitContainer:    options.noInitContainer,
-		PrometheusLogLevel: toPromLogLevel(strings.ToLower(options.controllerLogLevel)),
+		Namespace:            controlPlaneNamespace,
+		UUID:                 configs.GetInstall().GetUuid(),
+		ControllerReplicas:   options.controllerReplicas,
+		ControllerLogLevel:   options.controllerLogLevel,
+		ControllerUID:        options.controllerUID,
+		EnableH2Upgrade:      !options.disableH2Upgrade,
+		NoInitContainer:      options.noInitContainer,
+		WebhookFailurePolicy: "Ignore",
+		PrometheusLogLevel:   toPromLogLevel(strings.ToLower(options.controllerLogLevel)),
 
 		Configs: configJSONs{
 			Global:  globalJSON,
@@ -592,6 +594,8 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 	}
 
 	if options.highAvailability {
+		values.WebhookFailurePolicy = "Fail"
+
 		defaultConstraints := &resources{
 			CPU:    constraints{Request: "100m"},
 			Memory: constraints{Request: "50Mi"},

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -53,6 +53,7 @@ func TestRender(t *testing.T) {
 		ControllerUID:            2103,
 		EnableH2Upgrade:          true,
 		NoInitContainer:          false,
+		WebhookFailurePolicy:     "WebhookFailurePolicy",
 		Configs: configJSONs{
 			Global:  "GlobalConfig",
 			Proxy:   "ProxyConfig",

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -313,7 +313,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -381,7 +381,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -313,7 +313,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -381,7 +381,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -313,7 +313,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -381,7 +381,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -313,7 +313,7 @@ webhooks:
       namespace: Namespace
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: WebhookFailurePolicy
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -381,7 +381,7 @@ webhooks:
       namespace: Namespace
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: WebhookFailurePolicy
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -313,7 +313,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJveHkgaW5qZWN0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -381,7 +381,7 @@ webhooks:
       namespace: linkerd
       path: "/"
     caBundle: cHJvZmlsZSB2YWxpZGF0b3IgY3J0
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -240,20 +240,6 @@ func TestVersionPostInstall(t *testing.T) {
 	}
 }
 
-func TestInstallSP(t *testing.T) {
-	cmd := []string{"install-sp"}
-
-	out, _, err := TestHelper.LinkerdRun(cmd...)
-	if err != nil {
-		t.Fatalf("linkerd install-sp command failed\n%s", out)
-	}
-
-	out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
-	if err != nil {
-		t.Fatalf("kubectl apply command failed\n%s", out)
-	}
-}
-
 // TODO: run this after a `linkerd install config`
 func TestCheckConfigPostInstall(t *testing.T) {
 	cmd := []string{"check", "config", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
@@ -298,6 +284,20 @@ func TestCheckPostInstall(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+}
+
+func TestInstallSP(t *testing.T) {
+	cmd := []string{"install-sp"}
+
+	out, _, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		t.Fatalf("linkerd install-sp command failed\n%s", out)
+	}
+
+	out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
+	if err != nil {
+		t.Fatalf("kubectl apply command failed\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Fixes #2927

Also moved `TestInstallSP` after `TestCheckPostInstall` so we're sure
the validating webhook is ready before installing a service profile.

I still observed some flakiness in the `TestCheckProxy/smoke-test` integration test, but we can address separately.