### PR TITLE
Bump golangci-lint to 1.17.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,15 @@
 # This file specifies which linters golangci-lint should run.
 #
 # For descriptions of all available linters, run:
-# ./.golangci-lint-1.15.0 linters
+# ./.golangci-lint-1.17.1 linters
 # or browse to:
 # https://github.com/golangci/golangci-lint#supported-linters
 
 run:
   deadline: 5m
-issues:
-  exclude-use-default: false
 linters:
   enable:
+  - bodyclose
   - deadcode
   - depguard
   - goconst

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@
 
 run:
   deadline: 5m
+issues:
+  exclude-use-default: false
 linters:
   enable:
   - bodyclose

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.15.0
+lintversion=1.17.1
 
 cd "$(pwd -P)"
 

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -93,7 +93,7 @@ func TestConfigAccessors(t *testing.T) {
 		{id: "use overrides",
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
-					metav1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							k8s.ProxyDisableIdentityAnnotation:        "true",
 							k8s.ProxyImageAnnotation:                  "gcr.io/linkerd-io/proxy",
@@ -114,7 +114,7 @@ func TestConfigAccessors(t *testing.T) {
 							k8s.ProxyEnableExternalProfilesAnnotation: "false",
 							k8s.ProxyVersionOverrideAnnotation:        proxyVersionOverride},
 					},
-					corev1.PodSpec{},
+					Spec: corev1.PodSpec{},
 				},
 			},
 			expected: expectedProxyConfigs{
@@ -178,8 +178,8 @@ func TestConfigAccessors(t *testing.T) {
 		{id: "use defaults",
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
-					metav1.ObjectMeta{},
-					corev1.PodSpec{},
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec:       corev1.PodSpec{},
 				},
 			},
 			expected: expectedProxyConfigs{


### PR DESCRIPTION
Also add `bodyclose` linter and remove `exclude-use-default: false`

Signed-off-by: Andrew Seigner <siggy@buoyant.io>