### PR TITLE
edge-19.7.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 * Proxy
   * Fixed a bug where DNS queries could persist longer than necessary
   * Improved router eviction to remove idle services in a more timely manner
+  * Fixed a bug where the proxy would fail to process requests with obscure
+    characters in the URI
 
 ## edge-19.7.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## edge-19.7.2
+
+* CLI
+  * Refactored the `linkerd endpoints` to use the same interface as used by the
+    proxy for service discovery information
+  * Fixed a bug where `linkerd inject` would fail when given a path to a file
+    outside the current directory
+* Proxy
+  * Fixed a bug where DNS queries could persist longer than necessary
+  * Improved router eviction to remove idle services in a more timely manner
+
 ## edge-19.7.1
 
 * CLI


### PR DESCRIPTION
## edge-19.7.2

* CLI
  * Refactored the `linkerd endpoints` to use the same interface as used by the
    proxy for service discovery information
  * Fixed a bug where `linkerd inject` would fail when given a path to a file
    outside the current directory
* Proxy
  * Fixed a bug where DNS queries could persist longer than necessary
  * Improved router eviction to remove idle services in a more timely manner

Signed-off-by: Alex Leong <alex@buoyant.io>