### PR TITLE
Added Resource Limits when ha is Configured

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -581,6 +581,14 @@ func (options *installOptions) handleHA() {
 		if options.proxyMemoryRequest == "" {
 			options.proxyMemoryRequest = "20Mi"
 		}
+
+		if options.proxyCPULimit == "" {
+			options.proxyCPULimit = "1"
+		}
+
+		if options.proxyMemoryLimit == "" {
+			options.proxyMemoryLimit = "250Mi"
+		}
 	}
 
 	options.identityOptions.replicas = options.controllerReplicas

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -647,8 +647,8 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		values.WebhookFailurePolicy = "Fail"
 
 		defaultConstraints := &resources{
-			CPU:    constraints{Request: "100m"},
-			Memory: constraints{Request: "50Mi"},
+			CPU:    constraints{Request: "100m", Limit: "1"},
+			Memory: constraints{Request: "50Mi", Limit: "250Mi"},
 		}
 		// Copy constraints to each so that further modification isn't global.
 		*values.DestinationResources = *defaultConstraints
@@ -663,11 +663,12 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*ins
 		// The identity controller maintains no internal state, so it need not request
 		// 50Mi.
 		*values.IdentityResources = *defaultConstraints
-		values.IdentityResources.Memory = constraints{Request: "10Mi"}
+		values.IdentityResources.Memory = constraints{Request: "10Mi", Limit: "250Mi"}
 
+		values.GrafanaResources.Memory.Limit = "1024Mi"
 		values.PrometheusResources = &resources{
-			CPU:    constraints{Request: "300m"},
-			Memory: constraints{Request: "300Mi"},
+			CPU:    constraints{Request: "300m", Limit: "4"},
+			Memory: constraints{Request: "300Mi", Limit: "8192Mi"},
 		}
 	}
 

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1195,6 +1195,9 @@ spec:
               requests:
                 cpu: 100m
                 memory: 50Mi
+              limits:
+                cpu: 1
+                memory: 250Mi
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -601,7 +601,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy\nLmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE\nAxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0\nxtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364\n6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF\nBQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE\nAiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv\nOLO4Zsk1XrGZHGsmyiEyvYF9lpY=\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null,"omitWebhookSideEffects":false,"clusterDomain":"cluster.local"}
   proxy: |
-    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"100m","requestMemory":"20Mi","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxyInitImageVersion":"v1.0.0"}
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"100m","requestMemory":"20Mi","limitCpu":"1","limitMemory":"250Mi"},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxyInitImageVersion":"v1.0.0"}
   install: |
     {"uuid":"deaab91a-f4ab-448a-b7d1-c832a2fa0a60","cliVersion":"dev-undefined","flags":[{"name":"ha","value":"true"}]}
 ---
@@ -801,6 +801,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1095,6 +1098,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1356,6 +1362,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1665,6 +1674,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1940,6 +1952,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2169,6 +2184,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2428,6 +2446,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2659,6 +2680,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -712,6 +712,9 @@ spec:
             path: /ready
             port: 9990
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 10Mi
@@ -969,6 +972,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1002,6 +1008,9 @@ spec:
             path: /ready
             port: 9996
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1260,6 +1269,9 @@ spec:
             path: /ready
             port: 9994
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1561,6 +1573,9 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
         resources:
+          limits:
+            cpu: "4"
+            memory: 8Gi
           requests:
             cpu: 300m
             memory: 300Mi
@@ -1835,6 +1850,9 @@ spec:
             path: /api/health
             port: 3000
         resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2061,6 +2079,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2319,6 +2340,9 @@ spec:
             path: /ready
             port: 9997
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2551,6 +2575,9 @@ spec:
             path: /ready
             port: 9998
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -601,7 +601,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy\nLmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE\nAxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0\nxtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364\n6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF\nBQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE\nAiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv\nOLO4Zsk1XrGZHGsmyiEyvYF9lpY=\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null,"omitWebhookSideEffects":false,"clusterDomain":"cluster.local"}
   proxy: |
-    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"400m","requestMemory":"300Mi","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxyInitImageVersion":"v1.0.0"}
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"400m","requestMemory":"300Mi","limitCpu":"1","limitMemory":"250Mi"},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxyInitImageVersion":"v1.0.0"}
   install: |
     {"uuid":"deaab91a-f4ab-448a-b7d1-c832a2fa0a60","cliVersion":"dev-undefined","flags":[{"name":"ha","value":"true"},{"name":"controller-replicas","value":"2"},{"name":"proxy-cpu-request","value":"400m"},{"name":"proxy-memory-request","value":"300Mi"}]}
 ---
@@ -801,6 +801,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -1095,6 +1098,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -1356,6 +1362,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -1665,6 +1674,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -1940,6 +1952,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -2169,6 +2184,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -2428,6 +2446,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi
@@ -2659,6 +2680,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 400m
             memory: 300Mi

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1195,6 +1195,9 @@ spec:
               requests:
                 cpu: 100m
                 memory: 50Mi
+              limits:
+                cpu: 1
+                memory: 250Mi
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -712,6 +712,9 @@ spec:
             path: /ready
             port: 9990
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 10Mi
@@ -969,6 +972,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1002,6 +1008,9 @@ spec:
             path: /ready
             port: 9996
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1260,6 +1269,9 @@ spec:
             path: /ready
             port: 9994
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1561,6 +1573,9 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
         resources:
+          limits:
+            cpu: "4"
+            memory: 8Gi
           requests:
             cpu: 300m
             memory: 300Mi
@@ -1835,6 +1850,9 @@ spec:
             path: /api/health
             port: 3000
         resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2061,6 +2079,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2319,6 +2340,9 @@ spec:
             path: /ready
             port: 9997
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2551,6 +2575,9 @@ spec:
             path: /ready
             port: 9998
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -601,7 +601,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"UPGRADE-CONTROL-PLANE-VERSION","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0\neS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz\nMjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j\nYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg\nEMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw\nQDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\nMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW\nYmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj\n+U9K4WlbzA==\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s"},"autoInjectContext":null,"omitWebhookSideEffects":false,"clusterDomain":"cluster.local"}
   proxy: |
-    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"100m","requestMemory":"20Mi","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"UPGRADE-PROXY-VERSION","proxyInitImageVersion":"v1.0.0"}
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"100m","requestMemory":"20Mi","limitCpu":"1","limitMemory":"250Mi"},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true,"proxyVersion":"UPGRADE-PROXY-VERSION","proxyInitImageVersion":"v1.0.0"}
   install: |
     {"uuid":"57af298c-58b0-43fc-8d88-3c338789bfbc","cliVersion":"dev-undefined","flags":[{"name":"ha","value":"true"}]}
 ---
@@ -802,6 +802,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1097,6 +1100,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1359,6 +1365,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1669,6 +1678,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -1945,6 +1957,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2175,6 +2190,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2435,6 +2453,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi
@@ -2667,6 +2688,9 @@ spec:
             port: 4191
           initialDelaySeconds: 2
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1197,6 +1197,9 @@ spec:
               requests:
                 cpu: 100m
                 memory: 50Mi
+              limits:
+                cpu: 1
+                memory: 250Mi
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -712,6 +712,9 @@ spec:
             path: /ready
             port: 9990
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 10Mi
@@ -970,6 +973,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1003,6 +1009,9 @@ spec:
             path: /ready
             port: 9996
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1262,6 +1271,9 @@ spec:
             path: /ready
             port: 9994
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -1564,6 +1576,9 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
         resources:
+          limits:
+            cpu: "4"
+            memory: 8Gi
           requests:
             cpu: 300m
             memory: 300Mi
@@ -1839,6 +1854,9 @@ spec:
             path: /api/health
             port: 3000
         resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2066,6 +2084,9 @@ spec:
             path: /ready
             port: 9995
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2325,6 +2346,9 @@ spec:
             path: /ready
             port: 9997
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -2558,6 +2582,9 @@ spec:
             path: /ready
             port: 9998
         resources:
+          limits:
+            cpu: "1"
+            memory: 250Mi
           requests:
             cpu: 100m
             memory: 50Mi


### PR DESCRIPTION
Fixes #2640 

When `ha` is configured, this PR adds better resource limits.

- identity - 1 / 250Mi
- proxy-api - 1 / 250Mi
- public-api - 1 / 250Mi
- tap - 1 / 250Mi
- destination - 1 / 250Mi
- web - 1 / 250Mi
- proxy-injector - 1 / 250Mi
- sp-validator - 1 / 250Mi
- prometheus - 4 / 8192Mi
- grafana - 1 / 1024Mi
- init - 10m / 50Mi

@grampelberg @ihcsim 
Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>