### PR TITLE
Stop ignoring client-go log entries

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -44,6 +44,8 @@ func setLogLevel(logLevel string) {
 		flag.Set("stderrthreshold", "INFO")
 		flag.Set("logtostderr", "true")
 		flag.Set("v", "6") // At 7 and higher, authorization tokens get logged.
+		// pipe klog entries to logrus
+		klog.SetOutput(log.StandardLogger().Writer())
 	}
 }
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -489,6 +489,8 @@ func TestCheckProxy(t *testing.T) {
 func TestLogs(t *testing.T) {
 	controllerRegex := regexp.MustCompile("level=(panic|fatal|error|warn)")
 	proxyRegex := regexp.MustCompile(fmt.Sprintf("%s (ERR|WARN)", k8s.ProxyContainerName))
+	clientGoRegex := regexp.MustCompile("client-go@")
+	hasClientGoLogs := false
 
 	for deploy, spec := range linkerdDeployReplicas {
 		deploy := strings.TrimPrefix(deploy, "linkerd-")
@@ -537,9 +539,15 @@ func TestLogs(t *testing.T) {
 							}
 						}
 					}
+					if clientGoRegex.MatchString((line)) {
+						hasClientGoLogs = true
+					}
 				}
 			})
 		}
+	}
+	if !hasClientGoLogs {
+		t.Errorf("Didn't find any client-go entries")
 	}
 }
 


### PR DESCRIPTION
Pipe klog output into logrus. Not doing this avoids us from seeing
client-go log entries, for some reason I don't understand.

To enable, `--controller-log-level` must be `debug`.

This was discovered while trying to debug sending events for #3253.

I added an integration test that fails when this piping is not in place.