### PR TITLE
Add `namespace` to values returned by Edges API endpoint

### DIFF
--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	inboundIdentityQuery  = "count(response_total%s) by (%s, client_id)"
-	outboundIdentityQuery = "count(response_total%s) by (%s, dst_%s, server_id, no_tls_reason)"
+	inboundIdentityQuery  = "count(response_total%s) by (%s, client_id, namespace, no_tls_reason)"
+	outboundIdentityQuery = "count(response_total%s) by (%s, dst_%s, server_id, namespace, no_tls_reason)"
 )
 
 var formatMsg = map[string]string{
@@ -129,12 +129,14 @@ func processEdgeMetrics(inbound, outbound model.Vector, resourceType string) []*
 			}
 			edge := &pb.Edge{
 				Src: &pb.Resource{
-					Name: string(src[model.LabelName(resourceType)]),
-					Type: resourceType,
+					Namespace: string(src[model.LabelName("namespace")]),
+					Name:      string(src[model.LabelName(resourceType)]),
+					Type:      resourceType,
 				},
 				Dst: &pb.Resource{
-					Name: string(dst[model.LabelName(resourceType)]),
-					Type: resourceType,
+					Namespace: string(src[model.LabelName("namespace")]),
+					Name:      string(dst[model.LabelName(resourceType)]),
+					Type:      resourceType,
 				},
 				ClientId:      string(dst[model.LabelName("client_id")]),
 				ServerId:      string(src[model.LabelName("server_id")]),


### PR DESCRIPTION
This PR modifies the edges API endpoint so that the `namespace` for both SRC and DST is returned as requested in #2995. It also adds `no_tls_reason` to the `inbound` Prometheus query for future use.

This will not change behavior in the dashboard or CLI. There are no protobuf modifications.

To test easily:

1. Port forward Prometheus
```bash
kubectl -n linkerd port-forwd $(kubectl --namespace=linkerd get po --selector=linkerd.io/control-plane-component=prometheus -o jsonpath='{.items[*].metadata.name}') 9090:9090
```
2. Run the go server
```bash
go run controller/cmd/public-api/main.go --kubeconfig ~/.kube/config --prometheus-url http://localhost:9090 --log-level debug
```
3. With emojivoto installed, create a `main.go` file in `/linkerd2/` and run `go run main.go` - compare the results between `master` and this branch, should be identical except for the additional `namespace` values

```
package main

import (
	"context"
	"fmt"

	"github.com/linkerd/linkerd2/controller/api/public"
	pb "github.com/linkerd/linkerd2/controller/gen/public"
)

func main() {
	client, err := public.NewInternalClient("linkerd", "localhost:8085")
	if err != nil {
		panic(err)
	}

	rsp, err := client.Edges(context.Background(), &pb.EdgesRequest{
		Selector: &pb.ResourceSelection{
			Resource: &pb.Resource{
				Namespace: "emojivoto",
				Type:      "deployment",
			},
		},
	})
	if err != nil {
		panic(err)
	}

	fmt.Printf("%+v\n", rsp)
}

``` 