### PR TITLE
Add prometheus metrics for watchers

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -11,7 +11,7 @@ RUN (proxy=$(bin/fetch-proxy $PROXY_VERSION) && \
     echo "$version" >version.txt)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:7ac58ac0 as golang
+FROM gcr.io/linkerd-io/go-deps:4c8f4294 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 ENV CGO_ENABLED=0 GOOS=linux
 COPY pkg/flags pkg/flags

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -574,6 +574,7 @@
     "api/prometheus/v1",
     "prometheus",
     "prometheus/internal",
+    "prometheus/promauto",
     "prometheus/promhttp",
   ]
   pruneopts = ""
@@ -1323,6 +1324,7 @@
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/common/model",
     "github.com/sergi/go-diff/diffmatchpatch",

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:7ac58ac0 as golang
+FROM gcr.io/linkerd-io/go-deps:4c8f4294 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY cli cli
 COPY chart chart

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:7ac58ac0 as golang
+FROM gcr.io/linkerd-io/go-deps:4c8f4294 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:7ac58ac0 as golang
+FROM gcr.io/linkerd-io/go-deps:4c8f4294 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -2,9 +2,11 @@ package watcher
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
 	logging "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +71,7 @@ type (
 		exists    bool
 		pods      PodSet
 		listeners []EndpointUpdateListener
+		metrics   endpointsMetrics
 	}
 
 	// EndpointUpdateListener is the interface that subscribers must implement.
@@ -78,6 +81,8 @@ type (
 		NoEndpoints(exists bool)
 	}
 )
+
+var endpointsVecs = newEndpointsMetricsVecs()
 
 // NewEndpointsWatcher creates an EndpointsWatcher and begins watching the
 // k8sAPI for pod, service, and endpoint changes.
@@ -292,8 +297,6 @@ func (sp *servicePublisher) subscribe(srcPort Port, listener EndpointUpdateListe
 	port.subscribe(listener)
 }
 
-// unsubscribe returns true iff the listener was found and removed.
-// it also returns the number of listeners remaining after unsubscribing.
 func (sp *servicePublisher) unsubscribe(srcPort Port, listener EndpointUpdateListener) {
 	sp.Lock()
 	defer sp.Unlock()
@@ -301,6 +304,10 @@ func (sp *servicePublisher) unsubscribe(srcPort Port, listener EndpointUpdateLis
 	port, ok := sp.ports[srcPort]
 	if ok {
 		port.unsubscribe(listener)
+		if len(port.listeners) == 0 {
+			endpointsVecs.unregister(sp.metricsLabels(srcPort))
+			delete(sp.ports, srcPort)
+		}
 	}
 }
 
@@ -322,12 +329,15 @@ func (sp *servicePublisher) newPortPublisher(srcPort Port) *portPublisher {
 		exists = true
 	}
 
+	log := sp.log.WithField("port", srcPort)
+
 	port := &portPublisher{
 		listeners:  []EndpointUpdateListener{},
 		targetPort: targetPort,
 		exists:     exists,
 		k8sAPI:     sp.k8sAPI,
-		log:        sp.log.WithField("port", srcPort),
+		log:        log,
+		metrics:    endpointsVecs.newEndpointsMetrics(sp.metricsLabels(srcPort)),
 	}
 
 	endpoints, err := sp.k8sAPI.Endpoint().Lister().Endpoints(sp.id.Namespace).Get(sp.id.Name)
@@ -339,6 +349,14 @@ func (sp *servicePublisher) newPortPublisher(srcPort Port) *portPublisher {
 	}
 
 	return port
+}
+
+func (sp *servicePublisher) metricsLabels(port Port) prometheus.Labels {
+	return prometheus.Labels{
+		"namespace": sp.id.Namespace,
+		"service":   sp.id.Name,
+		"port":      strconv.Itoa(int(port)),
+	}
 }
 
 /////////////////////
@@ -368,6 +386,10 @@ func (pp *portPublisher) updateEndpoints(endpoints *corev1.Endpoints) {
 	}
 	pp.exists = true
 	pp.pods = newPods
+
+	pp.metrics.incUpdates()
+	pp.metrics.setPods(len(pp.pods))
+	pp.metrics.setExists(true)
 }
 
 func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSet {
@@ -425,9 +447,14 @@ func (pp *portPublisher) updatePort(targetPort namedPort) {
 
 func (pp *portPublisher) noEndpoints(exists bool) {
 	pp.exists = exists
+	pp.pods = make(PodSet)
 	for _, listener := range pp.listeners {
 		listener.NoEndpoints(exists)
 	}
+
+	pp.metrics.incUpdates()
+	pp.metrics.setExists(exists)
+	pp.metrics.setPods(0)
 }
 
 func (pp *portPublisher) subscribe(listener EndpointUpdateListener) {
@@ -441,6 +468,8 @@ func (pp *portPublisher) subscribe(listener EndpointUpdateListener) {
 		listener.NoEndpoints(false)
 	}
 	pp.listeners = append(pp.listeners, listener)
+
+	pp.metrics.setSubscribers(len(pp.listeners))
 }
 
 func (pp *portPublisher) unsubscribe(listener EndpointUpdateListener) {
@@ -450,9 +479,11 @@ func (pp *portPublisher) unsubscribe(listener EndpointUpdateListener) {
 			pp.listeners[i] = pp.listeners[n-1]
 			pp.listeners[n-1] = nil
 			pp.listeners = pp.listeners[:n-1]
-			return
+			break
 		}
 	}
+
+	pp.metrics.setSubscribers(len(pp.listeners))
 }
 
 ////////////

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -352,11 +352,7 @@ func (sp *servicePublisher) newPortPublisher(srcPort Port) *portPublisher {
 }
 
 func (sp *servicePublisher) metricsLabels(port Port) prometheus.Labels {
-	return prometheus.Labels{
-		"namespace": sp.id.Namespace,
-		"service":   sp.id.Name,
-		"port":      strconv.Itoa(int(port)),
-	}
+	return endpointsLabels(sp.id.Namespace, sp.id.Name, strconv.Itoa(int(port)))
 }
 
 /////////////////////

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -1,0 +1,129 @@
+package watcher
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type (
+	metricsVecs struct {
+		labelNames  []string
+		subscribers *prometheus.GaugeVec
+		updates     *prometheus.CounterVec
+	}
+
+	metrics struct {
+		labels      prometheus.Labels
+		subscribers prometheus.Gauge
+		updates     prometheus.Counter
+	}
+
+	endpointsMetricsVecs struct {
+		metricsVecs
+		pods   *prometheus.GaugeVec
+		exists *prometheus.GaugeVec
+	}
+
+	endpointsMetrics struct {
+		metrics
+		pods   prometheus.Gauge
+		exists prometheus.Gauge
+	}
+)
+
+func newMetricsVecs(name string, labels []string) metricsVecs {
+	subscribers := promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: fmt.Sprintf("%s_subscribers", name),
+			Help: fmt.Sprintf("A gauge for the current number of subscribers to a %s.", name),
+		},
+		labels,
+	)
+
+	updates := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: fmt.Sprintf("%s_updates", name),
+			Help: fmt.Sprintf("A counter for number of updates to a %s.", name),
+		},
+		labels,
+	)
+
+	return metricsVecs{
+		labelNames:  labels,
+		subscribers: subscribers,
+		updates:     updates,
+	}
+}
+
+func newEndpointsMetricsVecs() endpointsMetricsVecs {
+	labels := []string{"namespace", "service", "port"}
+	vecs := newMetricsVecs("endpoints", labels)
+
+	pods := promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "endpoints_pods",
+			Help: "A gauge for the current number of pods in a endpoints.",
+		},
+		labels,
+	)
+
+	exists := promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "endpoints_exists",
+			Help: "A gauge which is 1 if the endpoints exists and 0 if it does not.",
+		},
+		labels,
+	)
+
+	return endpointsMetricsVecs{
+		metricsVecs: vecs,
+		pods:        pods,
+		exists:      exists,
+	}
+}
+
+func (mv metricsVecs) newMetrics(labels prometheus.Labels) metrics {
+	return metrics{
+		labels:      labels,
+		subscribers: mv.subscribers.With(labels),
+		updates:     mv.updates.With(labels),
+	}
+}
+
+func (emv endpointsMetricsVecs) newEndpointsMetrics(labels prometheus.Labels) endpointsMetrics {
+	metrics := emv.newMetrics(labels)
+	return endpointsMetrics{
+		metrics: metrics,
+		pods:    emv.pods.With(labels),
+		exists:  emv.exists.With(labels),
+	}
+}
+
+func (emv endpointsMetricsVecs) unregister(labels prometheus.Labels) {
+	emv.metricsVecs.subscribers.Delete(labels)
+	emv.metricsVecs.updates.Delete(labels)
+	emv.pods.Delete(labels)
+	emv.exists.Delete(labels)
+}
+
+func (m metrics) setSubscribers(n int) {
+	m.subscribers.Set(float64(n))
+}
+
+func (m metrics) incUpdates() {
+	m.updates.Inc()
+}
+
+func (em endpointsMetrics) setPods(n int) {
+	em.pods.Set(float64(n))
+}
+
+func (em endpointsMetrics) setExists(exists bool) {
+	if exists {
+		em.exists.Set(1.0)
+	} else {
+		em.exists.Set(0.0)
+	}
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -26,7 +26,7 @@ COPY web/app .
 RUN $ROOT/bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:7ac58ac0 as golang
+FROM gcr.io/linkerd-io/go-deps:4c8f4294 as golang
 WORKDIR /go/src/github.com/linkerd/linkerd2
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
To give better visibility into the inner workings of the kubernetes watchers in the destination service, we add the following prometheus metrics:

```
# HELP endpoints_exists A gauge which is 1 if the endpoints exists and 0 if it does not.
# TYPE endpoints_exists gauge
endpoints_exists{namespace="default",port="80",service="webapp"} 1
# HELP endpoints_pods A gauge for the current number of pods in a endpoints.
# TYPE endpoints_pods gauge
endpoints_pods{namespace="default",port="80",service="webapp"} 3
# HELP endpoints_subscribers A gauge for the current number of subscribers to a endpoints.
# TYPE endpoints_subscribers gauge
endpoints_subscribers{namespace="default",port="80",service="webapp"} 1
# HELP endpoints_updates A counter for number of updates to a endpoints.
# TYPE endpoints_updates counter
endpoints_updates{namespace="default",port="80",service="webapp"} 5

# HELP profile_subscribers A gauge for the current number of subscribers to a profile.
# TYPE profile_subscribers gauge
profile_subscribers{namespace="default",profile="webapp.default.svc.cluster.local"} 0
# HELP profile_updates A counter for number of updates to a profile.
# TYPE profile_updates counter
profile_updates{namespace="default",profile="webapp.default.svc.cluster.local"} 0

# HELP trafficsplit_subscribers A gauge for the current number of subscribers to a trafficsplit.
# TYPE trafficsplit_subscribers gauge
trafficsplit_subscribers{namespace="default",service="authors"} 0
trafficsplit_subscribers{namespace="default",service="webapp"} 0
# HELP trafficsplit_updates A counter for number of updates to a trafficsplit.
# TYPE trafficsplit_updates counter
trafficsplit_updates{namespace="default",service="authors"} 1
trafficsplit_updates{namespace="default",service="webapp"} 0
```

Signed-off-by: Alex Leong <alex@buoyant.io>