### PR TITLE
Add changes for `edge-19.8.1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,23 @@
 ## edge-19.8.1
 
+**Significant Update**
+
+This edge release introduces a new tap APIService. The Kubernetes apiserver
+authenticates the requesting tap user and then forwards tap requests to the new
+tap APIServer. The `linkerd tap` command now makes requests against the
+APIService.
+
+With this release, additional authorization is not required to use the `linkerd
+tap` command. In future releases, users authorize to the new
+`tap.linkerd.io/v1alpha1` via RBAC. Only the `watch` verb is supported. Access
+is also available via subresources such as `deployments/tap` and `pods/tap`.
+
 * CLI
   * Added a check to the `linkerd check` command to validate the user has
     privileges necessary to create CronJobs
   * Introduced the `linkerd --as` flag which sets a `ImpersonationConfig` in the
     Kubernetes API config
+  * The `linkerd tap` command now makes requests against the tap APIService
 * Controller
   * Added missing HTTP security headers on all dashboard responses
   * Fixed endpoints watcher to check for `TargetRef` prior to dereferencing
@@ -14,6 +27,13 @@
     name services so that the proxy does not immediately fail the request
   * The `l5d-require-id` header is now set on tap requests so that a connection
     is established over TLS
+  * Introduced the `APIService/v1alpha1.tap.linkerd.io` global resource
+  * Introduced the `ClusterRoleBinding/linkerd-linkerd-tap-auth-delegator`
+    global resource
+  * Introduced the `Secret/linkerd-tap-tls` resource into the `linkerd`
+    namespace
+  * Introduced the `RoleBinding/linkerd-linkerd-tap-auth-reader` resource into
+    the `kube-system` namespace
 * Proxy
   * Added the `LINKERD2_PROXY_TAP_SVC_NAME` environment variable so that the tap
     server attempts to authorize client identities

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## edge-19.8.1
+
+* CLI
+  * Added a check to the `linkerd check` command to validate the user has
+    privileges necessary to create CronJobs
+  * Introduced the `linkerd --as` flag which sets a `ImpersonationConfig` in the
+    Kubernetes API config
+* Controller
+  * Added missing HTTP security headers on all dashboard responses
+  * Fixed endpoints watcher to check for `TargetRef` prior to dereferencing
+  * Added resource limits when HA is enabled
+  * Added RSA support to TLS libraries
+  * Updated the destination service to return `InvalidArgument` for external
+    name services so that the proxy does not immediately fail the request
+  * The `l5d-require-id` header is now set on tap requests so that a connection
+    is established over TLS
+* Proxy
+  * Added the `LINKERD2_PROXY_TAP_SVC_NAME` environment variable so that the tap
+    server attempts to authorize client identities
+* Internal
+  * Replaced `dep` with Go modules for dependency management
+
 ## edge-19.7.5
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ APIService.
 With this release, users must be authorized via RBAC to use the `linkerd tap`
 command. Specifically `linkerd tap` requires the `watch` verb on all resources
 in the `tap.linkerd.io/v1alpha1` APIGroup. More granular access is also
-available via subresources such as `deployments/tap` and `pods/tap`.
+available via sub-resources such as `deployments/tap` and `pods/tap`.
 
 * CLI
   * Added a check to the `linkerd check` command to validate the user has

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,21 +7,21 @@ authenticates the requesting tap user and then forwards tap requests to the new
 tap APIServer. The `linkerd tap` command now makes requests against the
 APIService.
 
-With this release, additional role bindings are not required to use the `linkerd
-tap`
-command. In future releases, users will authorize to the new
-`tap.linkerd.io/v1alpha1` via RBAC. Only the `watch` verb is supported. Access
-is also available via subresources such as `deployments/tap` and `pods/tap`.
+With this release, users must be authorized via RBAC to use the `linkerd tap`
+command. Specifically `linkerd tap` requires the `watch` verb on all resources
+in the `tap.linkerd.io/v1alpha1` APIGroup. More granular access is also
+available via subresources such as `deployments/tap` and `pods/tap`.
 
 * CLI
   * Added a check to the `linkerd check` command to validate the user has
     privileges necessary to create CronJobs
-  * Introduced the `linkerd --as` flag which sets a `ImpersonationConfig` in the
-    Kubernetes API config
+  * Introduced the `linkerd --as` flag which allows users to impersonate another
+    user for Kubernetes operations
   * The `linkerd tap` command now makes requests against the tap APIService
 * Controller
-  * Added missing HTTP security headers on all dashboard responses
-  * Fixed endpoints watcher to check for `TargetRef` prior to dereferencing
+  * Added HTTP security headers on all dashboard responses
+  * Fixed nil pointer dereference in the destination service when an endpoint
+    does not have a `TargetRef`
   * Added resource limits when HA is enabled
   * Added RSA support to TLS libraries
   * Updated the destination service to return `InvalidArgument` for external

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,9 @@ authenticates the requesting tap user and then forwards tap requests to the new
 tap APIServer. The `linkerd tap` command now makes requests against the
 APIService.
 
-With this release, additional authorization is not required to use the `linkerd
-tap` command. In future releases, users authorize to the new
+With this release, additional role bindings are not required to use the `linkerd
+tap`
+command. In future releases, users will authorize to the new
 `tap.linkerd.io/v1alpha1` via RBAC. Only the `watch` verb is supported. Access
 is also available via subresources such as `deployments/tap` and `pods/tap`.
 


### PR DESCRIPTION
**Significant Update**

This edge release introduces a new tap APIService. The Kubernetes apiserver
authenticates the requesting tap user and then forwards tap requests to the new
tap APIServer. The `linkerd tap` command now makes requests against the
APIService.

With this release, users must be authorized via RBAC to use the `linkerd tap`
command. Specifically `linkerd tap` requires the `watch` verb on all resources
in the `tap.linkerd.io/v1alpha1` APIGroup. More granular access is also
available via sub-resources such as `deployments/tap` and `pods/tap`.

* CLI
  * Added a check to the `linkerd check` command to validate the user has
    privileges necessary to create CronJobs
  * Introduced the `linkerd --as` flag which allows users to impersonate another
    user for Kubernetes operations
  * The `linkerd tap` command now makes requests against the tap APIService
* Controller
  * Added HTTP security headers on all dashboard responses
  * Fixed nil pointer dereference in the destination service when an endpoint
    does not have a `TargetRef`
  * Added resource limits when HA is enabled
  * Added RSA support to TLS libraries
  * Updated the destination service to return `InvalidArgument` for external
    name services so that the proxy does not immediately fail the request
  * The `l5d-require-id` header is now set on tap requests so that a connection
    is established over TLS
  * Introduced the `APIService/v1alpha1.tap.linkerd.io` global resource
  * Introduced the `ClusterRoleBinding/linkerd-linkerd-tap-auth-delegator`
    global resource
  * Introduced the `Secret/linkerd-tap-tls` resource into the `linkerd`
    namespace
  * Introduced the `RoleBinding/linkerd-linkerd-tap-auth-reader` resource into
    the `kube-system` namespace
* Proxy
  * Added the `LINKERD2_PROXY_TAP_SVC_NAME` environment variable so that the tap
    server attempts to authorize client identities
* Internal
  * Replaced `dep` with Go modules for dependency management

Signed-off by: Kevin Leimkuhler <kleimkuhler@icloud.com>
