### PR TITLE
Add NET_RAW to `linkerd check --pre`

### DIFF
--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -391,7 +391,7 @@ status:
 
 }
 
-func TestCheckNetAdmin(t *testing.T) {
+func TestChecCapability(t *testing.T) {
 	tests := []struct {
 		k8sConfigs []string
 		err        error
@@ -409,13 +409,13 @@ spec:
   requiredDropCapabilities:
     - ALL`,
 			},
-			fmt.Errorf("found 1 PodSecurityPolicies, but none provide NET_ADMIN, proxy injection will fail if the PSP admission controller is running"),
+			fmt.Errorf("found 1 PodSecurityPolicies, but none provide TEST_CAP, proxy injection will fail if the PSP admission controller is running"),
 		},
 	}
 
 	for i, test := range tests {
 		test := test // pin
-		t.Run(fmt.Sprintf("%d: returns expected NET_ADMIN result", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d: returns expected capability result", i), func(t *testing.T) {
 			hc := NewHealthChecker(
 				[]CategoryID{},
 				&Options{},
@@ -427,7 +427,7 @@ spec:
 				t.Fatalf("Unexpected error: %s", err)
 			}
 
-			err = hc.checkNetAdmin()
+			err = hc.checkCapability("TEST_CAP")
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -25,6 +25,7 @@ pre-kubernetes-setup
 pre-kubernetes-capability
 -------------------------
 √ has NET_ADMIN capability
+√ has NET_RAW capability
 
 pre-linkerd-global-resources
 ----------------------------


### PR DESCRIPTION
`linkerd check --pre` validates that PSPs provide `NET_ADMIN`, but was
not validating `NET_RAW`, despite `NET_RAW` being required by Linkerd's
proxy-init container since #2969.

Introduce a `has NET_RAW capability` check to `linkerd check --pre`.

Fixes #3054

Signed-off-by: Andrew Seigner <siggy@buoyant.io>