### PR TITLE
Require go 1.12.9 for controller builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - language: go
       # Quote the version number to avoid parsing issues like
       # https://github.com/travis-ci/gimme/issues/132.
-      go: "1.12.7"
+      go: "1.12.9"
       go_import_path: github.com/linkerd/linkerd2
       env:
         - GO111MODULE=on
@@ -118,7 +118,7 @@ jobs:
     - stage: integration-test
 
       language: go
-      go: "1.12.7"
+      go: "1.12.9"
       go_import_path: github.com/linkerd/linkerd2
       env:
         - GO111MODULE=on

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.12.7
+FROM golang:1.12.9
 
 WORKDIR /linkerd-build
 

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:773dfbc7 as golang
+FROM gcr.io/linkerd-io/go-deps:df2264ad as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:773dfbc7 as golang
+FROM gcr.io/linkerd-io/go-deps:df2264ad as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:773dfbc7 as golang
+FROM gcr.io/linkerd-io/go-deps:df2264ad as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller services
-FROM gcr.io/linkerd-io/go-deps:773dfbc7 as golang
+FROM gcr.io/linkerd-io/go-deps:df2264ad as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.12
+go 1.12.9
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/linkerd/linkerd2-proxy-api v0.1.9 h1:QIFoVxJEjzPrAhWj2ZwRjUlCjL2VJAtOWAgXJMKEelw=
 github.com/linkerd/linkerd2-proxy-api v0.1.9/go.mod h1:2WJHEYXoww5ALM6c1QspRFiROGZg08tGxCO1js0tTVA=
-github.com/linkerd/linkerd2-proxy-init v1.0.0 h1:FKpZtN1ZUojvps+ZQXDAuebA+78lf7Mt0ekqwYginRA=
-github.com/linkerd/linkerd2-proxy-init v1.0.0/go.mod h1:JNuEmZkYNFgBrd/89LMDRG4vDq3qEeU4qYm33M+UulU=
 github.com/linkerd/linkerd2-proxy-init v1.1.0 h1:CbUNLPcZYBq5NFBDQNhG6R3mCMtMch9Rc4bL4ZHP4tQ=
 github.com/linkerd/linkerd2-proxy-init v1.1.0/go.mod h1:JNuEmZkYNFgBrd/89LMDRG4vDq3qEeU4qYm33M+UulU=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:773dfbc7 as golang
+FROM gcr.io/linkerd-io/go-deps:df2264ad as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
Netflix recently announced a security advisory that identified several
Denial of Service attack vectors that can affect server implementations
of the HTTP/2 protocol, and has issued eight CVEs. [1]

Go is affected by two of the vulnerabilities (CVE-2019-9512 and
CVE-2019-9514) and so Linkerd components that serve HTTP/2 traffic are
also affected. [2]

These vulnerabilities allow untrusted clients to allocate an unlimited
amount of memory, until the server crashes. The Kubernetes Product
Security Committee has assigned this set of vulnerabilities with a CVSS
score of 7.5. [3]

[1] https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-002.md
[2] https://golang.org/doc/devel/release.html#go1.12
[3] https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H