### PR TITLE
Introduce tap APIService, update `linkerd tap`

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -219,6 +219,15 @@ You can also send test requests to the destination's discovery interface:
 bin/go-run controller/script/discovery-client
 ```
 
+##### Running the Tap APIService for development
+
+```bash
+openssl req -nodes -x509 -newkey rsa:4096 -keyout $HOME/key.pem -out $HOME/crt.pem -subj "/C=US"
+bin/go-run controller/cmd/tap --disable-common-names --tls-cert=$HOME/crt.pem --tls-key=$HOME/key.pem
+
+curl -k https://localhost:8089/apis/tap.linkerd.io/v1alpha1
+```
+
 #### Generating CLI docs
 
 The [documentation](https://linkerd.io/2/cli/) for the CLI

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -40,6 +40,18 @@ if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresour
   echo "no customresourcedefinitions found" >&2
 fi
 
-if [[ $namespaces_controlplane || $namespaces_dataplane || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions ]]; then
-  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_dataplane $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions
+if ! apiservices=$(kubectl --context=$k8s_context get apiservices -l linkerd.io/control-plane-ns -oname); then
+  echo "no apiservices found" >&2
+fi
+
+if [[ $namespaces_controlplane || $namespaces_dataplane || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions || $apiservices ]]; then
+  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_dataplane $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions $apiservices
+fi
+
+echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"
+if ! rolebindings=$(kubectl --context=$k8s_context -n kube-system get rolebindings -l linkerd.io/control-plane-ns -oname); then
+  echo "no rolebindings found in the kube-system namespace" >&2
+fi
+if [[ $rolebindings ]]; then
+  kubectl --context=$k8s_context delete $rolebindings -n kube-system
 fi

--- a/chart/templates/tap-rbac.yaml
+++ b/chart/templates/tap-rbac.yaml
@@ -38,6 +38,22 @@ subjects:
   name: linkerd-tap
   namespace: {{.Namespace}}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-{{.Namespace}}-tap-auth-delegator
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: {{.Namespace}}
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -46,4 +62,53 @@ metadata:
   labels:
     {{.ControllerComponentLabel}}: tap
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-{{.Namespace}}-tap-auth-reader
+  namespace: kube-system
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: {{.Namespace}}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: {{ .Namespace }}
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+  annotations:
+    {{ .CreatedByAnnotation }}: {{ .CliVersion }}
+type: Opaque
+data:
+  crt.pem: {{ b64enc .Tap.CrtPEM }}
+  key.pem: {{ b64enc .Tap.KeyPEM }}
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    {{.ControllerComponentLabel}}: tap
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: {{.Namespace}}
+  caBundle: {{ b64enc .Tap.CrtPEM }}
 {{end -}}

--- a/chart/templates/tap.yaml
+++ b/chart/templates/tap.yaml
@@ -22,6 +22,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1
@@ -48,8 +51,14 @@ spec:
         ports:
         - name: grpc
           containerPort: 8088
+        - name: apiserver
+          containerPort: 8089
         - name: admin-http
           containerPort: 9998
+        volumeMounts:
+        - name: tls
+          mountPath: /var/run/linkerd/tls
+          readOnly: true
         image: {{.ControllerImage}}
         imagePullPolicy: {{.ImagePullPolicy}}
         args:
@@ -69,6 +78,10 @@ spec:
         {{- include "resources" .TapResources | nindent 8 }}
         securityContext:
           runAsUser: {{.ControllerUID}}
+      volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       {{- if .HighAvailability }}
       {{- $local := dict "Label" .ControllerComponentLabel "Component" "tap" }}
       {{- include "pod-affinity" $local | nindent 6 }}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -80,6 +80,7 @@ type (
 		Identity         *installIdentityValues
 		ProxyInjector    *proxyInjectorValues
 		ProfileValidator *profileValidatorValues
+		Tap              *tapValues
 	}
 
 	configJSONs struct{ Global, Proxy, Install string }
@@ -112,6 +113,10 @@ type (
 	}
 
 	profileValidatorValues struct {
+		*tlsValues
+	}
+
+	tapValues struct {
 		*tlsValues
 	}
 
@@ -231,6 +236,7 @@ func newInstallOptionsWithDefaults() *installOptions {
 			return id.String()
 		},
 
+		// TODO: rename to generateTLS or something
 		generateWebhookTLS: func(webhook string) (*tlsValues, error) {
 			root, err := tls.GenerateRootCAWithDefaults(webhookCommonName(webhook))
 			if err != nil {
@@ -428,6 +434,12 @@ func (options *installOptions) validateAndBuild(stage string, flags *pflag.FlagS
 		return nil, nil, err
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
+
+	tapTLS, err := options.generateWebhookTLS(k8s.TapServiceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	values.Tap = &tapValues{tapTLS}
 
 	values.stage = stage
 

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -75,6 +75,12 @@ func TestRender(t *testing.T) {
 				CrtPEM: "profile validator crt",
 			},
 		},
+		Tap: &tapValues{
+			&tlsValues{
+				KeyPEM: "tap key",
+				CrtPEM: "tap crt",
+			},
+		},
 	}
 
 	haOptions := testInstallOptions()
@@ -236,7 +242,13 @@ func fakeGenerateWebhookTLS(webhook string) (*tlsValues, error) {
 			KeyPEM: "profile validator key",
 			CrtPEM: "profile validator crt",
 		}, nil
+	case k8s.TapServiceName:
+		return &tlsValues{
+			KeyPEM: "tap key",
+			CrtPEM: "tap crt",
+		}, nil
 	}
+
 	return nil, nil
 }
 

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -189,9 +189,9 @@ func requestTapByResourceFromAPI(w io.Writer, k8sAPI *k8s.KubernetesAPI, req *pb
 	return renderTap(w, reader, resource)
 }
 
-func renderTap(w io.Writer, tapStream *bufio.Reader, resource string) error {
+func renderTap(w io.Writer, tapByteStream *bufio.Reader, resource string) error {
 	tableWriter := tabwriter.NewWriter(w, 0, 0, 0, ' ', tabwriter.AlignRight)
-	err := writeTapEventsToBuffer(tapStream, tableWriter, resource)
+	err := writeTapEventsToBuffer(tapByteStream, tableWriter, resource)
 	if err != nil {
 		return err
 	}
@@ -200,11 +200,11 @@ func renderTap(w io.Writer, tapStream *bufio.Reader, resource string) error {
 	return nil
 }
 
-func writeTapEventsToBuffer(tapStream *bufio.Reader, w *tabwriter.Writer, resource string) error {
+func writeTapEventsToBuffer(tapByteStream *bufio.Reader, w *tabwriter.Writer, resource string) error {
 	for {
 		log.Debug("Waiting for data...")
 		event := pb.TapEvent{}
-		err := protohttp.FromByteStreamToProtocolBuffers(tapStream, &event)
+		err := protohttp.FromByteStreamToProtocolBuffers(tapByteStream, &event)
 		if err == io.EOF {
 			break
 		}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -116,7 +116,7 @@ func newCmdTap() *cobra.Command {
 				return fmt.Errorf("output format \"%s\" not recognized", options.output)
 			}
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -1778,6 +1778,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -1821,6 +1824,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -1831,6 +1836,10 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -1952,6 +1961,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2366,6 +2431,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2409,6 +2477,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2419,6 +2489,10 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2540,6 +2614,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2542,6 +2607,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2605,6 +2673,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2621,6 +2691,10 @@ spec:
             memory: 50Mi
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2748,6 +2822,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2542,6 +2607,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2605,6 +2673,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2621,6 +2691,10 @@ spec:
             memory: 50Mi
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2748,6 +2822,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2132,6 +2197,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2175,6 +2243,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2185,6 +2255,10 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2273,6 +2347,9 @@ spec:
           name: linkerd-identity-end-entity
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: Namespace
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-Namespace-tap-auth-delegator
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: Namespace
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     ControllerComponentLabel: tap
     ControllerNamespaceLabel: Namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-Namespace-tap-auth-reader
+  namespace: kube-system
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: Namespace
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: Namespace
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
+  annotations:
+    CreatedByAnnotation: CliVersion
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    ControllerComponentLabel: tap
+    ControllerNamespaceLabel: Namespace
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: Namespace
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2107,6 +2172,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2151,6 +2219,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2161,6 +2231,10 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2246,5 +2320,9 @@ spec:
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
+      volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
 status: {}
 ---

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2373,6 +2438,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2416,6 +2484,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2426,6 +2496,10 @@ spec:
         resources: {}
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2548,6 +2622,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP
@@ -2549,6 +2614,9 @@ spec:
   - name: grpc
     port: 8088
     targetPort: 8088
+  - name: apiserver
+    port: 443
+    targetPort: apiserver
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -2612,6 +2680,8 @@ spec:
         ports:
         - containerPort: 8088
           name: grpc
+        - containerPort: 8089
+          name: apiserver
         - containerPort: 9998
           name: admin-http
         readinessProbe:
@@ -2628,6 +2698,10 @@ spec:
             memory: 50Mi
         securityContext:
           runAsUser: 2103
+        volumeMounts:
+        - mountPath: /var/run/linkerd/tls
+          name: tls
+          readOnly: true
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd2_proxy=info
@@ -2756,6 +2830,9 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: linkerd-tap
       volumes:
+      - name: tls
+        secret:
+          secretName: linkerd-tap-tls
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -481,6 +481,22 @@ subjects:
   name: linkerd-tap
   namespace: linkerd
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-delegator
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -489,6 +505,55 @@ metadata:
   labels:
     linkerd.io/control-plane-component: tap
     linkerd.io/control-plane-ns: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-linkerd-tap-auth-reader
+  namespace: kube-system
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: linkerd-tap
+  namespace: linkerd
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+type: Opaque
+data:
+  crt.pem: dGFwIGNydA==
+  key.pem: dGFwIGtleQ==
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.tap.linkerd.io
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: tap.linkerd.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 100
+  service:
+    name: linkerd-tap
+    namespace: linkerd
+  caBundle: dGFwIGNydA==
 ---
 ###
 ### Control Plane PSP

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -263,6 +263,12 @@ func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Inter
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
+	tapTLS, err := fetchWebhookTLS(k, k8s.TapServiceName, options)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not fetch existing tap secret: %s", err)
+	}
+	values.Tap = &tapValues{tapTLS}
+
 	values.stage = stage
 
 	return values, configs, nil

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -263,6 +263,7 @@ func (options *upgradeOptions) validateAndBuild(stage string, k kubernetes.Inter
 	}
 	values.ProfileValidator = &profileValidatorValues{profileValidatorTLS}
 
+	// TODO: rename to fetchTLS or something
 	tapTLS, err := fetchWebhookTLS(k, k8s.TapServiceName, options)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not fetch existing tap secret: %s", err)

--- a/controller/api/public/client_test.go
+++ b/controller/api/public/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	discoveryPb "github.com/linkerd/linkerd2/controller/gen/controller/discovery"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/pkg/protohttp"
 )
 
 type mockTransport struct {
@@ -71,7 +72,7 @@ func TestFromByteStreamToProtocolBuffers(t *testing.T) {
 		var protobufMessageToBeFilledWithData pb.VersionInfo
 		reader := bufferedReader(t, &versionInfo)
 
-		err := fromByteStreamToProtocolBuffers(reader, &protobufMessageToBeFilledWithData)
+		err := protohttp.FromByteStreamToProtocolBuffers(reader, &protobufMessageToBeFilledWithData)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -114,7 +115,7 @@ func TestFromByteStreamToProtocolBuffers(t *testing.T) {
 		reader := bufferedReader(t, &msg)
 
 		protobufMessageToBeFilledWithData := &pb.StatSummaryResponse{}
-		err := fromByteStreamToProtocolBuffers(reader, protobufMessageToBeFilledWithData)
+		err := protohttp.FromByteStreamToProtocolBuffers(reader, protobufMessageToBeFilledWithData)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -125,7 +126,7 @@ func TestFromByteStreamToProtocolBuffers(t *testing.T) {
 
 		var protobufMessageToBeFilledWithData pb.ApiError
 		reader := bufferedReader(t, &apiError)
-		err := fromByteStreamToProtocolBuffers(reader, &protobufMessageToBeFilledWithData)
+		err := protohttp.FromByteStreamToProtocolBuffers(reader, &protobufMessageToBeFilledWithData)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -147,7 +148,7 @@ func TestFromByteStreamToProtocolBuffers(t *testing.T) {
 		reader := bufferedReader(t, versionInfo)
 
 		protobufMessageToBeFilledWithData := &pb.StatSummaryResponse{}
-		err := fromByteStreamToProtocolBuffers(reader, protobufMessageToBeFilledWithData)
+		err := protohttp.FromByteStreamToProtocolBuffers(reader, protobufMessageToBeFilledWithData)
 		if err == nil {
 			t.Fatal("Expecting error, got nothing")
 		}
@@ -190,7 +191,7 @@ func bufferedReader(t *testing.T, msg proto.Message) *bufio.Reader {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	payload := serializeAsPayload(msgBytes)
+	payload := protohttp.SerializeAsPayload(msgBytes)
 
 	return bufio.NewReader(bytes.NewReader(payload))
 }

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -13,6 +13,7 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
+	"github.com/linkerd/linkerd2/pkg/protohttp"
 	promApi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	log "github.com/sirupsen/logrus"
@@ -43,7 +44,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}).Debugf("Serving %s %s", req.Method, req.URL.Path)
 	// Validate request method
 	if req.Method != http.MethodPost {
-		writeErrorToHTTPResponse(w, fmt.Errorf("POST required"))
+		protohttp.WriteErrorToHTTPResponse(w, fmt.Errorf("POST required"))
 		return
 	}
 
@@ -80,20 +81,20 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (h *handler) handleStatSummary(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.StatSummaryRequest
 
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.StatSummary(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
@@ -101,20 +102,20 @@ func (h *handler) handleStatSummary(w http.ResponseWriter, req *http.Request) {
 func (h *handler) handleEdges(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.EdgesRequest
 
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.Edges(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
@@ -122,83 +123,83 @@ func (h *handler) handleEdges(w http.ResponseWriter, req *http.Request) {
 func (h *handler) handleTopRoutes(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.TopRoutesRequest
 
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.TopRoutes(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleVersion(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.Empty
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.Version(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleSelfCheck(w http.ResponseWriter, req *http.Request) {
 	var protoRequest healthcheckPb.SelfCheckRequest
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.SelfCheck(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleListPods(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.ListPodsRequest
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.ListPods(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
@@ -206,92 +207,92 @@ func (h *handler) handleListPods(w http.ResponseWriter, req *http.Request) {
 func (h *handler) handleListServices(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.ListServicesRequest
 
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.ListServices(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleTapByResource(w http.ResponseWriter, req *http.Request) {
-	flushableWriter, err := newStreamingWriter(w)
+	flushableWriter, err := protohttp.NewStreamingWriter(w)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	var protoRequest pb.TapByResourceRequest
-	err = httpRequestToProto(req, &protoRequest)
+	err = protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	server := tapServer{streamServer{w: flushableWriter, req: req}}
 	err = h.grpcServer.TapByResource(&protoRequest, server)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleDestGet(w http.ResponseWriter, req *http.Request) {
-	flushableWriter, err := newStreamingWriter(w)
+	flushableWriter, err := protohttp.NewStreamingWriter(w)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	var protoRequest destinationPb.GetDestination
-	err = httpRequestToProto(req, &protoRequest)
+	err = protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	server := destinationServer{streamServer{w: flushableWriter, req: req}}
 	err = h.grpcServer.Get(&protoRequest, server)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 func (h *handler) handleConfig(w http.ResponseWriter, req *http.Request) {
 	var protoRequest pb.Empty
-	err := httpRequestToProto(req, &protoRequest)
+	err := protohttp.HTTPRequestToProto(req, &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
 	rsp, err := h.grpcServer.Config(req.Context(), &protoRequest)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }
 
 type streamServer struct {
-	w   flushableResponseWriter
+	w   protohttp.FlushableResponseWriter
 	req *http.Request
 }
 
@@ -304,9 +305,9 @@ func (s streamServer) SendMsg(interface{}) error    { return nil }
 func (s streamServer) RecvMsg(interface{}) error    { return nil }
 
 func (s streamServer) Send(msg proto.Message) error {
-	err := writeProtoToHTTPResponse(s.w, msg)
+	err := protohttp.WriteProtoToHTTPResponse(s.w, msg)
 	if err != nil {
-		writeErrorToHTTPResponse(s.w, err)
+		protohttp.WriteErrorToHTTPResponse(s.w, err)
 		return err
 	}
 
@@ -337,12 +338,12 @@ func fullURLPathFor(method string) string {
 func (h *handler) handleEndpoints(w http.ResponseWriter, req *http.Request) {
 	rsp, err := h.grpcServer.Endpoints(req.Context(), &discoveryPb.EndpointsParams{})
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
-	err = writeProtoToHTTPResponse(w, rsp)
+	err = protohttp.WriteProtoToHTTPResponse(w, rsp)
 	if err != nil {
-		writeErrorToHTTPResponse(w, err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
 		return
 	}
 }

--- a/controller/api/public/stream_client.go
+++ b/controller/api/public/stream_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/linkerd/linkerd2/pkg/protohttp"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"
 )
@@ -23,7 +24,7 @@ func (c streamClient) SendMsg(interface{}) error    { return nil }
 func (c streamClient) RecvMsg(interface{}) error    { return nil }
 
 func getStreamClient(ctx context.Context, httpRsp *http.Response) (streamClient, error) {
-	if err := checkIfResponseHasError(httpRsp); err != nil {
+	if err := protohttp.CheckIfResponseHasError(httpRsp); err != nil {
 		httpRsp.Body.Close()
 		return streamClient{}, err
 	}

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -10,11 +12,13 @@ import (
 	"github.com/linkerd/linkerd2/controller/tap"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
+	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"
 )
 
 func main() {
 	addr := flag.String("addr", ":8088", "address to serve on")
+	apiServerAddr := flag.String("apiserver-addr", ":8089", "address to serve the apiserver on")
 	metricsAddr := flag.String("metrics-addr", ":9998", "address to serve scrapable metrics on")
 	kubeConfigPath := flag.String("kubeconfig", "", "path to kube config")
 	controllerNamespace := flag.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
@@ -45,17 +49,46 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	_, port, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	// TODO: remove the network hop in favor of APIServer calling TapByResource
+	// directly.
+	tapClient, cc, err := tap.NewClient("127.0.0.1:" + port)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	defer cc.Close()
+
+	// TODO: make this configurable for local development
+	cert, err := tls.LoadX509KeyPair(pkgK8s.MountPathTLSCrtPEM, pkgK8s.MountPathTLSKeyPEM)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	apiServer, apiLis, err := tap.NewAPIServer(*apiServerAddr, cert, k8sAPI, tapClient)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
 	k8sAPI.Sync() // blocks until caches are synced
 
 	go func() {
-		log.Println("starting gRPC server on", *addr)
+		log.Infof("starting gRPC server on %s", *addr)
 		server.Serve(lis)
+	}()
+
+	go func() {
+		log.Infof("starting APIServer on %s", *apiServerAddr)
+		apiServer.ServeTLS(apiLis, "", "")
 	}()
 
 	go admin.StartServer(*metricsAddr)
 
 	<-stop
 
-	log.Println("shutting down gRPC server on", *addr)
+	log.Infof("shutting down gRPC server on %s", *addr)
 	server.GracefulStop()
 }

--- a/controller/tap/apiserver.go
+++ b/controller/tap/apiserver.go
@@ -1,0 +1,342 @@
+package tap
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/tap"
+	"github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/prometheus"
+	"github.com/linkerd/linkerd2/pkg/protohttp"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type apiServer struct {
+	router         *httprouter.Router
+	k8sAPI         *k8s.API
+	allowedNames   []string
+	usernameHeader string
+	groupHeader    string
+	apiResList     []byte
+	tapClient      pb.TapClient
+	log            *logrus.Entry
+}
+
+// TODO: share with api_handlers.go
+type jsonError struct {
+	Error string `json:"error"`
+}
+
+var gvk = &schema.GroupVersionKind{
+	Group:   "tap.linkerd.io",
+	Version: "v1alpha1",
+	Kind:    "Tap",
+}
+
+var resources = []struct {
+	name       string
+	namespaced bool
+}{
+	{"namespaces", false},
+	{"pods", true},
+	{"replicationcontrollers", true},
+	{"services", true},
+	{"daemonsets", true},
+	{"deployments", true},
+	{"replicasets", true},
+	{"statefulsets", true},
+	{"jobs", true},
+}
+
+// NewAPIServer creates a new server that implements the Tap APIService.
+func NewAPIServer(addr string, cert tls.Certificate, k8sAPI *k8s.API, client pb.TapClient) (*http.Server, net.Listener, error) {
+	apiResList, err := apiResourceList()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clientCAPem, allowedNames, usernameHeader, groupHeader, err := apiServerAuth(k8sAPI)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	server := &apiServer{
+		router:         &httprouter.Router{},
+		k8sAPI:         k8sAPI,
+		apiResList:     apiResList,
+		allowedNames:   allowedNames,
+		usernameHeader: usernameHeader,
+		groupHeader:    groupHeader,
+		tapClient:      client,
+		log: logrus.WithFields(logrus.Fields{
+			"component": "apiserver",
+			"addr":      addr,
+		}),
+	}
+
+	server.router.GET("/apis/"+gvk.GroupVersion().String(), server.handleAPIResourceList)
+
+	for _, res := range resources {
+		route := ""
+		if !res.namespaced {
+			route = fmt.Sprintf("/apis/%s/watch/%s/:namespace/tap", gvk.GroupVersion().String(), res.name)
+		} else {
+			route = fmt.Sprintf("/apis/%s/watch/namespaces/:namespace/%s/:name/tap", gvk.GroupVersion().String(), res.name)
+		}
+		server.router.POST(route, server.handleTap)
+	}
+
+	clientCertPool := x509.NewCertPool()
+	clientCertPool.AppendCertsFromPEM([]byte(clientCAPem))
+
+	wrappedServer := prometheus.WithTelemetry(server)
+
+	s := &http.Server{
+		Addr:    addr,
+		Handler: wrappedServer,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			ClientAuth:   tls.VerifyClientCertIfGiven,
+			ClientCAs:    clientCertPool,
+		},
+	}
+
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		server.log.Fatalf("net.Listen failed with: %s", err)
+	}
+
+	return s, lis, nil
+}
+
+// ServeHTTP handles all routes for the APIServer.
+func (a *apiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	a.log.Debugf("ServeHTTP(): %+v", req)
+
+	// if `requestheader-allowed-names` was empty, allow any CN
+	if len(a.allowedNames) > 0 {
+		validCN := ""
+		clientNames := []string{}
+		for _, cn := range a.allowedNames {
+			for _, clientCert := range req.TLS.PeerCertificates {
+				clientNames = append(clientNames, clientCert.Subject.CommonName)
+				if cn == clientCert.Subject.CommonName {
+					validCN = clientCert.Subject.CommonName
+					break
+				}
+			}
+			if validCN != "" {
+				break
+			}
+		}
+		if validCN == "" {
+			err := fmt.Errorf("no valid CN found. allowed names: %s, client names: %s", a.allowedNames, clientNames)
+			a.log.Debug(err)
+			renderJSONError(w, err, http.StatusBadRequest)
+			return
+		}
+	}
+
+	a.router.ServeHTTP(w, req)
+}
+
+// /apis/tap.linkerd.io/v1alpha1
+// this is required for `kubectl api-resources` to work
+func (a *apiServer) handleAPIResourceList(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(a.apiResList)
+}
+
+// /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/tap
+// /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/:resource/:name/tap
+func (a *apiServer) handleTap(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
+	resource := ""
+
+	path := strings.Split(req.URL.Path, "/")
+	if len(path) == 8 {
+		resource = path[5]
+	} else if len(path) == 10 {
+		resource = path[7]
+	} else {
+		err := fmt.Errorf("invalid path: %s", req.URL.Path)
+		a.log.Error(err)
+		renderJSONError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	a.log.Debugf("SubjectAccessReview: namespace: %s, resource: %s, name: %s, user: %s, group: %s",
+		namespace, resource, name, req.Header.Get(a.usernameHeader), req.Header[a.groupHeader],
+	)
+
+	err := pkgK8s.ResourceAuthzForUser(
+		a.k8sAPI.Client,
+		namespace,
+		"watch",
+		gvk.Group,
+		gvk.Version,
+		resource,
+		"tap",
+		name,
+		req.Header.Get(a.usernameHeader),
+		req.Header[a.groupHeader],
+	)
+	if err != nil {
+		err = fmt.Errorf("SubjectAccessReview failed with: %s", err)
+		a.log.Error(err)
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	tapReq := public.TapByResourceRequest{}
+	err = protohttp.HTTPRequestToProto(req, &tapReq)
+	if err != nil {
+		err = fmt.Errorf("Error decoding Tap Request proto: %s", err)
+		a.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	url := protohttp.TapReqToURL(&tapReq)
+	if url != req.URL.Path {
+		err = fmt.Errorf("tap request body did not match APIServer URL: %+v != %+v", url, req.URL.Path)
+		a.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	flushableWriter, err := protohttp.NewStreamingWriter(w)
+	if err != nil {
+		a.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	client, err := a.tapClient.TapByResource(req.Context(), &tapReq)
+	if err != nil {
+		a.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+		return
+	}
+
+	for {
+		select {
+		case <-req.Context().Done():
+			a.log.Debug("Received Done context in Tap Stream")
+			return
+		default:
+			event, err := client.Recv()
+			if err != nil {
+				a.log.Errorf("Error receiving from tap client: %s", err)
+				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+				return
+			}
+			err = protohttp.WriteProtoToHTTPResponse(flushableWriter, event)
+			if err != nil {
+				a.log.Errorf("Error writing proto to HTTP Response: %s", err)
+				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+				return
+			}
+			flushableWriter.Flush()
+		}
+	}
+}
+
+// TODO: share with api_handlers.go
+func renderJSONError(w http.ResponseWriter, err error, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	rsp, _ := json.Marshal(jsonError{Error: err.Error()})
+	w.WriteHeader(status)
+	w.Write(rsp)
+}
+
+// copied from https://github.com/kubernetes/apiserver/blob/781c3cd1b3dc5b6f79c68ab0d16fe544600421ef/pkg/server/options/authentication.go#L360
+func deserializeStrings(in string) ([]string, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	var ret []string
+	if err := json.Unmarshal([]byte(in), &ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func apiResourceList() ([]byte, error) {
+	resList := metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: gvk.GroupVersion().String(),
+		APIResources: []metav1.APIResource{},
+	}
+
+	for _, res := range resources {
+		resList.APIResources = append(resList.APIResources,
+			metav1.APIResource{
+				Name:       fmt.Sprintf("%s/tap", res.name),
+				Namespaced: res.namespaced,
+				Kind:       gvk.Kind,
+				Group:      "tap",
+				Verbs:      metav1.Verbs{"watch"},
+			})
+	}
+
+	return json.MarshalIndent(resList, "", "  ")
+}
+
+// apiServerAuth parses the relevant data out of a ConfigMap to enable client
+// TLS authentication.
+// kubectl -n kube-system get cm/extension-apiserver-authentication
+// accessible via the extension-apiserver-authentication-reader role
+func apiServerAuth(k8sAPI *k8s.API) (string, []string, string, string, error) {
+	cmName := "extension-apiserver-authentication"
+
+	cm, err := k8sAPI.Client.CoreV1().
+		ConfigMaps("kube-system").
+		Get(cmName, metav1.GetOptions{})
+	if err != nil {
+		return "", nil, "", "", fmt.Errorf("failed to load [%s] config: %s", cmName, err)
+	}
+	clientCAPem, ok := cm.Data["requestheader-client-ca-file"]
+	if !ok {
+		return "", nil, "", "", fmt.Errorf("no client CA cert available for apiextension-server")
+	}
+
+	allowedNames, err := deserializeStrings(cm.Data["requestheader-allowed-names"])
+	if err != nil {
+		return "", nil, "", "", err
+	}
+
+	usernameHeaders, err := deserializeStrings(cm.Data["requestheader-username-headers"])
+	if err != nil {
+		return "", nil, "", "", err
+	}
+	usernameHeader := ""
+	if len(usernameHeaders) > 0 {
+		usernameHeader = usernameHeaders[0]
+	}
+
+	groupHeaders, err := deserializeStrings(cm.Data["requestheader-group-headers"])
+	if err != nil {
+		return "", nil, "", "", err
+	}
+	groupHeader := ""
+	if len(groupHeaders) > 0 {
+		groupHeader = groupHeaders[0]
+	}
+
+	return clientCAPem, allowedNames, usernameHeader, groupHeader, nil
+}

--- a/controller/tap/apiserver.go
+++ b/controller/tap/apiserver.go
@@ -7,93 +7,52 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	pb "github.com/linkerd/linkerd2/controller/gen/controller/tap"
-	"github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
-	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
-	"github.com/linkerd/linkerd2/pkg/protohttp"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type apiServer struct {
-	router         *httprouter.Router
-	k8sAPI         *k8s.API
-	allowedNames   []string
-	usernameHeader string
-	groupHeader    string
-	apiResList     []byte
-	tapClient      pb.TapClient
-	log            *logrus.Entry
-}
-
-// TODO: share with api_handlers.go
-type jsonError struct {
-	Error string `json:"error"`
-}
-
-var gvk = &schema.GroupVersionKind{
-	Group:   "tap.linkerd.io",
-	Version: "v1alpha1",
-	Kind:    "Tap",
-}
-
-var resources = []struct {
-	name       string
-	namespaced bool
-}{
-	{"namespaces", false},
-	{"pods", true},
-	{"replicationcontrollers", true},
-	{"services", true},
-	{"daemonsets", true},
-	{"deployments", true},
-	{"replicasets", true},
-	{"statefulsets", true},
-	{"jobs", true},
+	router       *httprouter.Router
+	allowedNames []string
+	log          *logrus.Entry
 }
 
 // NewAPIServer creates a new server that implements the Tap APIService.
-func NewAPIServer(addr string, cert tls.Certificate, k8sAPI *k8s.API, client pb.TapClient) (*http.Server, net.Listener, error) {
-	apiResList, err := apiResourceList()
-	if err != nil {
-		return nil, nil, err
-	}
-
+func NewAPIServer(addr string, cert tls.Certificate, k8sAPI *k8s.API, client pb.TapClient, disableCommonNames bool) (*http.Server, net.Listener, error) {
 	clientCAPem, allowedNames, usernameHeader, groupHeader, err := apiServerAuth(k8sAPI)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	server := &apiServer{
-		router:         &httprouter.Router{},
+	// for development
+	if disableCommonNames {
+		allowedNames = []string{}
+	}
+
+	log := logrus.WithFields(logrus.Fields{
+		"component": "apiserver",
+		"addr":      addr,
+	})
+
+	h := &handler{
 		k8sAPI:         k8sAPI,
-		apiResList:     apiResList,
-		allowedNames:   allowedNames,
 		usernameHeader: usernameHeader,
 		groupHeader:    groupHeader,
 		tapClient:      client,
-		log: logrus.WithFields(logrus.Fields{
-			"component": "apiserver",
-			"addr":      addr,
-		}),
+		log:            log,
 	}
 
-	server.router.GET("/apis/"+gvk.GroupVersion().String(), server.handleAPIResourceList)
+	router := initRouter(h)
 
-	for _, res := range resources {
-		route := ""
-		if !res.namespaced {
-			route = fmt.Sprintf("/apis/%s/watch/%s/:namespace/tap", gvk.GroupVersion().String(), res.name)
-		} else {
-			route = fmt.Sprintf("/apis/%s/watch/namespaces/:namespace/%s/:name/tap", gvk.GroupVersion().String(), res.name)
-		}
-		server.router.POST(route, server.handleTap)
+	server := &apiServer{
+		router:       router,
+		allowedNames: allowedNames,
+		log:          log,
 	}
 
 	clientCertPool := x509.NewCertPool()
@@ -113,7 +72,7 @@ func NewAPIServer(addr string, cert tls.Certificate, k8sAPI *k8s.API, client pb.
 
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		server.log.Fatalf("net.Listen failed with: %s", err)
+		log.Fatalf("net.Listen failed with: %s", err)
 	}
 
 	return s, lis, nil
@@ -148,153 +107,6 @@ func (a *apiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	a.router.ServeHTTP(w, req)
-}
-
-// /apis/tap.linkerd.io/v1alpha1
-// this is required for `kubectl api-resources` to work
-func (a *apiServer) handleAPIResourceList(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(a.apiResList)
-}
-
-// /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/tap
-// /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/:resource/:name/tap
-func (a *apiServer) handleTap(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-	namespace := p.ByName("namespace")
-	name := p.ByName("name")
-	resource := ""
-
-	path := strings.Split(req.URL.Path, "/")
-	if len(path) == 8 {
-		resource = path[5]
-	} else if len(path) == 10 {
-		resource = path[7]
-	} else {
-		err := fmt.Errorf("invalid path: %s", req.URL.Path)
-		a.log.Error(err)
-		renderJSONError(w, err, http.StatusBadRequest)
-		return
-	}
-
-	a.log.Debugf("SubjectAccessReview: namespace: %s, resource: %s, name: %s, user: %s, group: %s",
-		namespace, resource, name, req.Header.Get(a.usernameHeader), req.Header[a.groupHeader],
-	)
-
-	err := pkgK8s.ResourceAuthzForUser(
-		a.k8sAPI.Client,
-		namespace,
-		"watch",
-		gvk.Group,
-		gvk.Version,
-		resource,
-		"tap",
-		name,
-		req.Header.Get(a.usernameHeader),
-		req.Header[a.groupHeader],
-	)
-	if err != nil {
-		err = fmt.Errorf("SubjectAccessReview failed with: %s", err)
-		a.log.Error(err)
-		renderJSONError(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	tapReq := public.TapByResourceRequest{}
-	err = protohttp.HTTPRequestToProto(req, &tapReq)
-	if err != nil {
-		err = fmt.Errorf("Error decoding Tap Request proto: %s", err)
-		a.log.Error(err)
-		protohttp.WriteErrorToHTTPResponse(w, err)
-		return
-	}
-
-	url := protohttp.TapReqToURL(&tapReq)
-	if url != req.URL.Path {
-		err = fmt.Errorf("tap request body did not match APIServer URL: %+v != %+v", url, req.URL.Path)
-		a.log.Error(err)
-		protohttp.WriteErrorToHTTPResponse(w, err)
-		return
-	}
-
-	flushableWriter, err := protohttp.NewStreamingWriter(w)
-	if err != nil {
-		a.log.Error(err)
-		protohttp.WriteErrorToHTTPResponse(w, err)
-		return
-	}
-
-	client, err := a.tapClient.TapByResource(req.Context(), &tapReq)
-	if err != nil {
-		a.log.Error(err)
-		protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
-		return
-	}
-
-	for {
-		select {
-		case <-req.Context().Done():
-			a.log.Debug("Received Done context in Tap Stream")
-			return
-		default:
-			event, err := client.Recv()
-			if err != nil {
-				a.log.Errorf("Error receiving from tap client: %s", err)
-				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
-				return
-			}
-			err = protohttp.WriteProtoToHTTPResponse(flushableWriter, event)
-			if err != nil {
-				a.log.Errorf("Error writing proto to HTTP Response: %s", err)
-				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
-				return
-			}
-			flushableWriter.Flush()
-		}
-	}
-}
-
-// TODO: share with api_handlers.go
-func renderJSONError(w http.ResponseWriter, err error, status int) {
-	w.Header().Set("Content-Type", "application/json")
-	rsp, _ := json.Marshal(jsonError{Error: err.Error()})
-	w.WriteHeader(status)
-	w.Write(rsp)
-}
-
-// copied from https://github.com/kubernetes/apiserver/blob/781c3cd1b3dc5b6f79c68ab0d16fe544600421ef/pkg/server/options/authentication.go#L360
-func deserializeStrings(in string) ([]string, error) {
-	if len(in) == 0 {
-		return nil, nil
-	}
-	var ret []string
-	if err := json.Unmarshal([]byte(in), &ret); err != nil {
-		return nil, err
-	}
-	return ret, nil
-}
-
-func apiResourceList() ([]byte, error) {
-	resList := metav1.APIResourceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "APIResourceList",
-			APIVersion: "v1",
-		},
-		GroupVersion: gvk.GroupVersion().String(),
-		APIResources: []metav1.APIResource{},
-	}
-
-	for _, res := range resources {
-		resList.APIResources = append(resList.APIResources,
-			metav1.APIResource{
-				Name:       fmt.Sprintf("%s/tap", res.name),
-				Namespaced: res.namespaced,
-				Kind:       gvk.Kind,
-				Group:      "tap",
-				Verbs:      metav1.Verbs{"watch"},
-			})
-	}
-
-	return json.MarshalIndent(resList, "", "  ")
 }
 
 // apiServerAuth parses the relevant data out of a ConfigMap to enable client
@@ -339,4 +151,16 @@ func apiServerAuth(k8sAPI *k8s.API) (string, []string, string, string, error) {
 	}
 
 	return clientCAPem, allowedNames, usernameHeader, groupHeader, nil
+}
+
+// copied from https://github.com/kubernetes/apiserver/blob/781c3cd1b3dc5b6f79c68ab0d16fe544600421ef/pkg/server/options/authentication.go#L360
+func deserializeStrings(in string) ([]string, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	var ret []string
+	if err := json.Unmarshal([]byte(in), &ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
 }

--- a/controller/tap/apiserver_test.go
+++ b/controller/tap/apiserver_test.go
@@ -4,15 +4,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"testing"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/linkerd/linkerd2/controller/k8s"
-	"github.com/sirupsen/logrus"
 )
 
 func TestNewAPIServer(t *testing.T) {
@@ -52,7 +47,7 @@ data:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			_, _, err = NewAPIServer("localhost:0", tls.Certificate{}, k8sAPI, nil)
+			_, _, err = NewAPIServer("localhost:0", tls.Certificate{}, k8sAPI, nil, false)
 			if !reflect.DeepEqual(err, exp.err) {
 				t.Errorf("NewAPIServer returned unexpected error: %s, expected: %s", err, exp.err)
 			}
@@ -120,65 +115,6 @@ data:
 			}
 			if groupHeader != exp.groupHeader {
 				t.Errorf("apiServerAuth returned unexpected groupHeader: %s, expected: %s", groupHeader, exp.groupHeader)
-			}
-		})
-	}
-}
-
-func TestHandleTap(t *testing.T) {
-	expectations := []struct {
-		req    *http.Request
-		params httprouter.Params
-		code   int
-		header http.Header
-		body   string
-	}{
-		{
-			req: &http.Request{
-				URL: &url.URL{
-					Path: "/apis",
-				},
-			},
-			code:   http.StatusBadRequest,
-			header: http.Header{"Content-Type": []string{"application/json"}},
-			body:   `{"error":"invalid path: /apis"}`,
-		},
-		{
-			req: &http.Request{
-				URL: &url.URL{
-					Path: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/foo/tap",
-				},
-			},
-			code:   http.StatusInternalServerError,
-			header: http.Header{"Content-Type": []string{"application/json"}},
-			body:   `{"error":"SubjectAccessReview failed with: not authorized to access namespaces.tap.linkerd.io"}`,
-		},
-	}
-
-	for i, exp := range expectations {
-		exp := exp // pin
-
-		t.Run(fmt.Sprintf("%d parses the apiServerAuth ConfigMap", i), func(t *testing.T) {
-			k8sAPI, err := k8s.NewFakeAPI()
-			if err != nil {
-				t.Fatalf("NewFakeAPI returned an error: %s", err)
-			}
-
-			a := &apiServer{
-				k8sAPI: k8sAPI,
-				log:    logrus.WithField("test", t.Name),
-			}
-			recorder := httptest.NewRecorder()
-			a.handleTap(recorder, exp.req, exp.params)
-
-			if recorder.Code != exp.code {
-				t.Errorf("Unexpected code: %d, expected: %d", recorder.Code, exp.code)
-			}
-			if !reflect.DeepEqual(recorder.Header(), exp.header) {
-				t.Errorf("Unexpected header: %v, expected: %v", recorder.Header(), exp.header)
-			}
-			if recorder.Body.String() != exp.body {
-				t.Errorf("Unexpected body: %s, expected: %s", recorder.Body.String(), exp.body)
 			}
 		})
 	}

--- a/controller/tap/apiserver_test.go
+++ b/controller/tap/apiserver_test.go
@@ -1,0 +1,185 @@
+package tap
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/sirupsen/logrus"
+)
+
+func TestNewAPIServer(t *testing.T) {
+	expectations := []struct {
+		k8sRes []string
+		err    error
+	}{
+		{
+			err: errors.New("failed to load [extension-apiserver-authentication] config: configmaps \"extension-apiserver-authentication\" not found"),
+		},
+		{
+			err: nil,
+			k8sRes: []string{`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extension-apiserver-authentication
+  namespace: kube-system
+data:
+  client-ca-file: 'client-ca-file'
+  requestheader-allowed-names: '["name1", "name2"]'
+  requestheader-client-ca-file: 'requestheader-client-ca-file'
+  requestheader-extra-headers-prefix: '["X-Remote-Extra-"]'
+  requestheader-group-headers: '["X-Remote-Group"]'
+  requestheader-username-headers: '["X-Remote-User"]'
+`,
+			},
+		},
+	}
+
+	for i, exp := range expectations {
+		exp := exp // pin
+
+		t.Run(fmt.Sprintf("%d returns a configured API Server", i), func(t *testing.T) {
+			k8sAPI, err := k8s.NewFakeAPI(exp.k8sRes...)
+			if err != nil {
+				t.Fatalf("NewFakeAPI returned an error: %s", err)
+			}
+
+			_, _, err = NewAPIServer("localhost:0", tls.Certificate{}, k8sAPI, nil)
+			if !reflect.DeepEqual(err, exp.err) {
+				t.Errorf("NewAPIServer returned unexpected error: %s, expected: %s", err, exp.err)
+			}
+		})
+	}
+}
+
+func TestAPIServerAuth(t *testing.T) {
+	expectations := []struct {
+		k8sRes         []string
+		clientCAPem    string
+		allowedNames   []string
+		usernameHeader string
+		groupHeader    string
+		err            error
+	}{
+		{
+			err: errors.New("failed to load [extension-apiserver-authentication] config: configmaps \"extension-apiserver-authentication\" not found"),
+		},
+		{
+			k8sRes: []string{`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extension-apiserver-authentication
+  namespace: kube-system
+data:
+  client-ca-file: 'client-ca-file'
+  requestheader-allowed-names: '["name1", "name2"]'
+  requestheader-client-ca-file: 'requestheader-client-ca-file'
+  requestheader-extra-headers-prefix: '["X-Remote-Extra-"]'
+  requestheader-group-headers: '["X-Remote-Group"]'
+  requestheader-username-headers: '["X-Remote-User"]'
+`,
+			},
+			clientCAPem:    "requestheader-client-ca-file",
+			allowedNames:   []string{"name1", "name2"},
+			usernameHeader: "X-Remote-User",
+			groupHeader:    "X-Remote-Group",
+			err:            nil,
+		},
+	}
+
+	for i, exp := range expectations {
+		exp := exp // pin
+
+		t.Run(fmt.Sprintf("%d parses the apiServerAuth ConfigMap", i), func(t *testing.T) {
+			k8sAPI, err := k8s.NewFakeAPI(exp.k8sRes...)
+			if err != nil {
+				t.Fatalf("NewFakeAPI returned an error: %s", err)
+			}
+
+			clientCAPem, allowedNames, usernameHeader, groupHeader, err := apiServerAuth(k8sAPI)
+			if !reflect.DeepEqual(err, exp.err) {
+				t.Errorf("apiServerAuth returned unexpected error: %s, expected: %s", err, exp.err)
+			}
+			if clientCAPem != exp.clientCAPem {
+				t.Errorf("apiServerAuth returned unexpected clientCAPem: %s, expected: %s", clientCAPem, exp.clientCAPem)
+			}
+			if !reflect.DeepEqual(allowedNames, exp.allowedNames) {
+				t.Errorf("apiServerAuth returned unexpected allowedNames: %s, expected: %s", allowedNames, exp.allowedNames)
+			}
+			if usernameHeader != exp.usernameHeader {
+				t.Errorf("apiServerAuth returned unexpected usernameHeader: %s, expected: %s", usernameHeader, exp.usernameHeader)
+			}
+			if groupHeader != exp.groupHeader {
+				t.Errorf("apiServerAuth returned unexpected groupHeader: %s, expected: %s", groupHeader, exp.groupHeader)
+			}
+		})
+	}
+}
+
+func TestHandleTap(t *testing.T) {
+	expectations := []struct {
+		req    *http.Request
+		params httprouter.Params
+		code   int
+		header http.Header
+		body   string
+	}{
+		{
+			req: &http.Request{
+				URL: &url.URL{
+					Path: "/apis",
+				},
+			},
+			code:   http.StatusBadRequest,
+			header: http.Header{"Content-Type": []string{"application/json"}},
+			body:   `{"error":"invalid path: /apis"}`,
+		},
+		{
+			req: &http.Request{
+				URL: &url.URL{
+					Path: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/foo/tap",
+				},
+			},
+			code:   http.StatusInternalServerError,
+			header: http.Header{"Content-Type": []string{"application/json"}},
+			body:   `{"error":"SubjectAccessReview failed with: not authorized to access namespaces.tap.linkerd.io"}`,
+		},
+	}
+
+	for i, exp := range expectations {
+		exp := exp // pin
+
+		t.Run(fmt.Sprintf("%d parses the apiServerAuth ConfigMap", i), func(t *testing.T) {
+			k8sAPI, err := k8s.NewFakeAPI()
+			if err != nil {
+				t.Fatalf("NewFakeAPI returned an error: %s", err)
+			}
+
+			a := &apiServer{
+				k8sAPI: k8sAPI,
+				log:    logrus.WithField("test", t.Name),
+			}
+			recorder := httptest.NewRecorder()
+			a.handleTap(recorder, exp.req, exp.params)
+
+			if recorder.Code != exp.code {
+				t.Errorf("Unexpected code: %d, expected: %d", recorder.Code, exp.code)
+			}
+			if !reflect.DeepEqual(recorder.Header(), exp.header) {
+				t.Errorf("Unexpected header: %v, expected: %v", recorder.Header(), exp.header)
+			}
+			if recorder.Body.String() != exp.body {
+				t.Errorf("Unexpected body: %s, expected: %s", recorder.Body.String(), exp.body)
+			}
+		})
+	}
+}

--- a/controller/tap/handlers.go
+++ b/controller/tap/handlers.go
@@ -118,6 +118,8 @@ func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprout
 		namespace, resource, name, req.Header.Get(h.usernameHeader), req.Header[h.groupHeader],
 	)
 
+	// TODO: it's possible this SubjectAccessReview is redundant, consider
+	// removing, more info at https://github.com/linkerd/linkerd2/issues/3182
 	err := pkgK8s.ResourceAuthzForUser(
 		h.k8sAPI.Client,
 		namespace,

--- a/controller/tap/handlers.go
+++ b/controller/tap/handlers.go
@@ -1,0 +1,350 @@
+package tap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-openapi/spec"
+	"github.com/julienschmidt/httprouter"
+	pb "github.com/linkerd/linkerd2/controller/gen/controller/tap"
+	"github.com/linkerd/linkerd2/controller/gen/public"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/protohttp"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type handler struct {
+	k8sAPI         *k8s.API
+	usernameHeader string
+	groupHeader    string
+	tapClient      pb.TapClient
+	log            *logrus.Entry
+}
+
+// TODO: share with api_handlers.go
+type jsonError struct {
+	Error string `json:"error"`
+}
+
+var (
+	gvk = &schema.GroupVersionKind{
+		Group:   "tap.linkerd.io",
+		Version: "v1alpha1",
+		Kind:    "Tap",
+	}
+
+	gvfd = metav1.GroupVersionForDiscovery{
+		GroupVersion: gvk.GroupVersion().String(),
+		Version:      gvk.Version,
+	}
+
+	apiGroup = metav1.APIGroup{
+		Name:             gvk.Group,
+		Versions:         []metav1.GroupVersionForDiscovery{gvfd},
+		PreferredVersion: gvfd,
+	}
+
+	resources = []struct {
+		name       string
+		namespaced bool
+	}{
+		{"namespaces", false},
+		{"pods", true},
+		{"replicationcontrollers", true},
+		{"services", true},
+		{"daemonsets", true},
+		{"deployments", true},
+		{"replicasets", true},
+		{"statefulsets", true},
+		{"jobs", true},
+	}
+)
+
+func initRouter(h *handler) *httprouter.Router {
+	router := &httprouter.Router{}
+
+	router.GET("/", handleRoot)
+	router.GET("/apis", handleAPIs)
+	router.GET("/apis/"+gvk.Group, handleAPIGroup)
+	router.GET("/apis/"+gvk.GroupVersion().String(), handleAPIResourceList)
+	router.GET("/healthz", handleHealthz)
+	router.GET("/healthz/log", handleHealthz)
+	router.GET("/healthz/ping", handleHealthz)
+	router.GET("/metrics", handleMetrics)
+	router.GET("/openapi/v2", handleOpenAPI)
+	router.GET("/version", handleVersion)
+	router.NotFound = handleNotFound
+
+	for _, res := range resources {
+		route := ""
+		if !res.namespaced {
+			route = fmt.Sprintf("/apis/%s/watch/%s/:namespace/tap", gvk.GroupVersion().String(), res.name)
+		} else {
+			route = fmt.Sprintf("/apis/%s/watch/namespaces/:namespace/%s/:name/tap", gvk.GroupVersion().String(), res.name)
+		}
+		router.POST(route, h.handleTap)
+	}
+
+	return router
+}
+
+// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/tap
+// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/:resource/:name/tap
+func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
+	resource := ""
+
+	path := strings.Split(req.URL.Path, "/")
+	if len(path) == 8 {
+		resource = path[5]
+	} else if len(path) == 10 {
+		resource = path[7]
+	} else {
+		err := fmt.Errorf("invalid path: %s", req.URL.Path)
+		h.log.Error(err)
+		renderJSONError(w, err, http.StatusBadRequest)
+		return
+	}
+
+	h.log.Debugf("SubjectAccessReview: namespace: %s, resource: %s, name: %s, user: %s, group: %s",
+		namespace, resource, name, req.Header.Get(h.usernameHeader), req.Header[h.groupHeader],
+	)
+
+	err := pkgK8s.ResourceAuthzForUser(
+		h.k8sAPI.Client,
+		namespace,
+		"watch",
+		gvk.Group,
+		gvk.Version,
+		resource,
+		"tap",
+		name,
+		req.Header.Get(h.usernameHeader),
+		req.Header[h.groupHeader],
+	)
+	if err != nil {
+		err = fmt.Errorf("SubjectAccessReview failed with: %s", err)
+		h.log.Error(err)
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	tapReq := public.TapByResourceRequest{}
+	err = protohttp.HTTPRequestToProto(req, &tapReq)
+	if err != nil {
+		err = fmt.Errorf("Error decoding Tap Request proto: %s", err)
+		h.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	url := protohttp.TapReqToURL(&tapReq)
+	if url != req.URL.Path {
+		err = fmt.Errorf("tap request body did not match APIServer URL: %+v != %+v", url, req.URL.Path)
+		h.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	flushableWriter, err := protohttp.NewStreamingWriter(w)
+	if err != nil {
+		h.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(w, err)
+		return
+	}
+
+	client, err := h.tapClient.TapByResource(req.Context(), &tapReq)
+	if err != nil {
+		h.log.Error(err)
+		protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+		return
+	}
+
+	for {
+		select {
+		case <-req.Context().Done():
+			h.log.Debug("Received Done context in Tap Stream")
+			return
+		default:
+			event, err := client.Recv()
+			if err != nil {
+				h.log.Errorf("Error receiving from tap client: %s", err)
+				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+				return
+			}
+			err = protohttp.WriteProtoToHTTPResponse(flushableWriter, event)
+			if err != nil {
+				h.log.Errorf("Error writing proto to HTTP Response: %s", err)
+				protohttp.WriteErrorToHTTPResponse(flushableWriter, err)
+				return
+			}
+			flushableWriter.Flush()
+		}
+	}
+}
+
+// GET (not found)
+func handleNotFound(w http.ResponseWriter, _ *http.Request) {
+	handlePaths(w, http.StatusNotFound)
+}
+
+// GET /
+func handleRoot(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	handlePaths(w, http.StatusOK)
+}
+
+// GET /
+// GET (not found)
+func handlePaths(w http.ResponseWriter, status int) {
+	paths := map[string][]string{
+		"paths": {
+			"/apis",
+			"/apis/" + gvk.Group,
+			"/apis/" + gvk.GroupVersion().String(),
+			"/healthz",
+			"/healthz/log",
+			"/healthz/ping",
+			"/metrics",
+			"/openapi/v2",
+			"/version",
+		},
+	}
+
+	renderJSON(w, paths, status)
+}
+
+// GET /apis
+func handleAPIs(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	groupList := metav1.APIGroupList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "APIGroupList",
+		},
+		Groups: []metav1.APIGroup{
+			apiGroup,
+		},
+	}
+
+	renderJSON(w, groupList, http.StatusOK)
+}
+
+// GET /apis/tap.linkerd.io
+func handleAPIGroup(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	groupWithType := apiGroup
+	groupWithType.TypeMeta = metav1.TypeMeta{
+		Kind:       "APIGroup",
+		APIVersion: "v1",
+	}
+
+	renderJSON(w, groupWithType, http.StatusOK)
+}
+
+// GET /apis/tap.linkerd.io/v1alpha1
+// this is required for `kubectl api-resources` to work
+func handleAPIResourceList(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	resList := metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: gvk.GroupVersion().String(),
+		APIResources: []metav1.APIResource{},
+	}
+
+	for _, res := range resources {
+		resList.APIResources = append(resList.APIResources,
+			metav1.APIResource{
+				Name:       fmt.Sprintf("%s/tap", res.name),
+				Namespaced: res.namespaced,
+				Kind:       gvk.Kind,
+				Group:      "tap",
+				Verbs:      metav1.Verbs{"watch"},
+			})
+	}
+
+	renderJSON(w, resList, http.StatusOK)
+}
+
+// GET /healthz
+// GET /healthz/logs
+// GET /healthz/ping
+func handleHealthz(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Write([]byte("ok"))
+}
+
+// GET /metrics
+func handleMetrics(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	promhttp.Handler().ServeHTTP(w, req)
+}
+
+// GET /openapi/v2
+func handleOpenAPI(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	swagger := spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Swagger: "2.0",
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title:   "Api",
+					Version: "v0",
+				},
+			},
+			Paths: &spec.Paths{
+				Paths: map[string]spec.PathItem{
+					"/":                                    mkPathItem("get all paths"),
+					"/apis":                                mkPathItem("get available API versions"),
+					"/apis/" + gvk.Group:                   mkPathItem("get information of a group"),
+					"/apis/" + gvk.GroupVersion().String(): mkPathItem("get available resources"),
+				},
+			},
+		},
+	}
+
+	renderJSON(w, swagger, http.StatusOK)
+}
+
+func mkPathItem(desc string) spec.PathItem {
+	return spec.PathItem{
+		PathItemProps: spec.PathItemProps{
+			Get: &spec.Operation{
+				OperationProps: spec.OperationProps{
+					Description: desc,
+					Consumes:    []string{"application/json"},
+					Produces:    []string{"application/json"},
+				},
+			},
+		},
+	}
+}
+
+// GET /version
+func handleVersion(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	renderJSON(w, version.Info{}, http.StatusOK)
+}
+
+func renderJSON(w http.ResponseWriter, obj interface{}, status int) {
+	bytes, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(bytes)
+}
+
+// TODO: share with api_handlers.go
+func renderJSONError(w http.ResponseWriter, err error, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	rsp, _ := json.Marshal(jsonError{Error: err.Error()})
+	w.WriteHeader(status)
+	w.Write(rsp)
+}

--- a/controller/tap/handlers_test.go
+++ b/controller/tap/handlers_test.go
@@ -1,0 +1,73 @@
+package tap
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/sirupsen/logrus"
+)
+
+func TestHandleTap(t *testing.T) {
+	expectations := []struct {
+		req    *http.Request
+		params httprouter.Params
+		code   int
+		header http.Header
+		body   string
+	}{
+		{
+			req: &http.Request{
+				URL: &url.URL{
+					Path: "/apis",
+				},
+			},
+			code:   http.StatusBadRequest,
+			header: http.Header{"Content-Type": []string{"application/json"}},
+			body:   `{"error":"invalid path: /apis"}`,
+		},
+		{
+			req: &http.Request{
+				URL: &url.URL{
+					Path: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/foo/tap",
+				},
+			},
+			code:   http.StatusInternalServerError,
+			header: http.Header{"Content-Type": []string{"application/json"}},
+			body:   `{"error":"SubjectAccessReview failed with: not authorized to access namespaces.tap.linkerd.io"}`,
+		},
+	}
+
+	for i, exp := range expectations {
+		exp := exp // pin
+
+		t.Run(fmt.Sprintf("%d handle the tap request", i), func(t *testing.T) {
+			k8sAPI, err := k8s.NewFakeAPI()
+			if err != nil {
+				t.Fatalf("NewFakeAPI returned an error: %s", err)
+			}
+
+			h := &handler{
+				k8sAPI: k8sAPI,
+				log:    logrus.WithField("test", t.Name),
+			}
+			recorder := httptest.NewRecorder()
+			h.handleTap(recorder, exp.req, exp.params)
+
+			if recorder.Code != exp.code {
+				t.Errorf("Unexpected code: %d, expected: %d", recorder.Code, exp.code)
+			}
+			if !reflect.DeepEqual(recorder.Header(), exp.header) {
+				t.Errorf("Unexpected header: %v, expected: %v", recorder.Header(), exp.header)
+			}
+			if recorder.Body.String() != exp.body {
+				t.Errorf("Unexpected body: %s, expected: %s", recorder.Body.String(), exp.body)
+			}
+		})
+	}
+}

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 )
 
@@ -36,6 +37,7 @@ func NewFakeAPI(configs ...string) (*KubernetesAPI, error) {
 	}
 
 	return &KubernetesAPI{
+		Config:        &rest.Config{},
 		Interface:     client,
 		Apiextensions: apiextClient,
 	}, nil

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -227,6 +227,9 @@ const (
 	// SPValidatorWebhookConfigName is the name of the validating webhook configuration
 	SPValidatorWebhookConfigName = SPValidatorWebhookServiceName + "-webhook-config"
 
+	// TapServiceName is the name of the tap APIService
+	TapServiceName = "linkerd-tap"
+
 	/*
 	 * Mount paths
 	 */

--- a/pkg/protohttp/protohttp.go
+++ b/pkg/protohttp/protohttp.go
@@ -200,6 +200,8 @@ func FromByteStreamToProtocolBuffers(byteStreamContainingMessage *bufio.Reader, 
 
 // TapReqToURL converts a TapByResourceRequest protobuf object to a URL for use
 // with the Kubernetes tap.linkerd.io APIService.
+// TODO: Move this, probably into its own package, when /controller/gen/public
+// moves into /pkg.
 func TapReqToURL(req *pb.TapByResourceRequest) string {
 	res := req.GetTarget().GetResource()
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -168,7 +168,7 @@ func TestInstallOrUpgrade(t *testing.T) {
 		}
 
 		// apply stage 1
-		out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
+		out, err = TestHelper.KubectlApply(out, "")
 		if err != nil {
 			t.Fatalf("kubectl apply command failed\n%s", out)
 		}
@@ -204,7 +204,7 @@ func TestInstallOrUpgrade(t *testing.T) {
 		}
 	}
 
-	out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
+	out, err = TestHelper.KubectlApply(out, "")
 	if err != nil {
 		t.Fatalf("kubectl apply command failed\n%s", out)
 	}

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -80,13 +80,14 @@ func (h *KubernetesHelper) CreateNamespaceIfNotExists(namespace string, annotati
 
 // KubectlApply applies a given configuration string in a namespace. If the
 // namespace does not exist, it creates it first. If no namespace is provided,
-// it uses the default namespace.
+// it does not specify the `--namespace` flag.
 func (h *KubernetesHelper) KubectlApply(stdin string, namespace string) (string, error) {
-	if namespace == "" {
-		namespace = "default"
+	args := []string{"apply", "-f", "-"}
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
 	}
 
-	return h.Kubectl(stdin, "apply", "-f", "-", "--namespace", namespace)
+	return h.Kubectl(stdin, args...)
 }
 
 // Kubectl executes an arbitrary Kubectl command


### PR DESCRIPTION
The Tap Service enabled tapping of any meshed pod, regardless of user
privilege.

This change introduces a new Tap APIService. Kubernetes provides
authentication and authorization of Tap requests, and then forwards
requests to a new Tap APIServer, which implements a Kubernetes
aggregated API server. The Tap APIServer authenticates the client TLS
from Kubernetes, and authorizes the user via a SubjectAccessReview.

The `linkerd tap` command now makes requests against the new APIService.

The Tap APIService implements three Kubernetes-style endpoints:
GET  /apis/tap.linkerd.io/v1alpha1
POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:ns/tap
POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:ns/:res/:name/tap

Users authorize to the new `tap.linkerd.io/v1alpha1` via RBAC. Only the
`watch` verb is supported. Access is also available via subresources
such as `deployments/tap` and `pods/tap`.

This change introduces the following resources into the default Linkerd
install:
- Global
  - APIService/v1alpha1.tap.linkerd.io
  - ClusterRoleBinding/linkerd-linkerd-tap-auth-delegator
- `linkerd` namespace:
  - Secret/linkerd-tap-tls
- `kube-system` namespace:
  - RoleBinding/linkerd-linkerd-tap-auth-reader

Tasks not covered by this PR:
- `linkerd top`
- `linkerd dashboard`
- `linkerd profile --tap`
- removal of the unauthenticated tap controller

Fixes #2725, #3162

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

This PR is based on https://github.com/linkerd/linkerd2/compare/dad/tap-pod-2