### PR TITLE
Allow setting custom cluster domain in service profiles

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -100,17 +100,17 @@ func newCmdProfile() *cobra.Command {
 			}
 
 			if options.template {
-				return profiles.RenderProfileTemplate(options.namespace, options.name, os.Stdout)
+				return profiles.RenderProfileTemplate(options.namespace, options.name, defaultClusterDomain, os.Stdout)
 			} else if options.openAPI != "" {
-				return profiles.RenderOpenAPI(options.openAPI, options.namespace, options.name, os.Stdout)
+				return profiles.RenderOpenAPI(options.openAPI, options.namespace, defaultClusterDomain, options.name, os.Stdout)
 			} else if options.tap != "" {
 				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 				if err != nil {
 					return err
 				}
-				return profiles.RenderTapOutputProfile(k8sAPI, options.tap, options.namespace, options.name, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
+				return profiles.RenderTapOutputProfile(k8sAPI, options.tap, options.namespace, options.name, defaultClusterDomain, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
 			} else if options.proto != "" {
-				return profiles.RenderProto(options.proto, options.namespace, options.name, os.Stdout)
+				return profiles.RenderProto(options.proto, options.namespace, options.name, defaultClusterDomain, os.Stdout)
 			}
 
 			// we should never get here

--- a/cli/cmd/profile_test.go
+++ b/cli/cmd/profile_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseProfile(t *testing.T) {
 	var buf bytes.Buffer
 
-	err := profiles.RenderProfileTemplate("myns", "mysvc", &buf)
+	err := profiles.RenderProfileTemplate("myns", "mysvc", "mycluster.local", &buf)
 	if err != nil {
 		t.Fatalf("Error rendering service profile template: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestParseProfile(t *testing.T) {
 		t.Fatalf("Error parsing service profile: %v", err)
 	}
 
-	expectedServiceProfile := profiles.GenServiceProfile("mysvc", "myns")
+	expectedServiceProfile := profiles.GenServiceProfile("mysvc", "myns", "mycluster.local")
 
 	err = profiles.ServiceProfileYamlEquals(serviceProfile, expectedServiceProfile)
 	if err != nil {

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -20,7 +20,7 @@ var pathParamRegex = regexp.MustCompile(`\\{[^\}]*\\}`)
 // RenderOpenAPI reads an OpenAPI spec file and renders the corresponding
 // ServiceProfile to a buffer, given a namespace, service, and control plane
 // namespace.
-func RenderOpenAPI(fileName, namespace, name string, w io.Writer) error {
+func RenderOpenAPI(fileName, namespace, name, clusterDomain string, w io.Writer) error {
 
 	input, err := readFile(fileName)
 	if err != nil {
@@ -42,15 +42,15 @@ func RenderOpenAPI(fileName, namespace, name string, w io.Writer) error {
 		return fmt.Errorf("Error parsing OpenAPI spec: %s", err)
 	}
 
-	profile := swaggerToServiceProfile(swagger, namespace, name)
+	profile := swaggerToServiceProfile(swagger, namespace, name, clusterDomain)
 
 	return writeProfile(profile, w)
 }
 
-func swaggerToServiceProfile(swagger spec.Swagger, namespace, name string) sp.ServiceProfile {
+func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomain string) sp.ServiceProfile {
 	profile := sp.ServiceProfile{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
+			Name:      fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain),
 			Namespace: namespace,
 		},
 		TypeMeta: serviceProfileMeta,

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -11,6 +11,7 @@ import (
 func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
+	clusterDomain := "mycluster.local"
 
 	swagger := spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
@@ -39,7 +40,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 	expectedServiceProfile := sp.ServiceProfile{
 		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "." + namespace + ".svc.cluster.local",
+			Name:      name + "." + namespace + ".svc." + clusterDomain,
 			Namespace: namespace,
 		},
 		Spec: sp.ServiceProfileSpec{
@@ -66,7 +67,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 		},
 	}
 
-	actualServiceProfile := swaggerToServiceProfile(swagger, namespace, name)
+	actualServiceProfile := swaggerToServiceProfile(swagger, namespace, name, clusterDomain)
 
 	err := ServiceProfileYamlEquals(actualServiceProfile, expectedServiceProfile)
 	if err != nil {

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -19,7 +19,7 @@ import (
 type profileTemplateConfig struct {
 	ServiceNamespace string
 	ServiceName      string
-	ClusterZone      string
+	ClusterDomain    string
 }
 
 var (
@@ -31,8 +31,6 @@ var (
 
 	minStatus uint32 = 100
 	maxStatus uint32 = 599
-
-	clusterZoneSuffix = "svc.cluster.local"
 
 	errRequestMatchField  = errors.New("A request match must have a field set")
 	errResponseMatchField = errors.New("A response match must have a field set")
@@ -202,18 +200,18 @@ func ValidateResponseMatch(rspMatch *sp.ResponseMatch) error {
 	return nil
 }
 
-func buildConfig(namespace, service string) *profileTemplateConfig {
+func buildConfig(namespace, service, clusterDomain string) *profileTemplateConfig {
 	return &profileTemplateConfig{
 		ServiceNamespace: namespace,
 		ServiceName:      service,
-		ClusterZone:      clusterZoneSuffix,
+		ClusterDomain:    clusterDomain,
 	}
 }
 
 // RenderProfileTemplate renders a ServiceProfile template to a buffer, given a
 // namespace, service, and control plane namespace.
-func RenderProfileTemplate(namespace, service string, w io.Writer) error {
-	config := buildConfig(namespace, service)
+func RenderProfileTemplate(namespace, service, clusterDomain string, w io.Writer) error {
+	config := buildConfig(namespace, service, clusterDomain)
 	template, err := template.New("profile").Parse(Template)
 	if err != nil {
 		return err

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -14,7 +14,7 @@ import (
 // RenderProto reads a protobuf definition file and renders the corresponding
 // ServiceProfile to a buffer, given a namespace, service, and control plane
 // namespace.
-func RenderProto(fileName, namespace, name string, w io.Writer) error {
+func RenderProto(fileName, namespace, name, clusterDomain string, w io.Writer) error {
 	input, err := readFile(fileName)
 	if err != nil {
 		return err
@@ -22,7 +22,7 @@ func RenderProto(fileName, namespace, name string, w io.Writer) error {
 
 	parser := proto.NewParser(input)
 
-	profile, err := protoToServiceProfile(parser, namespace, name)
+	profile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func RenderProto(fileName, namespace, name string, w io.Writer) error {
 	return writeProfile(*profile, w)
 }
 
-func protoToServiceProfile(parser *proto.Parser, namespace, name string) (*sp.ServiceProfile, error) {
+func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain string) (*sp.ServiceProfile, error) {
 	definition, err := parser.Parse()
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name string) (*sp.Se
 
 	return &sp.ServiceProfile{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
+			Name:      fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain),
 			Namespace: namespace,
 		},
 		TypeMeta: serviceProfileMeta,

--- a/pkg/profiles/proto_test.go
+++ b/pkg/profiles/proto_test.go
@@ -12,6 +12,7 @@ import (
 func TestProtoToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
+	clusterDomain := "mycluster.local"
 
 	protobuf := `syntax = "proto3";
 
@@ -34,7 +35,7 @@ service VotingService {
 	expectedServiceProfile := sp.ServiceProfile{
 		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "." + namespace + ".svc.cluster.local",
+			Name:      name + "." + namespace + ".svc." + clusterDomain,
 			Namespace: namespace,
 		},
 		Spec: sp.ServiceProfileSpec{
@@ -50,7 +51,7 @@ service VotingService {
 		},
 	}
 
-	actualServiceProfile, err := protoToServiceProfile(parser, namespace, name)
+	actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
 	if err != nil {
 		t.Fatalf("Failed to create ServiceProfile: %v", err)
 	}

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -23,7 +23,7 @@ import (
 // RenderTapOutputProfile performs a tap on the desired resource and generates
 // a service profile with routes pre-populated from the tap data
 // Only inbound tap traffic is considered.
-func RenderTapOutputProfile(k8sAPI *k8s.KubernetesAPI, tapResource, namespace, name string, tapDuration time.Duration, routeLimit int, w io.Writer) error {
+func RenderTapOutputProfile(k8sAPI *k8s.KubernetesAPI, tapResource, namespace, name, clusterDomain string, tapDuration time.Duration, routeLimit int, w io.Writer) error {
 	requestParams := util.TapRequestParams{
 		Resource:  tapResource,
 		Namespace: namespace,
@@ -35,7 +35,7 @@ func RenderTapOutputProfile(k8sAPI *k8s.KubernetesAPI, tapResource, namespace, n
 		return err
 	}
 
-	profile, err := tapToServiceProfile(k8sAPI, req, namespace, name, tapDuration, routeLimit)
+	profile, err := tapToServiceProfile(k8sAPI, req, namespace, name, clusterDomain, tapDuration, routeLimit)
 	if err != nil {
 		return err
 	}
@@ -48,10 +48,10 @@ func RenderTapOutputProfile(k8sAPI *k8s.KubernetesAPI, tapResource, namespace, n
 	return nil
 }
 
-func tapToServiceProfile(k8sAPI *k8s.KubernetesAPI, tapReq *pb.TapByResourceRequest, namespace, name string, tapDuration time.Duration, routeLimit int) (sp.ServiceProfile, error) {
+func tapToServiceProfile(k8sAPI *k8s.KubernetesAPI, tapReq *pb.TapByResourceRequest, namespace, name, clusterDomain string, tapDuration time.Duration, routeLimit int) (sp.ServiceProfile, error) {
 	profile := sp.ServiceProfile{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace),
+			Name:      fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain),
 			Namespace: namespace,
 		},
 		TypeMeta: serviceProfileMeta,

--- a/pkg/profiles/tap_test.go
+++ b/pkg/profiles/tap_test.go
@@ -17,6 +17,7 @@ import (
 func TestTapToServiceProfile(t *testing.T) {
 	name := "service-name"
 	namespace := "service-namespace"
+	clusterDomain := "service-cluster.local"
 	tapDuration := 5 * time.Second
 	routeLimit := 20
 
@@ -95,7 +96,7 @@ func TestTapToServiceProfile(t *testing.T) {
 	expectedServiceProfile := sp.ServiceProfile{
 		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "." + namespace + ".svc.cluster.local",
+			Name:      name + "." + namespace + ".svc." + clusterDomain,
 			Namespace: namespace,
 		},
 		Spec: sp.ServiceProfileSpec{
@@ -118,7 +119,7 @@ func TestTapToServiceProfile(t *testing.T) {
 		},
 	}
 
-	actualServiceProfile, err := tapToServiceProfile(kubeAPI, tapReq, namespace, name, tapDuration, routeLimit)
+	actualServiceProfile, err := tapToServiceProfile(kubeAPI, tapReq, namespace, name, clusterDomain, tapDuration, routeLimit)
 	if err != nil {
 		t.Fatalf("Failed to create ServiceProfile: %v", err)
 	}

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -5,7 +5,7 @@ const Template = `### ServiceProfile for {{.ServiceName}}.{{.ServiceNamespace}} 
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: {{.ServiceName}}.{{.ServiceNamespace}}.{{.ClusterZone}}
+  name: {{.ServiceName}}.{{.ServiceNamespace}}.svc.{{.ClusterDomain}}
   namespace: {{.ServiceNamespace}}
 spec:
   # A service profile defines a list of routes.  Linkerd can aggregate metrics

--- a/pkg/profiles/test_helper.go
+++ b/pkg/profiles/test_helper.go
@@ -10,11 +10,11 @@ import (
 )
 
 // GenServiceProfile generates a mock ServiceProfile.
-func GenServiceProfile(service, namespace string) v1alpha2.ServiceProfile {
+func GenServiceProfile(service, namespace, clusterDomain string) v1alpha2.ServiceProfile {
 	return v1alpha2.ServiceProfile{
 		TypeMeta: serviceProfileMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      service + "." + namespace + ".svc.cluster.local",
+			Name:      service + "." + namespace + ".svc." + clusterDomain,
 			Namespace: namespace,
 		},
 		Spec: v1alpha2.ServiceProfileSpec{

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -23,6 +23,7 @@ type (
 		apiClient           public.APIClient
 		uuid                string
 		controllerNamespace string
+		clusterDomain       string
 		grafanaProxy        *grafanaProxy
 	}
 )
@@ -68,7 +69,7 @@ func (h *handler) handleProfileDownload(w http.ResponseWriter, req *http.Request
 	}
 
 	profileYaml := &bytes.Buffer{}
-	err := profiles.RenderProfileTemplate(namespace, service, profileYaml)
+	err := profiles.RenderProfileTemplate(namespace, service, h.clusterDomain, profileYaml)
 
 	if err != nil {
 		log.Error(err)

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -78,6 +78,7 @@ func TestHandleConfigDownload(t *testing.T) {
 		render:              server.RenderTemplate,
 		apiClient:           mockAPIClient,
 		controllerNamespace: "linkerd",
+		clusterDomain:       "mycluster.local",
 	}
 
 	recorder := httptest.NewRecorder()
@@ -109,7 +110,7 @@ func TestHandleConfigDownload(t *testing.T) {
 		t.Fatalf("Error parsing service profile: %v", err)
 	}
 
-	expectedServiceProfile := helpers.GenServiceProfile("authors", "booksns")
+	expectedServiceProfile := helpers.GenServiceProfile("authors", "booksns", "mycluster.local")
 
 	err = helpers.ServiceProfileYamlEquals(serviceProfile, expectedServiceProfile)
 	if err != nil {

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -59,6 +59,7 @@ func NewServer(
 	staticDir string,
 	uuid string,
 	controllerNamespace string,
+	clusterDomain string,
 	reload bool,
 	apiClient public.APIClient,
 ) *http.Server {
@@ -79,6 +80,7 @@ func NewServer(
 		render:              server.RenderTemplate,
 		uuid:                uuid,
 		controllerNamespace: controllerNamespace,
+		clusterDomain:       clusterDomain,
 		grafanaProxy:        newGrafanaProxy(grafanaAddr),
 	}
 


### PR DESCRIPTION
Continue of #2950.

I decided to check for the `clusterDomain` in the config map in web server main for the same reasons as as pointed out here https://github.com/linkerd/linkerd2/pull/3113#discussion_r306935817

It decouples the server implementations from the config.