### PR TITLE
Update `linkerd profile --tap` to Tap APIService

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -103,7 +104,11 @@ func newCmdProfile() *cobra.Command {
 			} else if options.openAPI != "" {
 				return profiles.RenderOpenAPI(options.openAPI, options.namespace, options.name, os.Stdout)
 			} else if options.tap != "" {
-				return profiles.RenderTapOutputProfile(checkPublicAPIClientOrExit(), options.tap, options.namespace, options.name, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
+				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+				if err != nil {
+					return err
+				}
+				return profiles.RenderTapOutputProfile(k8sAPI, options.tap, options.namespace, options.name, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
 			} else if options.proto != "" {
 				return profiles.RenderProto(options.proto, options.namespace, options.name, os.Stdout)
 			}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/linkerd/linkerd2/cli/tap"
 	"github.com/linkerd/linkerd2/controller/api/util"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
+	"github.com/linkerd/linkerd2/pkg/tap"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -151,7 +151,7 @@ func requestTapByResourceFromAPI(w io.Writer, k8sAPI *k8s.KubernetesAPI, req *pb
 		resource = req.GetTarget().GetResource().GetType()
 	}
 
-	reader, body, err := tap.Reader(k8sAPI, req)
+	reader, body, err := tap.Reader(k8sAPI, req, 0)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/linkerd/linkerd2/cli/tap"
 	"github.com/linkerd/linkerd2/controller/api/public"
 	"github.com/linkerd/linkerd2/controller/api/util"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
+	"github.com/linkerd/linkerd2/pkg/tap"
 	runewidth "github.com/mattn/go-runewidth"
 	termbox "github.com/nsf/termbox-go"
 	log "github.com/sirupsen/logrus"
@@ -372,7 +372,7 @@ func newCmdTop() *cobra.Command {
 }
 
 func getTrafficByResourceFromAPI(k8sAPI *k8s.KubernetesAPI, req *pb.TapByResourceRequest, table *topTable) error {
-	reader, body, err := tap.Reader(k8sAPI, req)
+	reader, body, err := tap.Reader(k8sAPI, req, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/tap/tap.go
+++ b/pkg/tap/tap.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
@@ -16,11 +17,12 @@ import (
 
 // Reader initiates a TapByResourceRequest and returns a buffered Reader.
 // It is the caller's responsibility to call Close() on the io.ReadCloser.
-func Reader(k8sAPI *k8s.KubernetesAPI, req *pb.TapByResourceRequest) (*bufio.Reader, io.ReadCloser, error) {
+func Reader(k8sAPI *k8s.KubernetesAPI, req *pb.TapByResourceRequest, timeout time.Duration) (*bufio.Reader, io.ReadCloser, error) {
 	client, err := k8sAPI.NewClient()
 	if err != nil {
 		return nil, nil, err
 	}
+	client.Timeout = timeout
 
 	reqBytes, err := proto.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
PR #3167 introduced a Tap APIService, and migrated linkerd tap to it.

This change migrates `linkerd profile --tap` to the new Tap APIService.

Depends on #3186
Fixes #3169

Signed-off-by: Andrew Seigner <siggy@buoyant.io>