### PR TITLE
Add RSA support to TLS libraries

### DIFF
--- a/pkg/tls/codec.go
+++ b/pkg/tls/codec.go
@@ -52,7 +52,7 @@ func encode(buf *bytes.Buffer, blk *pem.Block) {
 func DecodePEMKey(txt string) (GenericPrivateKey, error) {
 	block, _ := pem.Decode([]byte(txt))
 	if block == nil {
-		return nil, errors.New("Not PEM-encoded")
+		return nil, errors.New("not PEM-encoded")
 	}
 	switch block.Type {
 	case "EC PRIVATE KEY":
@@ -60,15 +60,15 @@ func DecodePEMKey(txt string) (GenericPrivateKey, error) {
 		if err != nil {
 			return nil, err
 		}
-		return PrivateKeyEC{k}, nil
+		return privateKeyEC{k}, nil
 	case "RSA PRIVATE KEY":
 		k, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 		if err != nil {
 			return nil, err
 		}
-		return PrivateKeyRSA{k}, nil
+		return privateKeyRSA{k}, nil
 	default:
-		return nil, fmt.Errorf("Unsupported block type: '%s'", block.Type)
+		return nil, fmt.Errorf("unsupported block type: '%s'", block.Type)
 	}
 }
 
@@ -96,7 +96,7 @@ func DecodePEMCertPool(txt string) (pool *x509.CertPool, err error) {
 		return
 	}
 	if len(certs) == 0 {
-		err = errors.New("No certificates found")
+		err = errors.New("no certificates found")
 		return
 	}
 

--- a/pkg/tls/cred.go
+++ b/pkg/tls/cred.go
@@ -14,12 +14,12 @@ import (
 
 type (
 	// PrivateKeyEC wraps an EC private key
-	PrivateKeyEC struct {
+	privateKeyEC struct {
 		*ecdsa.PrivateKey
 	}
 
 	// PrivateKeyRSA wraps an RSA private key
-	PrivateKeyRSA struct {
+	privateKeyRSA struct {
 		*rsa.PrivateKey
 	}
 
@@ -45,27 +45,27 @@ type (
 	}
 )
 
-func (k PrivateKeyEC) matchesCertificate(c *x509.Certificate) bool {
+func (k privateKeyEC) matchesCertificate(c *x509.Certificate) bool {
 	pub, ok := c.PublicKey.(*ecdsa.PublicKey)
 	return ok && pub.X.Cmp(k.X) == 0 && pub.Y.Cmp(k.Y) == 0
 }
 
-func (k PrivateKeyEC) marshal() ([]byte, error) {
+func (k privateKeyEC) marshal() ([]byte, error) {
 	return x509.MarshalECPrivateKey(k.PrivateKey)
 }
 
-func (k PrivateKeyRSA) matchesCertificate(c *x509.Certificate) bool {
+func (k privateKeyRSA) matchesCertificate(c *x509.Certificate) bool {
 	pub, ok := c.PublicKey.(*rsa.PublicKey)
 	return ok && pub.N.Cmp(k.N) == 0 && pub.E == k.E
 }
 
-func (k PrivateKeyRSA) marshal() ([]byte, error) {
+func (k privateKeyRSA) marshal() ([]byte, error) {
 	return x509.MarshalPKCS1PrivateKey(k.PrivateKey), nil
 }
 
 // validCredOrPanic creates a  Cred, panicking if the key does not match the certificate.
 func validCredOrPanic(ecKey *ecdsa.PrivateKey, crt Crt) Cred {
-	k := PrivateKeyEC{ecKey}
+	k := privateKeyEC{ecKey}
 	if !k.matchesCertificate(crt.Certificate) {
 		panic("Cert's public key does not match private key")
 	}


### PR DESCRIPTION
Fixes #3131

Wrapped private keys into either `PrivateKeyEC` or `PrivateKeyRSA` to
provide different certificate matching logic and marshaling depending on
the block type.

You can test having an RSA cert for the proxy injector by applying this
patch:

```diff
$ diff -u chart/templates/proxy_injector-rbac.yaml ~/tmp/proxy_injector-rbac.yaml
--- chart/templates/proxy_injector-rbac.yaml    2019-07-24 14:34:43.570616936 -0500
+++ /home/alpeb/tmp/proxy_injector-rbac.yaml    2019-07-24 13:41:03.150285099 -0500
@@ -1,4 +1,5 @@
 {{with .Values -}}
+{{- $ca := genCA "linkerd-proxy-injector.linkerd.svc" 365 -}}
 ---
 ###
 ### Proxy Injector RBAC
@@ -60,8 +61,8 @@
     {{ .CreatedByAnnotation }}: {{ .CliVersion }}
 type: Opaque
 data:
-  crt.pem: {{ b64enc .ProxyInjector.CrtPEM }}
-  key.pem: {{ b64enc .ProxyInjector.KeyPEM }}
+  crt.pem: {{ b64enc $ca.Cert }}
+  key.pem: {{ b64enc $ca.Key }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
@@ -81,7 +82,7 @@
       name: linkerd-proxy-injector
       namespace: {{ .Namespace }}
       path: "/"
-    caBundle: {{ b64enc .ProxyInjector.CrtPEM }}
+    caBundle: {{ b64enc $ca.Cert }}
   failurePolicy: {{ .WebhookFailurePolicy }}
   rules:
   - operations: [ "CREATE" ]
```

This will replace the logic to generate the cert with a call to Helm's
`genCA`, which uses RSA.