### PR TITLE
Set heartbeat cronjobs to not restart on failure

### DIFF
--- a/chart/templates/heartbeat.yaml
+++ b/chart/templates/heartbeat.yaml
@@ -26,7 +26,7 @@ spec:
             {{.CreatedByAnnotation}}: {{.CliVersion}}
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: {{.ControllerImage}}

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -527,7 +527,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1115,7 +1115,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1185,7 +1185,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1185,7 +1185,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1046,7 +1046,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1041,7 +1041,7 @@ spec:
             CreatedByAnnotation: CliVersion
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: ControllerImage

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1117,7 +1117,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1187,7 +1187,7 @@ spec:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
           serviceAccountName: linkerd-heartbeat
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: heartbeat
             image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION


### PR DESCRIPTION
The heartbeat cronjob specified `restartPolicy: OnFailure`. In cases
where failure was non-transient, such as if a cluster did not have
internet access, this would continuously restart and fail.

Change the heartbeat cronjob to `restartPolicy: Never`, as a failed job
has no user-facing impact.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>