### PR TITLE
Fix linkerd inject url handling

### DIFF
--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/inject"
 	corev1 "k8s.io/api/core/v1"
@@ -141,7 +141,7 @@ func read(path string) ([]io.Reader, error) {
 	)
 	if path == "-" {
 		in = append(in, os.Stdin)
-	} else if isValidURL(path) {
+	} else if strings.Index(path, "http://") == 0 || strings.Index(path, "https://") == 0 {
 		resp, err := http.Get(path)
 		if err != nil {
 			return nil, err
@@ -167,12 +167,6 @@ func read(path string) ([]io.Reader, error) {
 	}
 
 	return in, nil
-}
-
-// checks if the given string is a valid URL
-func isValidURL(path string) bool {
-	_, err := url.ParseRequestURI(path)
-	return err == nil
 }
 
 // walk walks the file tree rooted at path. path may be a file or a directory.


### PR DESCRIPTION
PR #2988 introduced support for `linkerd inject` with a URL parameter.
Some edge cases such as `/foo/bar/baz.yml` will return without error
from `url.ParseRequestURI`, even though we know this is a valid local
filename.

Modify inject's URL check to specifically look for a valid `http[s]://`
prefix. If that check succeeds, we will still rely on `http.Get` for URL
validation, as it calls `url.Parse` under the hood.

Fixes #3037

Signed-off-by: Andrew Seigner <siggy@buoyant.io>