### PR TITLE
Update install failure message to list resources

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -163,7 +163,17 @@ const (
 	defaultIdentityIssuanceLifetime   = 24 * time.Hour
 	defaultIdentityClockSkewAllowance = 20 * time.Second
 
-	errMsgGlobalResourcesExist           = "Can't install the Linkerd control plane in the '%s' namespace. Global resources from an existing Linkerd installation detected:\n%s\n\nRemove these resources, or use the --ignore-cluster flag to overwrite them.\n"
+	errMsgGlobalResourcesExist = `Unable to install the Linkerd control plane. It appears that there is an existing installation:
+
+%s
+
+If you are sure you'd like to have a fresh install, remove these resources with:
+
+    linkerd install --ignore-cluster | kubectl delete -f -
+
+Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
+`
+
 	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
 	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
@@ -256,7 +266,7 @@ resources for the Linkerd control plane. This command should be followed by
   linkerd install config -l linkerdtest | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := errIfGlobalResourcesExist(); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, controlPlaneNamespace, err)
+				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
 				os.Exit(1)
 			}
 
@@ -348,7 +358,7 @@ control plane.`,
   # subcommands.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := errIfGlobalResourcesExist(); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, controlPlaneNamespace, err)
+				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
 				os.Exit(1)
 			}
 
@@ -865,7 +875,15 @@ func errIfGlobalResourcesExist() error {
 	errMsgs := []string{}
 	hc.RunChecks(func(result *healthcheck.CheckResult) {
 		if result.Err != nil {
-			errMsgs = append(errMsgs, result.Err.Error())
+			if re, ok := result.Err.(*healthcheck.ResourceError); ok {
+				// resource error, print in kind.group/name format
+				for _, res := range re.Resources {
+					errMsgs = append(errMsgs, res.String())
+				}
+			} else {
+				// unknown error, just print it
+				errMsgs = append(errMsgs, result.Err.Error())
+			}
 		}
 	})
 

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -19,6 +19,7 @@ import (
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes"
@@ -151,4 +152,15 @@ func ToRuntimeObject(config string) (runtime.Object, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(config), nil, nil)
 	return obj, err
+}
+
+// ObjectKinds wraps client-go's scheme.Scheme.ObjectKinds()
+// It returns all possible group,version,kind of the go object, true if the
+// object is considered unversioned, or an error if it's not a pointer or is
+// unregistered.
+func ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	apiextensionsv1beta1.AddToScheme(scheme.Scheme)
+	spscheme.AddToScheme(scheme.Scheme)
+	tsscheme.AddToScheme(scheme.Scheme)
+	return scheme.Scheme.ObjectKinds(obj)
 }


### PR DESCRIPTION
The existing `linkerd install` error message for existing resources was
shared with `linkerd check`. Given the different contexts, the messaging
made more sense for `linkerd check` than for `linkerd install`.

Modify the error messaging for `linkerd install` to print a bare list
of existing resources, and provide instructions for proceeding.

For example:
```bash
$ linkerd install
Unable to install the Linkerd control plane. It appears that there is an existing installation:

clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-controller
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-identity

If you are sure you'd like to have a fresh install, remove these resources with:

    linkerd install --ignore-cluster | kubectl delete -f -

Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
```

Fixes #3045

Signed-off-by: Andrew Seigner <siggy@buoyant.io>