### PR TITLE
Add container cpu and mem to heartbeat requests

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -210,7 +210,11 @@ func newInstallOptionsWithDefaults() (*installOptions, error) {
 		},
 
 		heartbeatSchedule: func() string {
-			t := time.Now().Add(5 * time.Minute).UTC()
+			// Some of the heartbeat Prometheus queries rely on 5m resolution, which
+			// means at least 5 minutes of data available. Start the first CronJob 10
+			// minutes after `linkerd install` is run, to give the user 5 minutes to
+			// install.
+			t := time.Now().Add(10 * time.Minute).UTC()
 			return fmt.Sprintf("%d %d * * * ", t.Minute(), t.Hour())
 		},
 	}, nil

--- a/controller/cmd/heartbeat/main.go
+++ b/controller/cmd/heartbeat/main.go
@@ -47,7 +47,7 @@ func main() {
 		log.Errorf("Failed to initialize Prometheus client: %s", err)
 	} else {
 		promAPI := promv1.NewAPI(prometheusClient)
-		promV := heartbeat.PromValues(promAPI)
+		promV := heartbeat.PromValues(promAPI, *controllerNamespace)
 		v = heartbeat.MergeValues(v, promV)
 	}
 

--- a/controller/heartbeat/heartbeat.go
+++ b/controller/heartbeat/heartbeat.go
@@ -41,27 +41,81 @@ func K8sValues(kubeAPI *k8s.KubernetesAPI, controlPlaneNamespace string) url.Val
 }
 
 // PromValues gathers relevant heartbeat information from Prometheus
-func PromValues(promAPI promv1.API) url.Values {
+func PromValues(promAPI promv1.API, controlPlaneNamespace string) url.Values {
 	v := url.Values{}
 
-	value, err := promQuery(promAPI, "sum(irate(request_total{direction=\"inbound\"}[30s]))")
+	jobProxyLabels := model.LabelSet{"job": "linkerd-proxy"}
+
+	// total-rps
+	query := fmt.Sprintf("sum(irate(request_total%s[30s]))", jobProxyLabels.Merge(model.LabelSet{"direction": "inbound"}))
+	value, err := promQuery(promAPI, query, 0)
 	if err != nil {
 		log.Errorf("Prometheus query failed: %s", err)
 	} else {
 		v.Set("total-rps", value)
 	}
 
-	value, err = promQuery(promAPI, "count(count by (pod) (request_total))")
+	// meshed-pods
+	query = fmt.Sprintf("count(count by (pod) (request_total%s))", jobProxyLabels)
+	value, err = promQuery(promAPI, query, 0)
 	if err != nil {
 		log.Errorf("Prometheus query failed: %s", err)
 	} else {
 		v.Set("meshed-pods", value)
 	}
 
+	// container metrics
+	for _, container := range []struct {
+		name model.LabelValue
+		ns   model.LabelValue
+	}{
+		{
+			name: "linkerd-proxy",
+		},
+		{
+			name: "destination",
+			ns:   "linkerd",
+		},
+		{
+			name: "prometheus",
+			ns:   "linkerd",
+		},
+	} {
+		containerLabels := model.LabelSet{
+			"job":            "kubernetes-nodes-cadvisor",
+			"container_name": container.name,
+		}
+		if container.ns != "" {
+			containerLabels["namespace"] = container.ns
+		}
+
+		// max-mem
+		query = fmt.Sprintf("max(container_memory_working_set_bytes%s)", containerLabels)
+		value, err = promQuery(promAPI, query, 0)
+		if err != nil {
+			log.Errorf("Prometheus query failed: %s", err)
+		} else {
+			param := fmt.Sprintf("max-mem-%s", container.name)
+			v.Set(param, value)
+		}
+
+		// p95-cpu
+		query = fmt.Sprintf("max(quantile_over_time(0.95,rate(container_cpu_usage_seconds_total%s[5m])[24h:5m]))", containerLabels)
+		value, err = promQuery(promAPI, query, 3)
+		if err != nil {
+			log.Errorf("Prometheus query failed: %s", err)
+		} else {
+			param := fmt.Sprintf("p95-cpu-%s", container.name)
+			v.Set(param, value)
+		}
+	}
+
 	return v
 }
 
-func promQuery(promAPI promv1.API, query string) (string, error) {
+func promQuery(promAPI promv1.API, query string, precision int) (string, error) {
+	log.Debugf("Prometheus query: %s", query)
+
 	res, err := promAPI.Query(context.Background(), query, time.Time{})
 	if err != nil {
 		return "", err
@@ -77,8 +131,7 @@ func promQuery(promAPI promv1.API, query string) (string, error) {
 			return "", fmt.Errorf("unexpected sample value: %v", result[0].Value)
 		}
 
-		value := int64(math.Round(f))
-		return strconv.FormatInt(value, 10), nil
+		return strconv.FormatFloat(f, 'f', precision, 64), nil
 	}
 
 	return "", fmt.Errorf("unexpected query result type (expected Vector): %s", res.Type())

--- a/controller/heartbeat/heartbeat_test.go
+++ b/controller/heartbeat/heartbeat_test.go
@@ -90,6 +90,7 @@ func TestPromValues(t *testing.T) {
 			url.Values{
 				"total-rps":             []string{"100"},
 				"meshed-pods":           []string{"100"},
+				"p99-handle-us":         []string{"100"},
 				"max-mem-linkerd-proxy": []string{"100"},
 				"max-mem-destination":   []string{"100"},
 				"max-mem-prometheus":    []string{"100"},

--- a/controller/heartbeat/heartbeat_test.go
+++ b/controller/heartbeat/heartbeat_test.go
@@ -74,23 +74,32 @@ data:
 
 func TestPromValues(t *testing.T) {
 	testCases := []struct {
-		promRes  model.Value
-		expected url.Values
+		namespace string
+		promRes   model.Value
+		expected  url.Values
 	}{
 		{
+			"linkerd",
 			model.Vector{
 				&model.Sample{
 					Metric:    model.Metric{"pod": "emojivoto-meshed"},
-					Value:     100.01,
+					Value:     100.1234,
 					Timestamp: 456,
 				},
 			},
 			url.Values{
-				"total-rps":   []string{"100"},
-				"meshed-pods": []string{"100"},
+				"total-rps":             []string{"100"},
+				"meshed-pods":           []string{"100"},
+				"max-mem-linkerd-proxy": []string{"100"},
+				"max-mem-destination":   []string{"100"},
+				"max-mem-prometheus":    []string{"100"},
+				"p95-cpu-linkerd-proxy": []string{"100.123"},
+				"p95-cpu-destination":   []string{"100.123"},
+				"p95-cpu-prometheus":    []string{"100.123"},
 			},
 		},
 		{
+			"bad-ns",
 			model.Vector{},
 			url.Values{},
 		},
@@ -99,7 +108,7 @@ func TestPromValues(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc // pin
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			v := PromValues(&public.MockProm{Res: tc.promRes})
+			v := PromValues(&public.MockProm{Res: tc.promRes}, tc.namespace)
 			if !reflect.DeepEqual(v, tc.expected) {
 				t.Fatalf("PromValues returned: %+v, expected: %+v", v, tc.expected)
 			}


### PR DESCRIPTION
PR #3217 re-introduced container metrics collection to
linkerd-prometheus. This enabled linkerd-heartbeat to collect mem and
cpu metrics at the container-level.

Add container cpu and mem metrics to heartbeat requests. For each of
(destination, prometheus, linkerd-proxy), collect maximum memory and p95
cpu.

Concretely, this introduces 6 new query params to heartbeat requests:
- max-mem-linkerd-proxy
- max-mem-destination
- max-mem-prometheus
- p95-cpu-linkerd-proxy
- p95-cpu-destination
- p95-cpu-prometheus

Part of #2961

Signed-off-by: Andrew Seigner <siggy@buoyant.io>