### PR TITLE
Fix issue where webhook configs were not being deleted

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -24,12 +24,12 @@ if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname | gre
   echo "no clusterroles found for [$linkerd_namespace]" >&2
 fi
 
-if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname | grep -E  "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no mutatingwebhookconfigurations found for [$linkerd_namespace]" >&2
+if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+  echo "no mutatingwebhookconfigurations found" >&2
 fi
 
-if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname | grep -E  "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no validatingwebhookconfigurations found for [$linkerd_namespace]" >&2
+if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+  echo "no validatingwebhookconfigurations found" >&2
 fi
 
 if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs ]]; then


### PR DESCRIPTION
#2945 was intended to cleanup the cluster level resources i.e. `ClusterRoleBinding`, `webhookconfigurations` before and after an integration test was run. In `bin/test-cleanup`, two lines were added to remove webhook configuration.
https://github.com/linkerd/linkerd2/blob/bd7d567fe1ca887df9c72df1db485c673dfcbf64/bin/test-cleanup#L27-L32

These lines were expected to search for webhooks based on a Linkerd namespace present in a config name. However, webhook configs do not have namespaces within their names so the lines would effectively do nothing. This PR edits the test-cleanup script with the proper filter to detect installed webhooks. 

Before:
```bash
➜  linkerd2 git:(master) ✗ bin/test-cleanup
cleaning up namespace [l5d-integration] in k8s-context [] and associated test namespaces
no mutatingwebhookconfigurations found for [l5d-integration]
no validatingwebhookconfigurations found for [l5d-integration]
namespace "l5d-integration" deleted
namespace "l5d-integration-egress-test" deleted
namespace "l5d-integration-get-test" deleted
namespace "l5d-integration-inject-test" deleted
...
➜  linkerd2 git:(master) ✗ kubectl get mutatingwebhookconfiguration
NAME                                    CREATED AT
linkerd-proxy-injector-webhook-config   2019-06-18T21:00:14Z
```

After:
```bash
➜  linkerd2 git:(dad/travis-webhook-cleanup-bug) ✗ bin/test-cleanup
cleaning up namespace [l5d-integration] in k8s-context [] and associated test namespaces
no clusterrolebindings found for [l5d-integration]
no clusterroles found for [l5d-integration]
mutatingwebhookconfiguration.admissionregistration.k8s.io "linkerd-proxy-injector-webhook-config" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "linkerd-sp-validator-webhook-config" deleted
...
➜  linkerd2 git:(dad/travis-webhook-cleanup-bug) ✗ kubectl get mutatingwebhookconfiguration
No resources found.
```