### PR TITLE
git-commit-proxy-version: Omit SHAs from commit

### DIFF
--- a/bin/git-commit-proxy-version
+++ b/bin/git-commit-proxy-version
@@ -35,7 +35,7 @@ echo "proxy: Update proxy to ${new_proxy_revision}" >"$tmp/commit.template"
 echo "" >>"$tmp/commit.template"
 
 git log --pretty=oneline --abbrev-commit --reverse "${old_proxy_version}..${new_proxy_version}" | \
-sed -E -e 's,^,* linkerd/linkerd2-proxy#,' \
+    sed -E -e 's,^[a-f0-9]{7} ,* ,' \
     -e 's, \((#[0-9]+)\), (linkerd/linkerd2-proxy\1),' \
     >>"$tmp/commit.template"
 


### PR DESCRIPTION
The git-commt-proxy-version script attempted to link to the specifc
SHAs. GitHub doesn't actually render these links, and the information is
redundant since we link the appropriate PR.