### PR TITLE
Fix flakey upgrade integration test

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -205,7 +205,16 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 
 		if out != upgradeFromManifests {
-			t.Fatalf("manifest upgrade differs from k8s upgrade.\nk8s upgrade:\n%s\nmanifest upgrade:\n%s", out, upgradeFromManifests)
+			// retry in case it's just a discrepancy in the heartbeat cron schedule
+			exec := append([]string{cmd}, args...)
+			out, _, err := TestHelper.LinkerdRun(exec...)
+			if err != nil {
+				t.Fatalf("command failed: %v\n%s", exec, out)
+			}
+
+			if out != upgradeFromManifests {
+				t.Fatalf("manifest upgrade differs from k8s upgrade.\nk8s upgrade:\n%s\nmanifest upgrade:\n%s", out, upgradeFromManifests)
+			}
 		}
 	}
 


### PR DESCRIPTION
The `linkerd upgrade` integration test compares the output from two
commands:
- `linkerd upgrade control-plane`
- `linkerd upgrade control-plane --from-manifests`

The output of these commands include the heartbeat cronjob schedule,
which is generated based on the current time.

Modify the upgrade integration test to retry the manifest comparison one
time, assuming that `linkerd upgrade control-plane` should not take more
than one minute to execute.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![Screen Shot 2019-08-27 at 10 20 17 AM](https://user-images.githubusercontent.com/236915/63793878-72131600-c8b5-11e9-967c-91eae0150436.png)
