### PR TITLE
Introduce `linkerd --as` flag for impersonation

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -171,6 +171,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		DataPlaneNamespace:    options.namespace,
 		KubeConfig:            kubeconfigPath,
 		KubeContext:           kubeContext,
+		Impersonate:           impersonate,
 		APIAddr:               apiAddr,
 		VersionOverride:       options.versionOverride,
 		RetryDeadline:         time.Now().Add(options.wait),

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -66,7 +66,7 @@ func newCmdDashboard() *cobra.Command {
 			// ensure we can connect to the public API before starting the proxy
 			checkPublicAPIClientOrRetryOrExit(time.Now().Add(options.wait), true)
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -898,6 +898,7 @@ func errIfGlobalResourcesExist() error {
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
+		Impersonate:           impersonate,
 	})
 
 	errMsgs := []string{}
@@ -923,7 +924,7 @@ func errIfGlobalResourcesExist() error {
 }
 
 func errIfLinkerdConfigConfigMapExists() error {
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -116,8 +116,8 @@ func getControlPlaneComponentsAndContainers(pods *corev1.PodList) ([]string, []s
 	return controlPlaneComponents, containers
 }
 
-func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext string) (*logCmdConfig, error) {
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext, impersonate string) (*logCmdConfig, error) {
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func newCmdLogs() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			color.NoColor = options.noColor
 
-			opts, err := newLogCmdConfig(options, kubeconfigPath, kubeContext)
+			opts, err := newLogCmdConfig(options, kubeconfigPath, kubeContext, impersonate)
 
 			if err != nil {
 				return err

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -91,7 +91,7 @@ func newCmdMetrics() *cobra.Command {
   )`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -21,7 +21,7 @@ func rawPublicAPIClient() (pb.ApiClient, error) {
 		return public.NewInternalClient(controlPlaneNamespace, apiAddr)
 	}
 
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +61,7 @@ func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time) 
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
 		KubeContext:           kubeContext,
+		Impersonate:           impersonate,
 		APIAddr:               apiAddr,
 		RetryDeadline:         retryDeadline,
 	})

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -40,6 +40,7 @@ var (
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
 	kubeContext           string
+	impersonate           string
 	verbose               bool
 
 	// These regexs are not as strict as they could be, but are a quick and dirty
@@ -91,6 +92,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "linkerd-namespace", "l", defaultNamespace, "Namespace in which Linkerd is installed [$LINKERD_NAMESPACE]")
 	RootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 	RootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "Name of the kubeconfig context to use")
+	RootCmd.PersistentFlags().StringVar(&impersonate, "as", "", "Username to impersonate for Kubernetes operations")
 	RootCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -152,7 +152,7 @@ func upgradeRunE(options *upgradeOptions, stage string, flags *pflag.FlagSet) er
 			upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
 		}
 	} else {
-		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, 0)
+		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
 		if err != nil {
 			upgradeErrorf("Failed to create a kubernetes client: %s", err)
 		}

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -164,7 +164,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 
 	if namespace != "" && podName != "" {
-		client, err := k8s.NewAPI(conf.Kubernetes.Kubeconfig, "linkerd-cni-context", 0)
+		client, err := k8s.NewAPI(conf.Kubernetes.Kubeconfig, "linkerd-cni-context", "", 0)
 		if err != nil {
 			return err
 		}

--- a/controller/cmd/heartbeat/main.go
+++ b/controller/cmd/heartbeat/main.go
@@ -34,7 +34,7 @@ func main() {
 	v.Set("version", version.Version)
 	v.Set("source", "heartbeat")
 
-	kubeAPI, err := k8s.NewAPI(*kubeConfigPath, "", 0)
+	kubeAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", 0)
 	if err != nil {
 		log.Errorf("Failed to initialize k8s API: %s", err)
 	} else {

--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	ca := tls.NewCA(*creds, validity)
 
-	k8s, err := k8s.NewAPI(*kubeConfigPath, "", 0)
+	k8s, err := k8s.NewAPI(*kubeConfigPath, "", "", 0)
 	if err != nil {
 		log.Fatalf("Failed to load kubeconfig: %s: %s", *kubeConfigPath, err)
 	}

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -85,7 +85,7 @@ type API struct {
 
 // InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
 func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
-	k8sClient, err := k8s.NewAPI(kubeConfig, "", 0)
+	k8sClient, err := k8s.NewAPI(kubeConfig, "", "", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -224,6 +224,7 @@ type Options struct {
 	DataPlaneNamespace    string
 	KubeConfig            string
 	KubeContext           string
+	Impersonate           string
 	APIAddr               string
 	VersionOverride       string
 	RetryDeadline         time.Time
@@ -287,7 +288,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "k8s-api",
 					fatal:       true,
 					check: func(context.Context) (err error) {
-						hc.kubeAPI, err = k8s.NewAPI(hc.KubeConfig, hc.KubeContext, requestTimeout)
+						hc.kubeAPI, err = k8s.NewAPI(hc.KubeConfig, hc.KubeContext, hc.Impersonate, requestTimeout)
 						return
 					},
 				},

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -34,7 +34,7 @@ type KubernetesAPI struct {
 
 // NewAPI validates a Kubernetes config and returns a client for accessing the
 // configured cluster.
-func NewAPI(configPath, kubeContext string, timeout time.Duration) (*KubernetesAPI, error) {
+func NewAPI(configPath, kubeContext string, impersonate string, timeout time.Duration) (*KubernetesAPI, error) {
 	config, err := GetConfig(configPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
@@ -46,6 +46,12 @@ func NewAPI(configPath, kubeContext string, timeout time.Duration) (*KubernetesA
 	config.Timeout = timeout
 	wt := config.WrapTransport
 	config.WrapTransport = prometheus.ClientWithTelemetry("k8s", wt)
+
+	if impersonate != "" {
+		config.Impersonate = rest.ImpersonationConfig{
+			UserName: impersonate,
+		}
+	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -248,7 +248,7 @@ func (h *KubernetesHelper) ParseNamespacedResource(resource string) (string, str
 // tests can use for access to the given deployment. Note that the port-forward
 // remains running for the duration of the test.
 func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) (string, error) {
-	k8sAPI, err := k8s.NewAPI("", h.k8sContext, 0)
+	k8sAPI, err := k8s.NewAPI("", h.k8sContext, "", 0)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Similar to `kubectl --as`, global flag across all linkerd subcommands
which sets a `ImpersonationConfig` in the Kubernetes API config.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

```bash
$ linkerd stat deploy --as foo
Cannot find Linkerd: configmaps "linkerd-config" is forbidden: User "foo" cannot get resource "configmaps" in API group "" in the namespace "linkerd"
Validate the install with: linkerd check
```

```bash
$ linkerd check --as foo
kubernetes-api
--------------
√ can initialize the client
√ can query the Kubernetes API

kubernetes-version
------------------
√ is running the minimum Kubernetes API version
√ is running the minimum kubectl version

linkerd-config
--------------
× control plane Namespace exists
    namespaces "linkerd" is forbidden: User "foo" cannot get resource "namespaces" in API group "" in the namespace "linkerd"
    see https://linkerd.io/checks/#l5d-existence-ns for hints

Status check results are ×
```