### PR TITLE
edge-19.6.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## edge-19.6.4
 
 This release adds support for the SMI [Traffic Split](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
-API.  Creating a TrafficSplit resource will cause Linkerd to split traffic
-between the specified backend services.  Please see [the spec](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
+API. Creating a TrafficSplit resource will cause Linkerd to split traffic
+between the specified backend services. Please see [the spec](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
 for more details.
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ for more details.
     into different namespaces
   * Added support for passing a URL directly to `linkerd inject` (thanks
     @Pothulapati!)
-  * Added a `--all-namespaces` flag to `linkerd edges`
+  * Added the `--all-namespaces` flag to `linkerd edges`
 * Controller
   * Added support for the SMI TrafficSplit API which allows users to define
     traffic splits in TrafficSplit custom resources

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,14 @@ between the specified backend services.  Please see [the spec](https://github.co
 for more details.
 
 * CLI
-  * Added a check to install to prevent installing multiple control planes into
-    different namespaces
-  * Added support for passing a URL directly to linkerd inject
+  * Added a check to `install` to prevent installing multiple control planes
+    into different namespaces
+  * Added support for passing a URL directly to `linkerd inject` (thanks
+    @Pothulapati!)
   * Added a `--all-namespaces` flag to `linkerd edges`
 * Controller
   * Added support for the SMI TrafficSplit API which allows users to define
     traffic splits in TrafficSplit custom resources
-* Proxy
 * Web UI
   * Improved UI for Edges table in dashboard by changing column names, adding a
     "Secured" icon and showing an empty Edges table in the case of no returned

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## edge-19.6.4
+
+This release adds support for the SMI [Traffic Split](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
+API.  Creating a TrafficSplit resource will cause Linkerd to split traffic
+between the specified backend services.  Please see [the spec](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
+for more details.
+
+* CLI
+  * Added a check to install to prevent installing multiple control planes into
+    different namespaces
+  * Added support for passing a URL directly to linkerd inject
+  * Added a `--all-namespaces` flag to `linkerd edges`
+* Controller
+  * Added support for the SMI TrafficSplit API which allows users to define
+    traffic splits in TrafficSplit custom resources
+* Proxy
+* Web UI
+  * Improved UI for Edges table in dashboard by changing column names, adding a
+    "Secured" icon and showing an empty Edges table in the case of no returned
+    edges
+
 ## edge-19.6.3
 
 * CLI


### PR DESCRIPTION
## edge-19.6.4

This release adds support for the SMI [Traffic Split](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md) API.  Creating a TrafficSplit resource will cause Linkerd to
split traffic between the specified backend services.  Please see [the spec](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
for more details.

* CLI
  * Added a check to install to prevent installing multiple control planes into
    different namespaces
  * Added support for passing a URL directly to linkerd inject
  * Added a `--all-namespaces` flag to `linkerd edges`
* Controller
  * Added support for the SMI TrafficSplit API which allows users to define
    traffic splits in TrafficSplit custom resources
* Proxy
* Web UI
  * Improved UI for Edges table in dashboard by changing column names, adding a
    "Secured" icon and showing an empty Edges table in the case of no returned
    edges

Signed-off-by: Alex Leong <alex@buoyant.io>