### PR TITLE
Bump proxy dep

### DIFF
--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -23,7 +23,7 @@ validate_go_deps_tag $dockerfile
 ) >/dev/null
 
 # Default to a pinned commit SHA of the proxy.
-PROXY_VERSION="${PROXY_VERSION:-0a7e206}"
+PROXY_VERSION="${PROXY_VERSION:-05b012d}"
 
 tag="$(head_root_tag)"
 docker_build proxy $tag $dockerfile --build-arg LINKERD_VERSION=$tag --build-arg PROXY_VERSION=$PROXY_VERSION


### PR DESCRIPTION
Pick up the following proxy changes:

* Update httparse to v1.3.4
* canonicalize: stop resolving when the receiver is dropped
* router: Remove interval from router eviction

Signed-off-by: Alex Leong <alex@buoyant.io>