### PR TITLE
Have `GetOwnerKindAndName` be able to skip the cache

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -385,7 +385,7 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 					pp.log.Errorf("Unable to fetch pod %v: %s", id, err)
 					continue
 				}
-				ownerKind, ownerName := pp.k8sAPI.GetOwnerKindAndName(pod)
+				ownerKind, ownerName := pp.k8sAPI.GetOwnerKindAndName(pod, false)
 				pods[id] = Address{
 					IP:        endpoint.IP,
 					Port:      resolvedPort,

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -154,7 +154,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 			continue
 		}
 
-		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod)
+		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
 		// filter out pods without matching owner
 		if targetOwner.GetNamespace() != "" && targetOwner.GetNamespace() != pod.GetNamespace() {
 			continue

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -388,8 +388,14 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, st
 		var err error
 		if skipCache {
 			rs, err = api.Client.AppsV1beta2().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
+			if err != nil {
+				log.Warnf("failed to retrieve replicaset from indexer %s/%s: %s", pod.Namespace, parent.Name, err)
+			}
 		} else {
 			rs, err = api.RS().Lister().ReplicaSets(pod.Namespace).Get(parent.Name)
+			if err != nil {
+				log.Warnf("failed to retrieve replicaset from k8s %s/%s: %s", pod.Namespace, parent.Name, err)
+			}
 		}
 
 		if err != nil || len(rs.GetOwnerReferences()) != 1 {

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -689,7 +689,7 @@ metadata:
 				}
 
 				pod := objs[0].(*corev1.Pod)
-				ownerKind, ownerName := api.GetOwnerKindAndName(pod)
+				ownerKind, ownerName := api.GetOwnerKindAndName(pod, !enableInformers)
 
 				if ownerKind != tt.expectedOwnerKind {
 					t.Fatalf("Expected kind to be [%s], got [%s]", tt.expectedOwnerKind, ownerKind)

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -87,6 +87,6 @@ func Inject(api *k8s.API,
 func ownerRetriever(api *k8s.API, ns string) inject.OwnerRetrieverFunc {
 	return func(p *v1.Pod) (string, string) {
 		p.SetNamespace(ns)
-		return api.GetOwnerKindAndName(p)
+		return api.GetOwnerKindAndName(p, true)
 	}
 }

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -503,7 +503,7 @@ func (s *server) hydrateIPLabels(ip *public.IPAddress, labels map[string]string)
 		log.Debugf("no pod for IP %s", addr.PublicIPToString(ip))
 		return nil
 	default:
-		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod)
+		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
 		podLabels := pkgK8s.GetPodLabels(ownerKind, ownerName, pod)
 		for key, value := range podLabels {
 			labels[key] = value


### PR DESCRIPTION
Refactored `GetOwnerKindAndName` so it can optionally skip the
shared informer cache and instead hit the k8s API directly.
Useful for the proxy injector, when the pod's replicaset got just
created and might not be in ready in the cache yet.

Fixes #2738, supersedes #2881