### PR TITLE
Fix bash checks in `bin/helm.sh` and `bin/test-cleanup`

### DIFF
--- a/bin/helm.sh
+++ b/bin/helm.sh
@@ -14,7 +14,7 @@ helm dep up $rootdir/charts/linkerd2
 helm lint --set Identity.TrustAnchorsPEM="fake-trust" --set Identity.Issuer.CrtPEM="fake-cert" --set Identity.Issuer.KeyPEM="fake-key" --set Identity.Issuer.CrtExpiry="fake-expiry-date" $rootdir/charts/linkerd2
 
 # if tiller is deployed, perform a dry run installation to check for errors
-if tiller=`kubectl get po -l app=helm,name=tiller --all-namespaces`; then
+if [ ! -z "$(kubectl get po -l app=helm,name=tiller --all-namespaces)" ]; then
   echo "Performing dry run installation"
   helm install --name=linkerd --dry-run --set Identity.TrustAnchorsPEM="fake-trust" --set Identity.Issuer.CrtPEM="fake-cert" --set Identity.Issuer.KeyPEM="fake-key" --set Identity.Issuer.CrtExpiry="fake-expiry-date" $rootdir/charts/linkerd2 2> /dev/null
 

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -6,41 +6,41 @@ k8s_context=${1:-""}
 
 echo "cleaning up control-plane namespaces in k8s-context [${k8s_context}]"
 
-if ! namespaces_controlplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-control-plane); then
+if [ -z "${namespaces_controlplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-control-plane)}" ]; then
   echo "no control-plane namespaces found" >&2
 fi
 
 echo "cleaning up data-plane namespaces in k8s-context [${k8s_context}]"
 
-if ! namespaces_dataplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-data-plane); then
+if [ -z "${namespaces_dataplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-data-plane)}" ]; then
   echo "no data-plane namespaces found" >&2
 fi
 
-if ! clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname -l linkerd.io/control-plane-ns); then
+if [ -z "${clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no clusterrolebindings found" >&2
 fi
 
-if ! clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname -l linkerd.io/control-plane-ns); then
+if [ -z "${clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no clusterroles found" >&2
 fi
 
-if ! webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns); then
+if [ -z "${webhookconfigs=$(kubectl --context=$k8s_context get mutatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no mutatingwebhookconfigurations found" >&2
 fi
 
-if ! validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns); then
+if [ -z "${validatingconfigs=$(kubectl --context=$k8s_context get validatingwebhookconfigurations -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no validatingwebhookconfigurations found" >&2
 fi
 
-if ! podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname -l linkerd.io/control-plane-ns); then
+if [ -z "${podsecuritypolicies=$(kubectl --context=$k8s_context get podsecuritypolicies -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no podsecuritypolicies found" >&2
 fi
 
-if ! customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/control-plane-ns -oname); then
+if [ -z "${customresourcedefinitions=$(kubectl --context=$k8s_context get customresourcedefinitions -l linkerd.io/control-plane-ns -oname)}" ]; then
   echo "no customresourcedefinitions found" >&2
 fi
 
-if ! apiservices=$(kubectl --context=$k8s_context get apiservices -l linkerd.io/control-plane-ns -oname); then
+if [ -z "${apiservices=$(kubectl --context=$k8s_context get apiservices -l linkerd.io/control-plane-ns -oname)}" ]; then
   echo "no apiservices found" >&2
 fi
 


### PR DESCRIPTION
I'm not sure of the portability of these changes. I've only tested it
successfully on Linux, so more testing is welcomed.

`bin/helm.sh`: you should see the following only if you have Tiller
installed in your cluster (which is installed with `helm init`):
```
Performing dry run installation
NAME:   linkerd
Performing dry run installation (HA mode)
NAME:   linkerd
```

`bin/test-cleanup`: when linkerd is not installed:

Before:
```bash
$ bin/test-cleanup
cleaning up control-plane namespaces in k8s-context []
cleaning up data-plane namespaces in k8s-context []
cleaning up rolebindings in kube-system namespace in k8s-context []
```

After this PR's changes:
```
$bin/test-cleanup
cleaning up control-plane namespaces in k8s-context []
no control-plane namespaces found
cleaning up data-plane namespaces in k8s-context []
no data-plane namespaces found
no clusterrolebindings found
no clusterroles found
no mutatingwebhookconfigurations found
no validatingwebhookconfigurations found
no podsecuritypolicies found
no customresourcedefinitions found
no apiservices found
cleaning up rolebindings in kube-system namespace in k8s-context []
```