### PR TITLE
Update warning event regex for integration test

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -85,7 +85,7 @@ var (
 		`(Liveness|Readiness) probe failed: HTTP probe failed with statuscode: 50(2|3)`,
 		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
-		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled \(Client\.Timeout exceeded while awaiting headers\)`,
+		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
 		`Failed to update endpoint .*-upgrade/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
 	}, "|"))
 


### PR DESCRIPTION
Kubernetes was generating events for failed readiness probes that did
not quite match the expected events regex in the install integration
test:
https://travis-ci.org/linkerd/linkerd2/jobs/577642724#L647

Update the readiness probe regex to handle these variations in events:
https://play.golang.org/p/OVGJkFNN-XA

Relates to CI failure in #3333.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>
