### PR TITLE
Fix integration test

### DIFF
--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -99,7 +99,7 @@ func TestNamespaceOverrideAnnotations(t *testing.T) {
 		t.Fatalf("failed to read inject test file: %s", err)
 	}
 
-	injectNS := "inject-namespace-override-test"
+	injectNS := "inj-ns-override-test"
 	deployName := "inject-test-terminus"
 	nsProxyMemReq := "50Mi"
 	nsProxyCPUReq := "200m"


### PR DESCRIPTION
Followup to #3194

The namespace was too long for l5d-bot:

```
    inject_test.go:117: failed to create
    l5d-integration-auto-git-9688d9ba-inject-namespace-override-test
    namespace: Namespace
    "l5d-integration-auto-git-9688d9ba-inject-namespace-override-test"
    is invalid: metadata.name: Invalid value:
    "l5d-integration-auto-git-9688d9ba-inject-namespace-override-test":
    must be no more than 63 characters
```

Signed-off-by: Alejandro Pedraza <alejandro@buoyant.io>