### PR TITLE
Set HTTP security headers on dashboard

### DIFF
--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -43,6 +43,9 @@ type (
 
 // this is called by the HTTP server to actually respond to a request
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	s.router.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
Set the following headers on every dashboard response:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `X-XSS-Protection: 1; mode=block`

Fixes #3082

Signed-off-by: Andrew Seigner <siggy@buoyant.io>