### PR TITLE
Label and cleanup helm after integration tests

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -10,6 +10,10 @@ if [ -z "${namespaces_controlplane=$(kubectl --context=$k8s_context get ns -onam
   echo "no control-plane namespaces found" >&2
 fi
 
+if [ -z "${namespaces_helm=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-helm)}" ]; then
+  echo "no helm namespaces found" >&2
+fi
+
 echo "cleaning up data-plane namespaces in k8s-context [${k8s_context}]"
 
 if [ -z "${namespaces_dataplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-data-plane)}" ]; then
@@ -18,6 +22,10 @@ fi
 
 if [ -z "${clusterrolebindings=$(kubectl --context=$k8s_context get clusterrolebindings -oname -l linkerd.io/control-plane-ns)}" ]; then
   echo "no clusterrolebindings found" >&2
+fi
+
+if [ -z "${clusterrolebindings_helm=$(kubectl --context=$k8s_context get clusterrolebindings -oname -l linkerd.io/is-test-helm)}" ]; then
+  echo "no helm clusterrolebindings found" >&2
 fi
 
 if [ -z "${clusterroles=$(kubectl --context=$k8s_context get clusterroles -oname -l linkerd.io/control-plane-ns)}" ]; then
@@ -44,8 +52,8 @@ if [ -z "${apiservices=$(kubectl --context=$k8s_context get apiservices -l linke
   echo "no apiservices found" >&2
 fi
 
-if [[ $namespaces_controlplane || $namespaces_dataplane || $clusterrolebindings || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions || $apiservices ]]; then
-  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_dataplane $clusterrolebindings $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions $apiservices
+if [[ $namespaces_controlplane || $namespaces_helm || $namespaces_dataplane || $clusterrolebindings || $clusterrolebindings_helm || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions || $apiservices ]]; then
+  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_helm $namespaces_dataplane $clusterrolebindings $clusterrolebindings_helm $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions $apiservices
 fi
 
 echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"

--- a/bin/test-run
+++ b/bin/test-run
@@ -31,7 +31,7 @@ function remove_l5d_if_exists() {
     cleanup
     printf "[ok]\\n"
   fi
-  
+
   # Cleanup Helm, in case it's there (if not, we ignore the error)
   helm_cleanup &> /dev/null || true
 }
@@ -78,7 +78,9 @@ function run_helm_test() {
     (
         set -e
         kubectl --context=$k8s_context create ns $tiller_namespace
+        kubectl --context=$k8s_context label ns $tiller_namespace linkerd.io/is-test-helm=true
         kubectl --context=$k8s_context create clusterrolebinding ${tiller_namespace}:tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=${tiller_namespace}:default
+        kubectl --context=$k8s_context label clusterrolebinding ${tiller_namespace}:tiller-cluster-admin linkerd.io/is-test-helm=true
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace init --wait
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace dependency update $helm_chart
     )


### PR DESCRIPTION
When helm integration tests fail, `bin/test-run` exits prior to calling
`helm_cleanup`, leaving behind a helm namespace and clusterrolebinding.

Update `bin/test-cleanup` to delete any remaining helm resources.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>