### PR TITLE
Fix `linkerd check` missing uuid on version check

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -887,7 +887,7 @@ func errIfLinkerdConfigConfigMapExists() error {
 		return err
 	}
 
-	_, err = fetchConfigs(kubeAPI)
+	_, err = healthcheck.FetchLinkerdConfigMap(kubeAPI, controlPlaneNamespace)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
-	"github.com/linkerd/linkerd2/pkg/config"
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/linkerd/linkerd2/pkg/version"
@@ -189,7 +189,7 @@ func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Inter
 	// to upgrade/reinstall the control plane when the API is not available; and
 	// this also serves as a passive check that we have privileges to access this
 	// control plane.
-	configs, err := fetchConfigs(k)
+	configs, err := healthcheck.FetchLinkerdConfigMap(k, controlPlaneNamespace)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not fetch configs from kubernetes: %s", err)
 	}
@@ -286,22 +286,6 @@ func repairInstall(generateUUID func() string, install *pb.Install) {
 	install.CliVersion = version.Version
 
 	// Install flags are updated separately.
-}
-
-// fetchConfigs checks the kubernetes API to fetch an existing
-// linkerd configuration.
-//
-// This bypasses the public API so that upgrades can proceed when the API pod is
-// not available.
-func fetchConfigs(k kubernetes.Interface) (*pb.All, error) {
-	configMap, err := k.CoreV1().
-		ConfigMaps(controlPlaneNamespace).
-		Get(k8s.ConfigConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	return config.FromConfigMap(configMap.Data)
 }
 
 func fetchWebhookTLS(k kubernetes.Interface, webhook string, options *upgradeOptions) (*tlsValues, error) {

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -8,11 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -197,93 +194,5 @@ data:
 	}
 	if configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem() == "" {
 		t.Errorf("identity config not serialized")
-	}
-}
-
-func TestFetchConfigs(t *testing.T) {
-	options := testInstallOptions()
-	_, exp, err := options.validateAndBuild("", nil)
-	if err != nil {
-		t.Fatalf("Unexpected error validating options: %v", err)
-	}
-
-	testCases := []struct {
-		k8sConfigs []string
-		expected   *pb.All
-		err        error
-	}{
-		{
-			[]string{`
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: linkerd-config
-  namespace: linkerd
-data:
-  global: |
-    {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy\nLmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE\nAxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0\nxtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364\n6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF\nBQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE\nAiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv\nOLO4Zsk1XrGZHGsmyiEyvYF9lpY=\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
-  proxy: |
-    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version", "proxy_init_image_version":"v1.0.0"}
-  install: |
-    {"uuid":"deaab91a-f4ab-448a-b7d1-c832a2fa0a60","cliVersion":"dev-undefined","flags":[]}`,
-			},
-			exp,
-			nil,
-		},
-		{
-			[]string{`
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: linkerd-config
-  namespace: linkerd
-data:
-  global: |
-    {"linkerdNamespace":"ns","identityContext":null}
-  proxy: "{}"
-  install: "{}"`,
-			},
-			&pb.All{Global: &pb.Global{LinkerdNamespace: "ns", IdentityContext: nil}, Proxy: &pb.Proxy{}, Install: &pb.Install{}},
-			nil,
-		},
-		{
-			[]string{`
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: linkerd-config
-  namespace: linkerd
-data:
-  global: "{}"
-  proxy: "{}"
-  install: "{}"`,
-			},
-			&pb.All{Global: &pb.Global{}, Proxy: &pb.Proxy{}, Install: &pb.Install{}},
-			nil,
-		},
-		{
-			nil,
-			nil,
-			k8sErrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "linkerd-config"),
-		},
-	}
-
-	for i, tc := range testCases {
-		tc := tc // pin
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			clientset, err := k8s.NewFakeAPI(tc.k8sConfigs...)
-			if err != nil {
-				t.Fatalf("Unexpected error: %s", err)
-			}
-
-			configs, err := fetchConfigs(clientset)
-			if !reflect.DeepEqual(err, tc.err) {
-				t.Fatalf("Expected \"%+v\", got \"%+v\"", tc.err, err)
-			}
-
-			if !proto.Equal(configs, tc.expected) {
-				t.Fatalf("Unexpected config:\nExpected:\n%+v\nGot:\n%+v", tc.expected, configs)
-			}
-		})
 	}
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -11,7 +11,9 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/public"
 	spclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
+	configPb "github.com/linkerd/linkerd2/controller/gen/config"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/tls"
@@ -19,11 +21,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sVersion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
 )
 
 // CategoryID is an identifier for the types of health checks.
@@ -201,6 +203,7 @@ type HealthChecker struct {
 	apiClient        public.APIClient
 	latestVersions   version.Channels
 	serverVersion    string
+	linkerdConfig    *configPb.All
 }
 
 // NewHealthChecker returns an initialized HealthChecker
@@ -286,7 +289,7 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "control plane namespace does not already exist",
 					hintAnchor:  "pre-ns",
 					check: func(context.Context) error {
-						return hc.CheckNamespace(hc.ControlPlaneNamespace, false)
+						return hc.checkNamespace(hc.ControlPlaneNamespace, false)
 					},
 				},
 				{
@@ -429,7 +432,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-ns",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.CheckNamespace(hc.ControlPlaneNamespace, true)
+						return hc.checkNamespace(hc.ControlPlaneNamespace, true)
 					},
 				},
 				{
@@ -497,8 +500,9 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "'linkerd-config' config map exists",
 					hintAnchor:  "l5d-existence-linkerd-config",
 					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkLinkerdConfigConfigMap(true)
+					check: func(context.Context) (err error) {
+						hc.linkerdConfig, err = hc.checkLinkerdConfigConfigMap()
+						return
 					},
 				},
 				{
@@ -615,21 +619,10 @@ func (hc *HealthChecker) allCategories() []category {
 						if hc.VersionOverride != "" {
 							hc.latestVersions, err = version.NewChannels(hc.VersionOverride)
 						} else {
-							// The UUID is only known to the web process. At some point we may want
-							// to consider providing it in the Public API.
+							// Retrieve the UUID from `linkerd-config`.
 							uuid := "unknown"
-							for _, pod := range hc.controlPlanePods {
-								if strings.Split(pod.Name, "-")[0] == "web" {
-									for _, container := range pod.Spec.Containers {
-										if container.Name == "web" {
-											for _, arg := range container.Args {
-												if strings.HasPrefix(arg, "-uuid=") {
-													uuid = strings.TrimPrefix(arg, "-uuid=")
-												}
-											}
-										}
-									}
-								}
+							if hc.linkerdConfig != nil {
+								uuid = hc.linkerdConfig.GetInstall().GetUuid()
 							}
 							hc.latestVersions, err = version.GetLatestVersions(ctx, uuid, "cli")
 						}
@@ -682,7 +675,7 @@ func (hc *HealthChecker) allCategories() []category {
 							// when checking proxies in all namespaces, this check is a no-op
 							return nil
 						}
-						return hc.CheckNamespace(hc.DataPlaneNamespace, true)
+						return hc.checkNamespace(hc.DataPlaneNamespace, true)
 					},
 				},
 				{
@@ -888,18 +881,28 @@ func (hc *HealthChecker) PublicAPIClient() public.APIClient {
 	return hc.apiClient
 }
 
-func (hc *HealthChecker) checkLinkerdConfigConfigMap(shouldExist bool) error {
-	cm, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get(k8s.ConfigConfigMapName, metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		return err
-	}
-
-	return checkResources("ConfigMaps", []runtime.Object{cm}, []string{k8s.ConfigConfigMapName}, shouldExist)
+func (hc *HealthChecker) checkLinkerdConfigConfigMap() (*configPb.All, error) {
+	return FetchLinkerdConfigMap(hc.kubeAPI, hc.ControlPlaneNamespace)
 }
 
-// CheckNamespace checks whether the given namespace exists, and returns an
+// FetchLinkerdConfigMap retrieves the `linkerd-config` ConfigMap from
+// Kubernetes and parses it into `linkerd2.config` protobuf.
+// TODO: Consider a different package for this function. This lives in the
+// healthcheck package because healthcheck depends on it, along with other
+// packages that also depend on healthcheck. This function depends on both
+// `pkg/k8s` and `pkg/config`, which do not depend on each other.
+func FetchLinkerdConfigMap(k kubernetes.Interface, controlPlaneNamespace string) (*configPb.All, error) {
+	cm, err := k.CoreV1().ConfigMaps(controlPlaneNamespace).Get(k8s.ConfigConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return config.FromConfigMap(cm.Data)
+}
+
+// checkNamespace checks whether the given namespace exists, and returns an
 // error if it does not match `shouldExist`.
-func (hc *HealthChecker) CheckNamespace(namespace string, shouldExist bool) error {
+func (hc *HealthChecker) checkNamespace(namespace string, shouldExist bool) error {
 	exists, err := hc.kubeAPI.NamespaceExists(namespace)
 	if err != nil {
 		return err

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -8,12 +8,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/linkerd/linkerd2/controller/api/public"
 	healthcheckPb "github.com/linkerd/linkerd2/controller/gen/common/healthcheck"
+	configPb "github.com/linkerd/linkerd2/controller/gen/config"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type observer struct {
@@ -1970,4 +1975,132 @@ metadata:
 			t.Errorf("Mismatch result.\nExpected: %v\n Actual: %v\n", expected, observer.results)
 		}
 	})
+}
+
+func TestFetchLinkerdConfigMap(t *testing.T) {
+	testCases := []struct {
+		k8sConfigs []string
+		expected   *configPb.All
+		err        error
+	}{
+		{
+			[]string{`
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-config
+  namespace: linkerd
+data:
+  global: |
+    {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
+  proxy: |
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version", "proxy_init_image_version":"v1.0.0"}
+  install: |
+    {"uuid":"deaab91a-f4ab-448a-b7d1-c832a2fa0a60","cliVersion":"dev-undefined","flags":[]}`,
+			},
+			&configPb.All{
+				Global: &configPb.Global{
+					LinkerdNamespace: "linkerd",
+					Version:          "install-control-plane-version",
+					IdentityContext: &configPb.IdentityContext{
+						TrustDomain:     "cluster.local",
+						TrustAnchorsPem: "fake-trust-anchors-pem",
+						IssuanceLifetime: &duration.Duration{
+							Seconds: 86400,
+						},
+						ClockSkewAllowance: &duration.Duration{
+							Seconds: 20,
+						},
+					},
+				}, Proxy: &configPb.Proxy{
+					ProxyImage: &configPb.Image{
+						ImageName:  "gcr.io/linkerd-io/proxy",
+						PullPolicy: "IfNotPresent",
+					},
+					ProxyInitImage: &configPb.Image{
+						ImageName:  "gcr.io/linkerd-io/proxy-init",
+						PullPolicy: "IfNotPresent",
+					},
+					ControlPort: &configPb.Port{
+						Port: 4190,
+					},
+					InboundPort: &configPb.Port{
+						Port: 4143,
+					},
+					AdminPort: &configPb.Port{
+						Port: 4191,
+					},
+					OutboundPort: &configPb.Port{
+						Port: 4140,
+					},
+					Resource: &configPb.ResourceRequirements{},
+					ProxyUid: 2102,
+					LogLevel: &configPb.LogLevel{
+						Level: "warn,linkerd2_proxy=info",
+					},
+					DisableExternalProfiles: true,
+					ProxyVersion:            "install-proxy-version",
+					ProxyInitImageVersion:   "v1.0.0",
+				}, Install: &configPb.Install{
+					Uuid:       "deaab91a-f4ab-448a-b7d1-c832a2fa0a60",
+					CliVersion: "dev-undefined",
+				}},
+			nil,
+		},
+		{
+			[]string{`
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-config
+  namespace: linkerd
+data:
+  global: |
+    {"linkerdNamespace":"ns","identityContext":null}
+  proxy: "{}"
+  install: "{}"`,
+			},
+			&configPb.All{Global: &configPb.Global{LinkerdNamespace: "ns", IdentityContext: nil}, Proxy: &configPb.Proxy{}, Install: &configPb.Install{}},
+			nil,
+		},
+		{
+			[]string{`
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-config
+  namespace: linkerd
+data:
+  global: "{}"
+  proxy: "{}"
+  install: "{}"`,
+			},
+			&configPb.All{Global: &configPb.Global{}, Proxy: &configPb.Proxy{}, Install: &configPb.Install{}},
+			nil,
+		},
+		{
+			nil,
+			nil,
+			k8sErrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "linkerd-config"),
+		},
+	}
+
+	for i, tc := range testCases {
+		tc := tc // pin
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			clientset, err := k8s.NewFakeAPI(tc.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			configs, err := FetchLinkerdConfigMap(clientset, "linkerd")
+			if !reflect.DeepEqual(err, tc.err) {
+				t.Fatalf("Expected \"%+v\", got \"%+v\"", tc.err, err)
+			}
+
+			if !proto.Equal(configs, tc.expected) {
+				t.Fatalf("Unexpected config:\nExpected:\n%+v\nGot:\n%+v", tc.expected, configs)
+			}
+		})
+	}
 }


### PR DESCRIPTION
PR #2603 modified the web process to read the UUID from the
`linkerd-config` ConfigMap rather than from a command line flag. The
`linkerd check` command relied on that command line flag to retrieve the
UUID as part of its version check.

Modify `linkerd check` to correctly retrieve the UUID from
`linkerd-config`. Also refactor `linkerd-config` retrieval and parsing
code to be shared between healthcheck, install, and upgrade.

Relates to #2961

Signed-off-by: Andrew Seigner <siggy@buoyant.io>