### PR TITLE
Add '--address' flag to 'linkerd dashboard'.

### DIFF
--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -28,11 +28,15 @@ const (
 	// webPort is the http port from the web pod spec in cli/install/template.go
 	webPort = 8084
 
+	// defaultHost is the default host used for port-forwarding via `linkerd dashboard`
+	defaultHost = "localhost"
+
 	// defaultPort is for port-forwarding via `linkerd dashboard`
 	defaultPort = 50750
 )
 
 type dashboardOptions struct {
+	host string
 	port int
 	show string
 	wait time.Duration
@@ -40,6 +44,7 @@ type dashboardOptions struct {
 
 func newDashboardOptions() *dashboardOptions {
 	return &dashboardOptions{
+		host: defaultHost,
 		port: defaultPort,
 		show: showLinkerd,
 		wait: 300 * time.Second,
@@ -79,6 +84,7 @@ func newCmdDashboard() *cobra.Command {
 				k8sAPI,
 				controlPlaneNamespace,
 				webDeployment,
+				options.host,
 				options.port,
 				webPort,
 				verbose,
@@ -132,6 +138,7 @@ func newCmdDashboard() *cobra.Command {
 	}
 
 	// This is identical to what `kubectl proxy --help` reports, `--port 0` indicates a random port.
+	cmd.PersistentFlags().StringVar(&options.host, "address", options.host, "The address at which to serve requests")
 	cmd.PersistentFlags().IntVarP(&options.port, "port", "p", options.port, "The local port on which to serve requests (when set to 0, a random port will be used)")
 	cmd.PersistentFlags().StringVar(&options.show, "show", options.show, "Open a dashboard in a browser or show URLs in the CLI (one of: linkerd, grafana, url)")
 	cmd.PersistentFlags().DurationVar(&options.wait, "wait", options.wait, "Wait for dashboard to become available if it's not available when the command is run")

--- a/controller/api/public/client.go
+++ b/controller/api/public/client.go
@@ -222,6 +222,7 @@ func NewExternalClient(controlPlaneNamespace string, kubeAPI *k8s.KubernetesAPI)
 		kubeAPI,
 		controlPlaneNamespace,
 		apiDeployment,
+		"localhost",
 		0,
 		apiPort,
 		false,

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -154,7 +154,7 @@ status:
 			if err != nil {
 				t.Fatalf("Unexpected error %s", err)
 			}
-			_, err = NewPortForward(&KubernetesAPI{Interface: k8sClient}, test.ns, test.deployName, 0, 0, false)
+			_, err = NewPortForward(&KubernetesAPI{Interface: k8sClient}, test.ns, test.deployName, "localhost", 0, 0, false)
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -346,7 +346,7 @@ func TestInstallSP(t *testing.T) {
 
 func TestDashboard(t *testing.T) {
 	dashboardPort := 52237
-	dashboardURL := fmt.Sprintf("http://127.0.0.1:%d", dashboardPort)
+	dashboardURL := fmt.Sprintf("http://localhost:%d", dashboardPort)
 
 	outputStream, err := TestHelper.LinkerdRunStream("dashboard", "-p",
 		strconv.Itoa(dashboardPort), "--show", "url")

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -258,7 +258,7 @@ func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) 
 		return "", err
 	}
 
-	pf, err := k8s.NewPortForward(k8sAPI, namespace, deployName, 0, remotePort, false)
+	pf, err := k8s.NewPortForward(k8sAPI, namespace, deployName, "localhost", 0, remotePort, false)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR adds a `--address` flag to `linkerd dashboard`, with default value `localhost`, as requested in #3100.

Closes #3100.