### PR TITLE
Helm Chart Support Design Doc

### DIFF
--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -1,6 +1,3 @@
-Helm Chart Support
-====================
-
 The current CLI install process uses Helm libraries under the hood, but just as a template library. There is currently a Helm chart under the `charts` directory that allows installing the control plane, but uninjected, and there's no `values.yaml` file provided.
                                                                                                                                                                                                                                              
 The intention here is to provide a new chart with an injected control plane so that users can install linkerd through a simple `helm install incubator/linkerd2` command.
@@ -126,19 +123,21 @@ The mechanism is the same as `linkerd install` just explained; the main chart wi
 
 Tasks
 ---------
-- Create new `linkerd check --chart values.yaml` command to fully validate the options in `values.yaml`. This includes ensuring the trust root for identity has been provided.
-- Refactor `injectPodSpec()` and `injectProxyInit()` in `pkg/inject/inject.go` that currently generates a JSON patch, but have it use the `patch` chart instead of the hard-coded go-client structs.
-- Refactor the TLS libraries relied upon by the `proxy-injector` and `sp-validor` webhooks to have them work with RSA as well (they currently only deal with EC).
-- Refactor the  `proxy-injector` and `sp-validator` charts so that they generate the certs/keys with Helm's `genSelfSignedCert()`.
-- Create `values.yaml` with all the default values, by hand (later, we can have this be automated based off of protobuf for the config part). The trust root for identity is expected to be provided by the user in this file.
-- As much as possible, copy the options validations into the Helm template files, leveraging [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html) function. This includes a new check for ensuring the identity trust root has been provided.
-- Have a well annotated main `values.yaml` file with the most common settings by default.
-- Create a detailed `NOTES.txt` file with the instructions/warnings detailed above.
-- Create a script to publish the `linkerd2` chart to https://github.com/helm/charts
-- Create a new website doc for Helm. A section should have a tutorial for generating the cert/key for identity.
+- Create new `linkerd check --chart values.yaml` command to fully validate the options in `values.yaml`. This includes ensuring the trust root for identity has been provided (#3130).
+- Refactor `injectPodSpec()` and `injectProxyInit()` in `pkg/inject/inject.go` that currently generates a JSON patch, but have it use the `patch` chart instead of the hard-coded go-client structs (#3128).
+- Refactor the TLS libraries relied upon by the `proxy-injector` and `sp-validor` webhooks to have them work with RSA as well (they currently only deal with EC) (#3131).
+- Refactor the  `proxy-injector` and `sp-validator` charts so that they generate the certs/keys with Helm's `genSelfSignedCert()` (#3126)
+- Create `values.yaml` with all the default values, by hand (later, we can have this be automated based off of protobuf for the config part). The trust root for identity is expected to be provided by the user in this file (#3126).
+- As much as possible, copy the options validations into the Helm template files, leveraging [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html) function. This includes a new check for ensuring the identity trust root has been provided (#3126).
+- Refactor `linkerd install` to work with the new `linkerd2` chart (#3127).
+- Have a well annotated main `values.yaml` file with the most common settings by default (#3126)
+- Create a detailed `NOTES.txt` file with the instructions/warnings detailed above (#3132).
+- Test `helm upgrade`, `helm delete` and `helm rollback` (#3129).
 
 ### Not necessarily for the first iteration of this project
 - Have `linkerd check --chart` highlight changes between versions.
+- Create a script to publish the `linkerd2` chart to https://github.com/helm/charts
+- Create a new website doc for Helm. A section should have a tutorial for generating the cert/key for identity.
 
 ### Definitely for later
 - Consider `install-cni`. Could be as a separate stage (`--set stage=cni`).
@@ -146,4 +145,3 @@ Tasks
 To-do
 ------
 - Validate how all this plays with Helm v3
-

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -140,6 +140,8 @@ Tasks
 ### Not necessarily for the first iteration of this project
 - Have `linkerd check --chart` highlight changes between versions.
 
+### Definetely for later
+- Consider `install-cni`. Could be as a separate stage (`--set stage=cni`) or a regular option (`--set cni`). The latter would imply solving the timing issues that motivated having that as a separate command to begin with (control plane components trying to come up without the iptables having been modified yet).
 
 To-do
 ------

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -140,8 +140,8 @@ Tasks
 ### Not necessarily for the first iteration of this project
 - Have `linkerd check --chart` highlight changes between versions.
 
-### Definetely for later
-- Consider `install-cni`. Could be as a separate stage (`--set stage=cni`) or a regular option (`--set cni`). The latter would imply solving the timing issues that motivated having that as a separate command to begin with (control plane components trying to come up without the iptables having been modified yet).
+### Definitely for later
+- Consider `install-cni`. Could be as a separate stage (`--set stage=cni`).
 
 To-do
 ------

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -28,6 +28,12 @@ This is an optional pre-install check that validates the options in the provided
 
 ```               
 helm install incubator/linkerd2
+
+# or, for users with cluster-level privileges
+helm install incubator/linkerd2 --set stage=config
+# followed by, for users with just namespace-level privileges
+helm upgrade incubator/linkerd2 --set stage=control-plane
+
 ```                                                                                                                                                                                                                                          
 That would install linkerd using the most common settings. The `NOTES.txt` file (rendered and shown when this command completes) could provide the follow instructions/warnings:
 - Instructions on how to, optionally, install the linkerd CLI

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -1,0 +1,131 @@
+Helm Chart Support
+====================
+
+The current CLI install process uses Helm libraries under the hood, but just as a template library. There is currently a Helm chart under the `charts` directory that allows installing the control plane, but uninjected, and there's no `values.yaml` file provided.
+                                                                                                                                                                                                                                             
+The intention here is to provide a new chart with an injected control plane so that users can install linkerd through a simple `helm install incubator/linkerd2` command.
+                                                                                                                                                                                                                                             
+Helm charts can't rely on go code besides the functions provided by the go template library, the Sprig library, and a few extra functions provided by Helm itself. This implies a few compromises:
+                                                         
+- We can't validate the install options provided in `values.yaml`. Instead, a new set of `linkerd check` checks could help catching invalid options, post-install.
+- We should provide a comprehensive `values.yaml` file that would contain the most common settings, but heavily annotated to instruct users about alternate settings for advanced scenarios.                                                              
+- Helm's crypto functions only allow us to use RSA certs/keys. We can move the cert/keys from the webhook configs (`proxy-injector` and `sp-validator`) to use RSA. As for the trust root for identity, we decided the user should provide their own in `values.yaml`. The docs should have instructions on how to generate that cert/key.
+   
+These compromises entail a less straightforward experience than what `linkerd install` provides, so the Helm installation alternative should be considered an "advanced" feature.                                                             
+                                                                                                                                                                                                                                             
+New alternative install workflow through Helm
+-----------------------------------------------
+```               
+helm install incubator/linkerd2
+```                                                                                                                                                                                                                                          
+That would install linkerd using the most common settings. The `NOTES.txt` file (rendered and shown when this command completes) could provide the follow instructions/warnings:
+- Warn that the identity trust root should have been provided, and show instructions on how to generate it.
+- Instructions on how to, optionally, install the linkerd CLI
+- Instructions on running `linkerd check` to verify everything is ok                                                                                                                                                                         
+- Instructions on how to change the most basic settings
+- Instructions on how to get ahold of `values.yaml` containing all the possible settings?
+
+### New Chart Layout
+This will replace the current single chart under the `charts` directory.
+```
+charts
+├── control-plane
+│   ├── charts
+│   │   └── partials -> ../../partials
+│   ├── Chart.yaml
+│   ├── templates
+│   │   ├── config.yaml
+│   │   ├── controller-rbac.yaml
+│   │   ├── controller.yaml
+│   │   ├── grafana-rbac.yaml
+│   │   ├── grafana.yaml
+│   │   ├── identity-rbac.yaml
+│   │   ├── identity.yaml
+│   │   ├── namespace.yaml
+│   │   ├── NOTES.txt
+│   │   ├── prometheus-rbac.yaml
+│   │   ├── prometheus.yaml
+│   │   ├── proxy_injector-rbac.yaml
+│   │   ├── proxy_injector.yaml
+│   │   ├── psp.yaml
+│   │   ├── _resources.yaml
+│   │   ├── serviceprofile-crd.yaml
+│   │   ├── sp_validator-rbac.yaml
+│   │   ├── sp_validator.yaml
+│   │   ├── tap-rbac.yaml
+│   │   ├── tap.yaml
+│   │   ├── trafficsplit-crd.yaml
+│   │   ├── web-rbac.yaml
+│   │   └── web.yaml
+│   └── values.yaml
+├── data-plane
+│   ├── charts
+│   │   └── partials -> ../../partials
+│   ├── Chart.yaml
+│   ├── templates
+│   │   └── patch.json
+│   └── values.yaml
+└── partials
+    ├── charts
+    ├── Chart.yaml
+    ├── templates
+    │   ├── _debug.yaml
+    │   ├── _metadata.yaml
+    │   ├── _proxy.yaml
+    │   ├── _proxy-init.yaml
+    │   └── _volumes.yaml
+    └── values.yaml
+```
+
+Current mechanisms and changes
+-------------------------------
+
+The user experience for the current way of doing things remains the same. There will be some changes under the hood though.
+
+### Automated proxy injection
+
+Currently the `proxy-injector` webhook is invoked for any pod that gets created. If the pod's namespace or the pod itself contains a `linkerd.io/inject: enabled` annotation then the webhook relies on the library `pkg/inject/inject.go` to programatically generate a proxy container (and a proxy-init container if necessary) using go-client structs. Those structs are transformed into JSON-patch format which is returned to Kubernetes, which will do the actual injection of the container into the pod.                                                                                                                                       
+
+The functionality and contract for `pkg/inject/inject.go` will remain the same but with a different mechanism underneath. The JSON-patch will be generated through the new `data-plane` chart which itself depends on the `_proxy.yaml` template under the `charts/partials` chart. `_proxy.yaml` will be the sole place containing the structure of the proxy container and it will replace the go-client structs currently used. This partial will also be used when doing `helm install` (see below) thus avoiding having more than one place for the proxy structure source-of-truth.                                                                  
+
+### `linkerd inject`
+
+Currently this only adds the `linkerd.io/inject: enabled` annotation to the pod template, and when Kuberenetes creates the pod it invokes the webhook as just explained. This remains as-is.
+
+### `linkerd inject --manual`
+
+Currently this calls `pkg/inject/inject.go` to perform the injection, just as the webhook does. So the changes detailed above also affect this execution path, but the experience remains the same.
+
+### `linkerd install`
+
+Currently this relies on the Helm go library and the charts under the `charts` directory to generate the control plane resources. The options passed as CLI arguments are converted into template values that are passed to the Helm template engine to be replaced in the placeholders inside those charts. Then, the generated yaml is fed into the `pkg/inject/inject.go` library to inject the proxies, just as `linkerd inject --manual` would do.
+
+Here we will be replacing the current chart with a new one under `charts/control-plane` to create the control plane resources, and that chart depends on various templates under the `charts/partials` charts, in particular the `_proxy.yaml` template for inserting the yaml for the proxy into all the control plane resources. Note that `charts/control-plane` doesn't depend on `charts/data-plane` because the latter's sole purpose is to generate a JSON-patch, which Helm can't interpret.                                                                                                                                                      
+
+The user experience for `linkerd install` remains the same as well.
+
+New alternative `helm install` mechanism
+---------------------------------------------
+The mechanism is the same as `linkerd install` just explained; the main chart will be `charts/control-plane` which depends on `charts/partials` for, among other things, the proxy insertion. The main difference will be that the chart values will come from `values.yml` (or provided by the user through `--set` on Helm's CLI).
+
+Published charts
+----------------
+The `control-plane` chart should be the main chart, published under `https://github.com/helm/charts/incubator/linkerd2`, copying the `partials` chart to `control-plane/charts` prior to publication. I'm not sure if there's a better way of doing this, given `partials` isn't suitable as as stand-alone public chart.
+
+`data-plane` can remain unpublished.
+
+Tasks
+---------
+- Refactor `injectPodSpec()` and `injectProxyInit()` in `pkg/inject/inject.go` that currently generates a JSON patch, but have it use the `data-plane` chart instead of the hard-coded go-client structs.
+- Refactor the TLS libraries relied upon by the `proxy-injector` and `sp-validor` webhooks to have them work with RSA as well (they currently only deal with EC).
+- Refactor the  `proxy-injector` and `sp-validator` charts so that they generate the certs/keys with Helm's `genSelfSignedCert()`.
+- Create `values.yaml` with all the default values, by hand (later, we can have this be automated based off of protobuf for the config part). The trust root for identity is expected to be provided by the user in this file.
+- Have a well annotated main `values.yaml` file with the most common settings by default.
+- Create a detailed `NOTES.txt` file with the instructions/warnings detailed above.
+- Create a new website doc for Helm. A section should have a tutorial for generating the cert/key for identity.
+- Enhance `linkerd check` with new checks that cover the options validations currently done in `linkerd install` that can't be performed with `helm install` (Maybe be leave this for later?)
+
+To-do
+------
+- Validate how all this plays with Helm v3
+

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -6,22 +6,32 @@ The current CLI install process uses Helm libraries under the hood, but just as 
 The intention here is to provide a new chart with an injected control plane so that users can install linkerd through a simple `helm install incubator/linkerd2` command.
                                                                                                                                                                                                                                              
 Helm charts can't rely on go code besides the functions provided by the go template library, the Sprig library, and a few extra functions provided by Helm itself. This implies a few compromises:
-                                                         
+
+- We can't have the same level of validation that `linkerd install` currently provides. Some of the basic checks can be performed and have `helm install` fail using [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html). The other checks can be performed with a new command `linkerd check --chart values.yaml`.
 - We can't validate the install options provided in `values.yaml`. Instead, a new set of `linkerd check` checks could help catching invalid options, post-install.
-- We should provide a comprehensive `values.yaml` file that would contain the most common settings, but heavily annotated to instruct users about alternate settings for advanced scenarios.                                                              
+- We should provide a comprehensive `values.yaml` file that would contain the most common settings, but heavily annotated to instruct users about alternate settings for advanced scenarios.    
+- Other alternative `values.yaml` files should be available, for different configuration scenarios like HA for example.
 - Helm's crypto functions only allow us to use RSA certs/keys. We can move the cert/keys from the webhook configs (`proxy-injector` and `sp-validator`) to use RSA. As for the trust root for identity, we decided the user should provide their own in `values.yaml`. The docs should have instructions on how to generate that cert/key.
    
 These compromises entail a less straightforward experience than what `linkerd install` provides, so the Helm installation alternative should be considered an "advanced" feature.                                                             
                                                                                                                                                                                                                                              
 New alternative install workflow through Helm
 -----------------------------------------------
+
+### values.yml validation
+```
+linkerd check --chart values.yaml
+```
+This is an optional pre-install check that validates the options in the provided `values.yaml` file. Some of these validations are also performed when `helm install` runs, but given Helm's limitations some others can only be done through go with this new check.
+
+### Installing the chart
+
 ```               
 helm install incubator/linkerd2
 ```                                                                                                                                                                                                                                          
 That would install linkerd using the most common settings. The `NOTES.txt` file (rendered and shown when this command completes) could provide the follow instructions/warnings:
-- Warn that the identity trust root should have been provided, and show instructions on how to generate it.
 - Instructions on how to, optionally, install the linkerd CLI
-- Instructions on running `linkerd check` to verify everything is ok                                                                                                                                                                         
+- Instructions on running `linkerd check` to verify everything is ok                                                                                                                        
 - Instructions on how to change the most basic settings
 - Instructions on how to get ahold of `values.yaml` containing all the possible settings?
 
@@ -116,14 +126,19 @@ The `control-plane` chart should be the main chart, published under `https://git
 
 Tasks
 ---------
+- Create new `linkerd check --chart values.yaml` command to fully validate the options in `values.yaml`. This includes ensuring the trust root for identity has been provided.
 - Refactor `injectPodSpec()` and `injectProxyInit()` in `pkg/inject/inject.go` that currently generates a JSON patch, but have it use the `data-plane` chart instead of the hard-coded go-client structs.
 - Refactor the TLS libraries relied upon by the `proxy-injector` and `sp-validor` webhooks to have them work with RSA as well (they currently only deal with EC).
 - Refactor the  `proxy-injector` and `sp-validator` charts so that they generate the certs/keys with Helm's `genSelfSignedCert()`.
 - Create `values.yaml` with all the default values, by hand (later, we can have this be automated based off of protobuf for the config part). The trust root for identity is expected to be provided by the user in this file.
+- As much as possible, copy the options validations into the Helm template files, leveraging [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html) function. This includes a new check for ensuring the identity trust root has been provided.
 - Have a well annotated main `values.yaml` file with the most common settings by default.
 - Create a detailed `NOTES.txt` file with the instructions/warnings detailed above.
 - Create a new website doc for Helm. A section should have a tutorial for generating the cert/key for identity.
-- Enhance `linkerd check` with new checks that cover the options validations currently done in `linkerd install` that can't be performed with `helm install` (Maybe be leave this for later?)
+
+### Not necessarily for the first iteration of this project
+- Have `linkerd check --chart` highlight changes between versions.
+
 
 To-do
 ------

--- a/rfc/helm.md
+++ b/rfc/helm.md
@@ -39,7 +39,7 @@ That would install linkerd using the most common settings. The `NOTES.txt` file 
 This will replace the current single chart under the `charts` directory.
 ```
 charts
-├── control-plane
+├── control-plane # This is the only chart that will be pushed to incubator/linkerd2
 │   ├── charts
 │   │   └── partials -> ../../partials
 │   ├── Chart.yaml
@@ -117,12 +117,6 @@ The user experience for `linkerd install` remains the same as well.
 New alternative `helm install` mechanism
 ---------------------------------------------
 The mechanism is the same as `linkerd install` just explained; the main chart will be `charts/control-plane` which depends on `charts/partials` for, among other things, the proxy insertion. The main difference will be that the chart values will come from `values.yml` (or provided by the user through `--set` on Helm's CLI).
-
-Published charts
-----------------
-The `control-plane` chart should be the main chart, published under `https://github.com/helm/charts/incubator/linkerd2`, copying the `partials` chart to `control-plane/charts` prior to publication. I'm not sure if there's a better way of doing this, given `partials` isn't suitable as as stand-alone public chart.
-
-`data-plane` can remain unpublished.
 
 Tasks
 ---------


### PR DESCRIPTION
_Note: Helm support for Linkerd 2 is now being tracked under the project https://github.com/orgs/linkerd/projects/13_

Project kick-off presentation:[Helm Support.pdf](https://github.com/linkerd/linkerd2/files/3431051/Helm.Support.pdf)

The current CLI install process uses Helm libraries under the hood, but just as a template library. There is currently a Helm chart under the `charts` directory that allows installing the control plane, but uninjected, and there's no `values.yaml` file provided.
                                                                                                                                                                                                                                             
The intention here is to provide a new chart with an injected control plane so that users can install linkerd through a simple `helm install incubator/linkerd2` command.
                                                                                                                                                                                                                                             
Helm charts can't rely on go code besides the functions provided by the go template library, the Sprig library, and a few extra functions provided by Helm itself. This implies a few compromises:

- We can't have the same level of validation that `linkerd install` currently provides. Some of the basic checks can be performed and have `helm install` fail using [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html). The other checks can be performed with a new command `linkerd check --chart values.yaml`.
- We can't validate the install options provided in `values.yaml`. Instead, a new set of `linkerd check` checks could help catching invalid options, post-install.
- We should provide a comprehensive `values.yaml` file that would contain the most common settings, but heavily annotated to instruct users about alternate settings for advanced scenarios.    
- Other alternative `values.yaml` files should be available, for different configuration scenarios like HA for example.
- Helm's crypto functions only allow us to use RSA certs/keys. We can move the cert/keys from the webhook configs (`proxy-injector` and `sp-validator`) to use RSA. As for the trust root for identity, we decided the user should provide their own in `values.yaml`. The docs should have instructions on how to generate that cert/key.
   
These compromises entail a less straightforward experience than what `linkerd install` provides, so the Helm installation alternative should be considered an "advanced" feature.                                                             
                                                                                                                                                                                                                                             
New alternative install workflow through Helm
-----------------------------------------------

### values.yml validation
```
linkerd check --chart values.yaml
```
This is an optional pre-install check that validates the options in the provided `values.yaml` file. Some of these validations are also performed when `helm install` runs, but given Helm's limitations some others can only be done through go with this new check.

### Installing the chart

```               
helm install incubator/linkerd2

# or, for users with cluster-level privileges
helm install incubator/linkerd2 --set stage=config
# followed by, for users with just namespace-level privileges
helm upgrade incubator/linkerd2 --set stage=control-plane

```                                                                                                                                                                                                                                          
That would install linkerd using the most common settings. The `NOTES.txt` file (rendered and shown when this command completes) could provide the follow instructions/warnings:
- Instructions on how to, optionally, install the linkerd CLI
- Instructions on running `linkerd check` to verify everything is ok                                                                                                                        
- Instructions on how to change the most basic settings
- Instructions on how to get ahold of `values.yaml` containing all the possible settings?

### New Chart Layout
This will replace the current single chart under the `charts` directory.
```
charts
├── linkerd2
│   ├── charts
│   │   └── partials -> ../../partials
│   ├── Chart.yaml
│   ├── templates
│   │   ├── config.yaml
│   │   ├── controller-rbac.yaml
│   │   ├── controller.yaml
│   │   ├── grafana-rbac.yaml
│   │   ├── grafana.yaml
│   │   ├── identity-rbac.yaml
│   │   ├── identity.yaml
│   │   ├── namespace.yaml
│   │   ├── NOTES.txt
│   │   ├── prometheus-rbac.yaml
│   │   ├── prometheus.yaml
│   │   ├── proxy_injector-rbac.yaml
│   │   ├── proxy_injector.yaml
│   │   ├── psp.yaml
│   │   ├── _resources.yaml
│   │   ├── serviceprofile-crd.yaml
│   │   ├── sp_validator-rbac.yaml
│   │   ├── sp_validator.yaml
│   │   ├── tap-rbac.yaml
│   │   ├── tap.yaml
│   │   ├── trafficsplit-crd.yaml
│   │   ├── web-rbac.yaml
│   │   └── web.yaml
│   └── values.yaml
├── patch
│   ├── charts
│   │   └── partials -> ../../partials
│   ├── Chart.yaml
│   ├── templates
│   │   └── patch.json
│   └── values.yaml
└── partials
    ├── charts
    ├── Chart.yaml
    ├── templates
    │   ├── _debug.yaml
    │   ├── _metadata.yaml
    │   ├── _proxy.yaml
    │   ├── _proxy-init.yaml
    │   └── _volumes.yaml
    └── values.yaml
```

Current mechanisms and changes
-------------------------------

The user experience for the current way of doing things remains the same. There will be some changes under the hood though.

### Automated proxy injection

Currently the `proxy-injector` webhook is invoked for any pod that gets created. If the pod's namespace or the pod itself contains a `linkerd.io/inject: enabled` annotation then the webhook relies on the library `pkg/inject/inject.go` to programatically generate a proxy container (and a proxy-init container if necessary) using go-client structs. Those structs are transformed into JSON-patch format which is returned to Kubernetes, which will do the actual injection of the container into the pod.                                                                                                                                       

The functionality and contract for `pkg/inject/inject.go` will remain the same but with a different mechanism underneath. The JSON-patch will be generated through the new `patch` chart which itself depends on the `_proxy.yaml` template under the `charts/partials` chart. `_proxy.yaml` will be the sole place containing the structure of the proxy container and it will replace the go-client structs currently used. This partial will also be used when doing `helm install` (see below) thus avoiding having more than one place for the proxy structure source-of-truth.

### `linkerd inject`

Currently this only adds the `linkerd.io/inject: enabled` annotation to the pod template, and when Kuberenetes creates the pod it invokes the webhook as just explained. This remains as-is.

### `linkerd inject --manual`

Currently this calls `pkg/inject/inject.go` to perform the injection, just as the webhook does. So the changes detailed above also affect this execution path, but the experience remains the same.

### `linkerd install`

Currently this relies on the Helm go library and the charts under the `charts` directory to generate the control plane resources. The options passed as CLI arguments are converted into template values that are passed to the Helm template engine to be replaced in the placeholders inside those charts. Then, the generated yaml is fed into the `pkg/inject/inject.go` library to inject the proxies, just as `linkerd inject --manual` would do.

Here we will be replacing the current chart with a new one under `charts/linkerd2` to create the control plane resources, and that chart depends on various templates under the `charts/partials` charts, in particular the `_proxy.yaml` template for inserting the yaml for the proxy into all the control plane resources. Note that `charts/linkerd2` doesn't depend on `charts/patch` because the latter's sole purpose is to generate a JSON-patch, which Helm can't interpret.

The user experience for `linkerd install` remains the same as well.

New alternative `helm install` mechanism
---------------------------------------------
The mechanism is the same as `linkerd install` just explained; the main chart will be `charts/linkerd2` which depends on `charts/partials` for, among other things, the proxy insertion. The main difference will be that the chart values will come from `values.yml` (or provided by the user through `--set` on Helm's CLI).

Tasks
---------
- Create new `linkerd check --chart values.yaml` command to fully validate the options in `values.yaml`. This includes ensuring the trust root for identity has been provided (#3130).
- Refactor `injectPodSpec()` and `injectProxyInit()` in `pkg/inject/inject.go` that currently generates a JSON patch, but have it use the `patch` chart instead of the hard-coded go-client structs (#3128).
- Refactor the TLS libraries relied upon by the `proxy-injector` and `sp-validor` webhooks to have them work with RSA as well (they currently only deal with EC) (#3131).
- Refactor the  `proxy-injector` and `sp-validator` charts so that they generate the certs/keys with Helm's `genSelfSignedCert()` (#3126)
- Create `values.yaml` with all the default values, by hand (later, we can have this be automated based off of protobuf for the config part). The trust root for identity is expected to be provided by the user in this file (#3126).
- As much as possible, copy the options validations into the Helm template files, leveraging [Sprig's fail](http://masterminds.github.io/sprig/flow_control.html) function. This includes a new check for ensuring the identity trust root has been provided (#3126).
- Refactor `linkerd install` to work with the new `linkerd2` chart (#3127).
- Have a well annotated main `values.yaml` file with the most common settings by default (#3126)
- Create a detailed `NOTES.txt` file with the instructions/warnings detailed above (#3132).
- Test `helm upgrade`, `helm delete` and `helm rollback` (#3129).

### Not necessarily for the first iteration of this project
- Have `linkerd check --chart` highlight changes between versions.
- Create a script to publish the `linkerd2` chart to https://github.com/helm/charts
- Create a new website doc for Helm. A section should have a tutorial for generating the cert/key for identity.

### Definitely for later
- Consider `install-cni`. Could be as a separate stage (`--set stage=cni`).

To-do
------
- Validate how all this plays with Helm v3
