### PR TITLE
Fix nil pointer dereference in endpoints watcher

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -421,7 +421,7 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 				continue
 			}
 			if endpoint.TargetRef == nil {
-				pp.log.Debugf("Endpoint missing TargetRef: %+v", endpoint)
+				pp.log.Warnf("Endpoint missing TargetRef: %+v", endpoint)
 				continue
 			}
 			if endpoint.TargetRef.Kind == "Pod" {

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -420,6 +420,10 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 			if pp.hostname != "" && pp.hostname != endpoint.Hostname {
 				continue
 			}
+			if endpoint.TargetRef == nil {
+				pp.log.Debugf("Endpoint missing TargetRef: %+v", endpoint)
+				continue
+			}
 			if endpoint.TargetRef.Kind == "Pod" {
 				id := PodID{
 					Name:      endpoint.TargetRef.Name,

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -91,6 +91,7 @@ subsets:
       kind: Pod
       name: name1-3
       namespace: ns
+  - ip: 172.17.0.21
   ports:
   - port: 8989`,
 				`


### PR DESCRIPTION
The destination service's endpoints watcher assumed every `Endpoints`
object contained a `TargetRef`. This field is optional, and in cases
such as the default `ep/kubernetes` object, `TargetRef` is nil, causing
a nil pointer dereference.

Fix endpoints watcher to check for `TargetRef` prior to dereferencing.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>