### PR TITLE
Updating CLI output for `linkerd edges`

### DIFF
--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -228,7 +228,7 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 
 			if len(msg) == 0 {
 				if options.outputFormat == jsonOutput {
-					msg = "-"
+					msg = ""
 				} else {
 					msg = okStatus
 				}

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -311,18 +311,13 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 		fmt.Sprintf(dstTemplate, dstHeader),
 		fmt.Sprintf(srcNamespaceTemplate, srcNamespaceHeader),
 		fmt.Sprintf(dstNamespaceTemplate, dstNamespaceHeader),
-		fmt.Sprintf(msgTemplate, msgHeader),
 	}
 
 	if outputFormat == wideOutput {
-		// insert CLIENT_ID and SERVER_ID headers before final SECURED header
-		headers = append(headers[:len(headers)-1], append([]string{
-			fmt.Sprintf(clientTemplate, clientHeader),
-			fmt.Sprintf(serverTemplate, serverHeader),
-		}, headers[len(headers)-1:]...)...)
+		headers = append(headers, fmt.Sprintf(clientTemplate, clientHeader), fmt.Sprintf(serverTemplate, serverHeader))
 	}
 
-	headers[len(headers)-1] = headers[len(headers)-1] + "\t" // trailing \t is required to format last column
+	headers = append(headers, fmt.Sprintf(msgTemplate, msgHeader)+"\t")
 
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 
@@ -339,7 +334,6 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 		if outputFormat == wideOutput {
 			templateString = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, clientTemplate, serverTemplate, msgTemplate)
 
-			// insert CLIENT_ID and SERVER_ID values before final SECURED value
 			values = append(values[:len(values)-1], append([]interface{}{
 				row.client,
 				row.server,

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -327,18 +327,16 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 			row.dst,
 			row.srcNamespace,
 			row.dstNamespace,
-			row.msg,
 		}
 		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, msgTemplate)
 
 		if outputFormat == wideOutput {
 			templateString = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, clientTemplate, serverTemplate, msgTemplate)
 
-			values = append(values[:len(values)-1], append([]interface{}{
-				row.client,
-				row.server,
-			}, values[len(values)-1:]...)...)
+			values = append(values, row.client, row.server)
 		}
+
+		values = append(values, row.msg)
 
 		fmt.Fprintf(w, templateString, values...)
 	}

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -108,7 +108,7 @@ func newCmdEdges() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the specified resource")
-	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\"")
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
 	cmd.PersistentFlags().BoolVar(&options.allNamespaces, "all-namespaces", options.allNamespaces, "If present, returns edges across all namespaces, ignoring the \"--namespace\" flag")
 	return cmd
 }
@@ -127,10 +127,10 @@ func validateEdgesRequestInputs(targets []pb.Resource, options *edgesOptions) er
 	}
 
 	switch options.outputFormat {
-	case tableOutput, jsonOutput:
+	case tableOutput, jsonOutput, wideOutput:
 		return nil
 	default:
-		return fmt.Errorf("--output currently only supports %s and %s", tableOutput, jsonOutput)
+		return fmt.Errorf("--output supports %s, %s and %s", tableOutput, jsonOutput, wideOutput)
 	}
 }
 
@@ -191,24 +191,30 @@ func renderEdgeStats(rows []*pb.Edge, options *edgesOptions) string {
 }
 
 type edgeRow struct {
-	src    string
-	dst    string
-	client string
-	server string
-	msg    string
+	src          string
+	srcNamespace string
+	dst          string
+	dstNamespace string
+	client       string
+	server       string
+	msg          string
 }
 
 const (
-	srcHeader    = "SRC"
-	dstHeader    = "DST"
-	clientHeader = "CLIENT"
-	serverHeader = "SERVER"
-	msgHeader    = "MSG"
+	srcHeader          = "SRC"
+	dstHeader          = "DST"
+	srcNamespaceHeader = "SRC_NS"
+	dstNamespaceHeader = "DST_NS"
+	clientHeader       = "CLIENT_ID"
+	serverHeader       = "SERVER_ID"
+	msgHeader          = "SECURED"
 )
 
 func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOptions) {
 	maxSrcLength := len(srcHeader)
 	maxDstLength := len(dstHeader)
+	maxSrcNamespaceLength := len(srcNamespaceHeader)
+	maxDstNamespaceLength := len(dstNamespaceHeader)
 	maxClientLength := len(clientHeader)
 	maxServerLength := len(serverHeader)
 	maxMsgLength := len(msgHeader)
@@ -221,7 +227,11 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			msg := r.NoIdentityMsg
 
 			if len(msg) == 0 {
-				msg = "-"
+				if options.outputFormat == "json" {
+					msg = "-"
+				} else {
+					msg = okStatus
+				}
 			}
 			if len(clientID) > 0 {
 				parts := strings.Split(clientID, ".")
@@ -233,11 +243,13 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			}
 
 			row := edgeRow{
-				client: clientID,
-				server: serverID,
-				msg:    msg,
-				src:    r.Src.Name,
-				dst:    r.Dst.Name,
+				client:       clientID,
+				server:       serverID,
+				msg:          msg,
+				src:          r.Src.Name,
+				srcNamespace: r.Src.Namespace,
+				dst:          r.Dst.Name,
+				dstNamespace: r.Dst.Namespace,
 			}
 
 			edgeRows = append(edgeRows, row)
@@ -245,8 +257,14 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			if len(r.Src.Name) > maxSrcLength {
 				maxSrcLength = len(r.Src.Name)
 			}
+			if len(r.Src.Namespace) > maxSrcNamespaceLength {
+				maxSrcNamespaceLength = len(r.Src.Namespace)
+			}
 			if len(r.Dst.Name) > maxDstLength {
 				maxDstLength = len(r.Dst.Name)
+			}
+			if len(r.Dst.Namespace) > maxDstNamespaceLength {
+				maxDstNamespaceLength = len(r.Dst.Namespace)
 			}
 			if len(clientID) > maxClientLength {
 				maxClientLength = len(clientID)
@@ -260,38 +278,48 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 		}
 	}
 
-	// sorting edgeRows by key for alphabetical listing
+	// ordering the rows first by SRC/DST namespace, then by SRC/DST resource
 	sort.Slice(edgeRows, func(i, j int) bool {
-		keyI := edgeRows[i].src + edgeRows[i].dst
-		keyJ := edgeRows[j].src + edgeRows[j].dst
+		keyI := edgeRows[i].srcNamespace + edgeRows[i].dstNamespace + edgeRows[i].src + edgeRows[i].dst
+		keyJ := edgeRows[j].srcNamespace + edgeRows[j].dstNamespace + edgeRows[j].src + edgeRows[j].dst
 		return keyI < keyJ
 	})
 
 	switch options.outputFormat {
-	case tableOutput:
+	case tableOutput, wideOutput:
 		if len(edgeRows) == 0 {
 			fmt.Fprintln(os.Stderr, "No edges found.")
 			os.Exit(0)
 		}
-		printEdgeTable(edgeRows, w, maxSrcLength, maxDstLength, maxClientLength, maxServerLength, maxMsgLength)
+		printEdgeTable(edgeRows, w, maxSrcLength, maxSrcNamespaceLength, maxDstLength, maxDstNamespaceLength, maxClientLength, maxServerLength, maxMsgLength, options.outputFormat)
 	case jsonOutput:
 		printEdgesJSON(edgeRows, w)
 	}
 }
 
-func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxDstLength, maxClientLength, maxServerLength, maxMsgLength int) {
+func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSrcNamespaceLength, maxDstLength, maxDstNamespaceLength, maxClientLength, maxServerLength, maxMsgLength int, outputFormat string) {
 	srcTemplate := fmt.Sprintf("%%-%ds", maxSrcLength)
 	dstTemplate := fmt.Sprintf("%%-%ds", maxDstLength)
+	srcNamespaceTemplate := fmt.Sprintf("%%-%ds", maxSrcNamespaceLength)
+	dstNamespaceTemplate := fmt.Sprintf("%%-%ds", maxDstNamespaceLength)
+	msgTemplate := fmt.Sprintf("%%-%ds", maxMsgLength)
 	clientTemplate := fmt.Sprintf("%%-%ds", maxClientLength)
 	serverTemplate := fmt.Sprintf("%%-%ds", maxServerLength)
-	msgTemplate := fmt.Sprintf("%%-%ds", maxMsgLength)
 
 	headers := []string{
 		fmt.Sprintf(srcTemplate, srcHeader),
 		fmt.Sprintf(dstTemplate, dstHeader),
-		fmt.Sprintf(clientTemplate, clientHeader),
-		fmt.Sprintf(serverTemplate, serverHeader),
+		fmt.Sprintf(srcNamespaceTemplate, srcNamespaceHeader),
+		fmt.Sprintf(dstNamespaceTemplate, dstNamespaceHeader),
 		fmt.Sprintf(msgTemplate, msgHeader),
+	}
+
+	if outputFormat == "wide" {
+		// insert CLIENT_ID and SERVER_ID headers before final SECURED header
+		headers = append(headers[:len(headers)-1], append([]string{
+			fmt.Sprintf(clientTemplate, clientHeader),
+			fmt.Sprintf(serverTemplate, serverHeader),
+		}, headers[len(headers)-1:]...)...)
 	}
 
 	headers[len(headers)-1] = headers[len(headers)-1] + "\t" // trailing \t is required to format last column
@@ -299,19 +327,26 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxDs
 	fmt.Fprintln(w, strings.Join(headers, "\t"))
 
 	for _, row := range edgeRows {
-		values := make([]interface{}, 0)
-		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, clientTemplate, serverTemplate, msgTemplate)
-
-		values = append(values, []interface{}{
+		values := []interface{}{
 			row.src,
 			row.dst,
-			row.client,
-			row.server,
+			row.srcNamespace,
+			row.dstNamespace,
 			row.msg,
-		}...)
+		}
+		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, msgTemplate)
+
+		if outputFormat == "wide" {
+			templateString = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, clientTemplate, serverTemplate, msgTemplate)
+
+			// insert CLIENT_ID and SERVER_ID values before final SECURED value
+			values = append(values[:len(values)-1], append([]interface{}{
+				row.client,
+				row.server,
+			}, values[len(values)-1:]...)...)
+		}
 
 		fmt.Fprintf(w, templateString, values...)
-
 	}
 }
 
@@ -330,11 +365,13 @@ func renderEdges(buffer bytes.Buffer, options *edgesOptions) string {
 }
 
 type edgesJSONStats struct {
-	Src    string `json:"src"`
-	Dst    string `json:"dst"`
-	Client string `json:"client_id"`
-	Server string `json:"server_id"`
-	Msg    string `json:"no_tls_reason"`
+	Src          string `json:"src"`
+	SrcNamespace string `json:"src_namespace"`
+	Dst          string `json:"dst"`
+	DstNamespace string `json:"dst_namespace"`
+	Client       string `json:"client_id"`
+	Server       string `json:"server_id"`
+	Msg          string `json:"no_tls_reason"`
 }
 
 func printEdgesJSON(edgeRows []edgeRow, w *tabwriter.Writer) {
@@ -343,11 +380,13 @@ func printEdgesJSON(edgeRows []edgeRow, w *tabwriter.Writer) {
 
 	for _, row := range edgeRows {
 		entry := &edgesJSONStats{
-			Src:    row.src,
-			Dst:    row.dst,
-			Client: row.client,
-			Server: row.server,
-			Msg:    row.msg}
+			Src:          row.src,
+			SrcNamespace: row.srcNamespace,
+			Dst:          row.dst,
+			DstNamespace: row.dstNamespace,
+			Client:       row.client,
+			Server:       row.server,
+			Msg:          row.msg}
 		entries = append(entries, entry)
 	}
 

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -227,7 +227,7 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			msg := r.NoIdentityMsg
 
 			if len(msg) == 0 {
-				if options.outputFormat == "json" {
+				if options.outputFormat == jsonOutput {
 					msg = "-"
 				} else {
 					msg = okStatus
@@ -314,7 +314,7 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 		fmt.Sprintf(msgTemplate, msgHeader),
 	}
 
-	if outputFormat == "wide" {
+	if outputFormat == wideOutput {
 		// insert CLIENT_ID and SERVER_ID headers before final SECURED header
 		headers = append(headers[:len(headers)-1], append([]string{
 			fmt.Sprintf(clientTemplate, clientHeader),
@@ -336,7 +336,7 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 		}
 		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, msgTemplate)
 
-		if outputFormat == "wide" {
+		if outputFormat == wideOutput {
 			templateString = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, clientTemplate, serverTemplate, msgTemplate)
 
 			// insert CLIENT_ID and SERVER_ID values before final SECURED value

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -225,13 +225,8 @@ func writeEdgesToBuffer(rows []*pb.Edge, w *tabwriter.Writer, options *edgesOpti
 			clientID := r.ClientId
 			serverID := r.ServerId
 			msg := r.NoIdentityMsg
-
-			if len(msg) == 0 {
-				if options.outputFormat == jsonOutput {
-					msg = ""
-				} else {
-					msg = okStatus
-				}
+			if len(msg) == 0 && options.outputFormat != jsonOutput {
+				msg = okStatus
 			}
 			if len(clientID) > 0 {
 				parts := strings.Split(clientID, ".")
@@ -328,14 +323,14 @@ func printEdgeTable(edgeRows []edgeRow, w *tabwriter.Writer, maxSrcLength, maxSr
 			row.srcNamespace,
 			row.dstNamespace,
 		}
-		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, msgTemplate)
+		templateString := fmt.Sprintf("%s\t%s\t%s\t%s\t", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate)
 
 		if outputFormat == wideOutput {
-			templateString = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", srcTemplate, dstTemplate, srcNamespaceTemplate, dstNamespaceTemplate, clientTemplate, serverTemplate, msgTemplate)
-
+			templateString += fmt.Sprintf("%s\t%s\t", clientTemplate, serverTemplate)
 			values = append(values, row.client, row.server)
 		}
 
+		templateString += fmt.Sprintf("%s\t\n", msgTemplate)
 		values = append(values, row.msg)
 
 		fmt.Fprintf(w, templateString, values...)

--- a/cli/cmd/edges_test.go
+++ b/cli/cmd/edges_test.go
@@ -7,76 +7,114 @@ import (
 )
 
 type edgesParamsExp struct {
-	options      *edgesOptions
-	resSrc       []string
-	resDst       []string
-	resClient    []string
-	resServer    []string
-	resMsg       []string
-	resourceType string
-	file         string
+	options         *edgesOptions
+	resSrc          []string
+	resSrcNamespace []string
+	resDst          []string
+	resDstNamespace []string
+	resClient       []string
+	resServer       []string
+	resMsg          []string
+	resourceType    string
+	file            string
 }
 
 func TestEdges(t *testing.T) {
-	// response content for SRC, DST, CLIENT, SERVER and MSG
+	// response content for SRC, DST, SRC_NS, DST_NS, CLIENT_ID, SERVER_ID and MSG
 	var (
 		resSrc = []string{
-			"web-57b7f9db85-297dw",
-			"web-57b7f9db85-297dw",
-			"vote-bot-7466ffc7f7-5rc4l",
+			"web",
+			"vote-bot",
+			"web",
+			"linkerd-controller",
 		}
 		resDst = []string{
-			"emoji-646ddcc5f9-zjgs9",
-			"voting-689f845d98-rj6nz",
-			"web-57b7f9db85-297dw",
+			"voting",
+			"web",
+			"emoji",
+			"linkerd-prometheus",
+		}
+		resSrcNamespace = []string{
+			"emojivoto",
+			"emojivoto",
+			"emojivoto",
+			"linkerd",
+		}
+		resDstNamespace = []string{
+			"emojivoto",
+			"emojivoto",
+			"emojivoto",
+			"linkerd",
 		}
 		resClient = []string{
 			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
 			"default.emojivoto.serviceaccount.identity.linkerd.cluster.local",
+			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
+			"linkerd-controller.linkerd.identity.linkerd.cluster.local",
 		}
 		resServer = []string{
-			"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local",
 			"voting.emojivoto.serviceaccount.identity.linkerd.cluster.local",
 			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
+			"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local",
+			"linkerd-prometheus.linkerd.identity.linkerd.cluster.local",
 		}
-		resMsg = []string{"", "", ""}
+		resMsg = []string{"", "", "", ""}
 	)
 
 	options := newEdgesOptions()
-	options.namespace = "emojivoto"
 	options.outputFormat = tableOutput
+	options.allNamespaces = true
 	t.Run("Returns edges", func(t *testing.T) {
 		testEdgesCall(edgesParamsExp{
-			options:      options,
-			resourceType: "pod",
-			resSrc:       resSrc,
-			resDst:       resDst,
-			resClient:    resClient,
-			resServer:    resServer,
-			resMsg:       resMsg,
-			file:         "edges_one_output.golden",
+			options:         options,
+			resourceType:    "deployment",
+			resSrc:          resSrc,
+			resSrcNamespace: resSrcNamespace,
+			resDst:          resDst,
+			resDstNamespace: resDstNamespace,
+			resClient:       resClient,
+			resServer:       resServer,
+			resMsg:          resMsg,
+			file:            "edges_one_output.golden",
 		}, t)
 	})
 
 	options.outputFormat = jsonOutput
 	t.Run("Returns edges (json)", func(t *testing.T) {
 		testEdgesCall(edgesParamsExp{
-			options:      options,
-			resourceType: "pod",
-			resSrc:       resSrc,
-			resDst:       resDst,
-			resClient:    resClient,
-			resServer:    resServer,
-			resMsg:       resMsg,
-			file:         "edges_one_output_json.golden",
+			options:         options,
+			resourceType:    "deployment",
+			resSrc:          resSrc,
+			resSrcNamespace: resSrcNamespace,
+			resDst:          resDst,
+			resDstNamespace: resDstNamespace,
+			resClient:       resClient,
+			resServer:       resServer,
+			resMsg:          resMsg,
+			file:            "edges_one_output_json.golden",
 		}, t)
 	})
 
-	t.Run("Returns an error if outputFormat specified is not table or json", func(t *testing.T) {
+	t.Run("Returns edges (wide)", func(t *testing.T) {
 		options.outputFormat = wideOutput
-		args := []string{"pod"}
-		expectedError := "--output currently only supports table and json"
+		testEdgesCall(edgesParamsExp{
+			options:         options,
+			resourceType:    "deployment",
+			resSrc:          resSrc,
+			resSrcNamespace: resSrcNamespace,
+			resDst:          resDst,
+			resDstNamespace: resDstNamespace,
+			resClient:       resClient,
+			resServer:       resServer,
+			resMsg:          resMsg,
+			file:            "edges_wide_output.golden",
+		}, t)
+	})
+
+	t.Run("Returns an error if outputFormat specified is not wide, table or json", func(t *testing.T) {
+		options.outputFormat = "test"
+		args := []string{"deployment"}
+		expectedError := "--output supports table, json and wide"
 
 		_, err := buildEdgesRequests(args, options)
 		if err == nil || err.Error() != expectedError {
@@ -131,11 +169,11 @@ func TestEdges(t *testing.T) {
 
 func testEdgesCall(exp edgesParamsExp, t *testing.T) {
 	mockClient := &public.MockAPIClient{}
-	response := public.GenEdgesResponse(exp.resourceType, exp.resSrc, exp.resDst, exp.resClient, exp.resServer, exp.resMsg)
+	response := public.GenEdgesResponse(exp.resourceType, exp.resSrc, exp.resDst, exp.resSrcNamespace, exp.resDstNamespace, exp.resClient, exp.resServer, exp.resMsg)
 
 	mockClient.EdgesResponseToReturn = &response
 
-	args := []string{"pod"}
+	args := []string{"deployment"}
 	reqs, err := buildEdgesRequests(args, exp.options)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/cli/cmd/testdata/edges_one_output.golden
+++ b/cli/cmd/testdata/edges_one_output.golden
@@ -1,4 +1,5 @@
-SRC                         DST                       CLIENT              SERVER             MSG
-vote-bot-7466ffc7f7-5rc4l   web-57b7f9db85-297dw      default.emojivoto   web.emojivoto      -  
-web-57b7f9db85-297dw        emoji-646ddcc5f9-zjgs9    web.emojivoto       emoji.emojivoto    -  
-web-57b7f9db85-297dw        voting-689f845d98-rj6nz   web.emojivoto       voting.emojivoto   -  
+SRC                  DST                  SRC_NS      DST_NS      SECURED
+vote-bot             web                  emojivoto   emojivoto   √      
+web                  emoji                emojivoto   emojivoto   √      
+web                  voting               emojivoto   emojivoto   √      
+linkerd-controller   linkerd-prometheus   linkerd     linkerd     √      

--- a/cli/cmd/testdata/edges_one_output_json.golden
+++ b/cli/cmd/testdata/edges_one_output_json.golden
@@ -1,23 +1,38 @@
 [
   {
-    "src": "vote-bot-7466ffc7f7-5rc4l",
-    "dst": "web-57b7f9db85-297dw",
+    "src": "vote-bot",
+    "src_namespace": "emojivoto",
+    "dst": "web",
+    "dst_namespace": "emojivoto",
     "client_id": "default.emojivoto",
     "server_id": "web.emojivoto",
     "no_tls_reason": "-"
   },
   {
-    "src": "web-57b7f9db85-297dw",
-    "dst": "emoji-646ddcc5f9-zjgs9",
+    "src": "web",
+    "src_namespace": "emojivoto",
+    "dst": "emoji",
+    "dst_namespace": "emojivoto",
     "client_id": "web.emojivoto",
     "server_id": "emoji.emojivoto",
     "no_tls_reason": "-"
   },
   {
-    "src": "web-57b7f9db85-297dw",
-    "dst": "voting-689f845d98-rj6nz",
+    "src": "web",
+    "src_namespace": "emojivoto",
+    "dst": "voting",
+    "dst_namespace": "emojivoto",
     "client_id": "web.emojivoto",
     "server_id": "voting.emojivoto",
+    "no_tls_reason": "-"
+  },
+  {
+    "src": "linkerd-controller",
+    "src_namespace": "linkerd",
+    "dst": "linkerd-prometheus",
+    "dst_namespace": "linkerd",
+    "client_id": "linkerd-controller.linkerd",
+    "server_id": "linkerd-prometheus.linkerd",
     "no_tls_reason": "-"
   }
 ]

--- a/cli/cmd/testdata/edges_one_output_json.golden
+++ b/cli/cmd/testdata/edges_one_output_json.golden
@@ -6,7 +6,7 @@
     "dst_namespace": "emojivoto",
     "client_id": "default.emojivoto",
     "server_id": "web.emojivoto",
-    "no_tls_reason": "-"
+    "no_tls_reason": ""
   },
   {
     "src": "web",
@@ -15,7 +15,7 @@
     "dst_namespace": "emojivoto",
     "client_id": "web.emojivoto",
     "server_id": "emoji.emojivoto",
-    "no_tls_reason": "-"
+    "no_tls_reason": ""
   },
   {
     "src": "web",
@@ -24,7 +24,7 @@
     "dst_namespace": "emojivoto",
     "client_id": "web.emojivoto",
     "server_id": "voting.emojivoto",
-    "no_tls_reason": "-"
+    "no_tls_reason": ""
   },
   {
     "src": "linkerd-controller",
@@ -33,6 +33,6 @@
     "dst_namespace": "linkerd",
     "client_id": "linkerd-controller.linkerd",
     "server_id": "linkerd-prometheus.linkerd",
-    "no_tls_reason": "-"
+    "no_tls_reason": ""
   }
 ]

--- a/cli/cmd/testdata/edges_wide_output.golden
+++ b/cli/cmd/testdata/edges_wide_output.golden
@@ -1,0 +1,5 @@
+SRC                  DST                  SRC_NS      DST_NS      CLIENT_ID                    SERVER_ID                    SECURED
+vote-bot             web                  emojivoto   emojivoto   default.emojivoto            web.emojivoto                √      
+web                  emoji                emojivoto   emojivoto   web.emojivoto                emoji.emojivoto              √      
+web                  voting               emojivoto   emojivoto   web.emojivoto                voting.emojivoto             √      
+linkerd-controller   linkerd-prometheus   linkerd     linkerd     linkerd-controller.linkerd   linkerd-prometheus.linkerd   √      

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -302,17 +302,19 @@ func GenStatSummaryResponse(resName, resType string, resNs []string, counts *Pod
 
 // GenEdgesResponse generates a mock Public API StatSummaryResponse
 // object.
-func GenEdgesResponse(resourceType string, resSrc, resDst, resClient, resServer, msg []string) pb.EdgesResponse {
+func GenEdgesResponse(resourceType string, resSrc, resDst, resSrcNamespace, resDstNamespace, resClient, resServer, msg []string) pb.EdgesResponse {
 	edges := []*pb.Edge{}
 	for i := range resSrc {
 		edge := &pb.Edge{
 			Src: &pb.Resource{
-				Name: resSrc[i],
-				Type: resourceType,
+				Name:      resSrc[i],
+				Namespace: resSrcNamespace[i],
+				Type:      resourceType,
 			},
 			Dst: &pb.Resource{
-				Name: resDst[i],
-				Type: resourceType,
+				Name:      resDst[i],
+				Namespace: resDstNamespace[i],
+				Type:      resourceType,
 			},
 			ClientId:      resClient[i],
 			ServerId:      resServer[i],


### PR DESCRIPTION
This PR updates the CLI output for `linkerd edges` to reflect the latest API and dashboard changes. It also updates the associated CLI unit test.

**Scenario No. 1: Running emojivoto with linkerd injected**:

Previous output for `linkerd edges deploy --all-namespaces`:
```bash
SRC                  DST                  CLIENT                       SERVER                       MSG
linkerd-controller   linkerd-prometheus   linkerd-controller.linkerd   linkerd-prometheus.linkerd   -
vote-bot             web                  default.emojivoto            web.emojivoto                -
web                  emoji                web.emojivoto                emoji.emojivoto              -
web                  voting               web.emojivoto                voting.emojivoto             -
```

New output for `linkerd edges deploy --all-namespaces`:
```bash
SRC                  DST                  SRC_NS      DST_NS      SECURED
vote-bot             web                  emojivoto   emojivoto   √
web                  emoji                emojivoto   emojivoto   √
web                  voting               emojivoto   emojivoto   √
linkerd-controller   linkerd-prometheus   linkerd     linkerd     √
```

`-o wide` is now supported and will print identity for client and server if known.
`linkerd edges deploy --all-namespaces -o wide`:
```bash
SRC                  DST                  SRC_NS      DST_NS      CLIENT_ID                    SERVER_ID                    SECURED
vote-bot             web                  emojivoto   emojivoto   default.emojivoto            web.emojivoto                √
web                  emoji                emojivoto   emojivoto   web.emojivoto                emoji.emojivoto              √
web                  voting               emojivoto   emojivoto   web.emojivoto                voting.emojivoto             √
linkerd-controller   linkerd-prometheus   linkerd     linkerd     linkerd-controller.linkerd   linkerd-prometheus.linkerd   √
```

**Scenario No. 2: Running emojivoto without linkerd injected. A meshed `vote-bot-clone` deployment runs in the `default` namespace, calling the web deployment in the `emojivoto` namespace.**

`linkerd edges deploy --all-namespaces`
```bash
SRC                  DST                  SRC_NS    DST_NS      SECURED
vote-bot-clone       web                  default   emojivoto   Not Provided By Service Discovery
linkerd-controller   linkerd-prometheus   linkerd   linkerd     √
```

`linkerd edges deploy --all-namespaces -o wide`
```bash
SRC                  DST                  SRC_NS    DST_NS      CLIENT_ID                    SERVER_ID                    SECURED
vote-bot-clone       web                  default   emojivoto                                                             Not Provided By Service Discovery
linkerd-controller   linkerd-prometheus   linkerd   linkerd     linkerd-controller.linkerd   linkerd-prometheus.linkerd   √
```

