### PR TITLE
Move Code of Conduct from wiki to repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+## Linkerd Community Code of Conduct
+
+As a CNCF project, we follow the [CNCF Contributor Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Additionally, we are committed to the following guidelines adapted
+from the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html):
+
+### Community Guidelines
+
+Our goal is to foster an inclusive and diverse community of technology
+enthusiasts.
+
+Try to be your best self. Treat your fellow community members with kindness
+and empathy. We welcome disagreements when they are conducted respectfully and
+without personal attacks.
+
+We ask that you keep unstructured critique to a minimum. Disparaging remarks
+about the project are unnecessary and a drain on community morale. Feedback
+should be constructive and relevant. Having passionately held opinions on what
+should improve is encouraged! We hope you will use that enthusiasm to roll up
+your sleeves and get involved by submitting pull requests. We have additional
+guidelines on
+[how to ask constructive questions](https://github.com/linkerd/linkerd/wiki/How-To-Ask-Questions-in-Slack).
+
+We don't tolerate insults, spamming, trolling, flaming, baiting, or
+harassment. We don't tolerate sexual language, imagery, or unwanted advances.
+Private harassment is also unacceptable.
+
+We do our best to avoid [subtle-isms](https://www.recurse.com/manual#sub-sec-social-rules):
+small actions that make others feel uncomfortable. If you
+witness a subtle-ism, you may respectfully point it out to the person publicly
+or privately, or you may ask a moderator to say something. Accidentally saying
+something biased is common, expected, and readily forgiven. It is not in and
+of itself a bannable offense.
+
+### Moderation
+
+If you feel that a channel needs moderation, please message one of the
+following moderators directly: @alex, @siggy, @olix0r, @kl.
+
+Moderators will issue a warning to users who don't follow the code of conduct.
+A second offense results in a temporary ban, a third warrants a permanent ban.
+It's at the moderator's discretion to un-ban a remorseful user, or immediately
+ban a toxic user without warning. Unjustified bans can be appealed by
+contacting banhammer@buoyant.io.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The complete list of Linkerd repos is:
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.9+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.12+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd


### PR DESCRIPTION
The Linkerd Community Code of Conduct lives in the wiki:
https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
Per Github's Community Profile checklist
(https://github.com/linkerd/linkerd2/community), it should live at the
root of the repo.

Copy the contents of the wiki to a markdown file in the root of the
repo. Once merged, we will modify the wiki to point to the repo.

Also update README.md to indicate k8s 1.12+ is required.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>