### PR TITLE
Rename debug annotation to enable-debug-sidecar

### DIFF
--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.linkerd.io/debug: "true"
+        config.linkerd.io/enable-debug-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -167,7 +167,7 @@ const (
 
 	// ProxyEnableDebugAnnotation is set to true if the debug container is
 	// injected.
-	ProxyEnableDebugAnnotation = ProxyConfigAnnotationsPrefix + "/debug"
+	ProxyEnableDebugAnnotation = ProxyConfigAnnotationsPrefix + "/enable-debug-sidecar"
 
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.


### PR DESCRIPTION
Linkerd's CLI flags all match 1:1 with their `config.linkerd.io/*`
annotation counterparts, except `--enable-debug-sidecar`, which
corresponded to `config.linkerd.io/debug`. Additionally, the Linkerd
docs assume this 1:1 mapping.

Rename the `config.linkerd.io/debug` annotation to
`config.linkerd.io/enable-debug-sidecar`.

Relates to https://github.com/linkerd/website/issues/381

Signed-off-by: Andrew Seigner <siggy@buoyant.io>