### PR TITLE
Make the routes command traffic split aware

### DIFF
--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath,
-		k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP,
+		k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP, k8s.TS,
 	)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)


### PR DESCRIPTION
The `linkerd routes` command gets the list of routes for a resource by checking which services that resource is a member of.  If a traffic split exists, it is possible for a resource to get traffic via a service that it is not a member of.  Specifically, a resource which is a member of a leaf service can get traffic to the apex service.  This means that even though the resource is serving routes associated with the apex service, these will not be displayed in the `linkerd routes` command.

We update `linkerd routes` to be traffic-split aware.  This means that when a traffic split exists, we consider resources which are members of a leaf service with non-zero weight to be members of the apex service for the purpose of determining which routes to display.

```
$ bin/linkerd routes deploy
==> deployment/authors-v1 <==
ROUTE                          SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
[DEFAULT]                   authors-v1     0.00%   0.0rps           0ms           0ms           0ms
DELETE /authors/{id}.json      authors   100.00%   0.4rps          35ms          40ms          40ms
GET /authors.json              authors   100.00%   0.5rps           5ms           9ms          10ms
GET /authors/{id}.json         authors   100.00%   1.1rps           4ms           5ms           5ms
HEAD /authors/{id}.json        authors    55.00%   1.3rps           3ms           5ms           5ms
POST /authors.json             authors   100.00%   0.3rps          15ms          20ms          20ms
[DEFAULT]                      authors     0.00%   0.0rps           0ms           0ms           0ms
[DEFAULT]                   kubernetes     0.00%   0.0rps           0ms           0ms           0ms

==> deployment/authors-v2 <==
ROUTE                          SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
[DEFAULT]                   authors-v2     0.00%   0.0rps           0ms           0ms           0ms
DELETE /authors/{id}.json      authors   100.00%   0.3rps          35ms          40ms          40ms
GET /authors.json              authors   100.00%   0.2rps           5ms           5ms           5ms
GET /authors/{id}.json         authors   100.00%   0.9rps           4ms           5ms           5ms
HEAD /authors/{id}.json        authors   100.00%   1.3rps           4ms           7ms           9ms
POST /authors.json             authors   100.00%   0.4rps          15ms          20ms          20ms
[DEFAULT]                      authors     0.00%   0.0rps           0ms           0ms           0ms
[DEFAULT]                   kubernetes     0.00%   0.0rps           0ms           0ms           0ms
```

Notice in this example that `deployment/authors-v2` is considered to be a member of `service/authors-v2` (true membership) and `service/authors` (via traffic split).

Signed-off-by: Alex Leong <alex@buoyant.io>