### PR TITLE
Make authorities in destination overrides absolute

### DIFF
--- a/controller/api/destination/traffic_split_adaptor.go
+++ b/controller/api/destination/traffic_split_adaptor.go
@@ -54,7 +54,9 @@ func (tsa *trafficSplitAdaptor) publish() {
 		overrides := []*sp.WeightedDst{}
 		for _, backend := range tsa.split.Spec.Backends {
 			dst := &sp.WeightedDst{
-				Authority: fmt.Sprintf("%s.%s.svc.cluster.local:%d", backend.Service, tsa.id.Namespace, tsa.port),
+				// The proxy expects authorities to be absolute and have the
+				// host part end with a trailing dot.
+				Authority: fmt.Sprintf("%s.%s.svc.cluster.local.:%d", backend.Service, tsa.id.Namespace, tsa.port),
 				Weight:    backend.Weight,
 			}
 			overrides = append(overrides, dst)

--- a/controller/api/destination/traffic_split_adaptor_test.go
+++ b/controller/api/destination/traffic_split_adaptor_test.go
@@ -66,7 +66,7 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 			Spec: sp.ServiceProfileSpec{
 				DstOverrides: []*sp.WeightedDst{
 					{
-						Authority: "bar.ns.svc.cluster.local:80",
+						Authority: "bar.ns.svc.cluster.local.:80",
 						Weight:    resource.MustParse("1000m"),
 					},
 				},
@@ -96,7 +96,7 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 				},
 				DstOverrides: []*sp.WeightedDst{
 					{
-						Authority: "bar.ns.svc.cluster.local:80",
+						Authority: "bar.ns.svc.cluster.local.:80",
 						Weight:    resource.MustParse("1000m"),
 					},
 				},


### PR DESCRIPTION
Fixes #3136 

When the destination service sends a destination profile with a traffic split to the proxy, the override destination authorities are absolute but do no contain a trailing dot.  e.g. "bar.ns.svc.cluster.local:80".  However, NameAddrs which have undergone canonicalization in the proxy will include the trailing dot.  When a traffic split includes the apex service as one of the overrides, the original apex NameAddr will have the trailing dot and the override will not.  Since these two NameAddrs are not identical, they will go into two distinct slots in the proxy's concrete dst router.  This will cause two services to be created for the same destination which will cause the stats clobbering described in the linked issue.

We change the destination service to always return absolute dst overrides including the trailing dot.

Signed-off-by: Alex Leong <alex@buoyant.io>