### PR TITLE
Add "can create cronjobs" to linkerd check

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -388,6 +388,13 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
+					description: "can create CronJobs",
+					hintAnchor:  "pre-k8s",
+					check: func(context.Context) error {
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "batch", "v1beta1", "cronjobs")
+					},
+				},
+				{
 					description: "can create ConfigMaps",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -19,6 +19,7 @@ pre-kubernetes-setup
 √ can create ServiceAccounts
 √ can create Services
 √ can create Deployments
+√ can create CronJobs
 √ can create ConfigMaps
 √ no clock skew detected
 


### PR DESCRIPTION
PR #3056 introduced a cluster heartbeat cronjob to the Linkerd
installation. This implies the user installing Linkerd requires the
privileges to create CronJobs.

Update `linkerd check` to validate the user has privileges necessary to
create CronJobs.

Fixes #3057

Signed-off-by: Andrew Seigner <siggy@buoyant.io>