### PR TITLE
More succinct HTTPError messages

### DIFF
--- a/pkg/protohttp/protohttp.go
+++ b/pkg/protohttp/protohttp.go
@@ -40,7 +40,7 @@ type FlushableResponseWriter interface {
 
 // Error satisfies the error interface for HTTPError.
 func (e HTTPError) Error() string {
-	return fmt.Sprintf("HTTP error, status Code [%d], wrapped error is: %v", e.Code, e.WrappedError)
+	return fmt.Sprintf("HTTP error, status Code [%d] (%v)", e.Code, e.WrappedError)
 }
 
 // HTTPRequestToProto converts an HTTP Request to a protobuf request.

--- a/pkg/protohttp/protohttp_test.go
+++ b/pkg/protohttp/protohttp_test.go
@@ -515,7 +515,7 @@ func TestCheckIfResponseHasError(t *testing.T) {
 			t.Fatalf("Expecting error, got nothing")
 		}
 
-		expectedErrorMessage := "HTTP error, status Code [503], wrapped error is: unexpected API response"
+		expectedErrorMessage := "HTTP error, status Code [503] (unexpected API response)"
 		actualErrorMessage := err.Error()
 		if actualErrorMessage != expectedErrorMessage {
 			t.Fatalf("Expected error message to be [%s], but it was [%s]", expectedErrorMessage, actualErrorMessage)


### PR DESCRIPTION
Before:
`HTTP error, status Code [503], wrapped error is: unexpected response`

After:
`HTTP error, status Code [503] (unexpected response)`

Signed-off-by: Andrew Seigner <siggy@buoyant.io>