### PR TITLE
Release notes for Edge-19.7.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * CLI
   * Made the `linkerd routes` command traffic-split aware
+  * Fixed bug the `linkerd upgrade config` command that was causing it to crash
   * Added pod status to the output of the `linkerd stat`command (thanks
     @jonathanbeber!)
   * Fixed incorrect "meshed" count in `linkerd stat` when resources share the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,7 @@
 ## edge-19.7.4
 
 * CLI
-  * Made the `linkerd routes` command traffic-split aware; it now considers
-    resources which are members of a leaf service with non-zero weight to be
-    members of the apex service for the purpose of determining which routes to
-    display
+  * Made the `linkerd routes` command traffic-split aware
   * Added pod status to the output of the `linkerd stat`command (thanks
     @jonathanbeber!)
   * Fixed `linkerd stat` wrong "meshed" count when resources share the same

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## edge-19.7.4
 
 * CLI
-  * Made the `linkerd routes` command traffic-split aware; it now consider
+  * Made the `linkerd routes` command traffic-split aware; it now considers
     resources which are members of a leaf service with non-zero weight to be
     members of the apex service for the purpose of determining which routes to
     display

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
     PSP is enabled, the NET_RAW capability is available
 
 * Proxy
-  * Improve performance by using a constant-time load balancer
+  * Improved performance by using a constant-time load balancer
   * Added a new `/proxy-log-level` endpoint to update the log level at runtime
 
 ## stable-2.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+## edge-19.7.4
+
+* CLI
+  * Made the `linkerd routes` command traffic-split aware; consider resources
+    which are members of a leaf service with non-zero weight to be members of
+    the apex service for the purpose of determining which routes to display
+  * Added pod status to the output of the `linkerd stat`command (thanks
+    @jonathanbeber!)
+  * Fixed `linkerd stat` wrong "meshed" count when resources share the same
+    label selector for pods (thanks @jonathanbeber!)
+  * Improved output of the `linkerd edges` command and added a new `-o wide`
+    flag to show the identity of the client and server if known
+  * Added a new check to the `linkerd check --pre` command validating that if
+    PSP is enabled, the NET_RAW capability is available
+
+* Proxy
+  * Improve performance by using a constant-time load balancer
+  * Added a new `/proxy-log-level` endpoint to update the log level at runtime
+
 ## stable-2.4.0
 
 This release adds traffic splitting functionality, support for the Kubernetes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@
     `-o wide` flag that shows the identity of the client and server if known
   * Added a new check to the `linkerd check --pre` command validating that if
     PSP is enabled, the NET_RAW capability is available
-
+* Controller
+  * Added pod anti-affinity rules to the control plane pods when HA is enabled
+    (thanks @Pothulapati!)
 * Proxy
   * Improved performance by using a constant-time load balancer
   * Added a new `/proxy-log-level` endpoint to update the log level at runtime

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
   * Made the `linkerd routes` command traffic-split aware
   * Added pod status to the output of the `linkerd stat`command (thanks
     @jonathanbeber!)
-  * Fixed `linkerd stat` wrong "meshed" count when resources share the same
-    label selector for pods (thanks @jonathanbeber!)
+  * Fixed incorrect "meshed" count in `linkerd stat` when resources share the
+    same label selector for pods (thanks @jonathanbeber!)
   * Added namespace information to the `linkerd edges` command output and a new
     `-o wide` flag that shows the identity of the client and server if known
   * Added a new check to the `linkerd check --pre` command validating that if

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,16 @@
 ## edge-19.7.4
 
 * CLI
-  * Made the `linkerd routes` command traffic-split aware; consider resources
-    which are members of a leaf service with non-zero weight to be members of
-    the apex service for the purpose of determining which routes to display
+  * Made the `linkerd routes` command traffic-split aware; it now consider
+    resources which are members of a leaf service with non-zero weight to be
+    members of the apex service for the purpose of determining which routes to
+    display
   * Added pod status to the output of the `linkerd stat`command (thanks
     @jonathanbeber!)
   * Fixed `linkerd stat` wrong "meshed" count when resources share the same
     label selector for pods (thanks @jonathanbeber!)
-  * Improved output of the `linkerd edges` command and added a new `-o wide`
-    flag to show the identity of the client and server if known
+  * Added namespace information to the `linkerd edges` command output and a new
+    `-o wide` flag that shows the identity of the client and server if known
   * Added a new check to the `linkerd check --pre` command validating that if
     PSP is enabled, the NET_RAW capability is available
 


### PR DESCRIPTION
* CLI
  * Made the `linkerd routes` command traffic-split aware; consider resources
    which are members of a leaf service with non-zero weight to be members of
    the apex service for the purpose of determining which routes to display
  * Added pod status to the output of the `linkerd stat`command (thanks
    @jonathanbeber!)
  * Fixed `linkerd stat` wrong "meshed" count when resources share the same
    label selector for pods (thanks @jonathanbeber!)
  * Improved output of the `linkerd edges` command and added a new `-o wide`
    flag to show the identity of the client and server if known
  * Added a new check to the `linkerd check --pre` command validating that if
    PSP is enabled, the NET_RAW capability is available

* Proxy
  * Improved performance by using a constant-time load balancer
  * Added a new `/proxy-log-level` endpoint to update the log level at runtime