### PR TITLE
Add unit test for edges API endpoint

### DIFF
--- a/cli/cmd/edges_test.go
+++ b/cli/cmd/edges_test.go
@@ -7,107 +7,38 @@ import (
 )
 
 type edgesParamsExp struct {
-	options         *edgesOptions
-	resSrc          []string
-	resSrcNamespace []string
-	resDst          []string
-	resDstNamespace []string
-	resClient       []string
-	resServer       []string
-	resMsg          []string
-	resourceType    string
-	file            string
+	options      *edgesOptions
+	resourceType string
+	file         string
 }
 
 func TestEdges(t *testing.T) {
-	// response content for SRC, DST, SRC_NS, DST_NS, CLIENT_ID, SERVER_ID and MSG
-	var (
-		resSrc = []string{
-			"web",
-			"vote-bot",
-			"web",
-			"linkerd-controller",
-		}
-		resDst = []string{
-			"voting",
-			"web",
-			"emoji",
-			"linkerd-prometheus",
-		}
-		resSrcNamespace = []string{
-			"emojivoto",
-			"emojivoto",
-			"emojivoto",
-			"linkerd",
-		}
-		resDstNamespace = []string{
-			"emojivoto",
-			"emojivoto",
-			"emojivoto",
-			"linkerd",
-		}
-		resClient = []string{
-			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"default.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"linkerd-controller.linkerd.identity.linkerd.cluster.local",
-		}
-		resServer = []string{
-			"voting.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local",
-			"linkerd-prometheus.linkerd.identity.linkerd.cluster.local",
-		}
-		resMsg = []string{"", "", "", ""}
-	)
-
 	options := newEdgesOptions()
 	options.outputFormat = tableOutput
 	options.allNamespaces = true
 	t.Run("Returns edges", func(t *testing.T) {
 		testEdgesCall(edgesParamsExp{
-			options:         options,
-			resourceType:    "deployment",
-			resSrc:          resSrc,
-			resSrcNamespace: resSrcNamespace,
-			resDst:          resDst,
-			resDstNamespace: resDstNamespace,
-			resClient:       resClient,
-			resServer:       resServer,
-			resMsg:          resMsg,
-			file:            "edges_one_output.golden",
+			options:      options,
+			resourceType: "deployment",
+			file:         "edges_one_output.golden",
 		}, t)
 	})
 
 	options.outputFormat = jsonOutput
 	t.Run("Returns edges (json)", func(t *testing.T) {
 		testEdgesCall(edgesParamsExp{
-			options:         options,
-			resourceType:    "deployment",
-			resSrc:          resSrc,
-			resSrcNamespace: resSrcNamespace,
-			resDst:          resDst,
-			resDstNamespace: resDstNamespace,
-			resClient:       resClient,
-			resServer:       resServer,
-			resMsg:          resMsg,
-			file:            "edges_one_output_json.golden",
+			options:      options,
+			resourceType: "deployment",
+			file:         "edges_one_output_json.golden",
 		}, t)
 	})
 
 	t.Run("Returns edges (wide)", func(t *testing.T) {
 		options.outputFormat = wideOutput
 		testEdgesCall(edgesParamsExp{
-			options:         options,
-			resourceType:    "deployment",
-			resSrc:          resSrc,
-			resSrcNamespace: resSrcNamespace,
-			resDst:          resDst,
-			resDstNamespace: resDstNamespace,
-			resClient:       resClient,
-			resServer:       resServer,
-			resMsg:          resMsg,
-			file:            "edges_wide_output.golden",
+			options:      options,
+			resourceType: "deployment",
+			file:         "edges_wide_output.golden",
 		}, t)
 	})
 

--- a/cli/cmd/edges_test.go
+++ b/cli/cmd/edges_test.go
@@ -169,7 +169,7 @@ func TestEdges(t *testing.T) {
 
 func testEdgesCall(exp edgesParamsExp, t *testing.T) {
 	mockClient := &public.MockAPIClient{}
-	response := public.GenEdgesResponse(exp.resourceType, exp.resSrc, exp.resDst, exp.resSrcNamespace, exp.resDstNamespace, exp.resClient, exp.resServer, exp.resMsg)
+	response := public.GenEdgesResponse(exp.resourceType, "all")
 
 	mockClient.EdgesResponseToReturn = &response
 

--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
@@ -189,5 +190,17 @@ func processEdgeMetrics(inbound, outbound model.Vector, resourceType, selectedNa
 		}
 	}
 
+	// sort rows before returning in order to have a consistent order for tests
+	edges = sortEdgeRows(edges)
+
 	return edges
+}
+
+func sortEdgeRows(rows []*pb.Edge) []*pb.Edge {
+	sort.Slice(rows, func(i, j int) bool {
+		keyI := rows[i].Src.Namespace + rows[i].Dst.Namespace + rows[i].Src.Name + rows[i].Dst.Name
+		keyJ := rows[j].Src.Namespace + rows[j].Dst.Namespace + rows[j].Src.Name + rows[j].Dst.Name
+		return keyI < keyJ
+	})
+	return rows
 }

--- a/controller/api/public/edges.go
+++ b/controller/api/public/edges.go
@@ -198,8 +198,8 @@ func processEdgeMetrics(inbound, outbound model.Vector, resourceType, selectedNa
 
 func sortEdgeRows(rows []*pb.Edge) []*pb.Edge {
 	sort.Slice(rows, func(i, j int) bool {
-		keyI := rows[i].Src.Namespace + rows[i].Dst.Namespace + rows[i].Src.Name + rows[i].Dst.Name
-		keyJ := rows[j].Src.Namespace + rows[j].Dst.Namespace + rows[j].Src.Name + rows[j].Dst.Name
+		keyI := rows[i].GetSrc().GetNamespace() + rows[i].GetDst().GetNamespace() + rows[i].GetSrc().GetName() + rows[i].GetDst().GetName()
+		keyJ := rows[j].GetSrc().GetNamespace() + rows[j].GetDst().GetNamespace() + rows[j].GetSrc().GetName() + rows[j].GetDst().GetName()
 		return keyI < keyJ
 	})
 	return rows

--- a/controller/api/public/edges_test.go
+++ b/controller/api/public/edges_test.go
@@ -1,0 +1,171 @@
+package public
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/linkerd/linkerd2/controller/gen/public"
+	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	clientIDLabel = model.LabelName("client_id")
+	serverIDLabel = model.LabelName("server_id")
+)
+
+type edgesExpected struct {
+	expectedStatRPC
+	req              pb.EdgesRequest  // the request we would like to test
+	expectedResponse pb.EdgesResponse // the edges response we expect
+}
+
+func genInboundPromSample(resourceType, resourceNamespace, resourceName, clientID string) *model.Sample {
+	resourceLabel := model.LabelName(resourceType)
+
+	return &model.Sample{
+		Metric: model.Metric{
+			resourceLabel:  model.LabelValue(resourceName),
+			namespaceLabel: model.LabelValue(resourceNamespace),
+			clientIDLabel:  model.LabelValue(clientID),
+		},
+		Value:     123,
+		Timestamp: 456,
+	}
+}
+
+func genOutboundPromSample(resourceType, resourceNamespace, resourceName, resourceNameDst, resourceNamespaceDst, serverID string) *model.Sample {
+	resourceLabel := model.LabelName(resourceType)
+	dstResourceLabel := "dst_" + resourceLabel
+
+	return &model.Sample{
+		Metric: model.Metric{
+			resourceLabel:     model.LabelValue(resourceName),
+			namespaceLabel:    model.LabelValue(resourceNamespace),
+			dstNamespaceLabel: model.LabelValue(resourceNamespaceDst),
+			dstResourceLabel:  model.LabelValue(resourceNameDst),
+			serverIDLabel:     model.LabelValue(serverID),
+		},
+		Value:     123,
+		Timestamp: 456,
+	}
+}
+
+func testEdges(t *testing.T, expectations []edgesExpected) {
+	for _, exp := range expectations {
+		mockProm, fakeGrpcServer, err := newMockGrpcServer(exp.expectedStatRPC)
+		if err != nil {
+			t.Fatalf("Error creating mock grpc server: %s", err)
+		}
+
+		rsp, err := fakeGrpcServer.Edges(context.TODO(), &exp.req)
+		if err != exp.err {
+			t.Fatalf("Expected error: %s, Got: %s", exp.err, err)
+		}
+
+		err = exp.verifyPromQueries(mockProm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rspEdgeRows := rsp.GetOk().Edges
+
+		if len(rspEdgeRows) != len(exp.expectedResponse.GetOk().Edges) {
+			t.Fatalf(
+				"Expected [%d] edge rows, got [%d].\nExpected:\n%s\nGot:\n%s",
+				len(exp.expectedResponse.GetOk().Edges),
+				len(rspEdgeRows),
+				exp.expectedResponse.GetOk().Edges,
+				rspEdgeRows,
+			)
+		}
+
+		for i, st := range rspEdgeRows {
+			expected := exp.expectedResponse.GetOk().Edges[i]
+			if !proto.Equal(st, expected) {
+				t.Fatalf("Expected: %+v\n Got: %+v\n", expected, st)
+			}
+		}
+
+		if !proto.Equal(exp.expectedResponse.GetOk(), rsp.GetOk()) {
+			t.Fatalf("Expected edgesOkResp: %+v\n Got: %+v", &exp.expectedResponse, rsp)
+		}
+	}
+}
+
+func TestEdges(t *testing.T) {
+	mockPromResponse := model.Vector{
+		genInboundPromSample("deployment", "emojivoto", "emoji", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("deployment", "emojivoto", "voting", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("deployment", "emojivoto", "web", "default.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("deployment", "linkerd", "linkerd-prometheus", "linkerd-controller.linkerd.identity.linkerd.cluster.local"),
+
+		genOutboundPromSample("deployment", "emojivoto", "web", "emoji", "emojivoto", "emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("deployment", "emojivoto", "web", "voting", "emojivoto", "voting.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("deployment", "emojivoto", "vote-bot", "web", "emojivoto", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("deployment", "linkerd", "linkerd-controller", "linkerd-prometheus", "linkerd", "linkerd-prometheus.linkerd.identity.linkerd.cluster.local"),
+	}
+
+	t.Run("Successfully returns edges for resource type Deployment and namespace emojivoto", func(t *testing.T) {
+		expectations := []edgesExpected{
+			{
+				expectedStatRPC: expectedStatRPC{
+					err:              nil,
+					mockPromResponse: mockPromResponse,
+				},
+				req: pb.EdgesRequest{
+					Selector: &pb.ResourceSelection{
+						Resource: &pb.Resource{
+							Namespace: "emojivoto",
+							Type:      pkgK8s.Deployment,
+						},
+					},
+				},
+				expectedResponse: GenEdgesResponse("deployment", "emojivoto"),
+			}}
+
+		testEdges(t, expectations)
+	})
+
+	t.Run("Successfully returns edges for resource type Deployment and namespace linkerd", func(t *testing.T) {
+		expectations := []edgesExpected{
+			{
+				expectedStatRPC: expectedStatRPC{
+					err:              nil,
+					mockPromResponse: mockPromResponse,
+				},
+				req: pb.EdgesRequest{
+					Selector: &pb.ResourceSelection{
+						Resource: &pb.Resource{
+							Namespace: "linkerd",
+							Type:      pkgK8s.Deployment,
+						},
+					},
+				},
+				expectedResponse: GenEdgesResponse("deployment", "linkerd"),
+			}}
+
+		testEdges(t, expectations)
+	})
+
+	t.Run("Successfully returns edges for resource type Deployment and all namespaces", func(t *testing.T) {
+		expectations := []edgesExpected{
+			{
+				expectedStatRPC: expectedStatRPC{
+					err:              nil,
+					mockPromResponse: mockPromResponse,
+				},
+				req: pb.EdgesRequest{
+					Selector: &pb.ResourceSelection{
+						Resource: &pb.Resource{
+							Type: pkgK8s.Deployment,
+						},
+					},
+				},
+				expectedResponse: GenEdgesResponse("deployment", "all"),
+			}}
+
+		testEdges(t, expectations)
+	})
+}

--- a/controller/api/public/edges_test.go
+++ b/controller/api/public/edges_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	clientIDLabel = model.LabelName("client_id")
 	serverIDLabel = model.LabelName("server_id")
+	resourceLabel = model.LabelName("deployment")
 )
 
 type edgesExpected struct {
@@ -21,9 +22,7 @@ type edgesExpected struct {
 	expectedResponse pb.EdgesResponse // the edges response we expect
 }
 
-func genInboundPromSample(resourceType, resourceNamespace, resourceName, clientID string) *model.Sample {
-	resourceLabel := model.LabelName(resourceType)
-
+func genInboundPromSample(resourceNamespace, resourceName, clientID string) *model.Sample {
 	return &model.Sample{
 		Metric: model.Metric{
 			resourceLabel:  model.LabelValue(resourceName),
@@ -35,8 +34,7 @@ func genInboundPromSample(resourceType, resourceNamespace, resourceName, clientI
 	}
 }
 
-func genOutboundPromSample(resourceType, resourceNamespace, resourceName, resourceNameDst, resourceNamespaceDst, serverID string) *model.Sample {
-	resourceLabel := model.LabelName(resourceType)
+func genOutboundPromSample(resourceNamespace, resourceName, resourceNameDst, resourceNamespaceDst, serverID string) *model.Sample {
 	dstResourceLabel := "dst_" + resourceLabel
 
 	return &model.Sample{
@@ -96,15 +94,15 @@ func testEdges(t *testing.T, expectations []edgesExpected) {
 
 func TestEdges(t *testing.T) {
 	mockPromResponse := model.Vector{
-		genInboundPromSample("deployment", "emojivoto", "emoji", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genInboundPromSample("deployment", "emojivoto", "voting", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genInboundPromSample("deployment", "emojivoto", "web", "default.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genInboundPromSample("deployment", "linkerd", "linkerd-prometheus", "linkerd-controller.linkerd.identity.linkerd.cluster.local"),
+		genInboundPromSample("emojivoto", "emoji", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("emojivoto", "voting", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("emojivoto", "web", "default.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genInboundPromSample("linkerd", "linkerd-prometheus", "linkerd-controller.linkerd.identity.linkerd.cluster.local"),
 
-		genOutboundPromSample("deployment", "emojivoto", "web", "emoji", "emojivoto", "emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genOutboundPromSample("deployment", "emojivoto", "web", "voting", "emojivoto", "voting.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genOutboundPromSample("deployment", "emojivoto", "vote-bot", "web", "emojivoto", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
-		genOutboundPromSample("deployment", "linkerd", "linkerd-controller", "linkerd-prometheus", "linkerd", "linkerd-prometheus.linkerd.identity.linkerd.cluster.local"),
+		genOutboundPromSample("emojivoto", "web", "emoji", "emojivoto", "emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("emojivoto", "web", "voting", "emojivoto", "voting.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("emojivoto", "vote-bot", "web", "emojivoto", "web.emojivoto.serviceaccount.identity.linkerd.cluster.local"),
+		genOutboundPromSample("linkerd", "linkerd-controller", "linkerd-prometheus", "linkerd", "linkerd-prometheus.linkerd.identity.linkerd.cluster.local"),
 	}
 
 	t.Run("Successfully returns edges for resource type Deployment and namespace emojivoto", func(t *testing.T) {

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -443,21 +443,21 @@ func GenEdgesResponse(resourceType string, edgeRowNamespace string) pb.EdgesResp
 	}
 
 	edges := []*pb.Edge{}
-	for _, i := range edgeRows {
+	for _, row := range edgeRows {
 		edge := &pb.Edge{
 			Src: &pb.Resource{
-				Name:      i.src,
-				Namespace: i.srcNamespace,
-				Type:      i.resourceType,
+				Name:      row.src,
+				Namespace: row.srcNamespace,
+				Type:      row.resourceType,
 			},
 			Dst: &pb.Resource{
-				Name:      i.dst,
-				Namespace: i.dstNamespace,
-				Type:      i.resourceType,
+				Name:      row.dst,
+				Namespace: row.dstNamespace,
+				Type:      row.resourceType,
 			},
-			ClientId:      i.clientID,
-			ServerId:      i.serverID,
-			NoIdentityMsg: i.msg,
+			ClientId:      row.clientID,
+			ServerId:      row.serverID,
+			NoIdentityMsg: row.msg,
 		}
 		edges = append(edges, edge)
 	}

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -430,7 +430,7 @@ var linkerdEdgeRows = []*mockEdgeRow{
 	},
 }
 
-// GenEdgesResponse generates a mock Public API StatSummaryResponse
+// GenEdgesResponse generates a mock Public API EdgesResponse
 // object.
 func GenEdgesResponse(resourceType string, edgeRowNamespace string) pb.EdgesResponse {
 	edgeRows := emojivotoEdgeRows

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -384,7 +384,7 @@ type mockEdgeRow struct {
 
 // a slice of edge rows to generate mock results
 var emojivotoEdgeRows = []*mockEdgeRow{
-	&mockEdgeRow{
+	{
 		resourceType: "deployment",
 		src:          "web",
 		dst:          "voting",
@@ -394,7 +394,7 @@ var emojivotoEdgeRows = []*mockEdgeRow{
 		serverID:     "voting.emojivoto.serviceaccount.identity.linkerd.cluster.local",
 		msg:          "",
 	},
-	&mockEdgeRow{
+	{
 		resourceType: "deployment",
 		src:          "vote-bot",
 		dst:          "web",
@@ -404,7 +404,7 @@ var emojivotoEdgeRows = []*mockEdgeRow{
 		serverID:     "web.emojivoto.serviceaccount.identity.linkerd.cluster.local",
 		msg:          "",
 	},
-	&mockEdgeRow{
+	{
 		resourceType: "deployment",
 		src:          "web",
 		dst:          "emoji",
@@ -418,7 +418,7 @@ var emojivotoEdgeRows = []*mockEdgeRow{
 
 // a slice of edge rows to generate mock results
 var linkerdEdgeRows = []*mockEdgeRow{
-	&mockEdgeRow{
+	{
 		resourceType: "deployment",
 		src:          "linkerd-controller",
 		dst:          "linkerd-prometheus",


### PR DESCRIPTION
Fixes #3052.

This PR adds a unit test for the `edges` API endpoint. 
* `linkerd edges` does not query the K8s API, it just returns Prometheus data, so we do not need k8s configs.
* Because it is important to test specifying a namespace (i.e. `linkerd edges deploy -n emojivoto`), `GenEdgesResponse` now accepts an `edgeRowNamespace` string. This affects both the CLI and API unit test for edges.  
* To maintain consistent test results we add sorting both to the returned edge rows in `api/public/edges.go` and the expected edge rows in `/api/public/test_helper.go`.
* Because I reuse `expectedStatRPC` and `newMockGrpcServer` I generate a single `MockPromResponse` that contains both SRC and DST responses, although `linkerd edges` actually makes 2 separate Prometheus queries. This seemed more efficient than creating multiple new functions based on `newMockGrpcServer` but I'm open to feedback on that.