### PR TITLE
Adding context to log warning

### DIFF
--- a/web/main.go
+++ b/web/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	installConfig, err := config.Install(pkgK8s.MountPathInstallConfig)
 	if err != nil {
-		log.Warnf("(disregard warning if running in development mode) failed to load uuid from install config: %s", err)
+		log.Warnf("failed to load uuid from install config: [%s] (disregard warning if running in development mode)", err)
 	}
 	uuid := installConfig.GetUuid()
 

--- a/web/main.go
+++ b/web/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	installConfig, err := config.Install(pkgK8s.MountPathInstallConfig)
 	if err != nil {
-		log.Warnf("failed to load uuid from install config: %s", err)
+		log.Warnf("(disregard warning if running in development mode) failed to load uuid from install config: %s", err)
 	}
 	uuid := installConfig.GetUuid()
 


### PR DESCRIPTION
Adds context to UUID warning when running web server locally. See #2974 for context.