### PR TITLE
Fix bug in service profile name generation

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -118,7 +118,7 @@ func newCmdProfile() *cobra.Command {
 			if options.template {
 				return profiles.RenderProfileTemplate(options.namespace, options.name, clusterDomain, os.Stdout)
 			} else if options.openAPI != "" {
-				return profiles.RenderOpenAPI(options.openAPI, options.namespace, clusterDomain, options.name, os.Stdout)
+				return profiles.RenderOpenAPI(options.openAPI, options.namespace, options.name, clusterDomain, os.Stdout)
 			} else if options.tap != "" {
 				return profiles.RenderTapOutputProfile(k8sAPI, options.tap, options.namespace, options.name, defaultClusterDomain, options.tapDuration, int(options.tapRouteLimit), os.Stdout)
 			} else if options.proto != "" {


### PR DESCRIPTION
Followup to #3148

Wrong args order in call to `profiles.RenderOpenAPI` was generating an
invalid service profile name.