### PR TITLE
Fix Tap resource/subresource APIGroupList

### DIFF
--- a/controller/tap/handlers_test.go
+++ b/controller/tap/handlers_test.go
@@ -37,7 +37,7 @@ func TestHandleTap(t *testing.T) {
 					Path: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/foo/tap",
 				},
 			},
-			code:   http.StatusInternalServerError,
+			code:   http.StatusForbidden,
 			header: http.Header{"Content-Type": []string{"application/json"}},
 			body:   `{"error":"SubjectAccessReview failed with: not authorized to access namespaces.tap.linkerd.io"}`,
 		},


### PR DESCRIPTION
The `/apis/tap.linkerd.io/v1alpha1` endpoint on the Tap APIServer
included tap resource/subresource pairs, such as `deployments/tap` and
`pods/tap`, but did not include the parent resources, such as
`deployments` and `pods`. This broke commands like `kubectl auth can-i`,
which expect the parent resource to exist.

Introduce parent resources for all tap-able subresources. Concretely, it
fixes this class of command:
```
$ kubectl auth can-i watch deployments.tap.linkerd.io/linkerd-grafana \
  --subresource=tap -n linkerd --as siggy@buoyant.io
Warning: the server doesn't have a resource type 'deployments' in group 'tap.linkerd.io'
no - no RBAC policy matched
```
Fixed:
```
$ kubectl auth can-i watch deployments.tap.linkerd.io/linkerd-grafana \
  --subresource=tap -n linkerd --as siggy@buoyant.io
yes
```

Signed-off-by: Andrew Seigner <siggy@buoyant.io>