### PR TITLE
Avoid the dashboard requesting stats when not needed

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -439,7 +440,7 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 					Port:      resolvedPort,
 					Pod:       pod,
 					OwnerName: owner.Name,
-					OwnerKind: owner.Kind,
+					OwnerKind: strings.ToLower(owner.Kind),
 				}
 			}
 		}

--- a/web/app/js/components/NamespaceLanding.jsx
+++ b/web/app/js/components/NamespaceLanding.jsx
@@ -38,6 +38,7 @@ class NamespaceLanding extends React.Component {
       getCurrentPromises: PropTypes.func.isRequired,
       setCurrentRequests: PropTypes.func.isRequired,
       urlsForResource: PropTypes.func.isRequired,
+      urlsForResourceNoStats: PropTypes.func.isRequired,
     }).isRequired,
     classes: PropTypes.shape({}).isRequired,
     controllerNamespace: PropTypes.string.isRequired
@@ -87,7 +88,7 @@ class NamespaceLanding extends React.Component {
 
     // TODO: make this one request
     let apiRequests = [
-      this.api.fetchMetrics(this.api.urlsForResource("namespace"))
+      this.api.fetchMetrics(this.api.urlsForResourceNoStats("namespace"))
     ];
     if (!_isEmpty(this.state.selectedNs)) {
       apiRequests = apiRequests.concat([

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -75,7 +75,7 @@ export class ResourceListBase extends React.Component {
 
 export default withREST(
   ResourceListBase,
-  ({ api, resource }) => [api.fetchMetrics(api.urlsForResourceNoStats(resource, true))],
+  ({ api, resource }) => [api.fetchMetrics(api.urlsForResource(resource, '', true))],
   {
     resetProps: ['resource'],
   },

--- a/web/app/js/components/ResourceList.jsx
+++ b/web/app/js/components/ResourceList.jsx
@@ -75,7 +75,7 @@ export class ResourceListBase extends React.Component {
 
 export default withREST(
   ResourceListBase,
-  ({ api, resource }) => [api.fetchMetrics(api.urlsForResource(resource, '', true))],
+  ({ api, resource }) => [api.fetchMetrics(api.urlsForResourceNoStats(resource, true))],
   {
     resetProps: ['resource'],
   },

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -69,7 +69,7 @@ class ServiceMesh extends React.Component {
       fetchMetrics: PropTypes.func.isRequired,
       getCurrentPromises: PropTypes.func.isRequired,
       setCurrentRequests: PropTypes.func.isRequired,
-      urlsForResource: PropTypes.func.isRequired,
+      urlsForResourceNoStats: PropTypes.func.isRequired,
     }).isRequired,
     controllerNamespace: PropTypes.string.isRequired,
     productName: PropTypes.string,
@@ -161,7 +161,7 @@ class ServiceMesh extends React.Component {
 
     this.api.setCurrentRequests([
       this.api.fetchPods(this.props.controllerNamespace),
-      this.api.fetchMetrics(this.api.urlsForResource("namespace"))
+      this.api.fetchMetrics(this.api.urlsForResourceNoStats("namespace"))
     ]);
 
     this.serverPromise = Promise.all(this.api.getCurrentPromises())

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -242,7 +242,7 @@ class Tap extends React.Component {
       pendingRequests: true
     });
 
-    let url = this.api.urlsForResource("all");
+    let url = this.api.urlsForResourceNoStats("all");
     this.api.setCurrentRequests([this.api.fetchMetrics(url)]);
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
       .then(([rsp]) => {

--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -92,7 +92,7 @@ class Top extends React.Component {
       pendingRequests: true
     });
 
-    let url = this.api.urlsForResource("all");
+    let url = this.api.urlsForResourceNoStats("all");
     this.api.setCurrentRequests([this.api.fetchMetrics(url)]);
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
       .then(rsp => {

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -109,7 +109,7 @@ class TopRoutes extends React.Component {
     }
     this.setState({ pendingRequests: true });
 
-    let allMetricsUrl = this.api.urlsForResource("all");
+    let allMetricsUrl = this.api.urlsForResourceNoStats("all");
     this.api.setCurrentRequests([
       this.api.fetchServices(),
       this.api.fetchMetrics(allMetricsUrl)

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -139,12 +139,14 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     return resourceUrl;
   };
 
-  const urlsForResourceNoStats = (type, includeTcp) => {
+  const urlsForResourceNoStats = (type, namespace) => {
     // Traffic Performance Summary. This retrieves (non-Prometheus) stats for the given resource.
-    let resourceUrl = '/api/tps-reports?skip_stats=true&all_namespaces=true&resource_type=' + type;
+    let resourceUrl = '/api/tps-reports?skip_stats=true&resource_type=' + type;
 
-    if (includeTcp) {
-      resourceUrl += '&tcp_stats=true';
+    if (_isEmpty(namespace)) {
+      resourceUrl += '&all_namespaces=true';
+    } else {
+      resourceUrl += '&namespace=' + namespace;
     }
 
     return resourceUrl;

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -139,6 +139,17 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     return resourceUrl;
   };
 
+  const urlsForResourceNoStats = (type, includeTcp) => {
+    // Traffic Performance Summary. This retrieves (non-Prometheus) stats for the given resource.
+    let resourceUrl = '/api/tps-reports?skip_stats=true&all_namespaces=true&resource_type=' + type;
+
+    if (includeTcp) {
+      resourceUrl += '&tcp_stats=true';
+    }
+
+    return resourceUrl;
+  };
+
   // maintain a list of a component's requests,
   // convenient for providing a cancel() functionality
   let currentRequests = [];
@@ -222,6 +233,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     getValidMetricsWindows: () => Object.keys(validMetricsWindows),
     getMetricsWindowDisplayText,
     urlsForResource,
+    urlsForResourceNoStats,
     PrefixedLink,
     prefixLink,
     ResourceLink,


### PR DESCRIPTION
Create an alternative to `urlsForResource` called
`urlsForResourceNoStats` that makes use of the `skip_stats` parameter in
the stats API (created in #1871) that doesn't query Prometheus when not needed.

When testing using the dashboard looking at the linkerd namespace,
queries per second went down from 2874 to 2756, a 4% decrease.
