### PR TITLE
Introduce the linkerd.io/shared-component label

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -12,31 +12,31 @@ fi
 
 echo "cleaning up namespace [${linkerd_namespace}] in k8s-context [${k8s_context}] and associated test namespaces"
 
-if ! namespaces=$(kubectl --context=$k8s_context get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
+if ! namespaces=$(kubectl --context=$k8s_context get ns -l linkerd.io/shared-component -oname); then
   echo "no namespaces found for [$linkerd_namespace]" >&2
 fi
 
-if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -l linkerd.io/shared-component -oname); then
   echo "no clusterrolebindings found for [$linkerd_namespace]" >&2
 fi
 
-if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -l linkerd.io/shared-component -oname); then
   echo "no clusterroles found for [$linkerd_namespace]" >&2
 fi
 
-if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations  -l linkerd.io/shared-component -oname); then
   echo "no mutatingwebhookconfigurations found" >&2
 fi
 
-if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -l linkerd.io/shared-component -oname); then
   echo "no validatingwebhookconfigurations found" >&2
 fi
 
-if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
+if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -l linkerd.io/shared-component -oname); then
   echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
 fi
 
-if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/control-plane-ns -oname); then
+if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/shared-component -oname); then
   echo "no customresourcedefinitions found for [$linkerd_namespace]" >&2
 fi
 

--- a/chart/templates/config.yaml
+++ b/chart/templates/config.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:

--- a/chart/templates/controller-rbac.yaml
+++ b/chart/templates/controller-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -35,6 +36,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,4 +54,5 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{end -}}

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -31,6 +32,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -50,6 +52,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: controller
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/grafana-rbac.yaml
+++ b/chart/templates/grafana-rbac.yaml
@@ -12,4 +12,5 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: grafana
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{- end}}

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: grafana
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:
@@ -69,6 +70,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: grafana
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -88,6 +90,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: grafana
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/identity-rbac.yaml
+++ b/chart/templates/identity-rbac.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -24,6 +25,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -41,5 +43,6 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{end -}}
 {{end -}}

--- a/chart/templates/identity.yaml
+++ b/chart/templates/identity.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
     {{- if .Identity.Issuer.CrtExpiryAnnotation}}
@@ -32,6 +33,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -51,6 +53,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: identity
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -12,4 +12,5 @@ metadata:
     {{.ProxyInjectAnnotation}}: {{.ProxyInjectDisabled}}
   labels:
     {{.LinkerdNamespaceLabel}}: "true"
+    {{.SharedComponentLabel}}: "false"
 {{end -}}

--- a/chart/templates/prometheus-rbac.yaml
+++ b/chart/templates/prometheus-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -23,6 +24,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -40,4 +42,5 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{- end}}

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 data:
@@ -101,6 +102,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -120,6 +122,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: prometheus
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/proxy_injector-rbac.yaml
+++ b/chart/templates/proxy_injector-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -29,6 +30,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -47,6 +49,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -54,8 +57,9 @@ metadata:
   name: linkerd-proxy-injector-tls
   namespace: {{ .Namespace }}
   labels:
-    {{ .ControllerComponentLabel }}: proxy-injector
+    {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{ .CreatedByAnnotation }}: {{ .CliVersion }}
 type: Opaque
@@ -68,8 +72,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
-    {{ .ControllerComponentLabel }}: proxy-injector
+    {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -76,6 +77,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: proxy-injector
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/psp.yaml
+++ b/chart/templates/psp.yaml
@@ -10,6 +10,7 @@ metadata:
   name: linkerd-{{.Namespace}}-control-plane
   labels:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -52,6 +53,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -66,6 +68,7 @@ metadata:
   namespace: {{.Namespace}}
   labels:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/chart/templates/serviceprofile-crd.yaml
+++ b/chart/templates/serviceprofile-crd.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "true"
 spec:
   group: linkerd.io
   version: v1alpha1

--- a/chart/templates/sp_validator-rbac.yaml
+++ b/chart/templates/sp_validator-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -23,6 +24,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -41,6 +43,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -50,6 +53,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{ .CreatedByAnnotation }}: {{ .CliVersion }}
 type: Opaque
@@ -64,6 +68,7 @@ metadata:
   labels:
     {{ .ControllerComponentLabel }}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:

--- a/chart/templates/sp_validator.yaml
+++ b/chart/templates/sp_validator.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -31,6 +32,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: sp-validator
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/tap-rbac.yaml
+++ b/chart/templates/tap-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -29,6 +30,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -46,4 +48,5 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{end -}}

--- a/chart/templates/tap.yaml
+++ b/chart/templates/tap.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -31,6 +32,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/chart/templates/trafficsplit-crd.yaml
+++ b/chart/templates/trafficsplit-crd.yaml
@@ -11,6 +11,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
+  labels:
+    {{.SharedComponentLabel}}: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/chart/templates/web-rbac.yaml
+++ b/chart/templates/web-rbac.yaml
@@ -12,4 +12,5 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: web
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
 {{- end}}

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: web
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
@@ -34,6 +35,7 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: web
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.SharedComponentLabel}}: "false"
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -50,6 +50,7 @@ type (
 		PrometheusLogLevel       string
 		ControllerComponentLabel string
 		ControllerNamespaceLabel string
+		SharedComponentLabel     string
 		CreatedByAnnotation      string
 		ProxyContainerName       string
 		ProxyInjectAnnotation    string
@@ -585,6 +586,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		CliVersion:               k8s.CreatedByAnnotationValue(),
 		ControllerComponentLabel: k8s.ControllerComponentLabel,
 		ControllerNamespaceLabel: k8s.ControllerNSLabel,
+		SharedComponentLabel:     k8s.SharedComponentLabel,
 		ProxyContainerName:       k8s.ProxyContainerName,
 		ProxyInjectAnnotation:    k8s.ProxyInjectAnnotation,
 		ProxyInjectDisabled:      k8s.ProxyInjectDisabled,

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -164,7 +164,7 @@ const (
 	defaultIdentityIssuanceLifetime   = 24 * time.Hour
 	defaultIdentityClockSkewAllowance = 20 * time.Second
 
-	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
+	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\n\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
 	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
 	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
@@ -872,7 +872,7 @@ func errIfGlobalResourcesExist() error {
 	})
 
 	if len(errMsgs) > 0 {
-		return errors.New(strings.Join(errMsgs, ","))
+		return errors.New(strings.Join(errMsgs, "\n"))
 	}
 
 	return nil

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -46,6 +46,7 @@ func TestRender(t *testing.T) {
 		PrometheusLogLevel:       "PrometheusLogLevel",
 		ControllerComponentLabel: "ControllerComponentLabel",
 		ControllerNamespaceLabel: "ControllerNamespaceLabel",
+		SharedComponentLabel:     "SharedComponentLabel",
 		CreatedByAnnotation:      "CreatedByAnnotation",
 		ProxyContainerName:       "ProxyContainerName",
 		ProxyInjectAnnotation:    "ProxyInjectAnnotation",

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -7,6 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -29,6 +30,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -44,6 +46,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -64,6 +67,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -253,6 +257,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -272,6 +277,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -292,6 +298,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -509,6 +516,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -532,6 +540,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -718,6 +727,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -807,6 +817,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -827,6 +838,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1020,6 +1032,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1077,6 +1090,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1097,6 +1111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1291,6 +1306,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1480,6 +1496,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1503,6 +1520,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1523,6 +1541,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -1711,6 +1730,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1731,6 +1751,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -872,6 +904,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -891,6 +924,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -911,6 +945,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1128,6 +1163,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1151,6 +1187,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1337,6 +1374,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1426,6 +1464,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1446,6 +1485,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1639,6 +1679,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1696,6 +1737,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1716,6 +1758,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1910,6 +1953,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2099,6 +2143,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2122,6 +2167,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2142,6 +2188,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2330,6 +2377,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2350,6 +2398,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -878,6 +910,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -897,6 +930,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -917,6 +951,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1143,6 +1178,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1166,6 +1202,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1358,6 +1395,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1447,6 +1485,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1467,6 +1506,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1666,6 +1706,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1723,6 +1764,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1743,6 +1785,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1943,6 +1986,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2138,6 +2182,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2161,6 +2206,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2181,6 +2227,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2375,6 +2422,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2395,6 +2443,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -878,6 +910,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -897,6 +930,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -917,6 +951,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1143,6 +1178,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1166,6 +1202,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1358,6 +1395,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1447,6 +1485,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1467,6 +1506,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1666,6 +1706,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1723,6 +1764,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1743,6 +1785,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1943,6 +1986,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2138,6 +2182,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2161,6 +2206,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2181,6 +2227,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2375,6 +2422,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2395,6 +2443,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -571,6 +597,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -585,6 +612,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -623,6 +651,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -645,6 +674,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -660,6 +690,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -680,6 +711,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -836,6 +868,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -855,6 +888,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -875,6 +909,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1059,6 +1094,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1082,6 +1118,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1235,6 +1272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1324,6 +1362,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1344,6 +1383,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1504,6 +1544,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1561,6 +1602,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1581,6 +1623,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1742,6 +1785,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -1898,6 +1942,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1921,6 +1966,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1941,6 +1987,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2096,6 +2143,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2116,6 +2164,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -11,6 +11,7 @@ metadata:
     ProxyInjectAnnotation: ProxyInjectDisabled
   labels:
     LinkerdNamespaceLabel: "true"
+    SharedComponentLabel: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     ControllerComponentLabel: web
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     CreatedByAnnotation: CliVersion
   labels:
-    ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     ControllerComponentLabel: grafana
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-Namespace-control-plane
   labels:
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: Namespace
   labels:
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
     linkerd.io/identity-issuer-expiry: 2029-02-28T02:03:52Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     ControllerComponentLabel: identity
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-identity
   namespace: Namespace
 spec:
@@ -837,6 +869,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -856,6 +889,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -876,6 +910,7 @@ metadata:
   labels:
     ControllerComponentLabel: controller
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-controller
   namespace: Namespace
 spec:
@@ -1058,6 +1093,7 @@ metadata:
   labels:
     ControllerComponentLabel: web
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1081,6 +1117,7 @@ metadata:
   labels:
     ControllerComponentLabel: web
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-web
   namespace: Namespace
 spec:
@@ -1232,6 +1269,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -1321,6 +1359,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1341,6 +1380,7 @@ metadata:
   labels:
     ControllerComponentLabel: prometheus
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-prometheus
   namespace: Namespace
 spec:
@@ -1499,6 +1539,7 @@ metadata:
   labels:
     ControllerComponentLabel: grafana
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 data:
@@ -1556,6 +1597,7 @@ metadata:
   labels:
     ControllerComponentLabel: grafana
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1576,6 +1618,7 @@ metadata:
   labels:
     ControllerComponentLabel: grafana
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-grafana
   namespace: Namespace
 spec:
@@ -1735,6 +1778,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-proxy-injector
   namespace: Namespace
 spec:
@@ -1889,6 +1933,7 @@ metadata:
   labels:
     ControllerComponentLabel: proxy-injector
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1912,6 +1957,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -1932,6 +1978,7 @@ metadata:
   labels:
     ControllerComponentLabel: sp-validator
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-sp-validator
   namespace: Namespace
 spec:
@@ -2085,6 +2132,7 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   annotations:
     CreatedByAnnotation: CliVersion
 spec:
@@ -2105,6 +2153,7 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+    SharedComponentLabel: "false"
   name: linkerd-tap
   namespace: Namespace
 spec:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     CreatedByAnnotation: CliVersion
+  labels:
+    SharedComponentLabel: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2020-04-03T23:53:57Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -873,6 +905,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -892,6 +925,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -912,6 +946,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1130,6 +1165,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1153,6 +1189,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1340,6 +1377,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1429,6 +1467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1449,6 +1488,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1643,6 +1683,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1700,6 +1741,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1720,6 +1762,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1915,6 +1958,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2105,6 +2149,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2128,6 +2173,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2148,6 +2194,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2337,6 +2384,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2357,6 +2405,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -245,6 +245,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/shared-component: "true"
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -11,6 +11,7 @@ metadata:
     linkerd.io/inject: disabled
   labels:
     linkerd.io/is-control-plane: "true"
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Identity Controller Service RBAC
@@ -23,6 +24,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -35,6 +37,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +55,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Controller RBAC
@@ -64,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -88,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -105,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Web RBAC
@@ -118,6 +125,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Service Profile CRD
@@ -130,7 +138,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "true"
 spec:
   group: linkerd.io
   version: v1alpha1
@@ -264,6 +272,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -276,6 +285,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -293,6 +303,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Grafana RBAC
@@ -306,6 +317,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Proxy Injector RBAC
@@ -318,6 +330,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -336,6 +349,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -354,6 +368,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -363,6 +378,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -377,6 +393,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -408,6 +425,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -420,6 +438,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
@@ -438,6 +457,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 kind: Secret
 apiVersion: v1
@@ -447,6 +467,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 type: Opaque
@@ -461,6 +482,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   clientConfig:
@@ -488,6 +510,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces"]
@@ -506,6 +529,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,6 +547,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 ---
 ###
 ### Control Plane PSP
@@ -534,6 +559,7 @@ metadata:
   name: linkerd-linkerd-control-plane
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -574,6 +600,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -588,6 +615,7 @@ metadata:
   namespace: linkerd
   labels:
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -626,6 +654,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -648,6 +677,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/identity-issuer-expiry: 2020-04-03T23:53:57Z
@@ -663,6 +693,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -683,6 +714,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-identity
   namespace: linkerd
 spec:
@@ -879,6 +911,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -898,6 +931,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -918,6 +952,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-controller
   namespace: linkerd
 spec:
@@ -1145,6 +1180,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1168,6 +1204,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: web
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-web
   namespace: linkerd
 spec:
@@ -1361,6 +1398,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1450,6 +1488,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1470,6 +1509,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: prometheus
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-prometheus
   namespace: linkerd
 spec:
@@ -1670,6 +1710,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
@@ -1727,6 +1768,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -1747,6 +1789,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: grafana
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-grafana
   namespace: linkerd
 spec:
@@ -1948,6 +1991,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-proxy-injector
   namespace: linkerd
 spec:
@@ -2144,6 +2188,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2167,6 +2212,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2187,6 +2233,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: sp-validator
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-sp-validator
   namespace: linkerd
 spec:
@@ -2382,6 +2429,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
@@ -2402,6 +2450,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+    linkerd.io/shared-component: "false"
   name: linkerd-tap
   namespace: linkerd
 spec:

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -939,7 +939,7 @@ func expectedServiceAccountNames() []string {
 
 func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	crList, err := hc.kubeAPI.RbacV1().ClusterRoles().List(options)
 	if err != nil {
@@ -957,7 +957,7 @@ func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
 
 func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	crbList, err := hc.kubeAPI.RbacV1().ClusterRoleBindings().List(options)
 	if err != nil {
@@ -975,7 +975,7 @@ func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 
 func (hc *HealthChecker) checkServiceAccounts(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	saList, err := hc.kubeAPI.CoreV1().ServiceAccounts(hc.ControlPlaneNamespace).List(options)
 	if err != nil {
@@ -993,7 +993,7 @@ func (hc *HealthChecker) checkServiceAccounts(shouldExist bool) error {
 
 func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	crdList, err := hc.kubeAPI.Apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
 	if err != nil {
@@ -1011,7 +1011,7 @@ func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error 
 
 func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	mwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(options)
 	if err != nil {
@@ -1029,7 +1029,7 @@ func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) er
 
 func (hc *HealthChecker) checkValidatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	vwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(options)
 	if err != nil {
@@ -1047,7 +1047,7 @@ func (hc *HealthChecker) checkValidatingWebhookConfigurations(shouldExist bool) 
 
 func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: k8s.SharedComponentLabel,
 	}
 	psp, err := hc.kubeAPI.PolicyV1beta1().PodSecurityPolicies().List(options)
 	if err != nil {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -469,7 +469,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -477,7 +477,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -485,7 +485,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -493,7 +493,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -501,7 +501,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -509,7 +509,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -531,7 +531,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -539,7 +539,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -547,7 +547,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -555,7 +555,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -563,7 +563,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -571,7 +571,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -579,7 +579,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -587,7 +587,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -595,7 +595,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -603,7 +603,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -611,7 +611,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -619,7 +619,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -628,7 +628,7 @@ metadata:
   name: linkerd-controller
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -637,7 +637,7 @@ metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -646,7 +646,7 @@ metadata:
   name: linkerd-prometheus
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -655,7 +655,7 @@ metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -664,7 +664,7 @@ metadata:
   name: linkerd-sp-validator
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -673,7 +673,7 @@ metadata:
   name: linkerd-grafana
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -682,7 +682,7 @@ metadata:
   name: linkerd-web
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -691,7 +691,7 @@ metadata:
   name: linkerd-tap
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -715,7 +715,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -723,7 +723,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -731,7 +731,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -739,7 +739,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -747,7 +747,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -755,7 +755,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -763,7 +763,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -771,7 +771,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -779,7 +779,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -787,7 +787,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -795,7 +795,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -803,7 +803,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -812,7 +812,7 @@ metadata:
   name: linkerd-controller
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -821,7 +821,7 @@ metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -830,7 +830,7 @@ metadata:
   name: linkerd-prometheus
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -839,7 +839,7 @@ metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -848,7 +848,7 @@ metadata:
   name: linkerd-sp-validator
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -857,7 +857,7 @@ metadata:
   name: linkerd-grafana
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -866,7 +866,7 @@ metadata:
   name: linkerd-web
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -875,7 +875,7 @@ metadata:
   name: linkerd-tap
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -883,7 +883,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -908,7 +908,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -916,7 +916,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -924,7 +924,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -932,7 +932,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -940,7 +940,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -948,7 +948,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -956,7 +956,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -964,7 +964,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -972,7 +972,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -980,7 +980,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -988,7 +988,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -996,7 +996,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1005,7 +1005,7 @@ metadata:
   name: linkerd-controller
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1014,7 +1014,7 @@ metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1023,7 +1023,7 @@ metadata:
   name: linkerd-prometheus
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1032,7 +1032,7 @@ metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1041,7 +1041,7 @@ metadata:
   name: linkerd-sp-validator
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1050,7 +1050,7 @@ metadata:
   name: linkerd-grafana
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1059,7 +1059,7 @@ metadata:
   name: linkerd-web
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1068,7 +1068,7 @@ metadata:
   name: linkerd-tap
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1076,7 +1076,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1084,7 +1084,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -1110,7 +1110,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1118,7 +1118,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1126,7 +1126,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1134,7 +1134,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1142,7 +1142,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1150,7 +1150,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1158,7 +1158,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1166,7 +1166,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1174,7 +1174,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1182,7 +1182,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1190,7 +1190,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1198,7 +1198,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1207,7 +1207,7 @@ metadata:
   name: linkerd-controller
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1216,7 +1216,7 @@ metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1225,7 +1225,7 @@ metadata:
   name: linkerd-prometheus
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1234,7 +1234,7 @@ metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1243,7 +1243,7 @@ metadata:
   name: linkerd-sp-validator
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1252,7 +1252,7 @@ metadata:
   name: linkerd-grafana
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1261,7 +1261,7 @@ metadata:
   name: linkerd-web
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1270,7 +1270,7 @@ metadata:
   name: linkerd-tap
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1278,7 +1278,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1286,7 +1286,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1294,7 +1294,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -1321,7 +1321,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1329,7 +1329,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1337,7 +1337,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1345,7 +1345,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1353,7 +1353,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRole
@@ -1361,7 +1361,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1369,7 +1369,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-controller
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1377,7 +1377,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-identity
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1385,7 +1385,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-prometheus
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1393,7 +1393,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-proxy-injector
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1401,7 +1401,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-sp-validator
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ClusterRoleBinding
@@ -1409,7 +1409,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-test-ns-tap
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1418,7 +1418,7 @@ metadata:
   name: linkerd-controller
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1427,7 +1427,7 @@ metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1436,7 +1436,7 @@ metadata:
   name: linkerd-prometheus
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1445,7 +1445,7 @@ metadata:
   name: linkerd-proxy-injector
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1454,7 +1454,7 @@ metadata:
   name: linkerd-sp-validator
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1463,7 +1463,7 @@ metadata:
   name: linkerd-grafana
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1472,7 +1472,7 @@ metadata:
   name: linkerd-web
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 kind: ServiceAccount
@@ -1481,7 +1481,7 @@ metadata:
   name: linkerd-tap
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1489,7 +1489,7 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1497,7 +1497,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -1505,7 +1505,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 				`
 apiVersion: policy/v1beta1
@@ -1513,7 +1513,7 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-test-ns-control-plane
   labels:
-    linkerd.io/control-plane-ns: test-ns
+    linkerd.io/shared-component: "false"
 `,
 			},
 			[]string{
@@ -1914,37 +1914,37 @@ kind: ClusterRole
 metadata:
   name: cluster-role
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-role-binding
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 			`apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: custom-resource-definition
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 			`apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 			`apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 			`apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: pod-security-policy
   labels:
-    linkerd.io/control-plane-ns: test-ns`,
+    linkerd.io/shared-component: "false"`,
 		}
 
 		var err error

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -31,12 +31,13 @@ const (
 	ControllerComponentLabel = Prefix + "/control-plane-component"
 
 	// SharedComponentLabel is used to identify if a resource is a shared global
-	// resource e.g. CRD and PSP. All Linkerd resources should have this label.
+	// resource e.g. CRD. All Linkerd resources should have this label with its value
+	// set to either 'true' or 'false'.
 	SharedComponentLabel = Prefix + "/shared-component"
 
 	// ControllerNSLabel is injected into mesh-enabled apps, identifying the
-	// namespace of the Linkerd control plane. All non-shared resources should
-	// have this label.
+	// namespace of the Linkerd control plane. In addition to linkerd.io/shared-component,
+	// all non-shared resources should have this label.
 	ControllerNSLabel = Prefix + "/control-plane-ns"
 
 	// ProxyDeploymentLabel is injected into mesh-enabled apps, identifying the

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -30,8 +30,13 @@ const (
 	// control plane (e.g. web, controller).
 	ControllerComponentLabel = Prefix + "/control-plane-component"
 
+	// SharedComponentLabel is used to identify if a resource is a shared global
+	// resource e.g. CRD and PSP. All Linkerd resources should have this label.
+	SharedComponentLabel = Prefix + "/shared-component"
+
 	// ControllerNSLabel is injected into mesh-enabled apps, identifying the
-	// namespace of the Linkerd control plane.
+	// namespace of the Linkerd control plane. All non-shared resources should
+	// have this label.
 	ControllerNSLabel = Prefix + "/control-plane-ns"
 
 	// ProxyDeploymentLabel is injected into mesh-enabled apps, identifying the


### PR DESCRIPTION
Following https://github.com/linkerd/linkerd2/issues/2376#issuecomment-506793743, this PR introduces a new label named, `linkerd.io/shared-component`, which can be used to retrieve all Linkerd shared and non-shared global resources, as well as namespace-scoped resources. The reason why this is a better choice than `linkerd.io/control-plane-ns` is because it doesn't imply the namespace served by shared global resources like CRDs.

`linkerd check --pre` is also updated to use this label to check for existence of global resources.

```
k -n linkerd get all,configmap,secret,sa,psp,crd,clusterrole,clusterrolebinding,role,rolebinding,mutatingwebhookconfiguration,validatingwebhookconfiguration -l linkerd.io/shared-component -L linkerd.io/shared-component
NAME                             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE     SHARED-COMPONENT
service/linkerd-controller-api   ClusterIP   10.99.251.216    <none>        8085/TCP            6m48s   false
service/linkerd-destination      ClusterIP   10.104.177.185   <none>        8086/TCP            6m48s   false
service/linkerd-grafana          ClusterIP   10.98.137.78     <none>        3000/TCP            6m48s   false
service/linkerd-identity         ClusterIP   10.108.195.71    <none>        8080/TCP            6m48s   false
service/linkerd-prometheus       ClusterIP   10.110.243.151   <none>        9090/TCP            6m48s   false
service/linkerd-proxy-injector   ClusterIP   10.101.199.147   <none>        443/TCP             6m48s   false
service/linkerd-sp-validator     ClusterIP   10.99.240.44     <none>        443/TCP             6m47s   false
service/linkerd-tap              ClusterIP   10.98.184.220    <none>        8088/TCP            6m47s   false
service/linkerd-web              ClusterIP   10.100.112.100   <none>        8084/TCP,9994/TCP   6m48s   false

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE     SHARED-COMPONENT
deployment.apps/linkerd-controller       1/1     1            1           6m48s   false
deployment.apps/linkerd-grafana          1/1     1            1           6m48s   false
deployment.apps/linkerd-identity         1/1     1            1           6m48s   false
deployment.apps/linkerd-prometheus       1/1     1            1           6m48s   false
deployment.apps/linkerd-proxy-injector   1/1     1            1           6m48s   false
deployment.apps/linkerd-sp-validator     1/1     1            1           6m47s   false
deployment.apps/linkerd-tap              1/1     1            1           6m47s   false
deployment.apps/linkerd-web              1/1     1            1           6m48s   false

NAME                                  DATA   AGE     SHARED-COMPONENT
configmap/linkerd-config              3      6m48s   false
configmap/linkerd-grafana-config      3      6m48s   false
configmap/linkerd-prometheus-config   1      6m48s   false

NAME                                TYPE     DATA   AGE     SHARED-COMPONENT
secret/linkerd-identity-issuer      Opaque   2      6m48s   false
secret/linkerd-proxy-injector-tls   Opaque   2      6m49s   false
secret/linkerd-sp-validator-tls     Opaque   2      6m48s   false

NAME                                    SECRETS   AGE     SHARED-COMPONENT
serviceaccount/linkerd-controller       1         6m49s   false
serviceaccount/linkerd-grafana          1         6m49s   false
serviceaccount/linkerd-identity         1         6m49s   false
serviceaccount/linkerd-prometheus       1         6m49s   false
serviceaccount/linkerd-proxy-injector   1         6m49s   false
serviceaccount/linkerd-sp-validator     1         6m49s   false
serviceaccount/linkerd-tap              1         6m48s   false
serviceaccount/linkerd-web              1         6m49s   false

NAME                                                         PRIV    CAPS                SELINUX    RUNASUSER   FSGROUP     SUPGROUP    READONLYROOTFS   VOLUMES                                                                 SHARED-COMPONENT
podsecuritypolicy.extensions/linkerd-linkerd-control-plane   false   NET_ADMIN,NET_RAW   RunAsAny   RunAsAny    MustRunAs   MustRunAs   true             configMap,emptyDir,secret,projected,downwardAPI,persistentVolumeClaim   false

NAME                                                                       CREATED AT             SHARED-COMPONENT
customresourcedefinition.apiextensions.k8s.io/serviceprofiles.linkerd.io   2019-06-28T18:48:35Z   true

NAME                                                                   AGE     SHARED-COMPONENT
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-controller       6m48s   false
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-identity         6m48s   false
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-prometheus       6m48s   false
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-proxy-injector   6m48s   false
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-sp-validator     6m48s   false
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-tap              6m47s   false

NAME                                                                          AGE     SHARED-COMPONENT
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-controller       6m48s   false
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-identity         6m48s   false
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-prometheus       6m48s   false
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-proxy-injector   6m48s   false
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-sp-validator     6m48s   false
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-tap              6m47s   false

NAME                                         AGE     SHARED-COMPONENT
role.rbac.authorization.k8s.io/linkerd-psp   6m47s   false

NAME                                                AGE     SHARED-COMPONENT
rolebinding.rbac.authorization.k8s.io/linkerd-psp   6m47s   false

NAME                                                                                              CREATED AT             SHARED-COMPONENT
mutatingwebhookconfiguration.admissionregistration.k8s.io/linkerd-proxy-injector-webhook-config   2019-06-28T18:48:35Z   false

NAME                                                                                              CREATED AT             SHARED-COMPONENT
validatingwebhookconfiguration.admissionregistration.k8s.io/linkerd-sp-validator-webhook-config   2019-06-28T18:48:36Z   false
```