### PR TITLE
Cleanup helm before full test-cleanup

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -144,9 +144,9 @@ cleanup
 
 run_helm_test
 exit_on_err "error testing Helm"
-cleanup
 helm_cleanup
 exit_on_err "error cleaning up Helm"
+cleanup
 
 run_test "$test_directory/install_test.go" -failfast --linkerd-namespace=$linkerd_namespace
 exit_on_err "error during install"


### PR DESCRIPTION
PR #3247 introduced additional helm cleanup in `bin/test-cleanup`.
During the integration tests, `bin/test-cleanup` is called prior to
`helm_cleanup` in `bin/test-run`. This causes `helm_cleanup` to fail, as
resources have already been deleted by `bin/test-cleanup`, and the
integration tests fail with `FAIL: error cleaning up Helm`.

Modify the integration tests to first call `helm_cleanup` prior to
calling `bin/test-cleanup`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>