### PR TITLE
Revert "Increase the retry duration in the post-upgrade 'check' integration test (#2944)"

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -434,7 +434,7 @@ func TestCheckProxy(t *testing.T) {
 			cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=0"}
 			golden := "check.proxy.golden"
 
-			err := TestHelper.RetryFor(time.Minute*5, func() error {
+			err := TestHelper.RetryFor(time.Minute, func() error {
 				out, _, err := TestHelper.LinkerdRun(cmd...)
 				if err != nil {
 					return fmt.Errorf("Check command failed\n%s", out)


### PR DESCRIPTION
This reverts commit 60c58c1f857f510fa4184b0978e07851167b9c42. It fixes the following timeout panic in the integration test:
```
goroutine 598 [chan receive, 2 minutes]:
testing.(*T).Run(0xc00056c800, 0x55daba4f78fe, 0xa, 0xc0000bce40, 0xf)
	/usr/lib/go/src/testing/testing.go:879 +0x385
command-line-arguments.TestCheckProxy(0xc00056c600)
	/root/go/src/github.com/linkerd/linkerd2/test/install_test.go:432 +0x14b
testing.tRunner(0xc00056c600, 0x55dabaae4888)
	/usr/lib/go/src/testing/testing.go:827 +0xc1
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:878 +0x35e
```