### PR TITLE
Add the 'linkerd.io/control-plane-ns' label to the Traffic Split CRD

### DIFF
--- a/chart/templates/trafficsplit-crd.yaml
+++ b/chart/templates/trafficsplit-crd.yaml
@@ -11,6 +11,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
+  labels:
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -163,7 +163,7 @@ const (
 	defaultIdentityIssuanceLifetime   = 24 * time.Hour
 	defaultIdentityClockSkewAllowance = 20 * time.Second
 
-	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
+	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\n\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
 	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
 	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
@@ -870,7 +870,7 @@ func errIfGlobalResourcesExist() error {
 	})
 
 	if len(errMsgs) > 0 {
-		return errors.New(strings.Join(errMsgs, ","))
+		return errors.New(strings.Join(errMsgs, "\n"))
 	}
 
 	return nil

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     CreatedByAnnotation: CliVersion
+  labels:
+    ControllerNamespaceLabel: Namespace
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -237,6 +237,8 @@ metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    linkerd.io/control-plane-ns: linkerd
 spec:
   group: split.smi-spec.io
   version: v1alpha1


### PR DESCRIPTION
This will allow us to retrieve all the 2.4 CRDs by label. E.g. `kubectl get crd -l linkerd.io/control-plane-ns: linkerd`.

Fixes https://github.com/linkerd/linkerd2/issues/3020.

Signed-off-by: Ivan Sim <ivan@buoyant.io>