### PR TITLE
Introduce bin/kind, move executables to target/bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,7 @@ web/web
 web/app/node_modules
 web/app/dist
 web/app/yarn-error.log
-.protoc
 .gorun
-.golangci-lint*
 **/*.gogen*
 **/*.swp
 charts/*/charts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
         - GO111MODULE=on
       cache:
         directories:
-          - target
+          - target/bin
           - "$GOPATH/pkg/mod"
           - "$HOME/.cache"
       before_install:

--- a/bin/helm
+++ b/bin/helm
@@ -4,8 +4,8 @@ set -eu
 
 helmversion=v2.14.3
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
-helmbin=$rootdir/target/helm-$helmversion
+targetbin="$( cd $bindir/.. && pwd )"/target/bin
+helmbin=$targetbin/helm-$helmversion
 
 if [ ! -f $helmbin ]; then
     if [ "$(uname -s)" = "Darwin" ]; then
@@ -21,7 +21,7 @@ if [ ! -f $helmbin ]; then
     helmcurl="https://get.helm.sh/helm-${helmversion}-${os}-${arch}.tar.gz"
     targetdir="${os}-${arch}"
     tmp=$(mktemp -d -t helm.XXX)
-    mkdir -p target
+    mkdir -p "$targetbin"
     (
         cd "$tmp"
         curl -Lsf -o "./helm.tar.gz" "$helmcurl"

--- a/bin/kind
+++ b/bin/kind
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+kindversion=v0.4.0
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+targetbin="$( cd $bindir/.. && pwd )"/target/bin
+kindbin="${targetbin}/.kind-${kindversion}"
+
+if [ ! -f "$kindbin" ]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
+    os=darwin
+    arch=amd64
+  elif [ "$(uname -o)" = "Msys" ]; then
+    os=windows
+    arch=amd64
+  else
+    os=linux
+    case $(uname -m) in
+      x86_64) arch="amd64" ;;
+      arm) arch="arm64" ;;
+    esac
+  fi
+
+  mkdir -p "$targetbin"
+  curl -sfL -o "$kindbin" https://github.com/kubernetes-sigs/kind/releases/download/$kindversion/kind-$os-$arch
+  chmod +x "$kindbin"
+fi
+
+$kindbin "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -8,6 +8,7 @@ cd "$(pwd -P)"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 rootdir="$( cd $bindir/.. && pwd )"
+targetbin="${rootdir}"/target/bin
 
 cd "$rootdir"
 
@@ -20,9 +21,10 @@ elif [ "$(uname -o)" = "Msys" ]; then
   exe=.exe
 fi
 
-lintbin="${rootdir}/.golangci-lint-${lintversion}${exe}"
+lintbin="${targetbin}/.golangci-lint-${lintversion}${exe}"
 
 if [ ! -f "$lintbin" ]; then
+  mkdir -p "$targetbin"
   curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v$lintversion/install.sh | sh -s -- -b . v$lintversion
   mv ./golangci-lint${exe} $lintbin
 fi

--- a/bin/protoc
+++ b/bin/protoc
@@ -9,13 +9,15 @@ else
 fi
 arch=$(uname -m)
 
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+targetbin="$( cd $bindir/.. && pwd )"/target/bin
 protocversion=3.6.0
-protocbin=target/protoc-${protocversion}
+protocbin=${targetbin}/protoc-${protocversion}
 protocurl="https://github.com/google/protobuf/releases/download/v${protocversion}/protoc-${protocversion}-${os}-${arch}.zip"
 
 if [ ! -f "$protocbin" ]; then
   tmp=$(mktemp -d -t protoc.XXX)
-  mkdir -p target
+  mkdir -p "$targetbin"
   (
     cd "$tmp"
     curl -L --silent --fail -o "./protoc.zip" "$protocurl"
@@ -26,4 +28,4 @@ if [ ! -f "$protocbin" ]; then
   rm -rf "$tmp"
 fi
 
-./$protocbin "$@"
+$protocbin "$@"


### PR DESCRIPTION
`bin/helm` and `bin/protoc` were downloading their binaries into
`./target`, while `bin/lint` was downloading to the root of the repo.
Also travis was caching `./target`, which could become problematic if
that part of the test script relied on `target/cli/linux/linkerd`.

Standardize helm, kind, lint, and protoc to all download into
`./target/bin`, and modify travis to strictly cache that subdirectory.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>