### PR TITLE
Have the proxy-injector emit events upon injection/skipping injection

### DIFF
--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -13,13 +13,19 @@ metadata:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -141,7 +141,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 	reports := []inject.Report{*report}
 
-	if !report.Injectable() {
+	if b, _ := report.Injectable(); !b {
 		return bytes, reports, nil
 	}
 
@@ -193,7 +193,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 	warningsPrinted := verbose
 
 	for _, r := range reports {
-		if r.Injectable() {
+		if b, _ := r.Injectable(); b {
 			injected = append(injected, r)
 		}
 
@@ -269,7 +269,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 	}
 
 	for _, r := range reports {
-		if r.Injectable() {
+		if b, _ := r.Injectable(); b {
 			output.Write([]byte(fmt.Sprintf("%s \"%s\" injected\n", r.Kind, r.Name)))
 		} else {
 			if r.Kind != "" {

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -322,13 +322,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -322,13 +322,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -302,13 +302,19 @@ metadata:
     ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -302,13 +302,19 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["namespaces"]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["namespaces", "replicationcontrollers"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list"]
-- apiGroups: ["apps"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -433,13 +433,13 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 					pp.log.Errorf("Unable to fetch pod %v: %s", id, err)
 					continue
 				}
-				ownerKind, ownerName := pp.k8sAPI.GetOwnerKindAndName(pod, false)
+				owner := pp.k8sAPI.GetOwnerKindAndName(pod, false)
 				pods[id] = Address{
 					IP:        endpoint.IP,
 					Port:      resolvedPort,
 					Pod:       pod,
-					OwnerName: ownerName,
-					OwnerKind: ownerKind,
+					OwnerName: owner.Name,
+					OwnerKind: owner.Kind,
 				}
 			}
 		}

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -155,21 +156,21 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 			continue
 		}
 
-		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
+		owner := s.k8sAPI.GetOwnerKindAndName(pod, false)
 		// filter out pods without matching owner
 		if targetOwner.GetNamespace() != "" && targetOwner.GetNamespace() != pod.GetNamespace() {
 			continue
 		}
-		if targetOwner.GetType() != "" && targetOwner.GetType() != ownerKind {
+		if targetOwner.GetType() != "" && targetOwner.GetType() != strings.ToLower(owner.Kind) {
 			continue
 		}
-		if targetOwner.GetName() != "" && targetOwner.GetName() != ownerName {
+		if targetOwner.GetName() != "" && targetOwner.GetName() != owner.Name {
 			continue
 		}
 
 		updated, added := reports[pod.Name]
 
-		item := util.K8sPodToPublicPod(*pod, ownerKind, ownerName)
+		item := util.K8sPodToPublicPod(*pod, strings.ToLower(owner.Kind), owner.Name)
 		item.Added = added
 
 		if added {

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -8,8 +8,9 @@ import (
 
 func main() {
 	webhook.Launch(
-		[]k8s.APIResource{k8s.NS, k8s.RS},
+		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod},
 		9995,
 		injector.Inject,
+		"linkerd-proxy-injector",
 	)
 }

--- a/controller/cmd/sp-validator/main.go
+++ b/controller/cmd/sp-validator/main.go
@@ -10,5 +10,6 @@ func main() {
 		nil,
 		9997,
 		validator.AdmitSP,
+		"linkerd-sp-validator",
 	)
 }

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -345,7 +345,7 @@ func (api *API) TS() tsinformers.TrafficSplitInformer {
 // If namespace is an empty string, match objects in all namespaces.
 // If name is an empty string, match all objects of the given type.
 func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, error) {
-	switch restype {
+	switch strings.ToLower(restype) {
 	case k8s.Namespace:
 		return api.getNamespaces(name)
 	case k8s.DaemonSet:
@@ -373,17 +373,17 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 // singular resource type (e.g. deployment, daemonset, job, etc.).
 // If skipCache is false we use the shared informer cache; otherwise we hit the
 // Kubernetes API directly.
-func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, string) {
+func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) *metav1.OwnerReference {
 	ownerRefs := pod.GetOwnerReferences()
 	if len(ownerRefs) == 0 {
 		// pod without a parent
-		return "pod", pod.Name
+		return &metav1.OwnerReference{Kind: "pod", Name: pod.Name}
 	} else if len(ownerRefs) > 1 {
 		log.Debugf("unexpected owner reference count (%d): %+v", len(ownerRefs), ownerRefs)
-		return "pod", pod.Name
+		return &metav1.OwnerReference{Kind: "pod", Name: pod.Name}
 	}
 
-	parent := ownerRefs[0]
+	parent := &ownerRefs[0]
 	if parent.Kind == "ReplicaSet" {
 		var rs *appsv1beta2.ReplicaSet
 		var err error
@@ -400,13 +400,13 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, st
 		}
 
 		if err != nil || len(rs.GetOwnerReferences()) != 1 {
-			return strings.ToLower(parent.Kind), parent.Name
+			return parent
 		}
 		rsParent := rs.GetOwnerReferences()[0]
-		return strings.ToLower(rsParent.Kind), rsParent.Name
+		return &rsParent
 	}
 
-	return strings.ToLower(parent.Kind), parent.Name
+	return parent
 }
 
 // GetPodsFor returns all running and pending Pods associated with a given

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -986,14 +987,14 @@ metadata:
 				}
 
 				pod := objs[0].(*corev1.Pod)
-				ownerKind, ownerName := api.GetOwnerKindAndName(pod, !enableInformers)
+				owner := api.GetOwnerKindAndName(pod, !enableInformers)
 
-				if ownerKind != tt.expectedOwnerKind {
-					t.Fatalf("Expected kind to be [%s], got [%s]", tt.expectedOwnerKind, ownerKind)
+				if strings.ToLower(owner.Kind) != tt.expectedOwnerKind {
+					t.Fatalf("Expected kind to be [%s], got [%s]", tt.expectedOwnerKind, owner.Kind)
 				}
 
-				if ownerName != tt.expectedOwnerName {
-					t.Fatalf("Expected name to be [%s], got [%s]", tt.expectedOwnerName, ownerName)
+				if owner.Name != tt.expectedOwnerName {
+					t.Fatalf("Expected name to be [%s], got [%s]", tt.expectedOwnerName, owner.Name)
 				}
 			})
 		}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -161,8 +161,8 @@ func getFakeReq(b []byte) *admissionv1beta1.AdmissionRequest {
 	}
 }
 
-func ownerRetrieverFake(p *v1.Pod) (string, string) {
-	return pkgK8s.Deployment, "owner-deployment"
+func ownerRetrieverFake(p *v1.Pod) *metav1.OwnerReference {
+	return &metav1.OwnerReference{Kind: pkgK8s.Deployment, Name: "owner-deployment"}
 }
 
 func unmarshalPatch(patchJSON []byte) (unmarshalledPatch, error) {

--- a/controller/sp-validator/webhook.go
+++ b/controller/sp-validator/webhook.go
@@ -5,12 +5,13 @@ import (
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 )
 
 // AdmitSP verifies that the received Admission Request contains a valid
 // Service Profile definition
 func AdmitSP(
-	_ *k8s.API, request *admissionv1beta1.AdmissionRequest,
+	_ *k8s.API, request *admissionv1beta1.AdmissionRequest, _ record.EventRecorder,
 ) (*admissionv1beta1.AdmissionResponse, error) {
 	admissionResponse := &admissionv1beta1.AdmissionResponse{Allowed: true}
 	if err := profiles.Validate(request.Object.Raw); err != nil {

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -524,8 +524,8 @@ func (s *GRPCTapServer) hydrateIPLabels(ip *public.IPAddress, labels map[string]
 		log.Debugf("no pod for IP %s", addr.PublicIPToString(ip))
 		return nil
 	default:
-		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
-		podLabels := pkgK8s.GetPodLabels(ownerKind, ownerName, pod)
+		owner := s.k8sAPI.GetOwnerKindAndName(pod, false)
+		podLabels := pkgK8s.GetPodLabels(owner.Kind, owner.Name, pod)
 		for key, value := range podLabels {
 			labels[key] = value
 		}

--- a/controller/webhook/launcher.go
+++ b/controller/webhook/launcher.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Launch sets up and starts the webhook and metrics servers
-func Launch(APIResources []k8s.APIResource, metricsPort uint32, handler handlerFunc) {
+func Launch(APIResources []k8s.APIResource, metricsPort uint32, handler handlerFunc, component string) {
 	metricsAddr := flag.String("metrics-addr", fmt.Sprintf(":%d", metricsPort), "address to serve scrapable metrics on")
 	addr := flag.String("addr", ":8443", "address to serve on")
 	kubeconfig := flag.String("kubeconfig", "", "path to kubeconfig")
@@ -38,7 +38,7 @@ func Launch(APIResources []k8s.APIResource, metricsPort uint32, handler handlerF
 		log.Fatalf("failed to read TLS secrets: %s", err)
 	}
 
-	s, err := NewServer(k8sAPI, *addr, cred, handler)
+	s, err := NewServer(k8sAPI, *addr, cred, handler, component)
 	if err != nil {
 		log.Fatalf("failed to initialize the webhook server: %s", err)
 	}

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -18,7 +18,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		testServer := &Server{nil, k8sAPI, nil}
+		testServer := &Server{nil, k8sAPI, nil, nil}
 
 		in := bytes.NewReader(nil)
 		request := httptest.NewRequest(http.MethodGet, "/", in)
@@ -38,7 +38,7 @@ func TestServe(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	server := &http.Server{Addr: ":0"}
-	testServer := &Server{server, nil, nil}
+	testServer := &Server{server, nil, nil, nil}
 
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil {

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -16,6 +16,7 @@ func TestInjectable(t *testing.T) {
 		nsAnnotations       map[string]string
 		unsupportedResource bool
 		injectable          bool
+		reason              string
 	}{
 		{
 			podSpec: &corev1.PodSpec{HostNetwork: false},
@@ -34,6 +35,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
+			reason:     "hostNetwork is enabled",
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -50,6 +52,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
+			reason:     "pod has a sidecar injected already",
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -66,6 +69,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
+			reason:     "pod has a sidecar injected already",
 		},
 		{
 			unsupportedResource: true,
@@ -76,6 +80,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
+			reason:     "this resource kind is unsupported",
 		},
 	}
 
@@ -90,8 +95,12 @@ func TestInjectable(t *testing.T) {
 			report := newReport(resourceConfig)
 			report.UnsupportedResource = testCase.unsupportedResource
 
-			if actual := report.Injectable(); testCase.injectable != actual {
+			actual, reason := report.Injectable()
+			if testCase.injectable != actual {
 				t.Errorf("Expected %t. Actual %t", testCase.injectable, actual)
+			}
+			if testCase.reason != reason {
+				t.Errorf("Expected reason '%s'. Actual reason '%s'", testCase.reason, reason)
 			}
 		})
 	}
@@ -194,7 +203,7 @@ func TestDisableByAnnotation(t *testing.T) {
 				resourceConfig.pod.meta = testCase.podMeta
 
 				report := newReport(resourceConfig)
-				if actual := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
+				if actual, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
 					t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 				}
 			})
@@ -235,7 +244,7 @@ func TestDisableByAnnotation(t *testing.T) {
 				resourceConfig.pod.meta = testCase.podMeta
 
 				report := newReport(resourceConfig)
-				if actual := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
+				if actual, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
 					t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 				}
 			})


### PR DESCRIPTION
Fixes #3253

Have the proxy-injector emit an event whenever a injection happens, or
when injection is skipped for some reason (also added that reason into
the proxy-injector logs). The level is associated to the parent workload
(it can't be associated to the pod because at this point the pod hasn't
been persisted).

The event recorder was setup at the `webhook/server.go` level and passed
to the proxy-injector's `Inject` function. The sp-validator thus also
has access to the event recorder, but for now it's not using it.

Related changes:

- Refactored `api.GetOwnerKindAndName()` to have it return a more
generic object.
- Refactored `report.Injectable()` to also have it return the reason why
a workload is not injectable.