### PR TITLE
Make NET_ADMIN check a warning, add PSP check

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -310,6 +310,13 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
+					description: "can create PodSecurityPolicies",
+					hintAnchor:  "pre-k8s",
+					check: func(context.Context) error {
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "policy", "v1beta1", "podsecuritypolicies")
+					},
+				},
+				{
 					description: "can create ServiceAccounts",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
@@ -352,6 +359,7 @@ func (hc *HealthChecker) allCategories() []category {
 				{
 					description: "has NET_ADMIN capability",
 					hintAnchor:  "pre-k8s-cluster-net-admin",
+					warning:     true,
 					check: func(context.Context) error {
 						return hc.checkNetAdmin()
 					},
@@ -408,7 +416,7 @@ func (hc *HealthChecker) allCategories() []category {
 			checkers: []checker{
 				{
 					description: "control plane components ready",
-					hintAnchor:  "l5d-existence-psp",
+					hintAnchor:  "l5d-existence-psp", // needs https://github.com/linkerd/website/issues/272
 					fatal:       true,
 					check: func(context.Context) error {
 						controlPlaneReplicaSet, err := hc.kubeAPI.GetReplicaSets(hc.ControlPlaneNamespace)
@@ -420,7 +428,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "no unschedulable pods",
-					hintAnchor:  "l5d-existence-unschedulable-pods",
+					hintAnchor:  "l5d-existence-unschedulable-pods", // needs https://github.com/linkerd/website/issues/272
 					fatal:       true,
 					check: func(context.Context) error {
 						// do not save this into hc.controlPlanePods, as this check may
@@ -1005,7 +1013,7 @@ func (hc *HealthChecker) checkNetAdmin() error {
 		}
 	}
 
-	return fmt.Errorf("found %d PodSecurityPolicies, but none provide NET_ADMIN", len(pspList.Items))
+	return fmt.Errorf("found %d PodSecurityPolicies, but none provide NET_ADMIN, proxy injection will fail if the PSP admission controller is running", len(pspList.Items))
 }
 
 func (hc *HealthChecker) checkClockSkew() error {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -404,7 +404,7 @@ spec:
   requiredDropCapabilities:
     - ALL`,
 			},
-			fmt.Errorf("found 1 PodSecurityPolicies, but none provide NET_ADMIN"),
+			fmt.Errorf("found 1 PodSecurityPolicies, but none provide NET_ADMIN, proxy injection will fail if the PSP admission controller is running"),
 		},
 	}
 

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -15,6 +15,7 @@ pre-kubernetes-setup
 √ can create ClusterRoles
 √ can create ClusterRoleBindings
 √ can create CustomResourceDefinitions
+√ can create PodSecurityPolicies
 √ can create ServiceAccounts
 √ can create Services
 √ can create Deployments


### PR DESCRIPTION
`linkerd check` validates whether PSP's exist, and if the caller has the
`NET_ADMIN` capability. This check was previously failing if `NET_ADMIN`
was not found, even in the case where the PSP admission controller was
not running. Related, `linkerd install` now includes a PSP, so
`linkerd check` should also validate that the caller can create PSP's.

Modify the `NET_ADMIN` check to warn, but not fail, if PSP's are found
but the caller does not have `NET_ADMIN`. Update the warning message to
mention that this is only a problem if the PSP admission controller is
running (and will only be a problem during injection, since #2920
handles control plane installation by adding its own PSP).

Also introduce a check to validate the caller can create PSP's.

Fixes #2884, #2849

Signed-off-by: Andrew Seigner <siggy@buoyant.io>