### PR TITLE
Fix upgrade tests conflicting with integration

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -41,5 +41,5 @@ if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresour
 fi
 
 if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then
-  kubectl --context=$k8s_context delete --wait=false $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
+  kubectl --context=$k8s_context delete $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
 fi

--- a/bin/test-run
+++ b/bin/test-run
@@ -35,7 +35,7 @@ function run_test(){
     shift
 
     printf "Running test [%s] %s\\n" "$(basename "$filename")" "$@"
-    go test -v "$filename" --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
+    go test "$filename" --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
 }
 
 # Install the latest stable release.
@@ -88,8 +88,16 @@ printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linke
 
 exit_code=0
 
-run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace || exit_code=$?
 run_upgrade_test "$linkerd_namespace"-upgrade
+# if run_upgrade_test succeeded, delete the installation to prepare for subsequent
+# full integration tests.
+# TODO: Consider running the the upgrade tests and normal integration tests on
+# separate clusters (in parallel? via kind?).
+if [ $exit_code -eq 0 ]; then
+    $bindir/test-cleanup "$linkerd_namespace"-upgrade $k8s_context
+fi
+
+run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace || exit_code=$?
 for test in $(find "$test_directory" -mindepth 2 -name '*_test.go'); do
     run_test "$test" --linkerd-namespace=$linkerd_namespace || exit_code=$?
 done

--- a/bin/test-run
+++ b/bin/test-run
@@ -63,7 +63,7 @@ function run_upgrade_test() {
     install_stable $stable_namespace
 
     printf "Upgrading release [%s] to [%s]\n" "$stable_version" "$linkerd_version"
-    run_test "$test_directory/install_test.go" --upgrade-from-version=$stable_version --linkerd-namespace=$stable_namespace || exit_code=$?
+    run_test "$test_directory/install_test.go" --upgrade-from-version=$stable_version --linkerd-namespace=$stable_namespace
 }
 
 linkerd_path=$1
@@ -88,10 +88,10 @@ printf "Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\\n" "$linke
 
 exit_code=0
 
-run_upgrade_test "$linkerd_namespace"-upgrade
+run_upgrade_test "$linkerd_namespace"-upgrade || exit_code=$?
 # if run_upgrade_test succeeded, delete the installation to prepare for subsequent
 # full integration tests.
-# TODO: Consider running the the upgrade tests and normal integration tests on
+# TODO: Consider running the upgrade tests and normal integration tests on
 # separate clusters (in parallel? via kind?).
 if [ $exit_code -eq 0 ]; then
     $bindir/test-cleanup "$linkerd_namespace"-upgrade $k8s_context


### PR DESCRIPTION
Integration tests on master broke following the 2.4 release, caused by
the recent disabling of multi control-plane support, coupled with the
upgrade integration test (which now upgrades from 2.4 to current sha).

The integration tests do the following:
1. install the current sha
2. test the current sha
3. install the latest stable in an `upgrade` namespace
4. in the `upgrade` namespace, upgrade from stable to latest sha
5. test the upgraded installation

Step 3 breaks because `linkerd install` with stable-2.4 will fail if
existing global resources (from step 1) are present.

For now, modify the integration tests to do the following:
1. install the latest stable in an `upgrade` namespace
2. in the `upgrade` namespace, upgrade from stable to latest sha
3. test the upgraded installation
4. upon successful step 3, remove all related resources
5. install the current sha
6. test the current sha

Signed-off-by: Andrew Seigner <siggy@buoyant.io>