### PR TITLE
Improve object cleanup when integration tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ jobs:
         - |
           # Run integration tests.
           version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
-          ./bin/test-cleanup linkerd-$version
+          ./bin/test-cleanup
           ./bin/test-run `pwd`/linkerd linkerd-$version
         - |
           # Run linkerd-cni integration tests.
@@ -171,8 +171,7 @@ jobs:
       after_script:
         - |
           # Cleanup after integration test run.
-          version="$(./linkerd version --client --short | tr -cd '[:alnum:]-')"
-          ./bin/test-cleanup linkerd-$version
+          ./bin/test-cleanup
 
 notifications:
   email:

--- a/TEST.md
+++ b/TEST.md
@@ -150,7 +150,7 @@ specialtest-get-test      Active    1m
 To cleanup the namespaces after the test has finished, run:
 
 ```bash
-$ bin/test-cleanup specialtest
+$ bin/test-cleanup
 ```
 
 ### Testing against a locally-built version of the CLI
@@ -322,7 +322,7 @@ bin/test-scale `pwd`/bin/linkerd
 ## Cleanup
 
 ```bash
-bin/test-cleanup l5d-scale
+bin/test-cleanup
 ```
 
 # Test against multiple cloud providers

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -2,44 +2,44 @@
 
 set -eu
 
-linkerd_namespace=${1:-l5d-integration}
-k8s_context=${2:-""}
+k8s_context=${1:-""}
 
-if [ -z "$linkerd_namespace" ]; then
-    echo "usage: $(basename "$0") <namespace> [k8s-context]">&2
-    exit 64
+echo "cleaning up control-plane namespaces in k8s-context [${k8s_context}]"
+
+if ! namespaces_controlplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-control-plane); then
+  echo "no control-plane namespaces found" >&2
 fi
 
-echo "cleaning up namespace [${linkerd_namespace}] in k8s-context [${k8s_context}] and associated test namespaces"
+echo "cleaning up data-plane namespaces in k8s-context [${k8s_context}]"
 
-if ! namespaces=$(kubectl --context=$k8s_context get ns -oname | grep -E "/$linkerd_namespace(-|$)"); then
-  echo "no namespaces found for [$linkerd_namespace]" >&2
+if ! namespaces_dataplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-data-plane); then
+  echo "no data-plane namespaces found" >&2
 fi
 
-if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no clusterrolebindings found for [$linkerd_namespace]" >&2
+if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname -l linkerd.io/control-plane-ns); then
+  echo "no clusterrolebindings found" >&2
 fi
 
-if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no clusterroles found for [$linkerd_namespace]" >&2
+if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname -l linkerd.io/control-plane-ns); then
+  echo "no clusterroles found" >&2
 fi
 
-if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns); then
   echo "no mutatingwebhookconfigurations found" >&2
 fi
 
-if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname | grep -E  "/linkerd(-|$)"); then
+if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns); then
   echo "no validatingwebhookconfigurations found" >&2
 fi
 
-if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname | grep -E "/linkerd-$linkerd_namespace(-|$)"); then
-  echo "no podsecuritypolicies found for [$linkerd_namespace]" >&2
+if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname -l linkerd.io/control-plane-ns); then
+  echo "no podsecuritypolicies found" >&2
 fi
 
 if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/control-plane-ns -oname); then
-  echo "no customresourcedefinitions found for [$linkerd_namespace]" >&2
+  echo "no customresourcedefinitions found" >&2
 fi
 
-if [[ $namespaces || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then
-  kubectl --context=$k8s_context delete $namespaces $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
+if [[ $namespaces_controlplane || $namespaces_dataplane || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then
+  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_dataplane $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
 fi

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -23,5 +23,5 @@ done
 for CLUSTER in $AKS $DO $EKS $GKE
 do
   printf "\n$CLUSTER\n"
-  bin/test-cleanup l5d-integration-cloud $CLUSTER
+  bin/test-cleanup $CLUSTER
 done

--- a/bin/test-run
+++ b/bin/test-run
@@ -94,7 +94,7 @@ run_upgrade_test "$linkerd_namespace"-upgrade || exit_code=$?
 # TODO: Consider running the upgrade tests and normal integration tests on
 # separate clusters (in parallel? via kind?).
 if [ $exit_code -eq 0 ]; then
-    $bindir/test-cleanup "$linkerd_namespace"-upgrade $k8s_context
+    $bindir/test-cleanup $k8s_context
 fi
 
 run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace || exit_code=$?

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -40,6 +40,10 @@ func TestEgressHttp(t *testing.T) {
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("egress-test")
+	err = TestHelper.CreateNamespaceIfNotExists(prefixedNs, nil)
+	if err != nil {
+		t.Fatalf("failed to create %s namespace: %s", prefixedNs, err)
+	}
 	out, err = TestHelper.KubectlApply(out, prefixedNs)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v output:\n%s", err, out)

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -55,6 +55,10 @@ func TestCliGet(t *testing.T) {
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("get-test")
+	err = TestHelper.CreateNamespaceIfNotExists(prefixedNs, nil)
+	if err != nil {
+		t.Fatalf("failed to create %s namespace: %s", prefixedNs, err)
+	}
 	out, err = TestHelper.KubectlApply(out, prefixedNs)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v output:\n%s", err, out)

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -33,6 +33,10 @@ func TestMain(m *testing.M) {
 func TestServiceProfiles(t *testing.T) {
 
 	testNamespace := TestHelper.GetTestNamespace("serviceprofile-test")
+	err := TestHelper.CreateNamespaceIfNotExists(testNamespace, nil)
+	if err != nil {
+		t.Fatalf("failed to create %s namespace: %s", testNamespace, err)
+	}
 	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -84,6 +84,10 @@ func TestCliTap(t *testing.T) {
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("tap-test")
+	err = TestHelper.CreateNamespaceIfNotExists(prefixedNs, nil)
+	if err != nil {
+		t.Fatalf("failed to create %s namespace: %s", prefixedNs, err)
+	}
 	out, err = TestHelper.KubectlApply(out, prefixedNs)
 	if err != nil {
 		t.Fatalf("kubectl apply command failed\n%s", out)

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -54,13 +54,16 @@ func (h *KubernetesHelper) CheckIfNamespaceExists(namespace string) error {
 	return err
 }
 
-// CreateNamespaceIfNotExists creates a namespace if it does not already exist.
+// CreateNamespaceIfNotExists creates a dataplane namespace if it does not already exist,
+// with a linkerd.io/is-test-data-plane label for easier cleanup afterwards
 func (h *KubernetesHelper) CreateNamespaceIfNotExists(namespace string, annotations map[string]string) error {
 	err := h.CheckIfNamespaceExists(namespace)
 
 	if err != nil {
+		labels := map[string]string{"linkerd.io/is-test-data-plane": "true"}
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
+				Labels:      labels,
 				Annotations: annotations,
 				Name:        namespace,
 			},
@@ -81,11 +84,6 @@ func (h *KubernetesHelper) CreateNamespaceIfNotExists(namespace string, annotati
 func (h *KubernetesHelper) KubectlApply(stdin string, namespace string) (string, error) {
 	if namespace == "" {
 		namespace = "default"
-	}
-
-	err := h.CreateNamespaceIfNotExists(namespace, nil)
-	if err != nil {
-		return "", err
 	}
 
 	return h.Kubectl(stdin, "apply", "-f", "-", "--namespace", namespace)


### PR DESCRIPTION
Integration tests may fail and leave behind namespaces that following
builds aren't able to clean up because the git sha is being included in
the namespace name, and the following builds don't know about those
shas.

This modifies the `test-cleanup` script to delete based on object labels
instead of relying on the objects names, now that after 2.4 all the
control plane components are labeled. Note that this will also remove
non-testing linkerd namespaces, but we were already kinda doing that
partially because we were removing the cluster-level resources (CRDs,
webhook configs, clusterroles, clusterrolebindings, psp).

`test-cleanup` no longer receives a namespace name as an argument.

The data plane namespaces aren't labeled though, so I've added the
`linkerd.io/is-test-data-plane` label for them in
`CreateNamespaceIfNotExists()`, and making sure all tests that need a
data plaine explicitly call that method instead of creating the
namespace as a side-effect in `KubectlApply()`.
