### PR TITLE
Fix resources yaml indentation

### DIFF
--- a/chart/templates/_resources.yaml
+++ b/chart/templates/_resources.yaml
@@ -1,21 +1,22 @@
-{{- define "resources" }}
-        resources:
-          {{- if or .CPU.Request .Memory.Request }}
-          requests:
-            {{- with .CPU.Request }}
-            cpu: {{.}}
-            {{- end }}
-            {{- with .Memory.Request }}
-            memory: {{.}}
-            {{- end }}
-          {{- end }}
-          {{- if or .CPU.Limit .Memory.Limit }}
-          limits:
-            {{- with .CPU.Limit }}
-            cpu: {{.}}
-            {{- end }}
-            {{- with .Memory.Limit }}
-            memory: {{.}}
-            {{- end }}
-          {{- end }}
-{{- end }}
+{{/* Specify resource requests and limits for workloads */}}
+{{- define "resources" -}}
+resources:
+  {{- if or .CPU.Request .Memory.Request }}
+  requests:
+    {{- with .CPU.Request }}
+    cpu: {{.}}
+    {{- end }}
+    {{- with .Memory.Request }}
+    memory: {{.}}
+    {{- end }}
+  {{- end }}
+  {{- if or .CPU.Limit .Memory.Limit }}
+  limits:
+    {{- with .CPU.Limit }}
+    cpu: {{.}}
+    {{- end }}
+    {{- with .Memory.Limit }}
+    memory: {{.}}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/chart/templates/controller.yaml
+++ b/chart/templates/controller.yaml
@@ -90,9 +90,7 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
-        {{ with .PublicAPIResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .PublicAPIResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       - name: destination
@@ -122,9 +120,7 @@ spec:
             path: /ready
             port: 9996
           failureThreshold: 7
-        {{ with .DestinationResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .DestinationResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/grafana.yaml
+++ b/chart/templates/grafana.yaml
@@ -140,9 +140,7 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-        {{- with .GrafanaResources }}
-        {{- template "resources" . }}
-        {{- end }}
+        {{- include "resources" .GrafanaResources | nindent 8 }}
         securityContext:
           runAsUser: 472
       serviceAccountName: linkerd-grafana

--- a/chart/templates/heartbeat.yaml
+++ b/chart/templates/heartbeat.yaml
@@ -36,7 +36,7 @@ spec:
             - "-prometheus-url=http://linkerd-prometheus.{{.Namespace}}.svc.cluster.local:9090"
             - "-controller-namespace={{.Namespace}}"
             - "-log-level={{.ControllerLogLevel}}"
-            {{- include "resources" .HeartbeatResources | indent 4 | trimPrefix "    " }}
+            {{- include "resources" .HeartbeatResources | nindent 12 }}
             securityContext:
               runAsUser: {{.ControllerUID}}
 {{end -}}

--- a/chart/templates/identity.yaml
+++ b/chart/templates/identity.yaml
@@ -90,9 +90,7 @@ spec:
             path: /ready
             port: 9990
           failureThreshold: 7
-        {{ with .IdentityResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .IdentityResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:
@@ -101,7 +99,7 @@ spec:
           name: linkerd-config
       - name: identity-issuer
         secret:
-          secretName: linkerd-identity-issuer 
+          secretName: linkerd-identity-issuer
       {{- if .HighAvailability }}
       {{- $local := dict "Label" .ControllerComponentLabel "Component" "identity" }}
       {{- include "pod-affinity" $local | nindent 6 }}

--- a/chart/templates/prometheus.yaml
+++ b/chart/templates/prometheus.yaml
@@ -168,9 +168,7 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
-        {{ with .PrometheusResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .PrometheusResources | nindent 8 }}
         securityContext:
           runAsUser: 65534
 {{- end}}

--- a/chart/templates/proxy_injector.yaml
+++ b/chart/templates/proxy_injector.yaml
@@ -55,9 +55,7 @@ spec:
             path: /ready
             port: 9995
           failureThreshold: 7
-        {{ with .ProxyInjectorResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .ProxyInjectorResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/sp_validator.yaml
+++ b/chart/templates/sp_validator.yaml
@@ -72,9 +72,7 @@ spec:
             path: /ready
             port: 9997
           failureThreshold: 7
-        {{ with .SPValidatorResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .SPValidatorResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       volumes:

--- a/chart/templates/tap.yaml
+++ b/chart/templates/tap.yaml
@@ -66,9 +66,7 @@ spec:
             path: /ready
             port: 9998
           failureThreshold: 7
-        {{ with .TapResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .TapResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       {{- if .HighAvailability }}

--- a/chart/templates/web.yaml
+++ b/chart/templates/web.yaml
@@ -72,9 +72,7 @@ spec:
             path: /ready
             port: 9994
           failureThreshold: 7
-        {{ with .WebResources -}}
-        {{- template "resources" . }}
-        {{ end -}}
+        {{- include "resources" .WebResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
       serviceAccountName: linkerd-web


### PR DESCRIPTION
The `_resources.yaml` partial hard-coded indentation, making it
cumbersome to use it in contexts that did not have a specific
indentation level.

Remove indentation from `_resources.yaml`, and instead specify required
indentation at the call site via `nindent`.

Fixes #3119

Signed-off-by: Andrew Seigner <siggy@buoyant.io>