### PR TITLE
Check for Namespace level config override annotations

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -558,7 +558,10 @@ func (conf *ResourceConfig) injectPodAnnotations(values *patch) {
 }
 
 func (conf *ResourceConfig) getOverride(annotation string) string {
-	return conf.pod.meta.Annotations[annotation]
+	if override := conf.pod.meta.Annotations[annotation]; override != "" {
+		return override
+	}
+	return conf.nsAnnotations[annotation]
 }
 
 func (conf *ResourceConfig) proxyImage() string {

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -98,16 +98,17 @@ func TestNamespaceOverrideAnnotations(t *testing.T) {
 		t.Fatalf("failed to read inject test file: %s", err)
 	}
 
-	injectNS := "inject-test"
-	deployName := "inject-test-namespace-override"
-	nsAnnotations := map[string]string{}
-	nsAnnotations[k8s.ProxyInjectAnnotation] = k8s.ProxyInjectEnabled
-
-	// Namespace level proxy configuration override
+	injectNS := "inject-namespace-override-test"
+	deployName := "inject-namespace-override-test-terminus"
 	nsInitImage := "test_init_image"
 	nsProxyImage := "test_proxy_image"
-	nsAnnotations[k8s.ProxyInitImageAnnotation] = nsInitImage
-	nsAnnotations[k8s.ProxyImageAnnotation] = nsProxyImage
+
+	// Namespace level proxy configuration override
+	nsAnnotations := map[string]string{
+		k8s.ProxyInjectAnnotation:    k8s.ProxyInjectEnabled,
+		k8s.ProxyInitImageAnnotation: nsInitImage,
+		k8s.ProxyImageAnnotation:     nsProxyImage,
+	}
 
 	ns := TestHelper.GetTestNamespace(injectNS)
 	err = TestHelper.CreateNamespaceIfNotExists(ns, nsAnnotations)
@@ -116,11 +117,11 @@ func TestNamespaceOverrideAnnotations(t *testing.T) {
 	}
 
 	// patch injectYAML with unique name and pod annotations
-	podAnnotations := map[string]string{}
-
 	// Pod Level proxy configuration override
 	podInitImage := "proxy_test_init_image"
-	podAnnotations[k8s.ProxyInitImageAnnotation] = podInitImage
+	podAnnotations := map[string]string{
+		k8s.ProxyInitImageAnnotation: podInitImage,
+	}
 
 	patchedYAML, err := patchDeploy(injectYAML, deployName, podAnnotations)
 	if err != nil {


### PR DESCRIPTION
Fixes #2499 

This PR makes the `proxy-injector` check for Namespace Level Override Config annotations after checking the Pod level override config annotations before going with the default values. 

I tried with a Cluster and it considers the annotations of the namespace before going with the defaults.

@ihcsim @grampelberg 

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>