### PR TITLE
Fix uninject

### DIFF
--- a/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/admin-port: "1234"
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+status: {}
+---

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -24,6 +24,12 @@ func TestUninjectYAML(t *testing.T) {
 			reportFileName: "inject_emojivoto_deployment_uninject.report",
 		},
 		{
+			// remove all the linkerd.io/* annotations
+			inputFileName:  "inject_emojivoto_deployment_overridden_noinject.golden.yml",
+			goldenFileName: "inject_emojivoto_deployment_uninjected.input.yml",
+			reportFileName: "inject_emojivoto_deployment_uninject.report",
+		},
+		{
 			inputFileName:  "inject_emojivoto_list.golden.yml",
 			goldenFileName: "inject_emojivoto_list.input.yml",
 			reportFileName: "inject_emojivoto_list_uninject.report",


### PR DESCRIPTION
Now that we inject at the pod level by default, `linkerd uninject` should remove the `linkerd.io/inject: enabled` annotation. Also added a test for that.

Fix #3156