### PR TITLE
Label all Linkerd resources

### DIFF
--- a/chart/templates/config.yaml
+++ b/chart/templates/config.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:

--- a/chart/templates/controller-rbac.yaml
+++ b/chart/templates/controller-rbac.yaml
@@ -8,6 +8,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-controller
+  labels:
+    {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -26,6 +29,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-controller
+  labels:
+    {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -40,4 +46,7 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{end -}}

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -29,6 +30,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -47,6 +49,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: controller
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/grafana-rbac.yaml
+++ b/chart/templates/grafana-rbac.yaml
@@ -9,4 +9,7 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: grafana
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{- end}}

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: grafana
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:
@@ -67,6 +68,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: grafana
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -85,6 +87,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: grafana
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/identity-rbac.yaml
+++ b/chart/templates/identity-rbac.yaml
@@ -9,6 +9,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-identity
+  labels:
+    {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -18,6 +21,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-identity
+  labels:
+    {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -32,5 +38,8 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{end -}}
 {{end -}}

--- a/chart/templates/identity.yaml
+++ b/chart/templates/identity.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
     {{- if .Identity.Issuer.CrtExpiryAnnotation}}
@@ -30,6 +31,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -48,6 +50,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/prometheus-rbac.yaml
+++ b/chart/templates/prometheus-rbac.yaml
@@ -8,6 +8,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-prometheus
+  labels:
+    {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -17,6 +20,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-prometheus
+  labels:
+    {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,4 +37,7 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{- end}}

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:
@@ -99,6 +100,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -117,6 +119,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: prometheus
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -8,6 +8,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Namespace}}-proxy-injector
+  labels:
+    {{.ControllerComponentLabel}}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -23,6 +26,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Namespace}}-proxy-injector
+  labels:
+    {{.ControllerComponentLabel}}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -38,6 +44,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 ---
 kind: Secret
 apiVersion: v1
@@ -46,6 +55,7 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     {{ .ControllerComponentLabel }}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{ .CreatedByAnnotation }}: {{ .CliVersion }}
 type: Opaque
@@ -59,6 +69,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -72,6 +73,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/psp.yaml
+++ b/chart/templates/psp.yaml
@@ -8,6 +8,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-{{.Namespace}}-control-plane
+  labels:
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -33,6 +35,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -45,6 +49,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/chart/templates/serviceprofile-crd.yaml
+++ b/chart/templates/serviceprofile-crd.yaml
@@ -10,6 +10,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
+  labels:
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 spec:
   group: linkerd.io
   version: v1alpha1

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -8,6 +8,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Namespace}}-sp-validator
+  labels:
+    {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -17,6 +20,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Namespace}}-sp-validator
+  labels:
+    {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -32,6 +38,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 ---
 kind: Secret
 apiVersion: v1
@@ -39,7 +48,8 @@ metadata:
   name: linkerd-sp-validator-tls
   namespace: {{ .Namespace }}
   labels:
-    {{ .ControllerComponentLabel }}: sp-validator
+    {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{ .CreatedByAnnotation }}: {{ .CliVersion }}
 type: Opaque
@@ -53,6 +63,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     {{ .ControllerComponentLabel }}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:

--- a/chart/templates/sp_validator.yaml
+++ b/chart/templates/sp_validator.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -29,6 +30,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: sp-validator
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/tap-rbac.yaml
+++ b/chart/templates/tap-rbac.yaml
@@ -8,6 +8,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-tap
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -23,6 +26,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-{{.Namespace}}-tap
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -37,4 +43,7 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{end -}}

--- a/chart/templates/tap.yaml
+++ b/chart/templates/tap.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -29,6 +30,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/web-rbac.yaml
+++ b/chart/templates/web-rbac.yaml
@@ -9,4 +9,7 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: web
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 {{- end}}

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: web
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -32,6 +33,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerComponentLabel}}: web
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -49,6 +49,7 @@ type (
 		ControllerLogLevel       string
 		PrometheusLogLevel       string
 		ControllerComponentLabel string
+		ControllerNamespaceLabel string
 		CreatedByAnnotation      string
 		ProxyContainerName       string
 		ProxyInjectAnnotation    string
@@ -560,6 +561,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		CreatedByAnnotation:      k8s.CreatedByAnnotation,
 		CliVersion:               k8s.CreatedByAnnotationValue(),
 		ControllerComponentLabel: k8s.ControllerComponentLabel,
+		ControllerNamespaceLabel: k8s.ControllerNSLabel,
 		ProxyContainerName:       k8s.ProxyContainerName,
 		ProxyInjectAnnotation:    k8s.ProxyInjectAnnotation,
 		ProxyInjectDisabled:      k8s.ProxyInjectDisabled,

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -45,6 +45,7 @@ func TestRender(t *testing.T) {
 		ControllerLogLevel:       "ControllerLogLevel",
 		PrometheusLogLevel:       "PrometheusLogLevel",
 		ControllerComponentLabel: "ControllerComponentLabel",
+		ControllerNamespaceLabel: "ControllerNamespaceLabel",
 		CreatedByAnnotation:      "CreatedByAnnotation",
 		ProxyContainerName:       "ProxyContainerName",
 		ProxyInjectAnnotation:    "ProxyInjectAnnotation",

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -6,6 +6,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -27,6 +28,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -41,6 +43,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -60,6 +63,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -247,6 +251,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -265,6 +270,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -284,6 +290,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -499,6 +506,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -521,6 +529,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -705,6 +714,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -793,6 +803,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -812,6 +823,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1003,6 +1015,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1059,6 +1072,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1078,6 +1092,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1270,6 +1285,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1455,6 +1471,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1477,6 +1494,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1496,6 +1514,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -1680,6 +1699,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1699,6 +1719,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -541,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -747,6 +823,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -765,6 +842,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -784,6 +862,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -999,6 +1078,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1021,6 +1101,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1205,6 +1286,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1293,6 +1375,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1312,6 +1395,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1503,6 +1587,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1559,6 +1644,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1578,6 +1664,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1770,6 +1857,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1955,6 +2043,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1977,6 +2066,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1996,6 +2086,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2180,6 +2271,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2199,6 +2291,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -541,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -753,6 +829,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -771,6 +848,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -790,6 +868,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1014,6 +1093,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1036,6 +1116,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1226,6 +1307,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1314,6 +1396,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1333,6 +1416,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1530,6 +1614,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1586,6 +1671,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1605,6 +1691,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1803,6 +1890,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1994,6 +2082,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2016,6 +2105,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2035,6 +2125,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2225,6 +2316,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2244,6 +2336,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -541,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -753,6 +829,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -771,6 +848,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -790,6 +868,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1014,6 +1093,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1036,6 +1116,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1226,6 +1307,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1314,6 +1396,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1333,6 +1416,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1530,6 +1614,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1586,6 +1671,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1605,6 +1691,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1803,6 +1890,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1994,6 +2082,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2016,6 +2105,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2035,6 +2125,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2225,6 +2316,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2244,6 +2336,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -455,6 +523,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -467,6 +537,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -504,6 +576,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -525,6 +598,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -539,6 +613,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -558,6 +633,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -713,6 +789,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -731,6 +808,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -750,6 +828,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -933,6 +1012,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -955,6 +1035,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1107,6 +1188,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1195,6 +1277,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1214,6 +1297,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1373,6 +1457,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1429,6 +1514,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1448,6 +1534,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1608,6 +1695,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1761,6 +1849,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1783,6 +1872,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1802,6 +1892,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -1954,6 +2045,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1973,6 +2065,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-identity
+  labels:
+    ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-identity
+  labels:
+    ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-controller
+  labels:
+    ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-controller
+  labels:
+    ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: web
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     CreatedByAnnotation: CliVersion
+  labels:
+    ControllerNamespaceLabel: Namespace
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-prometheus
+  labels:
+    ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-prometheus
+  labels:
+    ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: grafana
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-Namespace-proxy-injector
+  labels:
+    ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-Namespace-proxy-injector
+  labels:
+    ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-Namespace-sp-validator
+  labels:
+    ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-Namespace-sp-validator
+  labels:
+    ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-tap
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-Namespace-tap
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: Namespace
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-Namespace-control-plane
+  labels:
+    ControllerNamespaceLabel: Namespace
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: Namespace
+  labels:
+    ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: Namespace
+  labels:
+    ControllerNamespaceLabel: Namespace
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -541,6 +615,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: identity
+    ControllerNamespaceLabel: Namespace
   name: linkerd-identity
   namespace: Namespace
 spec:
@@ -712,6 +788,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -730,6 +807,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -749,6 +827,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: controller
+    ControllerNamespaceLabel: Namespace
   name: linkerd-controller
   namespace: Namespace
 spec:
@@ -929,6 +1008,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: web
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -951,6 +1031,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: web
+    ControllerNamespaceLabel: Namespace
   name: linkerd-web
   namespace: Namespace
 spec:
@@ -1100,6 +1181,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -1188,6 +1270,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1207,6 +1290,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: prometheus
+    ControllerNamespaceLabel: Namespace
   name: linkerd-prometheus
   namespace: Namespace
 spec:
@@ -1363,6 +1447,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: grafana
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -1419,6 +1504,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: grafana
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1438,6 +1524,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: grafana
+    ControllerNamespaceLabel: Namespace
   name: linkerd-grafana
   namespace: Namespace
 spec:
@@ -1595,6 +1682,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
   name: linkerd-proxy-injector
   namespace: Namespace
 spec:
@@ -1745,6 +1833,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: proxy-injector
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1767,6 +1856,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1786,6 +1876,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: sp-validator
+    ControllerNamespaceLabel: Namespace
   name: linkerd-sp-validator
   namespace: Namespace
 spec:
@@ -1935,6 +2026,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1954,6 +2046,7 @@ metadata:
   creationTimestamp: null
   labels:
     ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
   name: linkerd-tap
   namespace: Namespace
 spec:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2020-04-03T23:53:57Z
@@ -541,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -748,6 +824,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -766,6 +843,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -785,6 +863,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1001,6 +1080,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1023,6 +1103,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1208,6 +1289,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1296,6 +1378,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1315,6 +1398,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1507,6 +1591,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1563,6 +1648,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1582,6 +1668,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1775,6 +1862,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1961,6 +2049,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1983,6 +2072,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2002,6 +2092,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2187,6 +2278,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2206,6 +2298,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -20,6 +20,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -29,6 +32,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-identity
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +49,9 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Controller RBAC
@@ -52,6 +61,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -70,6 +82,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-controller
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -84,6 +99,9 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Web RBAC
@@ -94,6 +112,9 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Service Profile CRD
@@ -105,6 +126,8 @@ metadata:
   name: serviceprofiles.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -208,6 +231,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -217,6 +243,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-prometheus
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -231,6 +260,9 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Grafana RBAC
@@ -241,6 +273,9 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Proxy Injector RBAC
@@ -250,6 +285,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -265,6 +303,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-proxy-injector
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -280,6 +321,9 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -288,6 +332,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -301,6 +346,7 @@ metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -328,6 +374,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -337,6 +386,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-sp-validator
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -352,6 +404,9 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 ---
 kind: Secret
 apiVersion: v1
@@ -360,6 +415,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -373,6 +429,7 @@ metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -396,6 +453,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -411,6 +471,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-linkerd-tap
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -425,6 +488,9 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
 ---
 ###
 ### Control Plane PSP
@@ -434,6 +500,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-control-plane
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -457,6 +525,8 @@ kind: Role
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -469,6 +539,8 @@ kind: RoleBinding
 metadata:
   name: linkerd-psp
   namespace: linkerd
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -506,6 +578,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -527,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2020-04-03T23:53:57Z
@@ -541,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -560,6 +635,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: identity
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -754,6 +830,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -772,6 +849,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -791,6 +869,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: controller
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1016,6 +1095,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1038,6 +1118,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: web
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1229,6 +1310,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1317,6 +1399,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1336,6 +1419,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: prometheus
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1534,6 +1618,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1590,6 +1675,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1609,6 +1695,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: grafana
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1808,6 +1895,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2000,6 +2088,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2022,6 +2111,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2041,6 +2131,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2232,6 +2323,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2251,6 +2343,7 @@ metadata:
   creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
   name: linkerd-tap
   namespace: linkerd
 spec:


### PR DESCRIPTION
This PR updates all the existing Helm charts to label all resources with the `linkerd.io/control-plane-ns` label. The `linkerd.io/control-plane-component` label is also added to relevant resources.

E.g., to get all global and namespace resources that are part of the `linkerd` namespace, use:
```
kubectl get all,sa,cm,secret,role,rolebinding,clusterrole,clusterrolebinding,mutatingwebhookconfiguration,validatingwebhookconfiguration,crd,psp --all-namespaces -l linkerd.io/control-plane-ns=linkerd -L linkerd.io/control-plane-ns
```

To get all global and namespace resources relevant to the `controller` component, use:
```
kubectl get all,sa,cm,secret,clusterrole,clusterrolebinding --all-namespaces -l linkerd.io/control-plane-component=controller
```

Part of https://github.com/linkerd/linkerd2/issues/2954.