### PR TITLE
Add `NET_RAW` capability to the proxy-init container

### DIFF
--- a/chart/templates/psp.yaml
+++ b/chart/templates/psp.yaml
@@ -14,6 +14,7 @@ spec:
   {{- if not .NoInitContainer }}
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   {{- end}}
   seLinux:
     rule: RunAsAny

--- a/chart/templates/psp.yaml
+++ b/chart/templates/psp.yaml
@@ -16,18 +16,32 @@ spec:
   - NET_ADMIN
   - NET_RAW
   {{- end}}
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -136,6 +136,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -136,6 +136,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -285,6 +286,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -136,6 +136,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -307,6 +308,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -467,6 +469,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -627,6 +630,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -166,6 +166,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -307,6 +308,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -153,6 +153,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -148,6 +148,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -148,6 +148,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -149,6 +149,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -149,6 +149,7 @@ items:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
             privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: false
@@ -303,6 +304,7 @@ items:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
             privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -149,6 +149,7 @@ items:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
             privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: false
@@ -303,6 +304,7 @@ items:
             capabilities:
               add:
               - NET_ADMIN
+              - NET_RAW
             privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -130,6 +130,7 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+        - NET_RAW
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -136,6 +136,7 @@ spec:
       capabilities:
         add:
         - NET_ADMIN
+        - NET_RAW
       privileged: false
       readOnlyRootFilesystem: true
       runAsNonRoot: false

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -147,6 +147,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -149,6 +149,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -311,6 +312,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -218,6 +218,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -473,6 +474,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -679,6 +681,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -975,6 +978,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1234,6 +1238,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1430,6 +1435,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1654,6 +1660,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1853,6 +1860,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -718,6 +719,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -973,6 +975,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1179,6 +1182,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1475,6 +1479,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1734,6 +1739,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1930,6 +1936,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2154,6 +2161,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2353,6 +2361,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -724,6 +725,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -988,6 +990,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1200,6 +1203,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1502,6 +1506,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1767,6 +1772,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1969,6 +1975,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2199,6 +2206,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2404,6 +2412,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -724,6 +725,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -988,6 +990,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1200,6 +1203,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1502,6 +1506,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1767,6 +1772,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1969,6 +1975,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2199,6 +2206,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2404,6 +2412,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -437,18 +437,32 @@ metadata:
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -686,6 +687,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -906,6 +908,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1077,6 +1080,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1338,6 +1342,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1562,6 +1567,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1723,6 +1729,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1912,6 +1919,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2076,6 +2084,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -719,6 +720,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -975,6 +977,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1182,6 +1185,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1479,6 +1483,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1739,6 +1744,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1936,6 +1942,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2161,6 +2168,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2361,6 +2369,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -440,18 +440,32 @@ spec:
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
+  requiredDropCapabilities:
+  - ALL
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
   seLinux:
-    rule: RunAsAny
-  supplementalGroups:
     rule: RunAsAny
   runAsUser:
     rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   fsGroup:
-    rule: RunAsAny
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 65535
   volumes:
   - configMap
   - emptyDir
   - secret
+  - projected
+  - downwardAPI
+  - persistentVolumeClaim
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -439,6 +439,7 @@ spec:
   readOnlyRootFilesystem: true
   allowedCapabilities:
   - NET_ADMIN
+  - NET_RAW
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -725,6 +726,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -990,6 +992,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1203,6 +1206,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1506,6 +1510,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1772,6 +1777,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -1975,6 +1981,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2206,6 +2213,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
@@ -2412,6 +2420,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -55,7 +55,8 @@
       "securityContext": {
         "capabilities": {
           "add": [
-            "NET_ADMIN"
+            "NET_ADMIN",
+            "NET_RAW"
           ]
         },
         "privileged": false,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -624,7 +624,9 @@ func (conf *ResourceConfig) injectProxyInit(patch *Patch, saVolumeMount *corev1.
 	if capabilities.Add == nil {
 		capabilities.Add = []corev1.Capability{}
 	}
-	capabilities.Add = append(capabilities.Add, corev1.Capability("NET_ADMIN"))
+	capabilities.Add = append(capabilities.Add,
+		corev1.Capability("NET_ADMIN"),
+		corev1.Capability("NET_RAW"))
 
 	var (
 		nonRoot                  = false

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -71,15 +71,19 @@ const (
 	proxyInitResourceLimitMemory   = "50Mi"
 )
 
-var injectableKinds = []string{
-	k8s.DaemonSet,
-	k8s.Deployment,
-	k8s.Job,
-	k8s.Pod,
-	k8s.ReplicaSet,
-	k8s.ReplicationController,
-	k8s.StatefulSet,
-}
+var (
+	injectableKinds = []string{
+		k8s.DaemonSet,
+		k8s.Deployment,
+		k8s.Job,
+		k8s.Pod,
+		k8s.ReplicaSet,
+		k8s.ReplicationController,
+		k8s.StatefulSet,
+	}
+
+	proxyInitDefaultCapabilities = []corev1.Capability{"NET_ADMIN", "NET_RAW"}
+)
 
 // Origin defines where the input YAML comes from. Refer the ResourceConfig's
 // 'origin' field
@@ -618,15 +622,14 @@ func (conf *ResourceConfig) injectProxyInit(patch *Patch, saVolumeMount *corev1.
 	capabilities := &corev1.Capabilities{}
 	if conf.pod.spec.Containers != nil && len(conf.pod.spec.Containers) > 0 {
 		if sc := conf.pod.spec.Containers[0].SecurityContext; sc != nil && sc.Capabilities != nil {
-			capabilities = sc.Capabilities
+			capabilities.Add = sc.Capabilities.Add
+			capabilities.Drop = sc.Capabilities.Drop
 		}
 	}
 	if capabilities.Add == nil {
 		capabilities.Add = []corev1.Capability{}
 	}
-	capabilities.Add = append(capabilities.Add,
-		corev1.Capability("NET_ADMIN"),
-		corev1.Capability("NET_RAW"))
+	capabilities.Add = append(capabilities.Add, proxyInitDefaultCapabilities...)
 
 	var (
 		nonRoot                  = false

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -528,22 +528,22 @@ func TestInjectPodSpec(t *testing.T) {
 
 				for _, sidecar := range []string{k8s.ProxyContainerName, k8s.InitContainerName} {
 					if container.Name == sidecar {
-						t.Run(fmt.Sprintf("%s", sidecar), func(t *testing.T) {
+						t.Run(fmt.Sprintf(container.Name), func(t *testing.T) {
 							if sc := container.SecurityContext; sc != nil {
 								if *sc.AllowPrivilegeEscalation {
-									t.Errorf("Expected %s's 'allowPrivilegeEscalation' to be false", sidecar)
+									t.Errorf("Expected %s's 'allowPrivilegeEscalation' to be false", container.Name)
 								}
 
 								if !*sc.ReadOnlyRootFilesystem {
-									t.Errorf("Expected %s's 'readOnlyRootFilesystem' to be true", sidecar)
+									t.Errorf("Expected %s's 'readOnlyRootFilesystem' to be true", container.Name)
 								}
 
 								if *sc.RunAsUser != conf.proxyUID() {
-									t.Errorf("Expected %s's 'RunAsUser' to be %d", sidecar, conf.proxyUID())
+									t.Errorf("Expected %s's 'RunAsUser' to be %d", container.Name, conf.proxyUID())
 								}
 
 								expectedCapabilities := testContainer.SecurityContext.Capabilities
-								if sidecar == k8s.InitContainerName {
+								if container.Name == k8s.InitContainerName {
 									expectedCapabilities.Add = append(expectedCapabilities.Add, proxyInitDefaultCapabilities...)
 								}
 
@@ -553,7 +553,7 @@ func TestInjectPodSpec(t *testing.T) {
 										sc.Capabilities.Add)
 								}
 							} else {
-								t.Errorf("Expected %s security context to be non-empty", sidecar)
+								t.Errorf("Expected %s security context to be non-empty", container.Name)
 							}
 						})
 					}

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -112,6 +112,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -137,6 +137,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+            - NET_RAW
           privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false


### PR DESCRIPTION
Add the `NET_RAW` capability to the proxy-init container. This ensures that if a PSP or the primary container's security context contains the `Drop: All` capability rule, the proxy-init container won't fail.

Also, updated the control plane PSP to match that defined in https://github.com/linkerd/website/issues/94.

Test cases can be found [here](https://gist.github.com/ihcsim/d94f4cda94c1cce1662e12a68499c400). Also tested with multi-stage installation.

Fixes https://github.com/linkerd/linkerd2/issues/2959.