### PR TITLE
Introduce global resources checks to install and multi-stage install

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -36,8 +36,8 @@ if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicie
   echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
 fi
 
-if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
+if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/control-plane-ns -oname); then
+  echo "no customresourcedefinitions found for [$linkerd_namespace]" >&2
 fi
 
 if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -32,6 +32,14 @@ if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookcon
   echo "no validatingwebhookconfigurations found" >&2
 fi
 
-if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs ]]; then
-  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs
+if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
+fi
+
+if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+  echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
+fi
+
+if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then
+  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
 fi

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -155,9 +155,8 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		checks = append(checks, healthcheck.LinkerdConfigChecks)
 
 		if stage != configStage {
-			checks = append(checks,
-				healthcheck.LinkerdControlPlaneExistenceChecks,
-				healthcheck.LinkerdAPIChecks)
+			checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
+			checks = append(checks, healthcheck.LinkerdAPIChecks)
 
 			if options.dataPlaneOnly {
 				checks = append(checks, healthcheck.LinkerdDataPlaneChecks)

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -227,15 +227,8 @@ func runChecksTable(wout io.Writer, hc *healthcheck.HealthChecker) bool {
 		}
 
 		fmt.Fprintf(wout, "%s %s\n", status, result.Description)
-		if err := result.Err; err != nil {
-			errMsg := fmt.Sprintf("%s", err)
-
-			// indent multi-line error message
-			if n := strings.Count(errMsg, "\n"); n > 0 {
-				errMsg = strings.Replace(errMsg, "\n", "\n    ", n-1)
-			}
-			fmt.Fprintf(wout, "    %s\n", strings.TrimSpace(errMsg))
-
+		if result.Err != nil {
+			fmt.Fprintf(wout, "    %s\n", result.Err)
 			if result.HintAnchor != "" {
 				fmt.Fprintf(wout, "    see %s%s for hints\n", healthcheck.HintBaseURL, result.HintAnchor)
 			}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -227,8 +227,15 @@ func runChecksTable(wout io.Writer, hc *healthcheck.HealthChecker) bool {
 		}
 
 		fmt.Fprintf(wout, "%s %s\n", status, result.Description)
-		if result.Err != nil {
-			fmt.Fprintf(wout, "    %s\n", result.Err)
+		if err := result.Err; err != nil {
+			errMsg := fmt.Sprintf("%s", err)
+
+			// indent multi-line error message
+			if n := strings.Count(errMsg, "\n"); n > 0 {
+				errMsg = strings.Replace(errMsg, "\n", "\n    ", n-1)
+			}
+			fmt.Fprintf(wout, "    %s\n", strings.TrimSpace(errMsg))
+
 			if result.HintAnchor != "" {
 				fmt.Fprintf(wout, "    see %s%s for hints\n", healthcheck.HintBaseURL, result.HintAnchor)
 			}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -145,7 +145,9 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 	}
 
 	if options.preInstallOnly {
-		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
+		checks = append(checks,
+			healthcheck.LinkerdPreInstallChecks,
+			healthcheck.LinkerdPreInstallConfigChecks)
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -147,7 +147,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 	if options.preInstallOnly {
 		checks = append(checks,
 			healthcheck.LinkerdPreInstallChecks,
-			healthcheck.LinkerdPreInstallConfigChecks)
+			healthcheck.LinkerdPreInstallGlobalResourcesChecks)
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}
@@ -155,8 +155,9 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		checks = append(checks, healthcheck.LinkerdConfigChecks)
 
 		if stage != configStage {
-			checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
-			checks = append(checks, healthcheck.LinkerdAPIChecks)
+			checks = append(checks,
+				healthcheck.LinkerdControlPlaneExistenceChecks,
+				healthcheck.LinkerdAPIChecks)
 
 			if options.dataPlaneOnly {
 				checks = append(checks, healthcheck.LinkerdDataPlaneChecks)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -163,9 +163,9 @@ const (
 	defaultIdentityIssuanceLifetime   = 24 * time.Hour
 	defaultIdentityClockSkewAllowance = 20 * time.Second
 
-	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\nRemove these resources, or use the --ignore-cluster flag to overwrite them."
-	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation."
-	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation."
+	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
+	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
+	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
 
 // newInstallOptionsWithDefaults initializes install options with default
@@ -861,15 +861,15 @@ func errIfGlobalResourcesExist() error {
 		KubeConfig:            kubeconfigPath,
 	})
 
-	errMsgs := ""
+	errMsgs := []string{}
 	hc.RunChecks(func(result *healthcheck.CheckResult) {
 		if result.Err != nil {
-			errMsgs += fmt.Sprintf("%s", result.Err)
+			errMsgs = append(errMsgs, result.Err.Error())
 		}
 	})
 
 	if len(errMsgs) > 0 {
-		return fmt.Errorf("%s", errMsgs)
+		return errors.New(strings.Join(errMsgs, ","))
 	}
 
 	return nil

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -282,8 +282,7 @@ control plane. It should be run after "linkerd install config".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// check if global resources exist to determine if the `install config`
 			// stage succeeded
-			exists := globalResourcesExist()
-			if !exists && !options.skipChecks {
+			if !globalResourcesExist() && !options.skipChecks {
 				fmt.Fprintf(os.Stderr,
 					"Failed to find required control-plane namespace: %s. Run \"linkerd install config -l %s | kubectl apply -f -\" to create it (this requires cluster administration permissions).\nSee https://linkerd.io/2/getting-started/ for more information. Or use \"--skip-checks\" to proceed anyway.\n",
 					controlPlaneNamespace, controlPlaneNamespace,

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -848,8 +848,9 @@ func globalResourcesExist() bool {
 		KubeConfig:            kubeconfigPath,
 	})
 
-	notExist := hc.RunChecks(func(result *healthcheck.CheckResult) {})
-	return !notExist
+	checksPass := hc.RunChecks(func(result *healthcheck.CheckResult) {})
+	exist := !checksPass
+	return exist
 }
 
 func linkerdConfigConfigMapExists() bool {
@@ -862,8 +863,9 @@ func linkerdConfigConfigMapExists() bool {
 		KubeConfig:            kubeconfigPath,
 	})
 
-	notExists := hc.RunChecks(func(result *healthcheck.CheckResult) {})
-	return !notExists
+	checksPass := hc.RunChecks(func(result *healthcheck.CheckResult) {})
+	exist := !checksPass
+	return exist
 }
 
 func (idopts *installIdentityOptions) validate() error {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -592,6 +592,18 @@ func (hc *HealthChecker) allCategories() []category {
 			id: LinkerdControlPlaneExistenceChecks,
 			checkers: []checker{
 				{
+					description: "'linkerd-config' config map exists",
+					hintAnchor:  "l5d-existence-linkerd-config",
+					fatal:       true,
+					check: func(context.Context) error {
+						if err := hc.checkLinkerdConfigConfigMap(); err != nil {
+							return fmt.Errorf("%s", err)
+						}
+
+						return nil
+					},
+				},
+				{
 					description: "control plane components ready",
 					hintAnchor:  "l5d-existence-psp", // needs https://github.com/linkerd/website/issues/272
 					fatal:       true,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -57,7 +57,7 @@ const (
 	// These checks are no run when the `--linkerd-cni-enabled` flag is set.
 	LinkerdPreInstallCapabilityChecks CategoryID = "pre-kubernetes-capability"
 
-	// LinkerdPreInstallGlobalResourcesChecks adds a series of checks to determine the
+	// LinkerdPreInstallGlobalResourcesChecks adds a series of checks to determine
 	// the existence of the global resources like cluster roles, cluster role
 	// bindings, mutating webhook configuration validating webhook configuration
 	// and pod security policies during the pre-install phase. This check is used
@@ -65,8 +65,9 @@ const (
 	LinkerdPreInstallGlobalResourcesChecks CategoryID = "pre-linkerd-global-resources"
 
 	// LinkerdConfigNotExistsChecks adds a series of checks to determine
-	// if the `linkerd-config` config map already exist. In order for the control
-	// plane installation to succeed, this config map must not exist.
+	// if the `linkerd-config` config map already exist. In order to install a
+	// control plane in a namespace, this config map must not exist in that
+	// namespace.
 	LinkerdConfigNotExistsChecks CategoryID = "linkerd-config-config-map-not-exists"
 
 	// LinkerdConfigChecks enabled by `linkerd check config`

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -396,84 +396,42 @@ func (hc *HealthChecker) allCategories() []category {
 							}
 						}
 
-						objects, err := hc.checkClusterRoles(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd ClusterRoles", len(objects))
-						}
-						return nil
+						return hc.checkClusterRoles(false)
 					},
 				},
 				{
 					description: "no ClusterRoleBindings exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						objects, err := hc.checkClusterRoleBindings(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd ClusterRoleBindings", len(objects))
-						}
-						return nil
+						return hc.checkClusterRoleBindings(false)
 					},
 				},
 				{
 					description: "no CustomResourceDefinitions exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						objects, err := hc.checkCustomResourceDefinitions(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd CustomResourceDefinitions", len(objects))
-						}
-						return nil
+						return hc.checkCustomResourceDefinitions(false)
 					},
 				},
 				{
 					description: "no MutatingWebhookConfigurations exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						objects, err := hc.checkMutatingWebhookConfigurations(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd MutatingWebhookConfigurations", len(objects))
-						}
-						return nil
+						return hc.checkMutatingWebhookConfigurations(false)
 					},
 				},
 				{
 					description: "no ValidatingWebhookConfigurations exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						objects, err := hc.checkValidatingWebhookConfigurations(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd ValidatingWebhookConfigurations", len(objects))
-						}
-						return nil
+						return hc.checkValidatingWebhookConfigurations(false)
 					},
 				},
 				{
 					description: "no PodSecurityPolicies exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						objects, err := hc.checkPodSecurityPolicies(false)
-						if err != nil {
-							return err
-						}
-						if len(objects) > 0 {
-							return fmt.Errorf("found %d Linkerd PodSecurityPolicies", len(objects))
-						}
-						return nil
+						return hc.checkPodSecurityPolicies(false)
 					},
 				},
 			},
@@ -494,8 +452,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-cr",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkClusterRoles(true)
-						return err
+						return hc.checkClusterRoles(true)
 					},
 				},
 				{
@@ -503,8 +460,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-crb",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkClusterRoleBindings(true)
-						return err
+						return hc.checkClusterRoleBindings(true)
 					},
 				},
 				{
@@ -512,8 +468,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-sa",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkServiceAccounts(true)
-						return err
+						return hc.checkServiceAccounts(true)
 					},
 				},
 				{
@@ -521,8 +476,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-crd",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkCustomResourceDefinitions(true)
-						return err
+						return hc.checkCustomResourceDefinitions(true)
 					},
 				},
 				{
@@ -530,8 +484,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-mwc",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkMutatingWebhookConfigurations(true)
-						return err
+						return hc.checkMutatingWebhookConfigurations(true)
 					},
 				},
 				{
@@ -539,8 +492,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-vwc",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkValidatingWebhookConfigurations(true)
-						return err
+						return hc.checkValidatingWebhookConfigurations(true)
 					},
 				},
 				{
@@ -548,8 +500,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-psp",
 					fatal:       true,
 					check: func(context.Context) error {
-						_, err := hc.checkPodSecurityPolicies(true)
-						return err
+						return hc.checkPodSecurityPolicies(true)
 					},
 				},
 			},
@@ -1040,13 +991,13 @@ func expectedServiceAccountNames() []string {
 	}
 }
 
-func (hc *HealthChecker) checkClusterRoles(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	crList, err := hc.kubeAPI.RbacV1().ClusterRoles().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1055,20 +1006,23 @@ func (hc *HealthChecker) checkClusterRoles(checkName bool) ([]runtime.Object, er
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd ClusterRoles", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("ClusterRoles", objects, hc.expectedRBACNames())
+	return checkResources("ClusterRoles", objects, hc.expectedRBACNames())
 }
 
-func (hc *HealthChecker) checkClusterRoleBindings(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	crbList, err := hc.kubeAPI.RbacV1().ClusterRoleBindings().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1077,20 +1031,23 @@ func (hc *HealthChecker) checkClusterRoleBindings(checkName bool) ([]runtime.Obj
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd ClusterRoleBindings", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("ClusterRoleBindings", objects, hc.expectedRBACNames())
+	return checkResources("ClusterRoleBindings", objects, hc.expectedRBACNames())
 }
 
-func (hc *HealthChecker) checkServiceAccounts(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkServiceAccounts(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	saList, err := hc.kubeAPI.CoreV1().ServiceAccounts(hc.ControlPlaneNamespace).List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1099,20 +1056,23 @@ func (hc *HealthChecker) checkServiceAccounts(checkName bool) ([]runtime.Object,
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd ServiceAccounts", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("ServiceAccounts", objects, expectedServiceAccountNames())
+	return checkResources("ServiceAccounts", objects, expectedServiceAccountNames())
 }
 
-func (hc *HealthChecker) checkCustomResourceDefinitions(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	crdList, err := hc.kubeAPI.Apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1121,20 +1081,23 @@ func (hc *HealthChecker) checkCustomResourceDefinitions(checkName bool) ([]runti
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd CustomResourceDefinitions", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("CustomResourceDefinitions", objects, []string{"serviceprofiles.linkerd.io"})
+	return checkResources("CustomResourceDefinitions", objects, []string{"serviceprofiles.linkerd.io"})
 }
 
-func (hc *HealthChecker) checkMutatingWebhookConfigurations(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	mwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1143,20 +1106,23 @@ func (hc *HealthChecker) checkMutatingWebhookConfigurations(checkName bool) ([]r
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd MutatingWebhookConfigurations", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("MutatingWebhookConfigurations", objects, []string{k8s.ProxyInjectorWebhookConfigName})
+	return checkResources("MutatingWebhookConfigurations", objects, []string{k8s.ProxyInjectorWebhookConfigName})
 }
 
-func (hc *HealthChecker) checkValidatingWebhookConfigurations(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkValidatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	vwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1165,20 +1131,23 @@ func (hc *HealthChecker) checkValidatingWebhookConfigurations(checkName bool) ([
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd ValidatingWebhookConfigurations", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("ValidatingWebhookConfigurations", objects, []string{k8s.SPValidatorWebhookConfigName})
+	return checkResources("ValidatingWebhookConfigurations", objects, []string{k8s.SPValidatorWebhookConfigName})
 }
 
-func (hc *HealthChecker) checkPodSecurityPolicies(checkName bool) ([]runtime.Object, error) {
+func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
 	psp, err := hc.kubeAPI.PolicyV1beta1().PodSecurityPolicies().List(options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	objects := []runtime.Object{}
@@ -1187,11 +1156,14 @@ func (hc *HealthChecker) checkPodSecurityPolicies(checkName bool) ([]runtime.Obj
 		objects = append(objects, &item)
 	}
 
-	if !checkName {
-		return objects, nil
+	if !shouldExist {
+		if len(objects) > 0 {
+			return fmt.Errorf("found %d Linkerd PodSecurityPolicies", len(objects))
+		}
+		return nil
 	}
 
-	return objects, checkResources("PodSecurityPolicies", objects, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)})
+	return checkResources("PodSecurityPolicies", objects, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)})
 }
 
 func checkResources(resourceName string, objects []runtime.Object, expectedNames []string) error {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -890,10 +890,7 @@ func (hc *HealthChecker) PublicAPIClient() public.APIClient {
 
 func (hc *HealthChecker) checkLinkerdConfigConfigMap(shouldExist bool) error {
 	cm, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get(k8s.ConfigConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		if !shouldExist && kerrors.IsNotFound(err) {
-			return nil
-		}
+	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 
@@ -1075,9 +1072,9 @@ func checkResources(resourceName string, objects []runtime.Object, expectedNames
 				if err != nil {
 					return err
 				}
-				resources += fmt.Sprintf("- %s/%s\n", resourceName, m.GetName())
+				resources += fmt.Sprintf("%s ", m.GetName())
 			}
-			return fmt.Errorf("%s", resources)
+			return fmt.Errorf("%s found but should not exist: %s", resourceName, strings.TrimSpace(resources))
 		}
 		return nil
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1959,12 +1959,12 @@ metadata:
 		}
 
 		expected := []string{
-			"pre-linkerd-global-resources no ClusterRoles exist: - ClusterRoles/cluster-role\n",
-			"pre-linkerd-global-resources no ClusterRoleBindings exist: - ClusterRoleBindings/cluster-role-binding\n",
-			"pre-linkerd-global-resources no CustomResourceDefinitions exist: - CustomResourceDefinitions/custom-resource-definition\n",
-			"pre-linkerd-global-resources no MutatingWebhookConfigurations exist: - MutatingWebhookConfigurations/mutating-webhook-configuration\n",
-			"pre-linkerd-global-resources no ValidatingWebhookConfigurations exist: - ValidatingWebhookConfigurations/validating-webhook-configuration\n",
-			"pre-linkerd-global-resources no PodSecurityPolicies exist: - PodSecurityPolicies/pod-security-policy\n",
+			"pre-linkerd-global-resources no ClusterRoles exist: ClusterRoles found but should not exist: cluster-role",
+			"pre-linkerd-global-resources no ClusterRoleBindings exist: ClusterRoleBindings found but should not exist: cluster-role-binding",
+			"pre-linkerd-global-resources no CustomResourceDefinitions exist: CustomResourceDefinitions found but should not exist: custom-resource-definition",
+			"pre-linkerd-global-resources no MutatingWebhookConfigurations exist: MutatingWebhookConfigurations found but should not exist: mutating-webhook-configuration",
+			"pre-linkerd-global-resources no ValidatingWebhookConfigurations exist: ValidatingWebhookConfigurations found but should not exist: validating-webhook-configuration",
+			"pre-linkerd-global-resources no PodSecurityPolicies exist: PodSecurityPolicies found but should not exist: pod-security-policy",
 		}
 		if !reflect.DeepEqual(observer.results, expected) {
 			t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", expected, observer.results)

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -468,36 +468,48 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 			},
 			[]string{
@@ -518,72 +530,96 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -591,6 +627,8 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -598,6 +636,8 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -605,6 +645,8 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -612,6 +654,8 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -619,6 +663,8 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -626,6 +672,8 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -633,6 +681,8 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -640,6 +690,8 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 			},
 			[]string{
@@ -662,72 +714,96 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -735,6 +811,8 @@ apiVersion: v1
 metadata:
   name: linkerd-controller
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -742,6 +820,8 @@ apiVersion: v1
 metadata:
   name: linkerd-identity
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -749,6 +829,8 @@ apiVersion: v1
 metadata:
   name: linkerd-prometheus
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -756,6 +838,8 @@ apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -763,6 +847,8 @@ apiVersion: v1
 metadata:
   name: linkerd-sp-validator
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -770,6 +856,8 @@ apiVersion: v1
 metadata:
   name: linkerd-grafana
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -777,6 +865,8 @@ apiVersion: v1
 metadata:
   name: linkerd-web
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 kind: ServiceAccount
@@ -784,12 +874,16 @@ apiVersion: v1
 metadata:
   name: linkerd-tap
   namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
+  labels:
+    linkerd.io/control-plane-ns: test-ns
 `,
 			},
 			[]string{
@@ -798,6 +892,639 @@ metadata:
 				"linkerd-config control plane ClusterRoleBindings exist",
 				"linkerd-config control plane ServiceAccounts exist",
 				"linkerd-config control plane CustomResourceDefinitions exist",
+				"linkerd-config control plane MutatingWebhookConfigurations exist: missing MutatingWebhookConfigurations: linkerd-proxy-injector-webhook-config",
+			},
+		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-controller
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-identity
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-prometheus
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-tap
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceprofiles.linkerd.io
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: linkerd-proxy-injector-webhook-config
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist",
+				"linkerd-config control plane ServiceAccounts exist",
+				"linkerd-config control plane CustomResourceDefinitions exist",
+				"linkerd-config control plane MutatingWebhookConfigurations exist",
+				"linkerd-config control plane ValidatingWebhookConfigurations exist: missing ValidatingWebhookConfigurations: linkerd-sp-validator-webhook-config",
+			},
+		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-controller
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-identity
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-prometheus
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-tap
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceprofiles.linkerd.io
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: linkerd-proxy-injector-webhook-config
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: linkerd-sp-validator-webhook-config
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist",
+				"linkerd-config control plane ServiceAccounts exist",
+				"linkerd-config control plane CustomResourceDefinitions exist",
+				"linkerd-config control plane MutatingWebhookConfigurations exist",
+				"linkerd-config control plane ValidatingWebhookConfigurations exist",
+				"linkerd-config control plane PodSecurityPolicies exist: missing PodSecurityPolicies: linkerd-test-ns-control-plane",
+			},
+		},
+		{
+			[]string{`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-controller
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-identity
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-prometheus
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-proxy-injector
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-sp-validator
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-test-ns-tap
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-controller
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-identity
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-prometheus
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-sp-validator
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-grafana
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-web
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-tap
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceprofiles.linkerd.io
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: linkerd-proxy-injector-webhook-config
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: linkerd-sp-validator-webhook-config
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: linkerd-test-ns-control-plane
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+			},
+			[]string{
+				"linkerd-config control plane Namespace exists",
+				"linkerd-config control plane ClusterRoles exist",
+				"linkerd-config control plane ClusterRoleBindings exist",
+				"linkerd-config control plane ServiceAccounts exist",
+				"linkerd-config control plane CustomResourceDefinitions exist",
+				"linkerd-config control plane MutatingWebhookConfigurations exist",
+				"linkerd-config control plane ValidatingWebhookConfigurations exist",
+				"linkerd-config control plane PodSecurityPolicies exist",
 			},
 		},
 	}
@@ -1117,6 +1844,194 @@ func TestValidateDataPlanePodReporting(t *testing.T) {
 		}
 		if err.Error() != "Data plane metrics not found for ns2/test2." {
 			t.Fatalf("Unexpected error message: %s", err.Error())
+		}
+	})
+}
+
+func TestLinkerdPreInstallGlobalResourcesChecks(t *testing.T) {
+	hc := NewHealthChecker(
+		[]CategoryID{LinkerdPreInstallGlobalResourcesChecks},
+		&Options{})
+
+	t.Run("global resources dont' exist", func(t *testing.T) {
+		var err error
+		hc.kubeAPI, err = k8s.NewFakeAPI()
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		observer := newObserver()
+		if !hc.RunChecks(observer.resultFn) {
+			t.Errorf("Expect RunChecks to return true")
+		}
+
+		expected := []string{
+			"pre-linkerd-global-resources no ClusterRoles exist",
+			"pre-linkerd-global-resources no ClusterRoleBindings exist",
+			"pre-linkerd-global-resources no CustomResourceDefinitions exist",
+			"pre-linkerd-global-resources no MutatingWebhookConfigurations exist",
+			"pre-linkerd-global-resources no ValidatingWebhookConfigurations exist",
+			"pre-linkerd-global-resources no PodSecurityPolicies exist",
+		}
+		if !reflect.DeepEqual(observer.results, expected) {
+			t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", expected, observer.results)
+		}
+	})
+
+	t.Run("global resources exist", func(t *testing.T) {
+		resources := []string{
+			`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+			`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+			`apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: custom-resource-definition
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+			`apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+			`apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+			`apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: pod-security-policy
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+		}
+
+		var err error
+		hc.kubeAPI, err = k8s.NewFakeAPI(resources...)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		observer := newObserver()
+		if hc.RunChecks(observer.resultFn) {
+			t.Errorf("Expect RunChecks to return false")
+		}
+
+		expected := []string{
+			"pre-linkerd-global-resources no ClusterRoles exist: found 1 Linkerd ClusterRoles",
+			"pre-linkerd-global-resources no ClusterRoleBindings exist: found 1 Linkerd ClusterRoleBindings",
+			"pre-linkerd-global-resources no CustomResourceDefinitions exist: found 1 Linkerd CustomResourceDefinitions",
+			"pre-linkerd-global-resources no MutatingWebhookConfigurations exist: found 1 Linkerd MutatingWebhookConfigurations",
+			"pre-linkerd-global-resources no ValidatingWebhookConfigurations exist: found 1 Linkerd ValidatingWebhookConfigurations",
+			"pre-linkerd-global-resources no PodSecurityPolicies exist: found 1 Linkerd PodSecurityPolicies",
+		}
+		if !reflect.DeepEqual(observer.results, expected) {
+			t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", expected, observer.results)
+		}
+	})
+}
+
+func TestLinkerdConfigNotExistsChecks(t *testing.T) {
+	hc := NewHealthChecker(
+		[]CategoryID{LinkerdConfigNotExistsChecks},
+		&Options{
+			ControlPlaneNamespace: "test-ns",
+		})
+
+	t.Run("namespace doesn't exist", func(t *testing.T) {
+		var err error
+		hc.kubeAPI, err = k8s.NewFakeAPI()
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+
+		observer := newObserver()
+		if hc.RunChecks(observer.resultFn) {
+			t.Errorf("Expect RunChecks to return false")
+		}
+
+		expected := []string{
+			"linkerd-config-config-map-not-exists control plane namespace exists: The \"test-ns\" namespace does not exist",
+		}
+		if !reflect.DeepEqual(observer.results, expected) {
+			t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", expected, observer.results)
+		}
+	})
+
+	t.Run("namespace exists", func(t *testing.T) {
+		var testCases = []struct {
+			testID       string
+			resources    []string
+			expected     []string
+			checksPassed bool
+		}{
+			{
+				testID: "'linkerd-config' config map does not exist",
+				resources: []string{
+					`apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns`,
+				},
+				expected: []string{
+					"linkerd-config-config-map-not-exists control plane namespace exists",
+					"linkerd-config-config-map-not-exists 'linkerd-config' config map does not exist",
+				},
+				checksPassed: true,
+			},
+			{
+				testID: "'linkerd-config' config map exists",
+				resources: []string{
+					`apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns`,
+					`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linkerd-config
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns`,
+				},
+				expected: []string{
+					"linkerd-config-config-map-not-exists control plane namespace exists",
+					"linkerd-config-config-map-not-exists 'linkerd-config' config map does not exist: found existing 'linkerd-config' config map",
+				},
+				checksPassed: false,
+			},
+		}
+
+		for _, testCase := range testCases {
+			testCase := testCase
+			t.Run(fmt.Sprint(testCase.testID), func(t *testing.T) {
+				var err error
+				hc.kubeAPI, err = k8s.NewFakeAPI(testCase.resources...)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+
+				observer := newObserver()
+				if hc.RunChecks(observer.resultFn) != testCase.checksPassed {
+					t.Errorf("Expect RunChecks to return %t", testCase.checksPassed)
+				}
+
+				if !reflect.DeepEqual(observer.results, testCase.expected) {
+					t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", testCase.expected, observer.results)
+				}
+			})
 		}
 	})
 }

--- a/test/testdata/check.config.golden
+++ b/test/testdata/check.config.golden
@@ -15,6 +15,9 @@ linkerd-config
 √ control plane ClusterRoleBindings exist
 √ control plane ServiceAccounts exist
 √ control plane CustomResourceDefinitions exist
+√ control plane MutatingWebhookConfigurations exist
+√ control plane ValidatingWebhookConfigurations exist
+√ control plane PodSecurityPolicies exist
 
 linkerd-version
 ---------------

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -15,9 +15,13 @@ linkerd-config
 √ control plane ClusterRoleBindings exist
 √ control plane ServiceAccounts exist
 √ control plane CustomResourceDefinitions exist
+√ control plane MutatingWebhookConfigurations exist
+√ control plane ValidatingWebhookConfigurations exist
+√ control plane PodSecurityPolicies exist
 
 linkerd-existence
 -----------------
+√ 'linkerd-config' config map exists
 √ control plane components ready
 √ no unschedulable pods
 √ controller pod is running

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -26,6 +26,15 @@ pre-kubernetes-capability
 -------------------------
 √ has NET_ADMIN capability
 
+pre-linkerd-global-resources
+----------------------------
+√ no ClusterRoles exist
+√ no ClusterRoleBindings exist
+√ no CustomResourceDefinitions exist
+√ no MutatingWebhookConfigurations exist
+√ no ValidatingWebhookConfigurations exist
+√ no PodSecurityPolicies exist
+
 linkerd-version
 ---------------
 √ can determine the latest version

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -15,9 +15,13 @@ linkerd-config
 √ control plane ClusterRoleBindings exist
 √ control plane ServiceAccounts exist
 √ control plane CustomResourceDefinitions exist
+√ control plane MutatingWebhookConfigurations exist
+√ control plane ValidatingWebhookConfigurations exist
+√ control plane PodSecurityPolicies exist
 
 linkerd-existence
 -----------------
+√ 'linkerd-config' config map exists
 √ control plane components ready
 √ no unschedulable pods
 √ controller pod is running


### PR DESCRIPTION
This PR introduces the following two new checks to `pkg/healthcheck/healthcheck.go`:

`LinkerdPreInstallGlobalResourcesChecks` which checks for the existence of Linkerd global resources when user runs `linkerd check --pre`. The check fails if any of the Linkerd cluster roles, cluster role bindings, mutating webhook configuration, validating webhook configuration, custom resource definition or pod security policy exist. This error will point to new troubleshooting documentation informing the user that multi control plane setup isn't supported.

`LinkerdConfigNotExistsChecks` which checks if the `linkerd-config` config map exists. The check fails if the config map already exists. This error will point to new troubleshooting documentation informing the user can't install a control plane in the specified namespace, unless overridden with the `--ignore-cluster` option.

The checks use the `linkerd.io/control-plane-ns` label to select the resources. See https://github.com/linkerd/linkerd2/pull/2971.

The following are updates to install and multi-stage install:

Previously, `linkerd install` checks for existence of the `linkerd-config` config map to determine if the control plane installation is permitted. This is now changed to check for the existence of global resources, to ensure user can't install the control plane into a different namespace.

Previously, `linkerd install control-plane` checks for the existence of the specified control plane namespace to determine if `linkerd install config` has already been run. This is now changed to check for the existence of global resources that are installed by `linkerd install config`.

Previously, the `linkerd install` code calls the Kubernetes API directly. This is now changed to delegate the API interaction to `pkg/healthcheck/healthcheck.go`.

Test cases can be found [here](https://gist.github.com/ihcsim/1747c05f43e455a4e8f807b6d1b25434).

Open questions:

* The usage of the `linkerd.io/control-plane-ns` label won't work if the existing control plane is of an older version, since the older global resources aren't labelled. Do we need to support this use case?

Fixes https://github.com/linkerd/linkerd2/issues/2954.
