### PR TITLE
release notes for edge-19.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,15 @@
 ## edge-19.7.1
 
 * CLI
-  * Added more descriptive output to the `linkerd check` for control plane
-    ReplicaSet readiness
+  * Added more descriptive output to the `linkerd check` output for control
+    plane ReplicaSet readiness
   * **Breaking change** Renamed `config.linkerd.io/debug` annotation to
     `config.linkerd.io/enable-debug-sidecar`, to match the
     `--enable-debug-sidecar` CLI flag that sets it
   * Fixed a bug in `linkerd edges` that caused incorrect identities to be
     displayed when requests were sent from two or more namespaces
 * Controller
-  * Addws the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
+  * Added the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
 * Proxy
   * Fixed proxied HTTP/2 connections returning 502 errors when the upstream
     connection is reset, rather than propagating the reset to the client

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+## edge-19.7.1
+
+* CLI
+  * Added more descriptive output to the `linkerd check` for control plane
+    ReplicaSet readiness
+  * Renamed `config.linkerd.io/debug` annotation to
+    `config.linkerd.io/enable-debug-sidecar`, to match the CLI flag that sets it
+  * Fixed a bug in `linkerd edges` that caused incorrect identities to be
+    displayed when requests were sent from two or more namespaces
+* Controller
+  * Add the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
+* Proxy
+  * Fixed proxied HTTP/2 connections returning 502 errors when the upstream
+    connection is reset, rather than propagating the reset to the client
+  * Changed the proxy to treat unexpected HTTP/2 frames as stream errors rather
+    than connection errors
+
 ## edge-19.6.4
 
 This release adds support for the SMI [Traffic Split](https://github.com/deislabs/smi-spec/blob/master/traffic-split.md)
@@ -25,7 +42,7 @@ for more details.
   * Updated `linkerd check` to validate the caller can create
     `PodSecurityPolicy` resources
 * Controller
-  * Default the mutating and validating webhook configurations `sideEffects` 
+  * Default the mutating and validating webhook configurations `sideEffects`
     property to `None` to indicate that the webhooks have no side effects on
     other resources (thanks @Pothulapati!)
 * Proxy

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,12 @@
 * CLI
   * Added more descriptive output to the `linkerd check` for control plane
     ReplicaSet readiness
-  * Renamed `config.linkerd.io/debug` annotation to
+  * **Breaking change** Renamed `config.linkerd.io/debug` annotation to
     `config.linkerd.io/enable-debug-sidecar`, to match the CLI flag that sets it
   * Fixed a bug in `linkerd edges` that caused incorrect identities to be
     displayed when requests were sent from two or more namespaces
 * Controller
-  * Add the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
+  * Addws the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
 * Proxy
   * Fixed proxied HTTP/2 connections returning 502 errors when the upstream
     connection is reset, rather than propagating the reset to the client

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
   * Added more descriptive output to the `linkerd check` for control plane
     ReplicaSet readiness
   * **Breaking change** Renamed `config.linkerd.io/debug` annotation to
-    `config.linkerd.io/enable-debug-sidecar`, to match the CLI flag that sets it
+    `config.linkerd.io/enable-debug-sidecar`, to match the
+    `--enable-debug-sidecar` CLI flag that sets it
   * Fixed a bug in `linkerd edges` that caused incorrect identities to be
     displayed when requests were sent from two or more namespaces
 * Controller


### PR DESCRIPTION
## edge-19.7.1

* CLI
  * Added more descriptive output to the `linkerd check` output for control
    plane ReplicaSet readiness
  * **Breaking change** Renamed `config.linkerd.io/debug` annotation to
    `config.linkerd.io/enable-debug-sidecar`, to match the
    `--enable-debug-sidecar` CLI flag that sets it
  * Fixed a bug in `linkerd edges` that caused incorrect identities to be
    displayed when requests were sent from two or more namespaces
* Controller
  * Added the `linkerd.io/control-plane-ns` label to the SMI Traffic Split CRD
* Proxy
  * Fixed proxied HTTP/2 connections returning 502 errors when the upstream
    connection is reset, rather than propagating the reset to the client
  * Changed the proxy to treat unexpected HTTP/2 frames as stream errors rather
    than connection errors

Signed-off-by: Eliza Weisman <eliza@buoyant.io>