### PR TITLE
Increase the retry duration in the post-upgrade 'check' integration test

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -434,7 +434,7 @@ func TestCheckProxy(t *testing.T) {
 			cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=0"}
 			golden := "check.proxy.golden"
 
-			err := TestHelper.RetryFor(time.Minute, func() error {
+			err := TestHelper.RetryFor(time.Minute*5, func() error {
 				out, _, err := TestHelper.LinkerdRun(cmd...)
 				if err != nil {
 					return fmt.Errorf("Check command failed\n%s", out)


### PR DESCRIPTION
I believe this will fix the [current integration test failure](https://travis-ci.org/linkerd/linkerd2/jobs/545841434) on `master`. When I re-run the same `linkerd check --proxy` command, targeting the same control plane, the check was successful. Note that the 5 minutes value is just arbitrary, we can improve it once we confirm that this resolves the current problem.

Signed-off-by: Ivan Sim <ivan@buoyant.io>