### PR TITLE
Enable tap-admin ClusterRole privileges for `*`

### DIFF
--- a/chart/templates/tap-rbac.yaml
+++ b/chart/templates/tap-rbac.yaml
@@ -31,7 +31,7 @@ metadata:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -31,7 +31,7 @@ metadata:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -490,7 +490,7 @@ metadata:
     ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -490,7 +490,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: ["tap.linkerd.io"]
-  resources: ["*/tap"]
+  resources: ["*"]
   verbs: ["watch"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
The `linkerd-linkerd-tap-admin` ClusterRole had `watch` privileges on
`*/tap` resources. This disallowed non-namespaced tap requests of the
form: `/apis/tap.linkerd.io/v1alpha1/watch/namespaces/linkerd/tap`,
because that URL structure is interpreted by the Kubernetes API as
watching a resource of type `tap` within the linkerd namespace, rather
than tapping the linkerd namespace.

Modify `linkerd-linkerd-tap-admin` to have `watch` privileges on `*`,
enabling any request of the form
`/apis/tap.linkerd.io/v1alpha1/watch/namespaces/linkerd/*` to succeed.

Fixes #3212

Signed-off-by: Andrew Seigner <siggy@buoyant.io>