### PR TITLE
Sorting the expected response for trafficsplit test

### DIFF
--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -350,6 +350,9 @@ func GenStatTsResponse(resName, resType string, resNs []string, basicStats bool,
 		}
 	}
 
+	// sort rows before returning in order to have a consistent order for tests
+	rows = sortTrafficSplitRows(rows)
+
 	resp := pb.StatSummaryResponse{
 		Response: &pb.StatSummaryResponse_Ok_{ // https://github.com/golang/protobuf/issues/205
 			Ok: &pb.StatSummaryResponse_Ok{


### PR DESCRIPTION
This PR implements sorting for the mock Public API StatSummaryResponse object for `linkerd stat trafficsplit`. This ensures that the order of the expected rows is always consistent when running `stat_summary_test.go`.

Today @kleimkuhler discovered that `stat_summary_test.go` was occasionally failing. Though we have sorting for traffic split rows in `stat_summary.go`, `GenStatTsResponse` in `test_helper.go` -- which generates a mock Public API StatSummaryResponse object -- was *not* being sorted. Thus the `expectedResponse` passed into `testStatSummary` was sometimes swapping the leaf order, causing a test failure. This should resolve the problem.