### PR TITLE
Emit error when cannot connect to kubernetes

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -243,10 +243,7 @@ resources for the Linkerd control plane. This command should be followed by
   # Install Linkerd into a non-default namespace.
   linkerd install config -l linkerdtest | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err != nil && !options.ignoreCluster {
+			if err := errAfterRunningChecks(options); err != nil && !options.ignoreCluster {
 				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 				} else {
@@ -287,10 +284,7 @@ control plane. It should be run after "linkerd install config".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// check if global resources exist to determine if the `install config`
 			// stage succeeded
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err == nil && !options.skipChecks {
+			if err := errAfterRunningChecks(options); err == nil && !options.skipChecks {
 				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 				} else {
@@ -349,10 +343,7 @@ control plane.`,
   # Installation may also be broken up into two stages by user privilege, via
   # subcommands.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err != nil && !options.ignoreCluster {
+			if err := errAfterRunningChecks(options); err != nil && !options.ignoreCluster {
 				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 				} else {
@@ -820,38 +811,53 @@ func (options *installOptions) proxyConfig() *pb.Proxy {
 	}
 }
 
-func errAfterRunningChecks(options *installOptions, checks []healthcheck.CategoryID) error {
+func errAfterRunningChecks(options *installOptions) error {
+	checks := []healthcheck.CategoryID{
+		healthcheck.KubernetesAPIChecks,
+		healthcheck.LinkerdPreInstallGlobalResourcesChecks,
+	}
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
 		Impersonate:           impersonate,
+		KubeContext:           kubeContext,
+		APIAddr:               apiAddr,
 		NoInitContainer:       options.noInitContainer,
 	})
 
-	var outputError error
+	var k8sAPIError error
+	errMsgs := []string{}
 	hc.RunChecks(func(result *healthcheck.CheckResult) {
 		if result.Err != nil {
 			if ce, ok := result.Err.(*healthcheck.CategoryError); ok {
-				if re, ok := ce.Err.(*healthcheck.ResourceError); ok {
+				if ce.Category == healthcheck.KubernetesAPIChecks {
+					k8sAPIError = ce
+				} else if re, ok := ce.Err.(*healthcheck.ResourceError); ok {
 					// resource error, print in kind.group/name format
-					errMsgs := []string{}
 					for _, res := range re.Resources {
 						errMsgs = append(errMsgs, res.String())
 					}
-					outputError = &healthcheck.CategoryError{Category: ce.Category, Err: errors.New(strings.Join(errMsgs, "\n"))}
 				} else {
-					// unknown error, just print it
-					outputError = ce
+					// unknown category error, just print it
+					errMsgs = append(errMsgs, result.Err.Error())
 				}
 			} else {
 				// unknown error, just print it
-				outputError = result.Err
-
+				errMsgs = append(errMsgs, result.Err.Error())
 			}
 		}
 	})
 
-	return outputError
+	// errors from the KubernetesAPIChecks category take precedence
+	if k8sAPIError != nil {
+		return k8sAPIError
+	}
+
+	if len(errMsgs) > 0 {
+		return errors.New(strings.Join(errMsgs, "\n"))
+	}
+
+	return nil
 }
 
 func errIfLinkerdConfigConfigMapExists() error {

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -828,7 +828,7 @@ func errAfterRunningChecks(options *installOptions, checks []healthcheck.Categor
 		NoInitContainer:       options.noInitContainer,
 	})
 
-	var outputError error = nil
+	var outputError error
 	hc.RunChecks(func(result *healthcheck.CheckResult) {
 		if result.Err != nil {
 			if ce, ok := result.Err.(*healthcheck.CategoryError); ok {

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -87,9 +87,6 @@ If you are sure you'd like to have a fresh install, remove these resources with:
 
 Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
 `
-	errMsgCannotInitializeClient = `Unable to install the Linkerd control plane. Cannot connect to the Kubernetes cluster:
-
-%s`
 
 	errMsgLinkerdConfigConfigMapNotFound = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
 	errMsgGlobalResourcesMissing         = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
@@ -240,15 +237,7 @@ resources for the Linkerd control plane. This command should be followed by
   # Install Linkerd into a non-default namespace.
   linkerd install config -l linkerdtest | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-			}); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				os.Exit(1)
-			}
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err != nil && !options.ignoreCluster {
+			if err := errIfGlobalResourcesExist(options); err != nil && !options.ignoreCluster {
 				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
 				os.Exit(1)
 			}
@@ -285,15 +274,7 @@ control plane. It should be run after "linkerd install config".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// check if global resources exist to determine if the `install config`
 			// stage succeeded
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-			}); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				os.Exit(1)
-			}
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err == nil && !options.skipChecks {
+			if err := errIfGlobalResourcesExist(options); err == nil && !options.skipChecks {
 				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesMissing, controlPlaneNamespace)
 				os.Exit(1)
 			}
@@ -348,15 +329,7 @@ control plane.`,
   # Installation may also be broken up into two stages by user privilege, via
   # subcommands.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.KubernetesAPIChecks,
-			}); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				os.Exit(1)
-			}
-			if err := errAfterRunningChecks(options, []healthcheck.CategoryID{
-				healthcheck.LinkerdPreInstallGlobalResourcesChecks,
-			}); err != nil && !options.ignoreCluster {
+			if err := errIfGlobalResourcesExist(options); err != nil && !options.ignoreCluster {
 				fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
 				os.Exit(1)
 			}
@@ -820,8 +793,13 @@ func (options *installOptions) proxyConfig() *pb.Proxy {
 	}
 }
 
-func errAfterRunningChecks(options *installOptions, checkCategories []healthcheck.CategoryID) error {
-	hc := healthcheck.NewHealthChecker(checkCategories, &healthcheck.Options{
+func errIfGlobalResourcesExist(options *installOptions) error {
+	checks := []healthcheck.CategoryID{
+		healthcheck.KubernetesAPIChecks,
+		healthcheck.LinkerdPreInstallGlobalResourcesChecks,
+	}
+
+	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
 		Impersonate:           impersonate,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -181,9 +181,9 @@ func (e *CategoryError) Error() string {
 }
 
 // IsCategoryError returns true if passed in error is of type CategoryError
-func IsCategoryError(err error, categoryId CategoryID) bool {
+func IsCategoryError(err error, categoryID CategoryID) bool {
 	if ce, ok := err.(*CategoryError); ok {
-		return ce.Category == categoryId
+		return ce.Category == categoryID
 	}
 	return false
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -180,7 +180,7 @@ func (e *CategoryError) Error() string {
 	return e.Err.Error()
 }
 
-// IsCategoryError returns true if passed in error is of type CategoryError
+// IsCategoryError returns true if passed in error is of type CategoryError and belong to the given category
 func IsCategoryError(err error, categoryID CategoryID) bool {
 	if ce, ok := err.(*CategoryError); ok {
 		return ce.Category == categoryID

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -172,7 +172,7 @@ func (e *ResourceError) Error() string {
 // useful when needed to distinguish between errors from multiple categories
 type CategoryError struct {
 	Category CategoryID
-	Err error
+	Err      error
 }
 
 // Error satisfies the error interface for CategoryError.
@@ -180,6 +180,7 @@ func (e *CategoryError) Error() string {
 	return e.Err.Error()
 }
 
+// IsCategoryError returns true if passed in error is of type CategoryError
 func IsCategoryError(err error, categoryId CategoryID) bool {
 	if ce, ok := err.(*CategoryError); ok {
 		return ce.Category == categoryId
@@ -901,7 +902,7 @@ func (hc *HealthChecker) runCheck(categoryID CategoryID, c *checker, observer ch
 		defer cancel()
 		err := c.check(ctx)
 		if err != nil {
-			err = &CategoryError{ categoryID, err }
+			err = &CategoryError{categoryID, err}
 		}
 		checkResult := &CheckResult{
 			Category:    categoryID,
@@ -933,7 +934,7 @@ func (hc *HealthChecker) runCheckRPC(categoryID CategoryID, c *checker, observer
 	defer cancel()
 	checkRsp, err := c.checkRPC(ctx)
 	if err != nil {
-		err = &CategoryError{ categoryID, err }
+		err = &CategoryError{categoryID, err}
 	}
 	observer(&CheckResult{
 		Category:    categoryID,
@@ -952,7 +953,7 @@ func (hc *HealthChecker) runCheckRPC(categoryID CategoryID, c *checker, observer
 			err = fmt.Errorf(check.FriendlyMessageToUser)
 		}
 		if err != nil {
-			err = &CategoryError{ categoryID, err }
+			err = &CategoryError{categoryID, err}
 		}
 		observer(&CheckResult{
 			Category:    categoryID,


### PR DESCRIPTION
Right now when cannot connect to kubernetes, error indicates that there are existing resources in the cluster. This PR introduces separate error message just for checking connectivity to kubernetes.

Fixes #3313

Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>
