### PR TITLE
Introduces owner references verification for pods (#2932)

### DIFF
--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -142,6 +142,7 @@ kind: Deployment
 metadata:
   name: emoji
   namespace: emojivoto
+  uid: a1b2c3
 spec:
   selector:
     matchLabels:
@@ -152,6 +153,26 @@ spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  uid: a1b2c3d4
+  annotations:
+    deployment.kubernetes.io/revision: "2"
+  name: emojivoto-meshed_2
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3
+spec:
+  selector:
+    matchLabels:
+      app: emoji-svc
+      pod-template-hash: 3c2b1a
+`, `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -160,6 +181,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Running
 `, `
@@ -170,6 +195,10 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Running
 `, `
@@ -181,6 +210,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Completed
 `,
@@ -860,6 +893,7 @@ kind: Deployment
 metadata:
   name: emoji-deploy
   namespace: emojivoto
+  uid: a1b2c3
 spec:
   selector:
     matchLabels:
@@ -869,6 +903,26 @@ spec:
     spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
+`, `
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  uid: a1b2c3d4
+  annotations:
+    deployment.kubernetes.io/revision: "2"
+  name: emojivoto-meshed_2
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3
+spec:
+  selector:
+    matchLabels:
+      app: emoji-svc
+      pod-template-hash: 3c2b1a
 `, `
 apiVersion: v1
 kind: Service
@@ -899,6 +953,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Running
 `,
@@ -1274,6 +1332,7 @@ kind: Deployment
 metadata:
   name: emoji
   namespace: emojivoto
+  uid: a1b2c3
 spec:
   selector:
     matchLabels:
@@ -1284,6 +1343,26 @@ spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  uid: a1b2c3d4
+  annotations:
+    deployment.kubernetes.io/revision: "2"
+  name: emojivoto-meshed_2
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3
+spec:
+  selector:
+    matchLabels:
+      app: emoji-svc
+      pod-template-hash: 3c2b1a
+`, `
 apiVersion: v1
 kind: Pod
 metadata:
@@ -1292,6 +1371,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Running
 `, `
@@ -1302,6 +1385,10 @@ metadata:
   namespace: emojivoto
   labels:
     app: emoji-svc
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Running
 `, `
@@ -1313,6 +1400,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Failed
 `, `
@@ -1324,6 +1415,10 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+    pod-template-hash: 3c2b1a
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
 status:
   phase: Succeeded
 `},

--- a/controller/api/public/top_routes_test.go
+++ b/controller/api/public/top_routes_test.go
@@ -13,11 +13,12 @@ import (
 )
 
 // deployment/books
-var booksDeployConfig = `kind: Deployment
+var booksDeployConfig = []string{`kind: Deployment
 apiVersion: apps/v1beta2
 metadata:
   name: books
   namespace: default
+  uid: a1b2c3
 spec:
   replicas: 1
   selector:
@@ -30,7 +31,24 @@ spec:
     spec:
       dnsPolicy: ClusterFirst
       containers:
-      - image: buoyantio/booksapp:v0.0.2`
+      - image: buoyantio/booksapp:v0.0.2
+`, `
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  uid: a1b2c3d4
+  name: books
+  namespace: default
+  labels:
+    app: books
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3
+spec:
+  selector:
+    matchLabels:
+      app: books`,
+}
 
 // daemonset/books
 var booksDaemonsetConfig = `kind: DaemonSet
@@ -117,6 +135,9 @@ kind: Pod
 metadata:
   labels:
     app: books
+  ownerReferences:
+  - apiVersion: apps/v1
+    uid: a1b2c3d4
   name: books-64c68d6d46-jrmmx
   namespace: default
 spec:
@@ -140,7 +161,7 @@ spec:
 `,
 }
 
-var booksConfig = append(booksServiceConfig, booksDeployConfig)
+var booksConfig = append(booksServiceConfig, booksDeployConfig...)
 var booksDSConfig = append(booksServiceConfig, booksDaemonsetConfig)
 var booksSSConfig = append(booksServiceConfig, booksStatefulsetConfig)
 var booksJConfig = append(booksServiceConfig, booksJobConfig)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	arinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	appv1informers "k8s.io/client-go/informers/apps/v1"
@@ -413,9 +414,10 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, st
 func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Pod, error) {
 	var namespace string
 	var selector labels.Selector
-	var pods []*corev1.Pod
+	var ownerUID types.UID
 	var err error
 
+	pods := []*corev1.Pod{}
 	switch typed := obj.(type) {
 	case *corev1.Namespace:
 		namespace = typed.Name
@@ -424,22 +426,40 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 	case *appsv1.DaemonSet:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
+		ownerUID = typed.UID
 
 	case *appsv1beta2.Deployment:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
+		ret, err := api.RS().Lister().ReplicaSets(namespace).List(selector)
+		if err != nil {
+			return nil, err
+		}
+		for _, rs := range ret {
+			if isOwner(typed.UID, rs.GetOwnerReferences()) {
+				podsRS, err := api.GetPodsFor(rs, includeFailed)
+				if err != nil {
+					return nil, err
+				}
+				pods = append(pods, podsRS...)
+			}
+		}
+		return pods, nil
 
 	case *appsv1beta2.ReplicaSet:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
+		ownerUID = typed.UID
 
 	case *batchv1.Job:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
+		ownerUID = typed.UID
 
 	case *corev1.ReplicationController:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector).AsSelector()
+		ownerUID = typed.UID
 
 	case *corev1.Service:
 		if typed.Spec.Type == corev1.ServiceTypeExternalName {
@@ -451,6 +471,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 	case *appsv1.StatefulSet:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
+		ownerUID = typed.UID
 
 	case *corev1.Pod:
 		// Special case for pods:
@@ -478,11 +499,23 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 	allPods := []*corev1.Pod{}
 	for _, pod := range pods {
 		if isPendingOrRunning(pod) || (includeFailed && isFailed(pod)) {
-			allPods = append(allPods, pod)
+			if ownerUID == "" {
+				allPods = append(allPods, pod)
+			} else if isOwner(ownerUID, pod.GetOwnerReferences()) {
+				allPods = append(allPods, pod)
+			}
 		}
 	}
-
 	return allPods, nil
+}
+
+func isOwner(u types.UID, ownerRefs []metav1.OwnerReference) bool {
+	for _, or := range ownerRefs {
+		if u == or.UID {
+			return true
+		}
+	}
+	return false
 }
 
 // GetNameAndNamespaceOf returns the name and namespace of the given object.

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // NewFakeAPI provides a mock Kubernetes API for testing.
@@ -31,3 +32,11 @@ func NewFakeAPI(configs ...string) (*API, error) {
 		TS,
 	), nil
 }
+
+type byPod []*corev1.Pod
+
+func (s byPod) Len() int { return len(s) }
+
+func (s byPod) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s byPod) Less(i, j int) bool { return s[i].Name < s[j].Name }


### PR DESCRIPTION
When getting pods for specific kubernetes resources, the usage of just
labels, as a selector, generates wrong outputs. Once, two resources can use
the same label selector and manage distinct pods, a new mechanism to check
pods for a given resource it's needed. More details on #2932.

This commit introduces a verification through the pod owner references
`UID`s, comparing with the given resource's. Additional logic is needed
when handling `Deployments` since it creates a `ReplicaSet` and this last
one is the actual pod's owner. No verification is done in case of
`Services`.

Validation is possible with the [config](https://github.com/linkerd/linkerd2/issues/2932#issuecomment-502820970) provided by @olix0r.

Fixes #2932