### PR TITLE
Integrating Pulumi to create clusters for testing

### DIFF
--- a/pulumi-stuff/README.md
+++ b/pulumi-stuff/README.md
@@ -1,0 +1,25 @@
+# pulumi-stuff
+
+Uses clusters.makefile to create VPC and kubernetes cluster in GCP using pulumi (other functionalities haven't been ported to pulumi yet).
+
+First time execution: 
+
+make -f clusters.makefile bootstrap
+(installs dependencies)
+
+To create network:
+
+make -f clusters.makefile create-network
+(currently asks for permission before creating)
+
+To create cluster:
+
+make -f clusters.makefile create
+(currently asks for permission before creating)
+
+To delete cluster:
+
+make -f clusters.makefile delete
+(currently asks for permission before destroying)
+
+NOTE: just to be safe, and to avoid unintentionally spending all your GCP credits, cd into each directory (gcp-network and gcp-cluster) and manually execute the command: pulumi destroy

--- a/pulumi-stuff/clusters.makefile
+++ b/pulumi-stuff/clusters.makefile
@@ -1,0 +1,156 @@
+# Cluster management tools.
+
+export CLUSTER_NAME ?= $(shell cat tmp/current 2>/dev/null || echo $$(whoami)-dev)
+export MACHINE_TYPE ?= n1-standard-2
+export DISK_SIZE ?= 100
+export MAX_NODES ?= 10
+export NETWORK ?= dev
+export PROJECT ?= $(shell gcloud config get-value project)
+export VERSION ?= latest
+export ZONE ?= us-west1-a
+GKE_DASHBOARD = http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
+
+define gcloud_container
+	gcloud beta container \
+		--project "$(PROJECT)" \
+		clusters \
+		--zone "$(ZONE)"
+endef
+
+define gcloud_compute
+	gcloud compute --project=$(PROJECT)
+endef
+
+tmp:
+	mkdir tmp
+
+HAS_GCLOUD := $(shell command -v gcloud;)
+HAS_HELM := $(shell command -v helm;)
+HAS_KUBECTL := $(shell command -v kubectl;)
+HAS_AZ := $(shell command -v az;)
+HAS_PULUMI := $(shell command -v pulumi;)
+
+.PHONY: bootstrap
+bootstrap:
+	@# Bootstrap the local required binaries
+ifndef HAS_GCLOUD
+	curl https://sdk.cloud.google.com | bash
+endif
+ifndef HAS_KUBECTL
+	gcloud components install kubectl
+endif
+ifndef HAS_HELM
+	curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+endif
+ifndef HAS_PULUMI
+	curl -fsSL https://get.pulumi.com | sh
+endif
+
+
+.PHONY: create
+create: bootstrap
+	@# Create a cluster in GKE with some sane defaults.
+	@# Options:
+	@#
+	@#     CLUSTER_NAME                       :: ${CLUSTER_NAME}
+	@#     MACHINE_TYPE                       :: ${MACHINE_TYPE}
+	@#     MAX_NODES                          :: ${MAX_NODES}
+	@#     NETWORK                            :: ${NETWORK}
+	@#     PROJECT                            :: ${PROJECT}
+	@#     VERSION                            :: ${VERSION}
+	@#     ZONE                               :: ${ZONE}
+	cd gcp-cluster; \
+	npm install; \
+	pulumi config set gcp:project ${PROJECT}; \
+	pulumi config set gcp:zone ${ZONE}; \
+	pulumi up;
+	 $(MAKE) get-auth set-current run-proxy
+	 kubectl create clusterrolebinding \
+	 	$$(whoami)-cluster-admin \
+	 	--clusterrole=cluster-admin \
+	 	--user=$$(gcloud config get-value account)
+	 kubectl apply -f psp.yaml -f rbac.yaml -f tiller.yaml
+	 helm init --service-account tiller
+	 $(MAKE) show-dashboard
+
+.PHONY: delete
+delete:
+	@# Deletes the current cluster.
+	@# Options:
+	@#
+	@#     CLUSTER_NAME                       :: ${CLUSTER_NAME}
+	@#     PROJECT                            :: ${PROJECT}
+	@#     ZONE                               :: ${ZONE}
+	cd gcp-cluster; \
+	pulumi destroy;
+.PHONY: get-auth
+get-auth:
+	@# Configure kubectl to connect to remote cluster.
+	@# Options:
+	@#
+	@#     CLUSTER_NAME                       :: ${CLUSTER_NAME}
+	$(call gcloud_container) \
+		get-credentials \
+		$(CLUSTER_NAME)
+	kubectl config delete-context gke-$(CLUSTER_NAME) || true
+	kubectl config rename-context \
+		$$(kubectl config current-context) \
+		gke-$(CLUSTER_NAME)
+
+.PHONY: set-current
+set-current:
+	@# Set the current cluster and setup kubectl to use it.
+	@# Options:
+	@#
+	@#     CLUSTER_NAME                       :: ${CLUSTER_NAME}
+	kubectl config use-context gke-$(CLUSTER_NAME)
+
+.PHONY: run-proxy
+run-proxy: tmp
+	@# Run the proxy so that the dashboard is accessible.
+	lsof -i4TCP:8001 -sTCP:LISTEN -t | xargs kill
+	kubectl proxy >tmp/proxy.log 2>&1 &
+
+.PHONY: create-network
+create-network:
+	@# Create a VPC network for use by k8s clusters. Allow current IP by default.
+	@# Options:
+	@#
+	@#     NETWORK                            :: ${NETWORK}
+	@#     PROJECT                            :: ${PROJECT}
+	@#     ZONE                               :: ${ZONE}
+	cd gcp-network; \
+	npm install; \
+	pulumi config set gcp:project ${PROJECT}; \
+	pulumi config set gcp:zone ${ZONE}; \
+	pulumi up;
+
+.PHONY: show-dashboard
+show-dashboard:
+	@# Show the URL that can be used to access the dashboard
+	@echo "Go to $(GKE_DASHBOARD) for the dashboard. Note: RBAC is permissive for the dashboard, no need to enter a token."
+
+
+
+.PHONY: help
+help: SHELL := /bin/bash
+help:
+	@# Output all targets available.
+	@ echo "usage: make [target] ..."
+	@ echo ""
+	@eval "echo \"$$(grep -h -B1 $$'^\t@#' $(MAKEFILE_LIST) \
+		| sed 's/@#//' \
+		| awk \
+			-v NO_COLOR="$(NO_COLOR)" \
+			-v OK_COLOR="$(OK_COLOR)" \
+			-v RS="--\n" \
+			-v FS="\n" \
+			-v OFS="@@" \
+			'{ split($$1,target,":"); $$1=""; print OK_COLOR target[1] NO_COLOR $$0 }' \
+		| sort \
+		| awk \
+			-v FS="@@" \
+			-v OFS="\n" \
+			'{ CMD=$$1; $$1=""; print CMD $$0 }')\""
+
+.DEFAULT_GOAL := help

--- a/pulumi-stuff/gcp-cluster/.gitignore
+++ b/pulumi-stuff/gcp-cluster/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/pulumi-stuff/gcp-cluster/Pulumi.dev.yaml
+++ b/pulumi-stuff/gcp-cluster/Pulumi.dev.yaml
@@ -1,0 +1,3 @@
+config:
+  gcp:project: sincere-almanac-243215
+  gcp:zone: us-west1-a

--- a/pulumi-stuff/gcp-cluster/Pulumi.yaml
+++ b/pulumi-stuff/gcp-cluster/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: gcp-cluster
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/pulumi-stuff/gcp-cluster/clusterrolebinding.yaml
+++ b/pulumi-stuff/gcp-cluster/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: "2019-07-05T09:52:40Z"
+  name: cluster-admin-name
+  resourceVersion: "7031"
+  selfLink: /apis/rbac.authorization.k8s.io/v1beta1/clusterrolebindings/cluster-admin-name
+  uid: 76441bf1-9e41-11e9-9000-42010a8a0180
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: email id

--- a/pulumi-stuff/gcp-cluster/index.ts
+++ b/pulumi-stuff/gcp-cluster/index.ts
@@ -1,0 +1,137 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+import * as k8s from "@pulumi/kubernetes";
+import { ClusterRole } from "@pulumi/kubernetes/rbac/v1";
+const env = pulumi.getStack();
+const username =require("os").userInfo().username;
+const name=process.env.CLUSTER_NAME || "default-dev";
+const net = new pulumi.StackReference(`/gcp-network/${env}`);
+const primary = new gcp.container.Cluster(name, {
+    initialNodeCount: 1,
+    nodeVersion: process.env.VERSION,
+    minMasterVersion: process.env.VERSION,
+    location: process.env.ZONE,
+    // Setting an empty username and password explicitly disables basic auth
+    masterAuth: {
+        clientCertificateConfig:{
+            issueClientCertificate:false
+        },
+        password: "",
+        username: "",
+    },
+    loggingService: 'none',
+    network: process.env.NETWORK,
+    monitoringService: 'none',
+    enableLegacyAbac: false,
+    enableKubernetesAlpha: true,
+    podSecurityPolicyConfig:{
+        enabled:true
+    },
+    verticalPodAutoscaling:{
+        enabled:true
+    },
+    networkPolicy:{
+        enabled: true
+    },
+    ipAllocationPolicy:{
+        useIpAliases: false
+    },
+    addonsConfig:{
+        horizontalPodAutoscaling: {
+            disabled:false
+        },
+        httpLoadBalancing:{
+            disabled:false
+        },
+        kubernetesDashboard:{
+            disabled:false
+        },
+        networkPolicyConfig:{
+            disabled:false
+        }
+
+    },
+    // We can't create a cluster with no node pool defined, but we want to only use
+    // separately managed node pools. So we create the smallest possible default
+    // node pool and immediately delete it.
+    removeDefaultNodePool: true,
+});
+const primaryPreemptibleNodes = new gcp.container.NodePool(name+"-preemtible", {
+    cluster: primary.name,
+    location: process.env.ZONE,
+    nodeConfig: {
+        machineType: process.env.MACHINE_TYPE ,
+        imageType: "COS",
+        diskSizeGb: parseInt(process.env.DISK_SIZE || "15"),
+        minCpuPlatform:"Intel Skylake",
+        
+        diskType: "pd-standard",
+        metadata: {
+            "disable-legacy-endpoints": "true",
+        },
+        
+        oauthScopes: [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring",
+        ],
+        preemptible: true,
+    },
+    management:{
+        autoRepair: false,
+        autoUpgrade: false
+    },
+    nodeCount: 1,
+    autoscaling:{
+        minNodeCount:1,
+        maxNodeCount: parseInt(process.env.MAX_NODES || "5"),
+    },
+
+});
+
+export const kubeconfig = pulumi.
+    all([ primary.name, primary.endpoint, primary.masterAuth ]).
+    apply(([ name, endpoint, masterAuth ]) => {
+        const context = `${gcp.config.project}_${gcp.config.zone}_${name}`;
+        return `apiVersion: v1alpha1
+clusters:
+- cluster:
+    certificate-authority-data: ${masterAuth.clusterCaCertificate}
+    server: https://${endpoint}
+  name: ${context}
+contexts:
+- context:
+    cluster: ${context}
+    user: ${context}
+  name: ${context}
+current-context: ${context}
+kind: Config
+preferences: {}
+users:
+- name: ${context}
+  user:
+    auth-provider:
+      config:
+        cmd-args: config config-helper --format=json
+        cmd-path: gcloud
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+`;
+    });
+export const clusterProvider = new k8s.Provider(name, {
+    kubeconfig: kubeconfig,
+});
+
+const clusterRole= new k8s.rbac.v1alpha1.ClusterRole("cluster-admin");
+const clusterRBAC= new k8s.rbac.v1alpha1.ClusterRoleBinding( username+"-cluster-admin",{
+    roleRef: {
+        apiGroup: clusterRole.apiVersion,
+        kind: clusterRole.kind,
+        name: clusterRole.id,
+    },
+    subjects:[
+    ],
+});

--- a/pulumi-stuff/gcp-cluster/package-lock.json
+++ b/pulumi-stuff/gcp-cluster/package-lock.json
@@ -1,0 +1,1271 @@
+{
+    "name": "typescript",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@pulumi/gcp": {
+            "version": "0.18.9",
+            "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-0.18.9.tgz",
+            "integrity": "sha512-XaP2sMK2DvNKSY1gbMEaaPPgW46kFEGfqzEcgmiwkQlq7hWeETK4rpW6ldy/cBNJ8v98BYwGaoStk3r/ygkD8w==",
+            "requires": {
+                "@pulumi/pulumi": "^0.17.8",
+                "@types/express": "^4.16.0",
+                "read-package-json": "^2.0.13"
+            }
+        },
+        "@pulumi/kubernetes": {
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-0.25.0.tgz",
+            "integrity": "sha512-Un4muTw/90FGGFtJmglUwjiEgzTSfajWltjnDN1TDxB6sSifOG0m+yoaDw/6kHsp9h5S5hrs8d+uAxZySvKasg==",
+            "requires": {
+                "@pulumi/pulumi": "^0.17.17",
+                "@types/glob": "^5.0.35",
+                "@types/js-yaml": "^3.11.2",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "js-yaml": "^3.12.0",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "@pulumi/pulumi": {
+            "version": "0.17.21",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.21.tgz",
+            "integrity": "sha512-/0xt1Cy+aRcMZdTeA6d2Zi4496HBJezrdOPrvbuYBBNRH6jC3VTqUuQLWpjj0GcwfYKlSBN3DLMGCyeEWmmMWg==",
+            "requires": {
+                "@pulumi/query": "^0.3.0",
+                "deasync": "^0.1.15",
+                "google-protobuf": "^3.5.0",
+                "grpc": "^1.20.2",
+                "minimist": "^1.2.0",
+                "normalize-package-data": "^2.4.0",
+                "protobufjs": "^6.8.6",
+                "read-package-tree": "5.2.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^6.1.0",
+                "source-map-support": "^0.4.16",
+                "ts-node": "^7.0.0",
+                "typescript": "^3.0.0",
+                "upath": "^1.1.0"
+            }
+        },
+        "@pulumi/query": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/query/-/query-0.3.0.tgz",
+            "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
+        },
+        "@types/body-parser": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+            "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/connect": {
+            "version": "3.4.32",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+            "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+        },
+        "@types/express": {
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+            "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "4.16.7",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+            "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+            "requires": {
+                "@types/node": "*",
+                "@types/range-parser": "*"
+            }
+        },
+        "@types/glob": {
+            "version": "5.0.36",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+            "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA=="
+        },
+        "@types/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+        },
+        "@types/mime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+            "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+        },
+        "@types/node": {
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+            "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
+        },
+        "@types/node-fetch": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.3.7.tgz",
+            "integrity": "sha512-+bKtuxhj/TYSSP1r4CZhfmyA0vm/aDRQNo7vbAgf6/cZajn0SAniGGST07yvI4Q+q169WTa2/x9gEHfJrkcALw==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/range-parser": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+            "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+        },
+        "@types/serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+            "requires": {
+                "@types/express-serve-static-core": "*",
+                "@types/mime": "*"
+            }
+        },
+        "@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+        },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "ascli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+            "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+            "requires": {
+                "colour": "~0.7.1",
+                "optjs": "~3.2.2"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "bindings": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "bytebuffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+            "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+            "requires": {
+                "long": "~3"
+            }
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "colour": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+            "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "deasync": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
+            "integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
+            "requires": {
+                "bindings": "~1.2.1",
+                "node-addon-api": "^1.6.0"
+            }
+        },
+        "debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "google-protobuf": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.8.0.tgz",
+            "integrity": "sha512-tx39PTc//HaIT7K/baUF/8JYLGDozEi1e4xwPP1qSx3InP78cNpbSJpxiDsDMwj77qNOndVBDXnn7oi9zKxZew=="
+        },
+        "graceful-fs": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+        },
+        "grpc": {
+            "version": "1.21.1",
+            "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.21.1.tgz",
+            "integrity": "sha512-PFsZQazf62nP05a0xm23mlImMuw5oVlqF/0zakmsdqJgvbABe+d6VThY2PfhqJmWEL/FhQ6QNYsxS5EAM6++7g==",
+            "requires": {
+                "lodash.camelcase": "^4.3.0",
+                "lodash.clone": "^4.5.0",
+                "nan": "^2.13.2",
+                "node-pre-gyp": "^0.13.0",
+                "protobufjs": "^5.0.3"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "bundled": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true
+                        }
+                    }
+                },
+                "needle": {
+                    "version": "2.3.1",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "^4.1.0",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.13.0",
+                    "bundled": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.1",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.2.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true
+                },
+                "npm-packlist": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "protobufjs": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+                    "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+                    "requires": {
+                        "ascli": "~1",
+                        "bytebuffer": "~5",
+                        "glob": "^7.0.5",
+                        "yargs": "^3.10.0"
+                    }
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.4",
+                            "bundled": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "bundled": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true
+                }
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+        },
+        "lodash.clone": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+            "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+        },
+        "long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+            }
+        },
+        "nan": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "node-addon-api": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
+            "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+                }
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optjs": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+            "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "requires": {
+                "lcid": "^1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "protobufjs": {
+            "version": "6.8.8",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+            "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.0",
+                "@types/node": "^10.1.0",
+                "long": "^4.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.14.10",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
+                    "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
+                },
+                "long": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+                }
+            }
+        },
+        "read-package-json": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+            "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+            "requires": {
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "json-parse-better-errors": "^1.0.1",
+                "normalize-package-data": "^2.0.0",
+                "slash": "^1.0.0"
+            }
+        },
+        "read-package-tree": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
+            "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "once": "^1.3.0",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0"
+            }
+        },
+        "readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "resolve": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "semver": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+            "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+        },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "requires": {
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
+            }
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "requires": {
+                "source-map": "^0.5.6"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "ts-node": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "requires": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "source-map-support": {
+                    "version": "0.5.12",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+                    "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
+            }
+        },
+        "typescript": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "requires": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+            }
+        },
+        "yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
+    }
+}

--- a/pulumi-stuff/gcp-cluster/package.json
+++ b/pulumi-stuff/gcp-cluster/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "^0.18.9",
+        "@pulumi/kubernetes": "^0.25.0",
+        "@pulumi/pulumi": "^0.17.21"
+    }
+}

--- a/pulumi-stuff/gcp-cluster/pulstack.json
+++ b/pulumi-stuff/gcp-cluster/pulstack.json
@@ -1,0 +1,362 @@
+{
+    "version": 3,
+    "deployment": {
+        "manifest": {
+            "time": "2019-07-04T15:33:44.405501+05:30",
+            "magic": "1b7a05a9ab30f17b27a079ae9c410b548f2ccc0c4f3eace22c42b8f9649842c6",
+            "version": "v0.17.16"
+        },
+        "secrets_providers": {
+            "type": "service",
+            "state": {
+                "url": "https://api.pulumi.com",
+                "owner": "drholmie",
+                "project": "gcp-cluster",
+                "stack": "dev"
+            }
+        },
+        "resources": [
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::pulumi:pulumi:Stack::gcp-cluster-dev",
+                "custom": false,
+                "type": "pulumi:pulumi:Stack",
+                "outputs": {
+                    "kubeconfig": "apiVersion: v1alpha1\nclusters:\n- cluster:\n    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lSQUk0ZzJUc3FvMmF6Z085UDJjVk52TzB3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa01qYzVNRGswT1RVdFl6YzNNQzAwT0dGbUxXSXhaR1F0WVRFMU1USXlOakkwWWpjMgpNQjRYRFRFNU1EY3dOREE0TWpBeU9Gb1hEVEkwTURjd01qQTVNakF5T0Zvd0x6RXRNQ3NHQTFVRUF4TWtNamM1Ck1EazBPVFV0WXpjM01DMDBPR0ZtTFdJeFpHUXRZVEUxTVRJeU5qSTBZamMyTUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdStXV2UyUUFqbVBibGRWblkwMHpMOVN2MzFyejZtRnR4WmFWMms3Ygo2UmhDU0VJMjBIMzNvOFlWamI2ZGNweXdZN3djcUdXaXlobmR1cXRUSGI2bFdoSURqQ0ZENm9KNnlEMmw5NEp1Cis4MExzcXp2Z1BkVVJrYzZjQkI1YWtpR0lKMkhkcHNTQnN3M0tnMDZHUVF1VFBXM29mNlhqcW9TM2VXVzlOQ1gKT2o0dklGMGhrOTlLK3J2dGxBWTJxdHp0V1NXZFIyM1VKd1A2ZFNSc01oNWZPamdnMHVIWkYyNkNIZ3dNRG9XYwprRXpDZGgxMUNOOFl5ajhQNU0vTkVLQ0V4aU5KUG5DWTllcUxzWnZuSkY0ZVpYbDBBZUVLUWFwTVVSRnVyek5rClZEOS9ndStqK3NvbnhvR3IrTjBoM3VhT1hLaTRRTWxIcHdBcDVuWU1ka2kzendJREFRQUJveU13SVRBT0JnTlYKSFE4QkFmOEVCQU1DQWdRd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQppaENpcGNRMDZJSXYySGdFWkRnSHRVTkM2TGw1bE80d21UR2ROMDI4ejBKejB3WEozTXVKM1B0VE1SR0gxU3Q1Ci9lVEdtY0RCb3h6RFNjNjJQMCtITE1rMEZBdEx3TUgzbjNtREE5UEhrOEprU0NtUGJPdjZoakdzeDZYKzdSWGkKR29jYVlIc3JVYk5nK2JmbTF5UkhXUGVuSnBjZktJVGVQbkw2a2thMjZzNHBrTTIzRXlaK3VMSUFmMHRGdzZqZgpGOTlXVXd6d2xEdE5sTnMwMWJRUVFoNXFOTUFUa0VleDNlV1c1cmpuVHdWUVFncU0yZEQwb1luWVU3empYRWNqCnRpcVpJQjdpVmR0ekFnV3pwclI0YlNQMFNTRExoT3JPM2NWdkN5RHhKYWxBR3cyelZlVlQyNE1pNi9ZYU4yemoKZjAvenpFcDZ0Tk44MzZLK3ZiRm9HZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K\n    server: https://35.247.108.248\n  name: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\ncontexts:\n- context:\n    cluster: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\n    user: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\n  name: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\ncurrent-context: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\nkind: Config\npreferences: {}\nusers:\n- name: sincere-almanac-243215_us-west1-a_ronin-dev-6cebae0\n  user:\n    auth-provider:\n      config:\n        cmd-args: config config-helper --format=json\n        cmd-path: gcloud\n        expiry-key: '{.credential.token_expiry}'\n        token-key: '{.credential.access_token}'\n      name: gcp\n"
+                }
+            },
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::pulumi:providers:gcp::default",
+                "custom": true,
+                "id": "75eab57f-4cc6-4db2-b58f-246f44f6166f",
+                "type": "pulumi:providers:gcp",
+                "inputs": {
+                    "project": "sincere-almanac-243215",
+                    "version": "0.18.9",
+                    "zone": "us-west1-a"
+                },
+                "outputs": {
+                    "project": "sincere-almanac-243215",
+                    "version": "0.18.9",
+                    "zone": "us-west1-a"
+                }
+            },
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::pulumi:providers:pulumi::default",
+                "custom": true,
+                "id": "2a6bebc7-7315-450c-be1f-c170f9b62ddb",
+                "type": "pulumi:providers:pulumi"
+            },
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::pulumi:pulumi:StackReference::/gcp-network/dev",
+                "custom": true,
+                "id": "/gcp-network/dev",
+                "type": "pulumi:pulumi:StackReference",
+                "inputs": {
+                    "name": "/gcp-network/dev"
+                },
+                "outputs": {
+                    "name": "/gcp-network/dev",
+                    "outputs": {
+                        "scriptNetwork": {
+                            "autoCreateSubnetworks": true,
+                            "deleteDefaultRoutesOnCreate": false,
+                            "description": "",
+                            "gatewayIpv4": "",
+                            "id": "dev-0f65de6",
+                            "ipv4Range": "",
+                            "name": "dev-0f65de6",
+                            "project": "sincere-almanac-243215",
+                            "routingMode": "REGIONAL",
+                            "selfLink": "https://www.googleapis.com/compute/v1/projects/sincere-almanac-243215/global/networks/dev-0f65de6",
+                            "urn": "urn:pulumi:dev::gcp-network::gcp:compute/network:Network::dev"
+                        }
+                    }
+                },
+                "parent": "urn:pulumi:dev::gcp-cluster::pulumi:pulumi:Stack::gcp-cluster-dev",
+                "external": true,
+                "provider": "urn:pulumi:dev::gcp-cluster::pulumi:providers:pulumi::default::2a6bebc7-7315-450c-be1f-c170f9b62ddb"
+            },
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::gcp:container/cluster:Cluster::ronin-dev",
+                "custom": true,
+                "id": "ronin-dev-6cebae0",
+                "type": "gcp:container/cluster:Cluster",
+                "inputs": {
+                    "__defaults": [
+                        "enableBinaryAuthorization",
+                        "enableIntranodeVisibility",
+                        "enableTpu",
+                        "name"
+                    ],
+                    "addonsConfig": {
+                        "__defaults": [],
+                        "horizontalPodAutoscaling": {
+                            "__defaults": [],
+                            "disabled": false
+                        },
+                        "httpLoadBalancing": {
+                            "__defaults": [],
+                            "disabled": false
+                        },
+                        "kubernetesDashboard": {
+                            "__defaults": [],
+                            "disabled": false
+                        },
+                        "networkPolicyConfig": {
+                            "__defaults": [],
+                            "disabled": false
+                        }
+                    },
+                    "enableBinaryAuthorization": false,
+                    "enableIntranodeVisibility": false,
+                    "enableKubernetesAlpha": true,
+                    "enableLegacyAbac": false,
+                    "enableTpu": false,
+                    "initialNodeCount": 1,
+                    "ipAllocationPolicy": {
+                        "__defaults": [],
+                        "useIpAliases": false
+                    },
+                    "location": "us-west1-a",
+                    "loggingService": "none",
+                    "masterAuth": {
+                        "__defaults": [],
+                        "clientCertificateConfig": {
+                            "__defaults": [],
+                            "issueClientCertificate": false
+                        },
+                        "password": "",
+                        "username": ""
+                    },
+                    "minMasterVersion": "latest",
+                    "monitoringService": "none",
+                    "name": "ronin-dev-6cebae0",
+                    "network": "dev",
+                    "networkPolicy": {
+                        "__defaults": [
+                            "provider"
+                        ],
+                        "enabled": true,
+                        "provider": "PROVIDER_UNSPECIFIED"
+                    },
+                    "nodeVersion": "latest",
+                    "podSecurityPolicyConfig": {
+                        "__defaults": [],
+                        "enabled": true
+                    },
+                    "removeDefaultNodePool": true,
+                    "verticalPodAutoscaling": {
+                        "__defaults": [],
+                        "enabled": true
+                    }
+                },
+                "outputs": {
+                    "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":1800000000000,\"delete\":1800000000000,\"update\":3600000000000},\"schema_version\":\"1\"}",
+                    "additionalZones": [],
+                    "addonsConfig": {
+                        "horizontalPodAutoscaling": {
+                            "disabled": false
+                        },
+                        "httpLoadBalancing": {
+                            "disabled": false
+                        },
+                        "kubernetesDashboard": {
+                            "disabled": false
+                        },
+                        "networkPolicyConfig": {
+                            "disabled": false
+                        }
+                    },
+                    "clusterAutoscaling": {
+                        "enabled": false,
+                        "resourceLimits": []
+                    },
+                    "clusterIpv4Cidr": "10.4.0.0/14",
+                    "databaseEncryption": {
+                        "keyName": "",
+                        "state": "DECRYPTED"
+                    },
+                    "defaultMaxPodsPerNode": 110,
+                    "description": "",
+                    "enableBinaryAuthorization": false,
+                    "enableIntranodeVisibility": false,
+                    "enableKubernetesAlpha": true,
+                    "enableLegacyAbac": false,
+                    "enableTpu": false,
+                    "endpoint": "35.247.108.248",
+                    "id": "ronin-dev-6cebae0",
+                    "initialNodeCount": 1,
+                    "instanceGroupUrls": [],
+                    "location": "us-west1-a",
+                    "loggingService": "none",
+                    "masterAuth": {
+                        "clientCertificate": "",
+                        "clientCertificateConfig": {
+                            "issueClientCertificate": false
+                        },
+                        "clientKey": "",
+                        "clusterCaCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURERENDQWZTZ0F3SUJBZ0lSQUk0ZzJUc3FvMmF6Z085UDJjVk52TzB3RFFZSktvWklodmNOQVFFTEJRQXcKTHpFdE1Dc0dBMVVFQXhNa01qYzVNRGswT1RVdFl6YzNNQzAwT0dGbUxXSXhaR1F0WVRFMU1USXlOakkwWWpjMgpNQjRYRFRFNU1EY3dOREE0TWpBeU9Gb1hEVEkwTURjd01qQTVNakF5T0Zvd0x6RXRNQ3NHQTFVRUF4TWtNamM1Ck1EazBPVFV0WXpjM01DMDBPR0ZtTFdJeFpHUXRZVEUxTVRJeU5qSTBZamMyTUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdStXV2UyUUFqbVBibGRWblkwMHpMOVN2MzFyejZtRnR4WmFWMms3Ygo2UmhDU0VJMjBIMzNvOFlWamI2ZGNweXdZN3djcUdXaXlobmR1cXRUSGI2bFdoSURqQ0ZENm9KNnlEMmw5NEp1Cis4MExzcXp2Z1BkVVJrYzZjQkI1YWtpR0lKMkhkcHNTQnN3M0tnMDZHUVF1VFBXM29mNlhqcW9TM2VXVzlOQ1gKT2o0dklGMGhrOTlLK3J2dGxBWTJxdHp0V1NXZFIyM1VKd1A2ZFNSc01oNWZPamdnMHVIWkYyNkNIZ3dNRG9XYwprRXpDZGgxMUNOOFl5ajhQNU0vTkVLQ0V4aU5KUG5DWTllcUxzWnZuSkY0ZVpYbDBBZUVLUWFwTVVSRnVyek5rClZEOS9ndStqK3NvbnhvR3IrTjBoM3VhT1hLaTRRTWxIcHdBcDVuWU1ka2kzendJREFRQUJveU13SVRBT0JnTlYKSFE4QkFmOEVCQU1DQWdRd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQQppaENpcGNRMDZJSXYySGdFWkRnSHRVTkM2TGw1bE80d21UR2ROMDI4ejBKejB3WEozTXVKM1B0VE1SR0gxU3Q1Ci9lVEdtY0RCb3h6RFNjNjJQMCtITE1rMEZBdEx3TUgzbjNtREE5UEhrOEprU0NtUGJPdjZoakdzeDZYKzdSWGkKR29jYVlIc3JVYk5nK2JmbTF5UkhXUGVuSnBjZktJVGVQbkw2a2thMjZzNHBrTTIzRXlaK3VMSUFmMHRGdzZqZgpGOTlXVXd6d2xEdE5sTnMwMWJRUVFoNXFOTUFUa0VleDNlV1c1cmpuVHdWUVFncU0yZEQwb1luWVU3empYRWNqCnRpcVpJQjdpVmR0ekFnV3pwclI0YlNQMFNTRExoT3JPM2NWdkN5RHhKYWxBR3cyelZlVlQyNE1pNi9ZYU4yemoKZjAvenpFcDZ0Tk44MzZLK3ZiRm9HZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+                        "password": "",
+                        "username": ""
+                    },
+                    "masterVersion": "1.13.7-gke.8",
+                    "minMasterVersion": "latest",
+                    "monitoringService": "none",
+                    "name": "ronin-dev-6cebae0",
+                    "network": "projects/sincere-almanac-243215/global/networks/dev",
+                    "networkPolicy": {
+                        "enabled": true,
+                        "provider": ""
+                    },
+                    "nodeLocations": [],
+                    "nodePools": [],
+                    "nodeVersion": "1.13.7-gke.8",
+                    "podSecurityPolicyConfig": {
+                        "enabled": true
+                    },
+                    "project": "sincere-almanac-243215",
+                    "removeDefaultNodePool": true,
+                    "resourceLabels": {},
+                    "servicesIpv4Cidr": "10.7.240.0/20",
+                    "subnetwork": "projects/sincere-almanac-243215/regions/us-west1/subnetworks/dev",
+                    "tpuIpv4CidrBlock": "",
+                    "verticalPodAutoscaling": {
+                        "enabled": true
+                    },
+                    "zone": "us-west1-a"
+                },
+                "parent": "urn:pulumi:dev::gcp-cluster::pulumi:pulumi:Stack::gcp-cluster-dev",
+                "provider": "urn:pulumi:dev::gcp-cluster::pulumi:providers:gcp::default::75eab57f-4cc6-4db2-b58f-246f44f6166f",
+                "propertyDependencies": {
+                    "addonsConfig": null,
+                    "enableKubernetesAlpha": null,
+                    "enableLegacyAbac": null,
+                    "initialNodeCount": null,
+                    "ipAllocationPolicy": null,
+                    "location": null,
+                    "loggingService": null,
+                    "masterAuth": null,
+                    "minMasterVersion": null,
+                    "monitoringService": null,
+                    "network": null,
+                    "networkPolicy": null,
+                    "nodeVersion": null,
+                    "podSecurityPolicyConfig": null,
+                    "removeDefaultNodePool": null,
+                    "verticalPodAutoscaling": null
+                }
+            },
+            {
+                "urn": "urn:pulumi:dev::gcp-cluster::gcp:container/nodePool:NodePool::ronin-dev-preemtible",
+                "custom": true,
+                "id": "us-west1-a/ronin-dev-6cebae0/ronin-dev-preemtible-82bb268",
+                "type": "gcp:container/nodePool:NodePool",
+                "inputs": {
+                    "__defaults": [
+                        "name"
+                    ],
+                    "autoscaling": {
+                        "__defaults": [],
+                        "maxNodeCount": 10,
+                        "minNodeCount": 1
+                    },
+                    "cluster": "ronin-dev-6cebae0",
+                    "location": "us-west1-a",
+                    "management": {
+                        "__defaults": [],
+                        "autoRepair": false,
+                        "autoUpgrade": false
+                    },
+                    "name": "ronin-dev-preemtible-82bb268",
+                    "nodeConfig": {
+                        "__defaults": [],
+                        "diskSizeGb": 100,
+                        "diskType": "pd-standard",
+                        "imageType": "COS",
+                        "machineType": "n1-standard-2",
+                        "metadata": {
+                            "__defaults": [],
+                            "disable-legacy-endpoints": "true"
+                        },
+                        "minCpuPlatform": "Intel Skylake",
+                        "oauthScopes": [
+                            "https://www.googleapis.com/auth/devstorage.read_only",
+                            "https://www.googleapis.com/auth/service.management.readonly",
+                            "https://www.googleapis.com/auth/servicecontrol",
+                            "https://www.googleapis.com/auth/logging.write",
+                            "https://www.googleapis.com/auth/monitoring"
+                        ],
+                        "preemptible": true
+                    },
+                    "nodeCount": 1
+                },
+                "outputs": {
+                    "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\":{\"create\":1800000000000,\"delete\":600000000000,\"update\":600000000000},\"schema_version\":\"1\"}",
+                    "autoscaling": {
+                        "maxNodeCount": 10,
+                        "minNodeCount": 1
+                    },
+                    "cluster": "ronin-dev-6cebae0",
+                    "id": "us-west1-a/ronin-dev-6cebae0/ronin-dev-preemtible-82bb268",
+                    "initialNodeCount": 1,
+                    "instanceGroupUrls": [
+                        "https://www.googleapis.com/compute/v1/projects/sincere-almanac-243215/zones/us-west1-a/instanceGroupManagers/gke-ronin-dev-6cebae-ronin-dev-preemt-7fa4d202-grp"
+                    ],
+                    "location": "us-west1-a",
+                    "management": {
+                        "autoRepair": false,
+                        "autoUpgrade": false
+                    },
+                    "name": "ronin-dev-preemtible-82bb268",
+                    "namePrefix": "",
+                    "nodeConfig": {
+                        "diskSizeGb": 100,
+                        "diskType": "pd-standard",
+                        "guestAccelerators": [],
+                        "imageType": "COS",
+                        "labels": {},
+                        "localSsdCount": 0,
+                        "machineType": "n1-standard-2",
+                        "metadata": {
+                            "disable-legacy-endpoints": "true"
+                        },
+                        "minCpuPlatform": "Intel Skylake",
+                        "oauthScopes": [
+                            "https://www.googleapis.com/auth/monitoring",
+                            "https://www.googleapis.com/auth/devstorage.read_only",
+                            "https://www.googleapis.com/auth/logging.write",
+                            "https://www.googleapis.com/auth/service.management.readonly",
+                            "https://www.googleapis.com/auth/servicecontrol"
+                        ],
+                        "preemptible": true,
+                        "serviceAccount": "default",
+                        "tags": [],
+                        "taints": []
+                    },
+                    "nodeCount": 1,
+                    "project": "sincere-almanac-243215",
+                    "version": "1.13.7-gke.8",
+                    "zone": "us-west1-a"
+                },
+                "parent": "urn:pulumi:dev::gcp-cluster::pulumi:pulumi:Stack::gcp-cluster-dev",
+                "dependencies": [
+                    "urn:pulumi:dev::gcp-cluster::gcp:container/cluster:Cluster::ronin-dev"
+                ],
+                "provider": "urn:pulumi:dev::gcp-cluster::pulumi:providers:gcp::default::75eab57f-4cc6-4db2-b58f-246f44f6166f",
+                "propertyDependencies": {
+                    "autoscaling": null,
+                    "cluster": [
+                        "urn:pulumi:dev::gcp-cluster::gcp:container/cluster:Cluster::ronin-dev"
+                    ],
+                    "location": null,
+                    "management": null,
+                    "nodeConfig": null,
+                    "nodeCount": null
+                }
+            }
+        ],
+        "pending_operations": [
+            
+        ]
+    }
+}

--- a/pulumi-stuff/gcp-cluster/tsconfig.json
+++ b/pulumi-stuff/gcp-cluster/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/pulumi-stuff/gcp-network/.gitignore
+++ b/pulumi-stuff/gcp-network/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/pulumi-stuff/gcp-network/Pulumi.dev.yaml
+++ b/pulumi-stuff/gcp-network/Pulumi.dev.yaml
@@ -1,0 +1,3 @@
+config:
+  gcp:project: sincere-almanac-243215
+  gcp:zone: us-west1-a

--- a/pulumi-stuff/gcp-network/Pulumi.yaml
+++ b/pulumi-stuff/gcp-network/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: gcp-network
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/pulumi-stuff/gcp-network/index.ts
+++ b/pulumi-stuff/gcp-network/index.ts
@@ -1,0 +1,47 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+import * as k8s from "@pulumi/kubernetes";
+const networkname = process.env['NETWORK'] || "dev";
+export const scriptNetwork = new gcp.compute.Network(networkname,{
+    autoCreateSubnetworks: true
+});
+const scriptSsh = new gcp.compute.Firewall(networkname+"-allow-ssh", {
+    allows: [
+        {
+            ports: [
+                "22"
+            ],
+            protocol: "tcp",
+        },
+    ],
+    network: scriptNetwork.name,
+    priority: 65534,
+    description: "allow ssh",
+    direction: "INGRESS",
+    sourceRanges:["0.0.0.0/0"]
+});
+
+const scriptInternal = new gcp.compute.Firewall(networkname+"-allow-internal", {
+    allows: [
+        {
+            ports: [
+                "0-65535"
+            ],
+            protocol: "tcp",
+        },
+        {
+            ports: [
+                "0-65535"
+            ],
+            protocol: "udp",
+        },
+        {
+            protocol: "icmp",
+        },
+    ],
+    network: scriptNetwork.name,
+    priority:65534,
+    description: "allow internal",
+    direction: "INGRESS",
+    sourceRanges:["10.128.0.0/9"]
+});

--- a/pulumi-stuff/gcp-network/package-lock.json
+++ b/pulumi-stuff/gcp-network/package-lock.json
@@ -1,0 +1,1271 @@
+{
+    "name": "typescript",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@pulumi/gcp": {
+            "version": "0.18.9",
+            "resolved": "https://registry.npmjs.org/@pulumi/gcp/-/gcp-0.18.9.tgz",
+            "integrity": "sha512-XaP2sMK2DvNKSY1gbMEaaPPgW46kFEGfqzEcgmiwkQlq7hWeETK4rpW6ldy/cBNJ8v98BYwGaoStk3r/ygkD8w==",
+            "requires": {
+                "@pulumi/pulumi": "^0.17.8",
+                "@types/express": "^4.16.0",
+                "read-package-json": "^2.0.13"
+            }
+        },
+        "@pulumi/kubernetes": {
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/kubernetes/-/kubernetes-0.25.0.tgz",
+            "integrity": "sha512-Un4muTw/90FGGFtJmglUwjiEgzTSfajWltjnDN1TDxB6sSifOG0m+yoaDw/6kHsp9h5S5hrs8d+uAxZySvKasg==",
+            "requires": {
+                "@pulumi/pulumi": "^0.17.17",
+                "@types/glob": "^5.0.35",
+                "@types/js-yaml": "^3.11.2",
+                "@types/node-fetch": "^2.1.4",
+                "@types/tmp": "^0.0.33",
+                "glob": "^7.1.2",
+                "js-yaml": "^3.12.0",
+                "node-fetch": "^2.3.0",
+                "shell-quote": "^1.6.1",
+                "tmp": "^0.0.33"
+            }
+        },
+        "@pulumi/pulumi": {
+            "version": "0.17.21",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-0.17.21.tgz",
+            "integrity": "sha512-/0xt1Cy+aRcMZdTeA6d2Zi4496HBJezrdOPrvbuYBBNRH6jC3VTqUuQLWpjj0GcwfYKlSBN3DLMGCyeEWmmMWg==",
+            "requires": {
+                "@pulumi/query": "^0.3.0",
+                "deasync": "^0.1.15",
+                "google-protobuf": "^3.5.0",
+                "grpc": "^1.20.2",
+                "minimist": "^1.2.0",
+                "normalize-package-data": "^2.4.0",
+                "protobufjs": "^6.8.6",
+                "read-package-tree": "5.2.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^6.1.0",
+                "source-map-support": "^0.4.16",
+                "ts-node": "^7.0.0",
+                "typescript": "^3.0.0",
+                "upath": "^1.1.0"
+            }
+        },
+        "@pulumi/query": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/query/-/query-0.3.0.tgz",
+            "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
+        },
+        "@types/body-parser": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+            "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/connect": {
+            "version": "3.4.32",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+            "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+        },
+        "@types/express": {
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+            "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "4.16.7",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+            "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+            "requires": {
+                "@types/node": "*",
+                "@types/range-parser": "*"
+            }
+        },
+        "@types/glob": {
+            "version": "5.0.36",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+            "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA=="
+        },
+        "@types/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+        },
+        "@types/mime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+            "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+        },
+        "@types/node": {
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
+            "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ=="
+        },
+        "@types/node-fetch": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.3.7.tgz",
+            "integrity": "sha512-+bKtuxhj/TYSSP1r4CZhfmyA0vm/aDRQNo7vbAgf6/cZajn0SAniGGST07yvI4Q+q169WTa2/x9gEHfJrkcALw==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/range-parser": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+            "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+        },
+        "@types/serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+            "requires": {
+                "@types/express-serve-static-core": "*",
+                "@types/mime": "*"
+            }
+        },
+        "@types/tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0="
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+        },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "ascli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+            "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+            "requires": {
+                "colour": "~0.7.1",
+                "optjs": "~3.2.2"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "bindings": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+            "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "bytebuffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+            "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+            "requires": {
+                "long": "~3"
+            }
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "colour": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+            "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "deasync": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
+            "integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
+            "requires": {
+                "bindings": "~1.2.1",
+                "node-addon-api": "^1.6.0"
+            }
+        },
+        "debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "google-protobuf": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.8.0.tgz",
+            "integrity": "sha512-tx39PTc//HaIT7K/baUF/8JYLGDozEi1e4xwPP1qSx3InP78cNpbSJpxiDsDMwj77qNOndVBDXnn7oi9zKxZew=="
+        },
+        "graceful-fs": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+        },
+        "grpc": {
+            "version": "1.21.1",
+            "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.21.1.tgz",
+            "integrity": "sha512-PFsZQazf62nP05a0xm23mlImMuw5oVlqF/0zakmsdqJgvbABe+d6VThY2PfhqJmWEL/FhQ6QNYsxS5EAM6++7g==",
+            "requires": {
+                "lodash.camelcase": "^4.3.0",
+                "lodash.clone": "^4.5.0",
+                "nan": "^2.13.2",
+                "node-pre-gyp": "^0.13.0",
+                "protobufjs": "^5.0.3"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.1.1",
+                    "bundled": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "deep-extend": {
+                    "version": "0.6.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.23",
+                    "bundled": true,
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "bundled": true
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true
+                        }
+                    }
+                },
+                "needle": {
+                    "version": "2.3.1",
+                    "bundled": true,
+                    "requires": {
+                        "debug": "^4.1.0",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        }
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.13.0",
+                    "bundled": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.1",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.2.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.6",
+                    "bundled": true
+                },
+                "npm-packlist": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "protobufjs": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+                    "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+                    "requires": {
+                        "ascli": "~1",
+                        "bytebuffer": "~5",
+                        "glob": "^7.0.5",
+                        "yargs": "^3.10.0"
+                    }
+                },
+                "rc": {
+                    "version": "1.2.8",
+                    "bundled": true,
+                    "requires": {
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.4",
+                            "bundled": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.7.0",
+                    "bundled": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true
+                },
+                "tar": {
+                    "version": "4.4.8",
+                    "bundled": true,
+                    "requires": {
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "wide-align": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "string-width": "^1.0.2 || 2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "yallist": {
+                    "version": "3.0.3",
+                    "bundled": true
+                }
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "^1.0.0"
+            }
+        },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+        },
+        "lodash.clone": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+            "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+        },
+        "long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+            }
+        },
+        "nan": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "node-addon-api": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
+            "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+                }
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optjs": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+            "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "requires": {
+                "lcid": "^1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "protobufjs": {
+            "version": "6.8.8",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+            "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.0",
+                "@types/node": "^10.1.0",
+                "long": "^4.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.14.10",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
+                    "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
+                },
+                "long": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+                }
+            }
+        },
+        "read-package-json": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+            "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+            "requires": {
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "json-parse-better-errors": "^1.0.1",
+                "normalize-package-data": "^2.0.0",
+                "slash": "^1.0.0"
+            }
+        },
+        "read-package-tree": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
+            "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "once": "^1.3.0",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0"
+            }
+        },
+        "readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "resolve": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "semver": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+            "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+        },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "requires": {
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
+            }
+        },
+        "slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "requires": {
+                "source-map": "^0.5.6"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+            "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "ts-node": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "requires": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "source-map-support": {
+                    "version": "0.5.12",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+                    "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
+            }
+        },
+        "typescript": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA=="
+        },
+        "upath": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+            "version": "3.32.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "requires": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+            }
+        },
+        "yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
+    }
+}

--- a/pulumi-stuff/gcp-network/package.json
+++ b/pulumi-stuff/gcp-network/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "^0.18.9",
+        "@pulumi/kubernetes": "^0.25.0",
+        "@pulumi/pulumi": "^0.17.21"
+    }
+}

--- a/pulumi-stuff/gcp-network/tsconfig.json
+++ b/pulumi-stuff/gcp-network/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Pulumi files located in pulumi-stuff directory.
Currently, simple script to create cluster and network in GCP based on sane defaults mentioned in clusters.makefile.
In future would like to run kubernetes through pulumi as well (currently certain issues preventing that).
So far following a modular way of creating infrastructure, that is, each folder is a separate pulumi project.
this method follows from what is mentioned in the pulumi docs and loosely follows a similar usecase tutorial from pulumi itself. (kubernetes the prod way)
