### PR TITLE
Remove redundant `HTTPError` cast check in web server

### DIFF
--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Control Frame payload size can be no bigger than 125 bytes. 2 bytes are
-// reserverd for the status code when formatting the message.
+// reserved for the status code when formatting the message.
 const maxControlFrameMsgSize = 123
 
 type (

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -21,6 +21,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Control Frame payload size can be no bigger than 125 bytes. 2 bytes are
+// reserverd for the status code when formatting the message.
 const maxControlFrameMsgSize = 123
 
 type (
@@ -177,13 +179,8 @@ func (h *handler) handleAPITopRoutes(w http.ResponseWriter, req *http.Request, p
 // bytes. In the case of an unexpected HTTP status code or unexpected error,
 // truncate the message after `maxControlFrameMsgSize` bytes so that the web
 // socket message is properly written.
-func createTapErrorMessage(err error) string {
+func validateControlFrameMsg(err error) string {
 	log.Debugf("tap error: %s", err.Error())
-
-	// TODO: reconcile this cast and 403 check with the one in handleAPITap
-	if httpErr, ok := err.(protohttp.HTTPError); ok && httpErr.Code == http.StatusForbidden {
-		return fmt.Sprintf("Missing authorization, visit %s to remedy", tap.TapRbacURL)
-	}
 
 	msg := err.Error()
 	if len(msg) > maxControlFrameMsgSize {
@@ -194,7 +191,7 @@ func createTapErrorMessage(err error) string {
 }
 
 func websocketError(ws *websocket.Conn, wsError int, err error) {
-	msg := createTapErrorMessage(err)
+	msg := validateControlFrameMsg(err)
 
 	err = ws.WriteControl(websocket.CloseMessage,
 		websocket.FormatCloseMessage(wsError, msg),
@@ -219,7 +216,7 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 	}
 
 	if messageType != websocket.TextMessage {
-		websocketError(ws, websocket.CloseUnsupportedData, errors.New("MessageType not supported"))
+		websocketError(ws, websocket.CloseUnsupportedData, errors.New("messageType not supported"))
 		return
 	}
 
@@ -243,7 +240,8 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 			// socket with `ClosePolicyViolation` status code so that the error
 			// renders without the error prefix in the banner
 			if httpErr, ok := err.(protohttp.HTTPError); ok && httpErr.Code == http.StatusForbidden {
-				websocketError(ws, websocket.ClosePolicyViolation, err)
+				msg := fmt.Sprintf("Missing authorization, visit %s to remedy", tap.TapRbacURL)
+				websocketError(ws, websocket.ClosePolicyViolation, errors.New(msg))
 				return
 			}
 

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -240,8 +240,8 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 			// socket with `ClosePolicyViolation` status code so that the error
 			// renders without the error prefix in the banner
 			if httpErr, ok := err.(protohttp.HTTPError); ok && httpErr.Code == http.StatusForbidden {
-				msg := fmt.Sprintf("Missing authorization, visit %s to remedy", tap.TapRbacURL)
-				websocketError(ws, websocket.ClosePolicyViolation, errors.New(msg))
+				err := fmt.Errorf("Missing authorization, visit %s to remedy", tap.TapRbacURL)
+				websocketError(ws, websocket.ClosePolicyViolation, err)
 				return
 			}
 

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -240,7 +240,7 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 			// socket with `ClosePolicyViolation` status code so that the error
 			// renders without the error prefix in the banner
 			if httpErr, ok := err.(protohttp.HTTPError); ok && httpErr.Code == http.StatusForbidden {
-				err := fmt.Errorf("Missing authorization, visit %s to remedy", tap.TapRbacURL)
+				err := fmt.Errorf("missing authorization, visit %s to remedy", tap.TapRbacURL)
 				websocketError(ws, websocket.ClosePolicyViolation, err)
 				return
 			}


### PR DESCRIPTION
Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>