### PR TITLE
Remove unused argument

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -160,7 +160,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		conf.AppendPodAnnotations(rt.overrideAnnotations)
 	}
 
-	p, err := conf.GetPatch(bytes, rt.injectProxy)
+	p, err := conf.GetPatch(rt.injectProxy)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -61,7 +61,7 @@ func Inject(api *k8s.API,
 	resourceConfig.AppendPodAnnotations(map[string]string{
 		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
 	})
-	p, err := resourceConfig.GetPatch(request.Object.Raw, true)
+	p, err := resourceConfig.GetPatch(true)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -119,7 +119,7 @@ func TestGetPatch(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				p, err := fullConf.GetPatch(fakeReq.Object.Raw, true)
+				p, err := fullConf.GetPatch(true)
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -153,7 +153,7 @@ func TestGetPatch(t *testing.T) {
 
 		fakeReq := getFakeReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		p, err := conf.GetPatch(fakeReq.Object.Raw, true)
+		p, err := conf.GetPatch(true)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -205,7 +205,7 @@ func (conf *ResourceConfig) ParseMetaAndYAML(bytes []byte) (*Report, error) {
 
 // GetPatch returns the JSON patch containing the proxy and init containers specs, if any.
 // If injectProxy is false, only the config.linkerd.io annotations are set.
-func (conf *ResourceConfig) GetPatch(bytes []byte, injectProxy bool) (*Patch, error) {
+func (conf *ResourceConfig) GetPatch(injectProxy bool) (*Patch, error) {
 	patch := NewPatch(conf.workload.metaType.Kind)
 	if conf.pod.spec != nil {
 		conf.injectPodAnnotations(patch)


### PR DESCRIPTION
Removed unused argument in the `GetPatch()` function in `pkg/inject/inject.go`