### PR TITLE
Add Edges table to resource detail view of dashboard

### DIFF
--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -1,5 +1,6 @@
 import CloseIcon from '@material-ui/icons/Close';
 import FilterListIcon from '@material-ui/icons/FilterList';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Hidden from '@material-ui/core/Hidden';
 import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
@@ -19,6 +20,7 @@ import _get from 'lodash/get';
 import _isNil from 'lodash/isNil';
 import _orderBy from 'lodash/orderBy';
 import classNames from 'classnames';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
@@ -149,7 +151,11 @@ class BaseTable extends React.Component {
         <Typography
           className={classes.title}
           variant="h5">
-          {title}
+          {title} {this.props.showTitleTooltip &&
+            <Tooltip title={this.props.titleTooltipText}>
+              <FontAwesomeIcon icon={faQuestionCircle} />
+            </Tooltip>
+          }
         </Typography>
         {this.state.showFilter &&
           <TextField
@@ -223,6 +229,7 @@ BaseTable.propTypes = {
   enableFilter: PropTypes.bool,
   padding: PropTypes.string,
   rowKey: PropTypes.func,
+  showTitleTooltip: PropTypes.bool,
   tableClassName: PropTypes.string,
   tableColumns: PropTypes.arrayOf(PropTypes.shape({
     dataIndex: PropTypes.string,
@@ -233,7 +240,8 @@ BaseTable.propTypes = {
     title: PropTypes.string
   })).isRequired,
   tableRows: PropTypes.arrayOf(PropTypes.shape({})),
-  title: PropTypes.string
+  title: PropTypes.string,
+  titleTooltipText: PropTypes.string
 };
 
 BaseTable.defaultProps = {
@@ -244,7 +252,9 @@ BaseTable.defaultProps = {
   rowKey: null,
   tableClassName: "",
   tableRows: [],
-  title: ""
+  title: "",
+  showTitleTooltip: false,
+  titleTooltipText: ""
 };
 
 export default withStyles(styles)(BaseTable);

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -31,7 +31,7 @@ const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
       filter: d => d.dst.name,
       render: d => {
         // check that the destination is a k8s resource with a name we can link to
-        if (namespace && type && d.dst && d.src.name) {
+        if (namespace && type && d.dst && d.dst.name) {
           return (
             <PrefixedLink to={"/namespaces/" + namespace + "/" + type + "s/" + d.dst.name}>
               {d.dst.name}

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -71,8 +71,8 @@ const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
   ];
 };
 
-const tooltipText = "Edges show the source, destination name and identity " +
-  "for proxied connections. If no identity is known, a message is displayed.";
+const tooltipText = `Edges show the source, destination name and identity
+  for proxied connections. If no identity is known, a message is displayed.`;
 
 class EdgesTable extends React.Component {
   static propTypes = {

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -7,7 +7,7 @@ import { withContext } from './util/AppContext.jsx';
 const edgesColumns = [
   {
     title: "Source",
-    dataIndex: "name",
+    dataIndex: "source",
     isNumeric: false,
     filter: d => d.src.name,
     render: d => d.src.name,
@@ -19,7 +19,7 @@ const edgesColumns = [
     isNumeric: false,
     filter: d => d.dst.name,
     render: d => d.dst.name,
-    sorter: d => d.dst.name
+    sorter: d => d.dst.name + d.src.name
   },
   {
     title: "Client",
@@ -31,7 +31,7 @@ const edgesColumns = [
   },
   {
     title: "Server",
-    dataIndex: "source",
+    dataIndex: "server",
     isNumeric: false,
     filter: d => d.serverId,
     render: d => d.serverId.split('.')[0] + '.' + d.serverId.split('.')[1],
@@ -51,11 +51,11 @@ const tooltipText = "Edges show the source, destination name and identity " +
   "for proxied connections. If no identity is known, a message is displayed.";
 
 class EdgesTable extends React.Component {
-
   static propTypes = {
     edges: PropTypes.arrayOf(processedEdgesPropType),
     title: PropTypes.string
   };
+
   static defaultProps = {
     edges: [],
     title: ""
@@ -65,7 +65,7 @@ class EdgesTable extends React.Component {
     const { edges, title} = this.props;
     return (
       <BaseTable
-        defaultOrderBy="name"
+        defaultOrderBy="source"
         enableFilter={true}
         showTitleTooltip={true}
         tableRows={edges}

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -1,0 +1,81 @@
+import BaseTable from './BaseTable.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { processedEdgesPropType } from './util/EdgesUtils.jsx';
+import { withContext } from './util/AppContext.jsx';
+
+const edgesColumns = [
+  {
+    title: "Source",
+    dataIndex: "name",
+    isNumeric: false,
+    filter: d => d.src.name,
+    render: d => d.src.name,
+    sorter: d => d.src.name + d.dst.name
+  },
+  {
+    title: "Destination",
+    dataIndex: "destination",
+    isNumeric: false,
+    filter: d => d.dst.name,
+    render: d => d.dst.name,
+    sorter: d => d.dst.name
+  },
+  {
+    title: "Client",
+    dataIndex: "client",
+    isNumeric: false,
+    filter: d => d.clientId,
+    render: d => d.clientId.split('.')[0] + '.' + d.clientId.split('.')[1],
+    sorter: d => d.clientId
+  },
+  {
+    title: "Server",
+    dataIndex: "source",
+    isNumeric: false,
+    filter: d => d.serverId,
+    render: d => d.serverId.split('.')[0] + '.' + d.serverId.split('.')[1],
+    sorter: d => d.serverId
+  },
+  {
+    title: "Message",
+    dataIndex: "message",
+    isNumeric: false,
+    filter: d => d.noIdentityMsg,
+    render: d => d.noIdentityMsg,
+    sorter: d => d.noIdentityMsg
+  },
+];
+
+const tooltipText = "Edges show the source, destination name and identity " +
+  "for proxied connections. If no identity is known, a message is displayed.";
+
+class EdgesTable extends React.Component {
+
+  static propTypes = {
+    edges: PropTypes.arrayOf(processedEdgesPropType),
+    title: PropTypes.string
+  };
+  static defaultProps = {
+    edges: [],
+    title: ""
+  };
+
+  render() {
+    const { edges, title} = this.props;
+    return (
+      <BaseTable
+        defaultOrderBy="name"
+        enableFilter={true}
+        showTitleTooltip={true}
+        tableRows={edges}
+        tableColumns={edgesColumns}
+        tableClassName="metric-table"
+        title={title}
+        titleTooltipText={tooltipText}
+        padding="dense" />
+    );
+  }
+}
+
+export default withContext(EdgesTable);

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -6,7 +6,8 @@ import { withContext } from './util/AppContext.jsx';
 
 const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
   return [
-    { title: "Source",
+    {
+      title: "Source",
       dataIndex: "source",
       isNumeric: false,
       filter: d => d.src.name,
@@ -14,7 +15,7 @@ const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
         // check that the source is a k8s resource with a name we can link to
         if (namespace && type && d.src && d.src.name) {
           return (
-            <PrefixedLink to={"/namespaces/" + namespace + "/" + type + "s/" + d.src.name}>
+            <PrefixedLink to={`/namespaces/${namespace}/${type}s/${d.src.name}`}>
               {d.src.name}
             </PrefixedLink>
           );
@@ -33,7 +34,7 @@ const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
         // check that the destination is a k8s resource with a name we can link to
         if (namespace && type && d.dst && d.dst.name) {
           return (
-            <PrefixedLink to={"/namespaces/" + namespace + "/" + type + "s/" + d.dst.name}>
+            <PrefixedLink to={`/namespaces/${namespace}/${type}s/${d.dst.name}`}>
               {d.dst.name}
             </PrefixedLink>
           );

--- a/web/app/js/components/EdgesTable.jsx
+++ b/web/app/js/components/EdgesTable.jsx
@@ -4,56 +4,84 @@ import React from 'react';
 import { processedEdgesPropType } from './util/EdgesUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
 
-const edgesColumns = [
-  {
-    title: "Source",
-    dataIndex: "source",
-    isNumeric: false,
-    filter: d => d.src.name,
-    render: d => d.src.name,
-    sorter: d => d.src.name + d.dst.name
-  },
-  {
-    title: "Destination",
-    dataIndex: "destination",
-    isNumeric: false,
-    filter: d => d.dst.name,
-    render: d => d.dst.name,
-    sorter: d => d.dst.name + d.src.name
-  },
-  {
-    title: "Client",
-    dataIndex: "client",
-    isNumeric: false,
-    filter: d => d.clientId,
-    render: d => d.clientId.split('.')[0] + '.' + d.clientId.split('.')[1],
-    sorter: d => d.clientId
-  },
-  {
-    title: "Server",
-    dataIndex: "server",
-    isNumeric: false,
-    filter: d => d.serverId,
-    render: d => d.serverId.split('.')[0] + '.' + d.serverId.split('.')[1],
-    sorter: d => d.serverId
-  },
-  {
-    title: "Message",
-    dataIndex: "message",
-    isNumeric: false,
-    filter: d => d.noIdentityMsg,
-    render: d => d.noIdentityMsg,
-    sorter: d => d.noIdentityMsg
-  },
-];
+const edgesColumnDefinitions = (PrefixedLink, namespace, type) => {
+  return [
+    { title: "Source",
+      dataIndex: "source",
+      isNumeric: false,
+      filter: d => d.src.name,
+      render: d => {
+        // check that the source is a k8s resource with a name we can link to
+        if (namespace && type && d.src && d.src.name) {
+          return (
+            <PrefixedLink to={"/namespaces/" + namespace + "/" + type + "s/" + d.src.name}>
+              {d.src.name}
+            </PrefixedLink>
+          );
+        } else {
+          return d.src.name;
+        }
+      },
+      sorter: d => d.src.name + d.dst.name
+    },
+    {
+      title: "Destination",
+      dataIndex: "destination",
+      isNumeric: false,
+      filter: d => d.dst.name,
+      render: d => {
+        // check that the destination is a k8s resource with a name we can link to
+        if (namespace && type && d.dst && d.src.name) {
+          return (
+            <PrefixedLink to={"/namespaces/" + namespace + "/" + type + "s/" + d.dst.name}>
+              {d.dst.name}
+            </PrefixedLink>
+          );
+        } else {
+          return d.dst.name;
+        }
+      },
+      sorter: d => d.dst.name + d.src.name
+    },
+    {
+      title: "Client",
+      dataIndex: "client",
+      isNumeric: false,
+      filter: d => d.clientId,
+      render: d => d.clientId.split('.')[0] + '.' + d.clientId.split('.')[1],
+      sorter: d => d.clientId
+    },
+    {
+      title: "Server",
+      dataIndex: "server",
+      isNumeric: false,
+      filter: d => d.serverId,
+      render: d => d.serverId.split('.')[0] + '.' + d.serverId.split('.')[1],
+      sorter: d => d.serverId
+    },
+    {
+      title: "Message",
+      dataIndex: "message",
+      isNumeric: false,
+      filter: d => d.noIdentityMsg,
+      render: d => d.noIdentityMsg,
+      sorter: d => d.noIdentityMsg
+    }
+  ];
+};
 
 const tooltipText = "Edges show the source, destination name and identity " +
   "for proxied connections. If no identity is known, a message is displayed.";
 
 class EdgesTable extends React.Component {
   static propTypes = {
+    api: PropTypes.shape({
+      prefixedUrl: PropTypes.func.isRequired,
+    }).isRequired,
     edges: PropTypes.arrayOf(processedEdgesPropType),
-    title: PropTypes.string
+    namespace: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    type: PropTypes.string.isRequired
   };
 
   static defaultProps = {
@@ -61,8 +89,11 @@ class EdgesTable extends React.Component {
     title: ""
   };
 
+
   render() {
-    const { edges, title} = this.props;
+    const { edges, title, api, namespace, type } = this.props;
+    let edgesColumns = edgesColumnDefinitions(api.PrefixedLink, namespace, type);
+
     return (
       <BaseTable
         defaultOrderBy="source"

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -27,7 +27,7 @@ import { withContext } from './util/AppContext.jsx';
 // if there has been no traffic for some time, show a warning
 const showNoTrafficMsgDelayMs = 6000;
 // resource types supported when querying API for edge data
-const possibleResourceType = ["daemonset", "deployment", "job", "pod", "replicationcontroller", "statefulset"];
+const edgeDataAvailable = ["daemonset", "deployment", "job", "pod", "replicationcontroller", "statefulset"];
 
 const getResourceFromUrl = (match, pathPrefix) => {
   let resource = {
@@ -151,7 +151,7 @@ export class ResourceDetailBase extends React.Component {
         )
       ];
 
-    if (_indexOf(possibleResourceType, resource.type) > 0) {
+    if (_indexOf(edgeDataAvailable, resource.type) > 0) {
       apiRequests = apiRequests.concat([
         this.api.fetchEdges(resource.namespace, resource.type)
       ]);
@@ -293,7 +293,6 @@ export class ResourceDetailBase extends React.Component {
 
     let upstreamMetrics = this.getDisplayMetrics(this.state.upstreamMetrics);
     let downstreamMetrics = this.getDisplayMetrics(this.state.downstreamMetrics);
-    let noEdges = _isEmpty(this.state.edges);
 
     let upstreams = upstreamMetrics.concat(unmeshed);
 
@@ -367,10 +366,13 @@ export class ResourceDetailBase extends React.Component {
           metrics={this.state.podMetrics} />
 
         {
-          noEdges ? null :
+          _isEmpty(this.state.edges) ? null :
           <Grid container direction="column" justify="center">
             <Grid item>
               <EdgesTable
+                api={this.api}
+                namespace={this.state.resource.namespace}
+                type={this.state.resource.type}
                 title="Edges"
                 edges={edges} />
             </Grid>

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -59,6 +59,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   let metricsWindow = defaultMetricsWindow;
   const podsPath = `/api/pods`;
   const servicesPath = `/api/services`;
+  const edgesPath = `/api/edges`;
 
   const validMetricsWindows = {
     "10s": "10 minutes",
@@ -108,6 +109,10 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
       return apiFetch(servicesPath + "?namespace=" + namespace);
     }
     return apiFetch(servicesPath);
+  };
+
+  const fetchEdges = (namespace, resourceType) => {
+    return apiFetch(edgesPath + "?namespace=" + namespace + "&resource_type=" + resourceType);
   };
 
   const getMetricsWindow = () => metricsWindow;
@@ -211,6 +216,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     fetchMetrics,
     fetchPods,
     fetchServices,
+    fetchEdges,
     getMetricsWindow,
     setMetricsWindow,
     getValidMetricsWindows: () => Object.keys(validMetricsWindows),

--- a/web/app/js/components/util/EdgesUtils.jsx
+++ b/web/app/js/components/util/EdgesUtils.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import _each from 'lodash/each';
+import _isEmpty from 'lodash/isEmpty';
+import _startsWith from 'lodash/startsWith';
+
+export const processEdges = (rawEdges, resourceName) => {
+  let edges = [];
+  if (_isEmpty(rawEdges) || _isEmpty(rawEdges.ok) || _isEmpty(rawEdges.ok.edges)) {
+    return edges;
+  }
+  _each(rawEdges.ok.edges, edge => {
+    if (_isEmpty(edge)) {
+      return;
+    }
+    // check if any of the returned edges match the current resourceName
+    if (_startsWith(edge.src.name, resourceName) || _startsWith(edge.dst.name, resourceName)) {
+      edge.key = edge.src.name + edge.dst.name;
+      edges.push(edge);
+    }
+  });
+  return edges;
+};
+
+export const processedEdgesPropType = PropTypes.shape({
+  clientId: PropTypes.string,
+  dst: PropTypes.shape(edgeResourcePropType).isRequired,
+  key: PropTypes.string.isRequired,
+  noIdentityMsg: PropTypes.string,
+  serverId: PropTypes.string,
+  src: PropTypes.shape(edgeResourcePropType).isRequired,
+});
+
+const edgeResourcePropType = PropTypes.shape({
+  name: PropTypes.string,
+  type: PropTypes.string
+});

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -251,3 +251,23 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 		}
 	}
 }
+
+func (h *handler) handleAPIEdges(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	requestParams := util.EdgesRequestParams{
+		Namespace:    req.FormValue("namespace"),
+		ResourceType: req.FormValue("resource_type"),
+	}
+
+	edgesRequest, err := util.BuildEdgesRequest(requestParams)
+	if err != nil {
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	result, err := h.apiClient.Edges(req.Context(), edgesRequest)
+	if err != nil {
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+	renderJSONPb(w, result)
+}

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -124,6 +124,7 @@ func NewServer(
 	server.router.GET("/api/services", handler.handleAPIServices)
 	server.router.GET("/api/tap", handler.handleAPITap)
 	server.router.GET("/api/routes", handler.handleAPITopRoutes)
+	server.router.GET("/api/edges", handler.handleAPIEdges)
 
 	// grafana proxy
 	server.router.DELETE("/grafana/*grafanapath", handler.handleGrafana)


### PR DESCRIPTION
This PR adds an Edges table to the resource detail view if one or more edges are returned going to/from that specific resource. A tooltip icon to the right of the table title explains what "Edges" data is. If a specific resource is not part of any edges, the Edges table should not show.

You can check the data by running `linkerd edges`.

<img width="1140" alt="Screen Shot 2019-06-18 at 2 27 32 PM" src="https://user-images.githubusercontent.com/2289389/59721086-57496480-91d5-11e9-89bc-01e5742eb40c.png">

Resolves #2709.
