### PR TITLE
Introduce Github Actions CI workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
-    - name: ENV
-      run: env | sort
     - name: Validate go deps
       run: |
         . bin/_tag.sh

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,223 @@
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches:
+    - master
+    - refs/tags/edge-[0-9]?.[0-9]?.[0-9]?
+    - refs/tags/stable-2.[0-9]?.[0-9]?
+
+jobs:
+  validate_go_deps:
+    name: Validate go deps
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: ENV
+      run: env | sort
+    - name: Validate go deps
+      run: |
+        . bin/_tag.sh
+        for f in $( grep -lR --include=Dockerfile\* go-deps: . ) ; do
+          validate_go_deps_tag $f
+        done
+
+  go_unit_tests:
+    name: Go unit tests
+    runs-on: ubuntu-18.04
+    container:
+      image: golang:1.12.9
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Go unit tests
+      env:
+        GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+      run: |
+        echo "$GITCOOKIE_SH" | bash
+        # TODO: validate bin/protoc-go.sh does not dirty the repo
+        go test -cover -race -v -mod=readonly ./...
+
+  go_lint:
+    name: Go lint
+    runs-on: ubuntu-18.04
+    container:
+      image: golang:1.12.9
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Go lint
+      env:
+        GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+        # prevent OOM
+        GOGC: 20
+      run: |
+        echo "$GITCOOKIE_SH" | bash
+        bin/lint --verbose
+
+  js_unit_tests:
+    name: JS unit tests
+    runs-on: ubuntu-18.04
+    container:
+      image: node:10.16.0-stretch
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Yarn setup
+      run: |
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
+    - name: JS unit tests
+      run: |
+        export PATH="$HOME/.yarn/bin:$PATH"
+        export NODE_ENV=test
+        bin/web
+        bin/web test --reporters=jest-dot-reporter
+
+  docker_build:
+    name: Docker build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Docker SSH setup
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST_PRIVATE_KEY: ${{ secrets.DOCKER_HOST_PRIVATE_KEY }}
+      run: |
+        mkdir -p ~/.ssh/
+        echo "$DOCKER_HOST_PRIVATE_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan $DOCKER_ADDRESS >> ~/.ssh/known_hosts
+    - name: Docker build
+      env:
+        DOCKER_HOST: ssh://github@${{ secrets.DOCKER_ADDRESS }}
+      run: |
+        PATH="`pwd`/bin:$PATH" DOCKER_TRACE=1 bin/docker-build
+
+  kind_setup:
+    strategy:
+      matrix:
+        integration_test: [deep, upgrade, helm]
+    name: Cluster setup (${{ matrix.integration_test }})
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Docker SSH setup
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST_PRIVATE_KEY: ${{ secrets.DOCKER_HOST_PRIVATE_KEY }}
+      run: |
+        mkdir -p ~/.ssh/
+        echo "$DOCKER_HOST_PRIVATE_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan $DOCKER_ADDRESS >> ~/.ssh/known_hosts
+    - name: Kind cluster setup
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST: ssh://github@${{ secrets.DOCKER_ADDRESS }}
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        bin/kind create cluster --name=$KIND_CLUSTER
+        scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) github@$DOCKER_ADDRESS:/tmp
+
+  kind_integration:
+    strategy:
+      matrix:
+        integration_test: [deep, upgrade, helm]
+    needs: [docker_build, kind_setup]
+    name: Integration tests (${{ matrix.integration_test }})
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Docker SSH setup
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST_PRIVATE_KEY: ${{ secrets.DOCKER_HOST_PRIVATE_KEY }}
+      run: |
+        mkdir -p ~/.ssh/
+        echo "$DOCKER_HOST_PRIVATE_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan $DOCKER_ADDRESS >> ~/.ssh/known_hosts
+    - name: Kind load docker images
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        ssh -T github@$DOCKER_ADDRESS &> /dev/null << EOF
+          for IMG in controller grafana proxy web ; do
+            # TODO: This is using the kind binary on the remote host.
+            kind load docker-image gcr.io/linkerd-io/\$IMG:$TAG --name=$KIND_CLUSTER
+          done
+        EOF
+    - name: Install linkerd CLI
+      env:
+        DOCKER_HOST: ssh://github@${{ secrets.DOCKER_ADDRESS }}
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        image="gcr.io/linkerd-io/cli-bin:$TAG"
+        id=$(bin/docker create $image)
+        mkdir -p ./target/cli/linux
+        bin/docker cp "$id:/out/linkerd-linux" "./target/cli/linux/linkerd"
+        # validate CLI version matches the repo
+        [[ "$TAG" == "$(bin/linkerd version --short --client)" ]]
+        echo "Installed Linkerd CLI version: $TAG"
+    - name: Run integration tests
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST: ssh://github@${{ secrets.DOCKER_ADDRESS }}
+        GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+      run: |
+        echo "$GITCOOKIE_SH" | bash
+        # TODO: pin Go version
+        go version
+        export PATH="`pwd`/bin:$PATH"
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        # Restore kubeconfig from remote docker host.
+        mkdir -p $HOME/.kube
+        scp github@$DOCKER_ADDRESS:/tmp/kind-config-$KIND_CLUSTER $HOME/.kube
+        export KUBECONFIG=$(bin/kind get kubeconfig-path --name=$KIND_CLUSTER)
+        # Start ssh tunnel to allow kubectl to connect via localhost.
+        export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
+        ssh -4 -N -L $KIND_PORT:localhost:$KIND_PORT github@$DOCKER_ADDRESS &
+        sleep 2 # Wait for ssh tunnel to come up.
+        bin/kubectl version --short # Test connection to kind cluster.
+        (
+          . bin/_test-run.sh
+          init_test_run `pwd`/bin/linkerd
+          ${{ matrix.integration_test }}_integration_tests
+        )
+
+  kind_cleanup:
+    if: always()
+    strategy:
+      matrix:
+        integration_test: [deep, upgrade, helm]
+    needs: [kind_integration]
+    name: Cluster cleanup (${{ matrix.integration_test }})
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Docker SSH setup
+      env:
+        DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}
+        DOCKER_HOST_PRIVATE_KEY: ${{ secrets.DOCKER_HOST_PRIVATE_KEY }}
+      run: |
+        mkdir -p ~/.ssh/
+        echo "$DOCKER_HOST_PRIVATE_KEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        ssh-keyscan $DOCKER_ADDRESS >> ~/.ssh/known_hosts
+    - name: Kind cluster cleanup
+      env:
+        DOCKER_HOST: ssh://github@${{ secrets.DOCKER_ADDRESS }}
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        bin/kind delete cluster --name=$KIND_CLUSTER

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -119,7 +119,7 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
-        bin/kind create cluster --name=$KIND_CLUSTER
+        bin/kind create cluster --name=$KIND_CLUSTER --wait=1m
         scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) github@$DOCKER_ADDRESS:/tmp
 
   kind_integration:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,6 +15,18 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    # for debugging
+    - name: Dump env
+      run: |
+        env | sort
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
     - name: Validate go deps
       run: |
         . bin/_tag.sh
@@ -195,6 +207,7 @@ jobs:
   kind_cleanup:
     if: always()
     strategy:
+      fail-fast: false # always attempt to cleanup all clusters
       matrix:
         integration_test: [deep, upgrade, helm]
     needs: [kind_integration]
@@ -203,6 +216,18 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
+    # for debugging
+    - name: Dump env
+      run: |
+        env | sort
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
     - name: Docker SSH setup
       env:
         DOCKER_ADDRESS: ${{ secrets.DOCKER_ADDRESS }}


### PR DESCRIPTION
The existing Travis CI setup requires additional integrations and
permissions with Github, and also lacks some flexibility around job
dependency management.

Introduce a new CI workflow based on Github Actions. This initial
workflow performs the same CI work that Travis does, and will iniitially
run in parallel:
- Go unit tests
- JS unit tests
- Go lint
- Validate Go deps
- Integration tests (deep, upgrade, helm)

Signed-off-by: Andrew Seigner <siggy@buoyant.io>
