### PR TITLE
Bump proxy for edge-19.6.3

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -23,7 +23,7 @@ validate_go_deps_tag $dockerfile
 ) >/dev/null
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-35df8ab}"
+PROXY_VERSION="${PROXY_VERSION:-52eefa4}"
 
 tag="$(head_root_tag)"
 docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
* Fixed the proxy rejecting HTTP2 requests that don't have an `:authority`
* Improved idle service eviction to reduce resource consumption for clients
  that send requests to many services

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>