### PR TITLE
Fix `linkerd edges` and topology graph

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -3,7 +3,6 @@ package watcher
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -434,13 +433,13 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 					pp.log.Errorf("Unable to fetch pod %v: %s", id, err)
 					continue
 				}
-				owner := pp.k8sAPI.GetOwnerKindAndName(pod, false)
+				ownerKind, ownerName := pp.k8sAPI.GetOwnerKindAndName(pod, false)
 				pods[id] = Address{
 					IP:        endpoint.IP,
 					Port:      resolvedPort,
 					Pod:       pod,
-					OwnerName: owner.Name,
-					OwnerKind: strings.ToLower(owner.Kind),
+					OwnerName: ownerName,
+					OwnerKind: ownerKind,
 				}
 			}
 		}

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -159,21 +158,21 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 			continue
 		}
 
-		owner := s.k8sAPI.GetOwnerKindAndName(pod, false)
+		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
 		// filter out pods without matching owner
 		if targetOwner.GetNamespace() != "" && targetOwner.GetNamespace() != pod.GetNamespace() {
 			continue
 		}
-		if targetOwner.GetType() != "" && targetOwner.GetType() != strings.ToLower(owner.Kind) {
+		if targetOwner.GetType() != "" && targetOwner.GetType() != ownerKind {
 			continue
 		}
-		if targetOwner.GetName() != "" && targetOwner.GetName() != owner.Name {
+		if targetOwner.GetName() != "" && targetOwner.GetName() != ownerName {
 			continue
 		}
 
 		updated, added := reports[pod.Name]
 
-		item := util.K8sPodToPublicPod(*pod, strings.ToLower(owner.Kind), owner.Name)
+		item := util.K8sPodToPublicPod(*pod, ownerKind, ownerName)
 		item.Added = added
 
 		if added {

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -345,7 +345,7 @@ func (api *API) TS() tsinformers.TrafficSplitInformer {
 // If namespace is an empty string, match objects in all namespaces.
 // If name is an empty string, match all objects of the given type.
 func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, error) {
-	switch strings.ToLower(restype) {
+	switch restype {
 	case k8s.Namespace:
 		return api.getNamespaces(name)
 	case k8s.DaemonSet:
@@ -373,17 +373,17 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 // singular resource type (e.g. deployment, daemonset, job, etc.).
 // If skipCache is false we use the shared informer cache; otherwise we hit the
 // Kubernetes API directly.
-func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) *metav1.OwnerReference {
+func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, string) {
 	ownerRefs := pod.GetOwnerReferences()
 	if len(ownerRefs) == 0 {
 		// pod without a parent
-		return &metav1.OwnerReference{Kind: k8s.Pod, Name: pod.Name}
+		return "pod", pod.Name
 	} else if len(ownerRefs) > 1 {
 		log.Debugf("unexpected owner reference count (%d): %+v", len(ownerRefs), ownerRefs)
-		return &metav1.OwnerReference{Kind: k8s.Pod, Name: pod.Name}
+		return "pod", pod.Name
 	}
 
-	parent := &ownerRefs[0]
+	parent := ownerRefs[0]
 	if parent.Kind == "ReplicaSet" {
 		var rs *appsv1beta2.ReplicaSet
 		var err error
@@ -400,13 +400,13 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) *metav1.Own
 		}
 
 		if err != nil || len(rs.GetOwnerReferences()) != 1 {
-			return parent
+			return strings.ToLower(parent.Kind), parent.Name
 		}
 		rsParent := rs.GetOwnerReferences()[0]
-		return &rsParent
+		return strings.ToLower(rsParent.Kind), rsParent.Name
 	}
 
-	return parent
+	return strings.ToLower(parent.Kind), parent.Name
 }
 
 // GetPodsFor returns all running and pending Pods associated with a given

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -987,14 +986,14 @@ metadata:
 				}
 
 				pod := objs[0].(*corev1.Pod)
-				owner := api.GetOwnerKindAndName(pod, !enableInformers)
+				ownerKind, ownerName := api.GetOwnerKindAndName(pod, !enableInformers)
 
-				if strings.ToLower(owner.Kind) != tt.expectedOwnerKind {
-					t.Fatalf("Expected kind to be [%s], got [%s]", tt.expectedOwnerKind, owner.Kind)
+				if ownerKind != tt.expectedOwnerKind {
+					t.Fatalf("Expected kind to be [%s], got [%s]", tt.expectedOwnerKind, ownerKind)
 				}
 
-				if owner.Name != tt.expectedOwnerName {
-					t.Fatalf("Expected name to be [%s], got [%s]", tt.expectedOwnerName, owner.Name)
+				if ownerName != tt.expectedOwnerName {
+					t.Fatalf("Expected name to be [%s], got [%s]", tt.expectedOwnerName, ownerName)
 				}
 			})
 		}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 )
@@ -108,7 +107,7 @@ func Inject(api *k8s.API,
 }
 
 func ownerRetriever(api *k8s.API, ns string) inject.OwnerRetrieverFunc {
-	return func(p *v1.Pod) *metav1.OwnerReference {
+	return func(p *v1.Pod) (string, string) {
 		p.SetNamespace(ns)
 		return api.GetOwnerKindAndName(p, true)
 	}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -161,8 +161,8 @@ func getFakeReq(b []byte) *admissionv1beta1.AdmissionRequest {
 	}
 }
 
-func ownerRetrieverFake(p *v1.Pod) *metav1.OwnerReference {
-	return &metav1.OwnerReference{Kind: pkgK8s.Deployment, Name: "owner-deployment"}
+func ownerRetrieverFake(p *v1.Pod) (string, string) {
+	return pkgK8s.Deployment, "owner-deployment"
 }
 
 func unmarshalPatch(patchJSON []byte) (unmarshalledPatch, error) {

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -528,8 +528,8 @@ func (s *GRPCTapServer) hydrateIPLabels(ip *public.IPAddress, labels map[string]
 		log.Debugf("no pod for IP %s", addr.PublicIPToString(ip))
 		return nil
 	default:
-		owner := s.k8sAPI.GetOwnerKindAndName(pod, false)
-		podLabels := pkgK8s.GetPodLabels(owner.Kind, owner.Name, pod)
+		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
+		podLabels := pkgK8s.GetPodLabels(ownerKind, ownerName, pod)
 		for key, value := range podLabels {
 			labels[key] = value
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -51,7 +51,8 @@ const (
 )
 
 // OwnerRetrieverFunc is a function that returns a pod's owner reference
-type OwnerRetrieverFunc func(*corev1.Pod) *metav1.OwnerReference
+// kind and name
+type OwnerRetrieverFunc func(*corev1.Pod) (string, string)
 
 // ResourceConfig contains the parsed information for a given workload
 type ResourceConfig struct {
@@ -348,9 +349,9 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		conf.pod.meta = &v.ObjectMeta
 
 		if conf.ownerRetriever != nil {
-			conf.workload.ownerRef = conf.ownerRetriever(v)
-			name := conf.workload.ownerRef.Name
-			switch strings.ToLower(conf.workload.ownerRef.Kind) {
+			kind, name := conf.ownerRetriever(v)
+			conf.workload.ownerRef = &metav1.OwnerReference{Kind: kind, Name: name}
+			switch kind {
 			case k8s.Deployment:
 				conf.pod.labels[k8s.ProxyDeploymentLabel] = name
 			case k8s.ReplicationController:


### PR DESCRIPTION
Followup to #3316

`api.GetOwnerKindAndName()` was refactored in #3316 and it no longer
returns the resource kind lowercased, so consumers are responsible
for doing that when needed. I had missed doing that in a spot, that was
causing `linkerd edges` and the topology graph to fail.