### PR TITLE
Make ReplicaSet check more explicit.

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -502,8 +502,8 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
-					description: "control plane components ready",
-					hintAnchor:  "l5d-existence-psp", // needs https://github.com/linkerd/website/issues/272
+					description: "control plane replica sets are ready",
+					hintAnchor:  "l5d-existence-replicasets",
 					fatal:       true,
 					check: func(context.Context) error {
 						controlPlaneReplicaSet, err := hc.kubeAPI.GetReplicaSets(hc.ControlPlaneNamespace)
@@ -515,7 +515,7 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 				{
 					description: "no unschedulable pods",
-					hintAnchor:  "l5d-existence-unschedulable-pods", // needs https://github.com/linkerd/website/issues/272
+					hintAnchor:  "l5d-existence-unschedulable-pods",
 					fatal:       true,
 					check: func(context.Context) error {
 						// do not save this into hc.controlPlanePods, as this check may

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -22,7 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
-√ control plane components ready
+√ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
 √ can initialize the client

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -22,7 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
-√ control plane components ready
+√ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
 √ can initialize the client


### PR DESCRIPTION
The `linkerd check` for healthy ReplicaSets had a generic
`control plane components ready` description, and a hint anchor to
`l5d-existence-psp`. While a ReplicaSet failure could definitely occur
due to psp, that hintAnchor was already in use by the "control plane
PodSecurityPolicies exist" check.

Rename the `control plane components ready` check to
`control plane replica sets are ready`, and the hintAnchor from
`l5d-existence-psp` to `l5d-existence-replicasets`.

Relates to https://github.com/linkerd/website/issues/372.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>