### PR TITLE
linkerd inject from remote URL

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -56,8 +56,8 @@ sub-folders, or coming from stdin.`,
 		Example: `  # Inject all the deployments in the default namespace.
   kubectl get deploy -o yaml | linkerd inject - | kubectl apply -f -
 
-  # Download a resource and inject it through stdin.
-  curl http://url.to/yml | linkerd inject - | kubectl apply -f -
+  # Injecting a file from a remote URL
+  linkerd inject http://url.to/yml | kubectl apply -f -
 
   # Inject all the resources inside a folder and its sub-folders.
   linkerd inject <folder> | kubectl apply -f -`,

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -149,7 +148,7 @@ func read(path string) ([]io.Reader, error) {
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, errors.New(fmt.Sprintf("unable to read URL %q, server reported %s, status code=%d", path, resp.Status, resp.StatusCode))
+			return nil, fmt.Errorf("unable to read URL %q, server reported %s, status code=%d", path, resp.Status, resp.StatusCode)
 		}
 
 		// Save to a buffer, so that response can be closed here


### PR DESCRIPTION
Fixes #2983 

```
linkerd inject http://raw.githubusercontent.com/BuoyantIO/emojivoto/master/emojivoto-daemonset.yml --manual | kubectl apply -f -
```
Should work with this.

@olix0r @ihcsim 

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>