### PR TITLE
Simplify port-forwarding code

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -71,7 +71,6 @@ func newCmdDashboard() *cobra.Command {
 				return err
 			}
 
-			wait := make(chan struct{}, 1)
 			signals := make(chan os.Signal, 1)
 			signal.Notify(signals, os.Interrupt)
 			defer signal.Stop(signals)
@@ -89,7 +88,7 @@ func newCmdDashboard() *cobra.Command {
 				os.Exit(1)
 			}
 
-			if err = portforward.Init(wait); err != nil {
+			if err = portforward.Init(); err != nil {
 				// TODO: consider falling back to an ephemeral port if defaultPort is taken
 				fmt.Fprintf(os.Stderr, "Error running port-forward: %s\nCheck for `linkerd dashboard` running in other terminal sessions, or use the `--port` flag.\n", err)
 				os.Exit(1)
@@ -127,7 +126,7 @@ func newCmdDashboard() *cobra.Command {
 				// no-op, we already printed the URLs
 			}
 
-			<-wait
+			<-portforward.GetStop()
 			return nil
 		},
 	}

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -89,22 +89,16 @@ func newCmdDashboard() *cobra.Command {
 				os.Exit(1)
 			}
 
-			go func() {
-				err := portforward.Run()
-				if err != nil {
-					// TODO: consider falling back to an ephemeral port if defaultPort is taken
-					fmt.Fprintf(os.Stderr, "Error running port-forward: %s\nCheck for `linkerd dashboard` running in other terminal sessions, or use the `--port` flag.\n", err)
-					os.Exit(1)
-				}
-				close(wait)
-			}()
+			if err = portforward.Init(wait); err != nil {
+				// TODO: consider falling back to an ephemeral port if defaultPort is taken
+				fmt.Fprintf(os.Stderr, "Error running port-forward: %s\nCheck for `linkerd dashboard` running in other terminal sessions, or use the `--port` flag.\n", err)
+				os.Exit(1)
+			}
 
 			go func() {
 				<-signals
 				portforward.Stop()
 			}()
-
-			<-portforward.Ready()
 
 			webURL := portforward.URLFor("")
 			grafanaURL := portforward.URLFor("/grafana")

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -160,6 +160,7 @@ func getMetrics(
 		return nil, err
 	}
 
+	defer portforward.Stop()
 	if err = portforward.Init(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
 	}

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -160,17 +160,9 @@ func getMetrics(
 		return nil, err
 	}
 
-	defer portforward.Stop()
-
-	go func() {
-		err := portforward.Run()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
-			portforward.Stop()
-		}
-	}()
-
-	<-portforward.Ready()
+	if err = portforward.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+	}
 
 	metricsURL := portforward.URLFor("/metrics")
 	resp, err := http.Get(metricsURL)

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -252,27 +252,7 @@ func NewExternalClient(controlPlaneNamespace string, kubeAPI *k8s.KubernetesAPI)
 		return nil, err
 	}
 
-	log.Debugf("Starting port forward on [%s]", apiURL)
-
-	wait := make(chan error, 1)
-
-	go func() {
-		if err := portforward.Run(); err != nil {
-			wait <- err
-		}
-
-		portforward.Stop()
-	}()
-
-	select {
-	case <-portforward.Ready():
-		log.Debugf("Port forward initialised")
-
-		break
-
-	case err := <-wait:
-		log.Debugf("Port forward failed: %v", err)
-
+	if err = portforward.Init(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -186,11 +186,11 @@ func (pf *PortForward) Init() error {
 		}
 	}()
 
-	// The `select` statement below depends on one of two outcomes from `pf.Run()`:
-	// 1) Succeed and block, causing a receive on `<-pf.Ready()`
+	// The `select` statement below depends on one of two outcomes from `pf.run()`:
+	// 1) Succeed and block, causing a receive on `<-pf.readyCh`
 	// 2) Return an err, causing a receive `<-failure`
 	select {
-	case <-pf.Ready():
+	case <-pf.readyCh:
 		log.Debug("Port forward initialised")
 	case err := <-failure:
 		log.Debugf("Port forward failed: %v", err)
@@ -198,13 +198,6 @@ func (pf *PortForward) Init() error {
 	}
 
 	return nil
-}
-
-// Ready returns a channel that will receive a message when the port-forward
-// connection is ready. Clients should block and wait for the message before
-// using the port-forward connection.
-func (pf *PortForward) Ready() <-chan struct{} {
-	return pf.readyCh
 }
 
 // Stop terminates the port-forward connection.

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -260,8 +260,9 @@ func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) 
 		return "", err
 	}
 
-	go pf.Run()
-	<-pf.Ready()
+	if err = pf.Init(); err != nil {
+		return "", err
+	}
 
 	return pf.URLFor(""), nil
 }


### PR DESCRIPTION
Simplifies the establishment of a port-forwarding by moving the common logic into `PortForward.Init()`.

Stemmed from this [comment](https://github.com/linkerd/linkerd2/pull/2937#discussion_r295078800).