### PR TITLE
Revert add namespace name to MWC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,6 @@
   * Introduced control plane's PSP and RBAC resources into Helm templates;
     these policies are only in effect if the PSP admission controller is
     enabled
-  * Fixed MWC namespace value so that when installing multiple control planes,
-    there is a unique configuration for each one
   * Removed `UPDATE` operation from proxy-injector webhook because pod
     mutations are disallowed during update operations
 * Proxy

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -56,7 +56,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-{{ .Namespace }}-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: proxy-injector
 webhooks:

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -50,7 +50,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-{{ .Namespace }}-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-Namespace-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     ControllerComponentLabel: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-Namespace-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     ControllerComponentLabel: sp-validator
 webhooks:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -298,7 +298,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-proxy-injector-webhook-config
+  name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
 webhooks:
@@ -370,7 +370,7 @@ data:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: linkerd-linkerd-sp-validator-webhook-config
+  name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
 webhooks:


### PR DESCRIPTION
Reverts the "namespace name in MWC" change in favor of landing this fix together with #2913 