### PR TITLE
Setting SuccessfulJobHistoryLimit to 0 for CronJobs

### DIFF
--- a/chart/templates/heartbeat.yaml
+++ b/chart/templates/heartbeat.yaml
@@ -16,6 +16,7 @@ metadata:
     {{.CreatedByAnnotation}}: {{.CliVersion}}
 spec:
   schedule: "{{.HeartbeatSchedule}}"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -517,6 +517,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1170,6 +1170,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1240,6 +1240,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1240,6 +1240,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1101,6 +1101,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1096,6 +1096,7 @@ metadata:
     CreatedByAnnotation: CliVersion
 spec:
   schedule: ""
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1172,6 +1172,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1242,6 +1242,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Fixes #3189 

This sets the `SuccessfulJobHistoryLimit ` to 0, and `k -n linkerd get pods`, dosen't show history of any pods that ran successfully.

@grampelberg 