### PR TITLE
proxy: update to linkerd/linkerd2-proxy#0a7e206

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -23,7 +23,7 @@ validate_go_deps_tag $dockerfile
 ) >/dev/null
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-cb60637}"
+PROXY_VERSION="${PROXY_VERSION:-0a7e206}"
 
 tag="$(head_root_tag)"
 docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
* 0a7e206 Update h2 to v0.1.25 (linkerd2/linkerd2-proxy#282)
* 0e3ef79 Propagate HTTP2 errors from client RST_STREAMs (linkerd2/linkerd2-proxy#281)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>