### PR TITLE
travis integration test cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,11 @@ jobs:
 
       script:
         - |
-          # Run integration tests.
+          version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
+          # Cleanup previous integration test artifacts if present
+          ./bin/test-cleanup linkerd
+          kubectl delete mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config
+          kubectl delete validatingwebhookconfigurations linkerd-sp-validator-webhook-config
           version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,8 +161,8 @@ jobs:
 
       script:
         - |
+          # Run integration tests.
           version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
-          # Cleanup previous integration test artifacts if present
           ./bin/test-cleanup linkerd-$version
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ branches:
 stages:
   - name: test
   - name: docker-deploy
-    #if: type != pull_request
+    if: type != pull_request
   - name: integration-test
-   # if: type != pull_request
+    if: type != pull_request
 
 jobs:
   include:
@@ -111,7 +111,7 @@ jobs:
       after_success:
         - bin/docker-push-deps
         - bin/docker-push $LINKERD_TAG
-        # - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
+        - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
         - target/cli/linux/linkerd install --control-plane-version=$LINKERD_TAG |tee linkerd.yml
         - kubectl -n linkerd apply -f linkerd.yml --prune --selector='linkerd.io/control-plane-component'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ branches:
 stages:
   - name: test
   - name: docker-deploy
-    if: type != pull_request
+    #if: type != pull_request
   - name: integration-test
-    if: type != pull_request
+   # if: type != pull_request
 
 jobs:
   include:
@@ -111,7 +111,7 @@ jobs:
       after_success:
         - bin/docker-push-deps
         - bin/docker-push $LINKERD_TAG
-        - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
+        # - bin/docker-retag-all $LINKERD_TAG master && bin/docker-push master
         - target/cli/linux/linkerd install --control-plane-version=$LINKERD_TAG |tee linkerd.yml
         - kubectl -n linkerd apply -f linkerd.yml --prune --selector='linkerd.io/control-plane-component'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,8 +163,6 @@ jobs:
         - |
           # Cleanup previous integration test artifacts if present
           ./bin/test-cleanup linkerd
-          kubectl delete mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config
-          kubectl delete validatingwebhookconfigurations linkerd-sp-validator-webhook-config
           version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,6 @@ jobs:
 
       script:
         - |
-          version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
           # Cleanup previous integration test artifacts if present
           ./bin/test-cleanup linkerd
           kubectl delete mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,9 +161,9 @@ jobs:
 
       script:
         - |
-          # Cleanup previous integration test artifacts if present
-          ./bin/test-cleanup linkerd
           version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
+          # Cleanup previous integration test artifacts if present
+          ./bin/test-cleanup linkerd-$version
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |
           # Run linkerd-cni integration tests.

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -32,6 +32,4 @@ if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookcon
   echo "no validatingwebhookconfigurations found for [$linkerd_namespace]" >&2
 fi
 
-if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs ]]; then
-  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs
-fi
+kubectl --ignore-not-found=true --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -24,6 +24,14 @@ if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname | gre
   echo "no clusterroles found for [$linkerd_namespace]" >&2
 fi
 
-if [[ $namespaces || $clusterrolebindings || $clusterroles ]]; then
-  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles
+if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname | grep -E  "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no mutatingwebhookconfigurations found for [$linkerd_namespace]" >&2
+fi
+
+if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname | grep -E  "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no validatingwebhookconfigurations found for [$linkerd_namespace]" >&2
+fi
+
+if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs ]]; then
+  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs
 fi

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -32,4 +32,6 @@ if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookcon
   echo "no validatingwebhookconfigurations found for [$linkerd_namespace]" >&2
 fi
 
-kubectl --ignore-not-found=true --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs
+if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs ]]; then
+  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs
+fi


### PR DESCRIPTION
After #2887, integration tests will now leave stale validating and mutating webhook configurations since a new one is generated with a namespace name.

This PR adds a couple of clean up steps to the `test-cleanup` script to remove configs and also adds steps in the `.travis.yml` to clean up configs that were generated by Linkerd CLI's prior to #2887.
