### PR TITLE
Wait for `helm delete` to finish in integration test

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -92,12 +92,14 @@ function run_helm_test() {
 function helm_cleanup() {
     (
         set -e
+        # `helm delete` deletes $linkerd_namespace-helm
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace delete --purge $helm_release_name
         # `helm delete` doesn't wait for resources to be deleted, so we wait explicitly.
         # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
         # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
         # We don't have that problem with global resources, so no need to wait for them to be gone.
         kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=40s
+        # `helm reset` deletes the tiller pod in $tiller_namespace
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace reset
         kubectl --context=$k8s_context delete clusterrolebinding ${tiller_namespace}:tiller-cluster-admin
         echo $tiller_namespace

--- a/bin/test-run
+++ b/bin/test-run
@@ -93,6 +93,11 @@ function helm_cleanup() {
     (
         set -e
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace delete --purge $helm_release_name
+        # `helm delete` doesn't wait for resources to be deleted, so we wait explicitly.
+        # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
+        # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
+        # We don't have that problem with global resources, so no need to wait for them to be gone.
+        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=40s
         $helm_path --kube-context=$k8s_context --tiller-namespace=$tiller_namespace reset
         kubectl --context=$k8s_context delete clusterrolebinding ${tiller_namespace}:tiller-cluster-admin
         echo $tiller_namespace
@@ -146,6 +151,7 @@ run_helm_test
 exit_on_err "error testing Helm"
 helm_cleanup
 exit_on_err "error cleaning up Helm"
+# clean the data plane test resources
 cleanup
 
 run_test "$test_directory/install_test.go" -failfast --linkerd-namespace=$linkerd_namespace


### PR DESCRIPTION
Followup to #3251

In `helm_cleanup` block till the linkerd namespace has been deleted