### PR TITLE
Read dstOverrides directly from service profiles

### DIFF
--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -97,7 +97,7 @@ func toDstOverrides(dsts []*sp.WeightedDst) []*pb.WeightedDst {
 	pbDsts := []*pb.WeightedDst{}
 	for _, dst := range dsts {
 		pbDst := &pb.WeightedDst{
-			Authority: dst.Authority,
+			Authority: dst.Service,
 			// Weights are expressed in decimillis: 10_000 represents 100%
 			Weight: uint32(dst.Weight.MilliValue() * millisPerDecimilli),
 		}

--- a/controller/api/destination/traffic_split_adaptor.go
+++ b/controller/api/destination/traffic_split_adaptor.go
@@ -68,7 +68,7 @@ func (tsa *trafficSplitAdaptor) publish() {
 				port, err = strconv.Atoi(hostPort[1])
 				if err != nil {
 					log.Errorf("invalid dstOverride service port: %s", hostPort[1])
-					break
+					continue
 				}
 			}
 			segments := strings.Split(hostPort[0], ".")

--- a/controller/api/destination/traffic_split_adaptor_test.go
+++ b/controller/api/destination/traffic_split_adaptor_test.go
@@ -22,8 +22,8 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 			},
 			DstOverrides: []*sp.WeightedDst{
 				{
-					Authority: "foo",
-					Weight:    resource.MustParse("500m"),
+					Service: "foo",
+					Weight:  resource.MustParse("500m"),
 				},
 			},
 		},
@@ -66,8 +66,8 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 			Spec: sp.ServiceProfileSpec{
 				DstOverrides: []*sp.WeightedDst{
 					{
-						Authority: "bar.ns.svc.cluster.local:80",
-						Weight:    resource.MustParse("1000m"),
+						Service: "bar.ns.svc.cluster.local:80",
+						Weight:  resource.MustParse("1000m"),
 					},
 				},
 			},
@@ -76,7 +76,7 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 		testCompare(t, expected.Spec, listener.Profiles[0].Spec)
 	})
 
-	t.Run("Profile merged with traffic split", func(t *testing.T) {
+	t.Run("Profile has precidence over traffic split", func(t *testing.T) {
 		listener := watcher.NewBufferingProfileListener()
 		adaptor := newTrafficSplitAdaptor(listener, watcher.ServiceID{Name: "foo", Namespace: "ns"}, watcher.Port(80))
 
@@ -96,8 +96,8 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 				},
 				DstOverrides: []*sp.WeightedDst{
 					{
-						Authority: "bar.ns.svc.cluster.local:80",
-						Weight:    resource.MustParse("1000m"),
+						Service: "foo.ns.svc.cluster.local:80",
+						Weight:  resource.MustParse("500m"),
 					},
 				},
 			},

--- a/controller/gen/apis/serviceprofile/v1alpha1/types.go
+++ b/controller/gen/apis/serviceprofile/v1alpha1/types.go
@@ -82,8 +82,8 @@ type RetryBudget struct {
 
 // WeightedDst is a weighted alternate destination.
 type WeightedDst struct {
-	Authority string            `json:"authority"`
-	Weight    resource.Quantity `json:"weight"`
+	Service string            `json:"service"`
+	Weight  resource.Quantity `json:"weight"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Allow `dstOverrides` to be specified directly on a service profile as an alternative to using the SMI traffic split API.  This traffic split object:

```
apiVersion: split.smi-spec.io/v1alpha1
kind: TrafficSplit
metadata:
  name: books-error-inject
spec:
  service: books
  backends:
  - service: books
    weight: 80m
  - service: error-injector
    weight: 20m
```

is equivalent to this service profile:

```
apiVersion: linkerd.io/v1alpha2
kind: ServiceProfile
metadata:
  name: books.default.svc.cluster.local
  namespace: default
spec:
  dstOverrides:
  - service: error-injector
    weight: 20m
  - service: books
    weight: 80m
```

If a service has both a traffic split and a service profile that defines dstOverrides, the dstOverrides in the service profile are used and the traffic split is ignored.

Signed-off-by: Alex Leong <alex@buoyant.io>