### PR TITLE
Tweak the vertical positioning of arrows in octopus graph

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -39,10 +39,12 @@ const styles = () => ({
     marginRight: "auto"
   },
   centerNode: {
-    width: "244px"
+    width: "244px",
+    height: `${baseHeight - 24}px` // grid alignment adds 24px vertical padding
   },
   neighborNode: {
-    width: "220px"
+    width: "220px",
+    height: `${baseHeight - 24}px` // grid alignment adds 24px vertical padding
   }
 });
 class Octopus extends React.Component {

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -4,7 +4,7 @@ import grey from '@material-ui/core/colors/grey';
 const strokeOpacity = "0.7";
 const arrowColor = grey[500];
 
-export const baseHeight = 220; // the height of the neighbor node box
+export const baseHeight = 242; // the height of the neighbor node box plus padding
 const halfBoxHeight = baseHeight / 2;
 const controlPoint = 10; // width and height of the control points for the bezier curves
 const inboundAlignment = controlPoint * 2;
@@ -72,14 +72,14 @@ const arrowG = (id, arm, transform) => {
 };
 
 const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
-  let height = arrowHeight + (isEven ? 0 : halfBoxHeight);
+  let height = arrowHeight + (isEven ? 0 : halfBoxHeight) - controlPoint * 2;
 
   // up arrows start and the center of the middle node for outbound arms,
   // and at the noce position for inbound arms
   let y1 = isOutbound ? svgHeight / 2 : arrowHeight;
   let arm = generateSvgComponents(y1, width, height);
 
-  let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment})`;
+  let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment - controlPoint * 2})`;
 
   return arrowG(`up-arrow-${height}`, arm, translate);
 };
@@ -104,7 +104,7 @@ const flat = (width, height) => {
 const down = (width, svgHeight, arrowHeight, isOutbound) => {
   // down outbound arrows start at the middle of the svg's height, and
   // have end of block n at (1/2 block height) + (block height * n-1)
-  let height = (svgHeight / 2) - arrowHeight;
+  let height = svgHeight / 2 - arrowHeight - controlPoint * 2;
 
   // inbound arrows start at the offset of the card, and end in the center of the middle card
   // outbound arrows start in the center of the middle card, and end at the card's height


### PR DESCRIPTION
This branch fixes two small issues that impacted the height of the arrows drawn in the octopus graph. The code to calculate the height of each arrow was not taking into account the 10px curve that we draw at the top and bottom of each arrow. This caused the arrows to be 20px longer than they should be. This was not noticeable in most cases, however, because the box height that we were using to calculate arrow height did not take into account 24px of vertical padding around the boxes. So often these two issues canceled each other out, but with more nodes on the graph, it looked like this:

![Screen Shot 2019-07-08 at 1 05 30 PM](https://user-images.githubusercontent.com/9226/60839991-59bf2e80-a183-11e9-80ac-aae376f76d4a.png)

Whereas with the fix from this branch, it looks like this:

![Screen Shot 2019-07-08 at 1 05 34 PM](https://user-images.githubusercontent.com/9226/60840099-8ffcae00-a183-11e9-9467-8090655ecb3a.png)

Note that when we have 7 or more inbound or outbound boxes, we're aggregating them into a single box. It previously looked like this:

![Screen Shot 2019-07-08 at 1 13 53 PM](https://user-images.githubusercontent.com/9226/60840227-e36efc00-a183-11e9-8f89-f54e7340bc32.png)

And now it looks like this:

![Screen Shot 2019-07-08 at 1 13 56 PM](https://user-images.githubusercontent.com/9226/60840307-08636f00-a184-11e9-9d49-a0e99b7f2360.png)

It's a bit unfortunate that the overflow box is taller than it needs to be, but that seems preferable to adding support for dynamically sized arrows based on the box content.