### PR TITLE
Instrumenting Proxy-Injector

### DIFF
--- a/controller/proxy-injector/metrics.go
+++ b/controller/proxy-injector/metrics.go
@@ -1,0 +1,44 @@
+package injector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	labelOwnerKind = "owner_kind"
+	labelNamespace = "namespace"
+	labelSkip      = "skip"
+	labelReason    = "reason"
+)
+
+var (
+	requestLabels  = []string{labelOwnerKind, labelNamespace}
+	responseLabels = []string{labelOwnerKind, labelNamespace, labelSkip, labelReason}
+
+	proxyInjectionAdmissionRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "proxy_inject_admission_requests_total",
+		Help: "A counter for number of admission requests to proxy injector.",
+	}, requestLabels)
+
+	proxyInjectionAdmissionResponses = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "proxy_inject_admission_responses_total",
+		Help: "A counter for number of admission responses from proxy injector.",
+	}, responseLabels)
+)
+
+func admissionRequestLabels(ownerKind, namespace string) prometheus.Labels {
+	return prometheus.Labels{
+		labelOwnerKind: ownerKind,
+		labelNamespace: namespace,
+	}
+}
+
+func admissionResponseLabels(owner, namespace, skip, reason string) prometheus.Labels {
+	return prometheus.Labels{
+		labelOwnerKind: owner,
+		labelNamespace: namespace,
+		labelSkip:      skip,
+		labelReason:    reason,
+	}
+}

--- a/controller/proxy-injector/metrics.go
+++ b/controller/proxy-injector/metrics.go
@@ -11,15 +11,16 @@ import (
 )
 
 const (
-	labelOwnerKind = "owner_kind"
-	labelNamespace = "namespace"
-	labelSkip      = "skip"
-	labelReason    = "skip_reason"
+	labelOwnerKind    = "owner_kind"
+	labelNamespace    = "namespace"
+	labelSkip         = "skip"
+	labelAnnotationAt = "annotation_at"
+	labelReason       = "skip_reason"
 )
 
 var (
-	requestLabels  = []string{labelOwnerKind, labelNamespace}
-	responseLabels = []string{labelOwnerKind, labelNamespace, labelSkip, labelReason}
+	requestLabels  = []string{labelOwnerKind, labelNamespace, labelAnnotationAt}
+	responseLabels = []string{labelOwnerKind, labelNamespace, labelSkip, labelReason, labelAnnotationAt}
 
 	proxyInjectionAdmissionRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "proxy_inject_admission_requests_total",
@@ -32,17 +33,19 @@ var (
 	}, append(responseLabels, validLabelNames(inject.ProxyAnnotations)...))
 )
 
-func admissionRequestLabels(ownerKind, namespace string, configLabels prometheus.Labels) prometheus.Labels {
+func admissionRequestLabels(ownerKind, namespace, annotationAt string, configLabels prometheus.Labels) prometheus.Labels {
 	configLabels[labelOwnerKind] = ownerKind
 	configLabels[labelNamespace] = namespace
+	configLabels[labelAnnotationAt] = annotationAt
 	return configLabels
 }
 
-func admissionResponseLabels(owner, namespace, skip, reason string, configLabels prometheus.Labels) prometheus.Labels {
+func admissionResponseLabels(owner, namespace, skip, reason, annotationAt string, configLabels prometheus.Labels) prometheus.Labels {
 	configLabels[labelOwnerKind] = owner
 	configLabels[labelNamespace] = namespace
 	configLabels[labelSkip] = skip
 	configLabels[labelReason] = reason
+	configLabels[labelAnnotationAt] = annotationAt
 	return configLabels
 }
 

--- a/controller/proxy-injector/metrics.go
+++ b/controller/proxy-injector/metrics.go
@@ -3,6 +3,8 @@ package injector
 import (
 	"strings"
 
+	"github.com/linkerd/linkerd2/pkg/k8s"
+
 	"github.com/linkerd/linkerd2/pkg/inject"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -12,7 +14,7 @@ const (
 	labelOwnerKind = "owner_kind"
 	labelNamespace = "namespace"
 	labelSkip      = "skip"
-	labelReason    = "reason"
+	labelReason    = "skip_reason"
 )
 
 var (
@@ -65,5 +67,5 @@ func validLabelNames(labels []string) []string {
 }
 
 func validProxyConfigurationLabel(label string) string {
-	return strings.Replace(label[18:], "-", "_", -1)
+	return strings.Replace(label[len(k8s.ProxyConfigAnnotationsPrefix)+1:], "-", "_", -1)
 }

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -62,6 +62,7 @@ func Inject(api *k8s.API,
 		Allowed: true,
 	}
 
+	configLabels := configToPrometheusLabels(resourceConfig)
 	var parent *runtime.Object
 	ownerKind := ""
 	if ownerRef := resourceConfig.GetOwnerRef(); ownerRef != nil {
@@ -75,7 +76,7 @@ func Inject(api *k8s.API,
 		}
 		ownerKind = strings.ToLower(ownerRef.Kind)
 	}
-	proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace)).Inc()
+	proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace, configLabels)).Inc()
 
 	if injectable, reasons := report.Injectable(); !injectable {
 		var readableReasons, metricReasons string
@@ -88,7 +89,7 @@ func Inject(api *k8s.API,
 			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", readableReasons)
 		}
 		log.Infof("skipped %s: %s", report.ResName(), readableReasons)
-		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", metricReasons)).Inc()
+		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", metricReasons, configLabels)).Inc()
 		return admissionResponse, nil
 	}
 
@@ -109,7 +110,7 @@ func Inject(api *k8s.API,
 	}
 	log.Infof("patch generated for: %s", report.ResName())
 	log.Debugf("patch: %s", patchJSON)
-	proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "")).Inc()
+	proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "", configLabels)).Inc()
 	patchType := admissionv1beta1.PatchTypeJSONPatch
 	admissionResponse.Patch = patchJSON
 	admissionResponse.PatchType = &patchType

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -76,7 +76,7 @@ func Inject(api *k8s.API,
 		}
 		ownerKind = strings.ToLower(ownerRef.Kind)
 	}
-	proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace, configLabels)).Inc()
+	proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace, report.InjectAnnotationAt, configLabels)).Inc()
 
 	if injectable, reasons := report.Injectable(); !injectable {
 		var readableReasons, metricReasons string
@@ -90,7 +90,7 @@ func Inject(api *k8s.API,
 			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", readableReasons)
 		}
 		log.Infof("skipped %s: %s", report.ResName(), readableReasons)
-		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", metricReasons, configLabels)).Inc()
+		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", metricReasons, report.InjectAnnotationAt, configLabels)).Inc()
 		return admissionResponse, nil
 	}
 
@@ -111,7 +111,7 @@ func Inject(api *k8s.API,
 	}
 	log.Infof("patch generated for: %s", report.ResName())
 	log.Debugf("patch: %s", patchJSON)
-	proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "", configLabels)).Inc()
+	proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "", report.InjectAnnotationAt, configLabels)).Inc()
 	patchType := admissionv1beta1.PatchTypeJSONPatch
 	admissionResponse.Patch = patchJSON
 	admissionResponse.PatchType = &patchType

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -74,8 +74,8 @@ func Inject(api *k8s.API,
 			parent = &objs[0]
 		}
 		ownerKind = strings.ToLower(ownerRef.Kind)
-		proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace)).Inc()
 	}
+	proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace)).Inc()
 
 	if injectable, reason := report.Injectable(); !injectable {
 		if parent != nil {

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -63,6 +63,7 @@ func Inject(api *k8s.API,
 	}
 
 	var parent *runtime.Object
+	ownerKind := ""
 	if ownerRef := resourceConfig.GetOwnerRef(); ownerRef != nil {
 		objs, err := api.GetObjects(request.Namespace, ownerRef.Kind, ownerRef.Name)
 		if err != nil {
@@ -72,40 +73,41 @@ func Inject(api *k8s.API,
 		} else {
 			parent = &objs[0]
 		}
-		proxyInjectionAdmissionRequests.With(admissionRequestLabels(strings.ToLower(ownerRef.Kind), request.Namespace)).Inc()
-
-		if injectable, reason := report.Injectable(); !injectable {
-			if parent != nil {
-				recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", reason)
-			}
-			log.Infof("skipped %s: %s", report.ResName(), reason)
-			proxyInjectionAdmissionResponses.With(admissionResponseLabels(strings.ToLower(ownerRef.Kind), request.Namespace, "true", reason)).Inc()
-			return admissionResponse, nil
-		}
-
-		resourceConfig.AppendPodAnnotations(map[string]string{
-			pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
-		})
-		patchJSON, err := resourceConfig.GetPatch(true)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(patchJSON) == 0 {
-			return admissionResponse, nil
-		}
-
-		if parent != nil {
-			recorder.Event(*parent, v1.EventTypeNormal, eventTypeInjected, "Linkerd sidecar proxy injected")
-		}
-		log.Infof("patch generated for: %s", report.ResName())
-		log.Debugf("patch: %s", patchJSON)
-		proxyInjectionAdmissionResponses.With(admissionResponseLabels(strings.ToLower(ownerRef.Kind), request.Namespace, "false", "")).Inc()
-
-		patchType := admissionv1beta1.PatchTypeJSONPatch
-		admissionResponse.Patch = patchJSON
-		admissionResponse.PatchType = &patchType
+		ownerKind = strings.ToLower(ownerRef.Kind)
+		proxyInjectionAdmissionRequests.With(admissionRequestLabels(ownerKind, request.Namespace)).Inc()
 	}
+
+	if injectable, reason := report.Injectable(); !injectable {
+		if parent != nil {
+			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", reason)
+		}
+		log.Infof("skipped %s: %s", report.ResName(), reason)
+		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", reason)).Inc()
+		return admissionResponse, nil
+	}
+
+	resourceConfig.AppendPodAnnotations(map[string]string{
+		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
+	})
+	patchJSON, err := resourceConfig.GetPatch(true)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(patchJSON) == 0 {
+		return admissionResponse, nil
+	}
+
+	if parent != nil {
+		recorder.Event(*parent, v1.EventTypeNormal, eventTypeInjected, "Linkerd sidecar proxy injected")
+	}
+	log.Infof("patch generated for: %s", report.ResName())
+	log.Debugf("patch: %s", patchJSON)
+	proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "")).Inc()
+	patchType := admissionv1beta1.PatchTypeJSONPatch
+	admissionResponse.Patch = patchJSON
+	admissionResponse.PatchType = &patchType
+
 	return admissionResponse, nil
 }
 

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -2,6 +2,7 @@ package injector
 
 import (
 	"fmt"
+	"strings"
 
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -71,38 +72,40 @@ func Inject(api *k8s.API,
 		} else {
 			parent = &objs[0]
 		}
-	}
+		proxyInjectionAdmissionRequests.With(admissionRequestLabels(strings.ToLower(ownerRef.Kind), request.Namespace)).Inc()
 
-	if injectable, reason := report.Injectable(); !injectable {
-		if parent != nil {
-			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", reason)
+		if injectable, reason := report.Injectable(); !injectable {
+			if parent != nil {
+				recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", reason)
+			}
+			log.Infof("skipped %s: %s", report.ResName(), reason)
+			proxyInjectionAdmissionResponses.With(admissionResponseLabels(strings.ToLower(ownerRef.Kind), request.Namespace, "true", reason)).Inc()
+			return admissionResponse, nil
 		}
-		log.Infof("skipped %s: %s", report.ResName(), reason)
-		return admissionResponse, nil
+
+		resourceConfig.AppendPodAnnotations(map[string]string{
+			pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
+		})
+		patchJSON, err := resourceConfig.GetPatch(true)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(patchJSON) == 0 {
+			return admissionResponse, nil
+		}
+
+		if parent != nil {
+			recorder.Event(*parent, v1.EventTypeNormal, eventTypeInjected, "Linkerd sidecar proxy injected")
+		}
+		log.Infof("patch generated for: %s", report.ResName())
+		log.Debugf("patch: %s", patchJSON)
+		proxyInjectionAdmissionResponses.With(admissionResponseLabels(strings.ToLower(ownerRef.Kind), request.Namespace, "false", "")).Inc()
+
+		patchType := admissionv1beta1.PatchTypeJSONPatch
+		admissionResponse.Patch = patchJSON
+		admissionResponse.PatchType = &patchType
 	}
-
-	resourceConfig.AppendPodAnnotations(map[string]string{
-		pkgK8s.CreatedByAnnotation: fmt.Sprintf("linkerd/proxy-injector %s", version.Version),
-	})
-	patchJSON, err := resourceConfig.GetPatch(true)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(patchJSON) == 0 {
-		return admissionResponse, nil
-	}
-
-	if parent != nil {
-		recorder.Event(*parent, v1.EventTypeNormal, eventTypeInjected, "Linkerd sidecar proxy injected")
-	}
-	log.Infof("patch generated for: %s", report.ResName())
-	log.Debugf("patch: %s", patchJSON)
-
-	patchType := admissionv1beta1.PatchTypeJSONPatch
-	admissionResponse.Patch = patchJSON
-	admissionResponse.PatchType = &patchType
-
 	return admissionResponse, nil
 }
 

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -80,10 +80,11 @@ func Inject(api *k8s.API,
 
 	if injectable, reasons := report.Injectable(); !injectable {
 		var readableReasons, metricReasons string
-		metricReasons = strings.Join(reasons, ", ")
+		metricReasons = strings.Join(reasons, ",")
 		for _, reason := range reasons {
 			readableReasons = readableReasons + ", " + inject.Reasons[reason]
 		}
+		// removing the initial comma, space
 		readableReasons = readableReasons[2:]
 		if parent != nil {
 			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", readableReasons)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -29,7 +29,34 @@ const (
 	proxyInitResourceLimitMemory   = "50Mi"
 )
 
-var rTrail = regexp.MustCompile(`\},\s*\]`)
+var (
+	rTrail = regexp.MustCompile(`\},\s*\]`)
+
+	// ProxyAnnotations is the list of possible annotations that can be applied on a pod or namespace
+	ProxyAnnotations = []string{
+		k8s.ProxyAdminPortAnnotation,
+		k8s.ProxyControlPortAnnotation,
+		k8s.ProxyDisableIdentityAnnotation,
+		k8s.ProxyDisableTapAnnotation,
+		k8s.ProxyEnableDebugAnnotation,
+		k8s.ProxyEnableExternalProfilesAnnotation,
+		k8s.ProxyImagePullPolicyAnnotation,
+		k8s.ProxyInboundPortAnnotation,
+		k8s.ProxyInitImageAnnotation,
+		k8s.ProxyInitImageVersionAnnotation,
+		k8s.ProxyOutboundPortAnnotation,
+		k8s.ProxyCPULimitAnnotation,
+		k8s.ProxyCPURequestAnnotation,
+		k8s.ProxyImageAnnotation,
+		k8s.ProxyLogLevelAnnotation,
+		k8s.ProxyMemoryLimitAnnotation,
+		k8s.ProxyMemoryRequestAnnotation,
+		k8s.ProxyUIDAnnotation,
+		k8s.ProxyVersionAnnotation,
+		k8s.ProxyIgnoreInboundPortsAnnotation,
+		k8s.ProxyIgnoreOutboundPortsAnnotation,
+	}
+)
 
 // Origin defines where the input YAML comes from. Refer the ResourceConfig's
 // 'origin' field
@@ -781,6 +808,16 @@ func (conf *ResourceConfig) proxyOutboundSkipPorts() string {
 		ports = append(ports, portStr)
 	}
 	return strings.Join(ports, ",")
+}
+
+// GetOverriddenConfiguration returns a map of the overridden proxy annotations
+func (conf *ResourceConfig) GetOverriddenConfiguration() map[string]string {
+	proxyOverrideConfig := map[string]string{}
+	for _, annotation := range ProxyAnnotations {
+		proxyOverrideConfig[annotation] = conf.getOverride(annotation)
+	}
+
+	return proxyOverrideConfig
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -52,7 +52,7 @@ var (
 		k8s.ProxyMemoryLimitAnnotation,
 		k8s.ProxyMemoryRequestAnnotation,
 		k8s.ProxyUIDAnnotation,
-		k8s.ProxyVersionAnnotation,
+		k8s.ProxyVersionOverrideAnnotation,
 		k8s.ProxyIgnoreInboundPortsAnnotation,
 		k8s.ProxyIgnoreOutboundPortsAnnotation,
 	}

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -125,6 +125,8 @@ func checkUDPPorts(t *v1.PodSpec) bool {
 	return false
 }
 
+// disabledByAnnotation checks annotations for both workload, namespace and returns
+// if disabled, Inject Disabled reason and the resource where that annotation was present
 func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string, string) {
 	// truth table of the effects of the inject annotation:
 	//
@@ -152,7 +154,7 @@ func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string, string
 
 	if nsAnnotation == k8s.ProxyInjectEnabled {
 		if podAnnotation == k8s.ProxyInjectDisabled {
-			return true, injectDisableAnnotationPresent, annotationAtNamespace
+			return true, injectDisableAnnotationPresent, annotationAtWorkload
 		}
 		return false, "", annotationAtNamespace
 	}

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -73,13 +73,13 @@ func (r *Report) ResName() string {
 func (r *Report) Injectable() (bool, string) {
 	reasons := []string{}
 	if r.HostNetwork {
-		reasons = append(reasons, "hostNetwork is enabled")
+		reasons = append(reasons, "host_network_enabled")
 	}
 	if r.Sidecar {
-		reasons = append(reasons, "pod has a sidecar injected already")
+		reasons = append(reasons, "sidecar_already_exists")
 	}
 	if r.UnsupportedResource {
-		reasons = append(reasons, "this resource kind is unsupported")
+		reasons = append(reasons, "unsupported_resource")
 	}
 	if r.InjectDisabled {
 		reasons = append(reasons, r.InjectDisabledReason)
@@ -130,13 +130,13 @@ func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string) {
 
 	if nsAnnotation == k8s.ProxyInjectEnabled {
 		if podAnnotation == k8s.ProxyInjectDisabled {
-			return true, fmt.Sprintf("pod has the annotation \"%s:%s\"", k8s.ProxyInjectAnnotation, k8s.ProxyInjectDisabled)
+			return true, "injection_disable_annotation_present"
 		}
 		return false, ""
 	}
 
 	if podAnnotation != k8s.ProxyInjectEnabled {
-		return true, fmt.Sprintf("neither the namespace nor the pod have the annotation \"%s:%s\"", k8s.ProxyInjectAnnotation, k8s.ProxyInjectEnabled)
+		return true, "injection_enable_annotation_absent"
 	}
 
 	return false, ""

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -9,6 +9,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+const (
+	hostNetworkEnabled             = "host_network_enabled"
+	sidecarExists                  = "sidecar_already_exists"
+	unsupportedResource            = "unsupported_resource"
+	injectEnableAnnotationAbsent   = "injection_enable_annotation_absent"
+	injectDisableAnnotationPresent = "injection_disable_annotation_present"
+)
+
 // Report contains the Kind and Name for a given workload along with booleans
 // describing the result of the injection transformation
 type Report struct {
@@ -73,13 +81,13 @@ func (r *Report) ResName() string {
 func (r *Report) Injectable() (bool, string) {
 	reasons := []string{}
 	if r.HostNetwork {
-		reasons = append(reasons, "host_network_enabled")
+		reasons = append(reasons, hostNetworkEnabled)
 	}
 	if r.Sidecar {
-		reasons = append(reasons, "sidecar_already_exists")
+		reasons = append(reasons, sidecarExists)
 	}
 	if r.UnsupportedResource {
-		reasons = append(reasons, "unsupported_resource")
+		reasons = append(reasons, unsupportedResource)
 	}
 	if r.InjectDisabled {
 		reasons = append(reasons, r.InjectDisabledReason)
@@ -130,13 +138,13 @@ func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string) {
 
 	if nsAnnotation == k8s.ProxyInjectEnabled {
 		if podAnnotation == k8s.ProxyInjectDisabled {
-			return true, "injection_disable_annotation_present"
+			return true, injectDisableAnnotationPresent
 		}
 		return false, ""
 	}
 
 	if podAnnotation != k8s.ProxyInjectEnabled {
-		return true, "injection_enable_annotation_absent"
+		return true, injectEnableAnnotationAbsent
 	}
 
 	return false, ""

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -18,6 +18,7 @@ const (
 )
 
 var (
+	// Reasons is a map of inject skip reasons with human readable sentences
 	Reasons = map[string]string{
 		hostNetworkEnabled:             "hostNetwork is enabled",
 		sidecarExists:                  "pod has a sidecar injected already",

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -278,7 +278,7 @@ func TestDisableByAnnotation(t *testing.T) {
 				resourceConfig.pod.meta = testCase.podMeta
 
 				report := newReport(resourceConfig)
-				if actual, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
+				if actual, _, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
 					t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 				}
 			})
@@ -319,7 +319,7 @@ func TestDisableByAnnotation(t *testing.T) {
 				resourceConfig.pod.meta = testCase.podMeta
 
 				report := newReport(resourceConfig)
-				if actual, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
+				if actual, _, _ := report.disableByAnnotation(resourceConfig); testCase.expected != actual {
 					t.Errorf("Expected %t. Actual %t", testCase.expected, actual)
 				}
 			})

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -171,7 +171,7 @@ func TestInjectable(t *testing.T) {
 				t.Errorf("Expected %d number of reasons. Actual %d", len(testCase.reasons), len(reasons))
 			}
 
-			for i, _ := range reasons {
+			for i := range reasons {
 				if testCase.reasons[i] != reasons[i] {
 					t.Errorf("Expected reason '%s'. Actual reason '%s'", testCase.reasons[i], reasons[i])
 				}

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -35,7 +35,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
-			reason:     "hostNetwork is enabled",
+			reason:     hostNetworkEnabled,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -52,7 +52,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
-			reason:     "pod has a sidecar injected already",
+			reason:     sidecarExists,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -69,7 +69,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
-			reason:     "pod has a sidecar injected already",
+			reason:     sidecarExists,
 		},
 		{
 			unsupportedResource: true,
@@ -80,7 +80,7 @@ func TestInjectable(t *testing.T) {
 				},
 			},
 			injectable: false,
-			reason:     "this resource kind is unsupported",
+			reason:     unsupportedResource,
 		},
 	}
 


### PR DESCRIPTION
Fixes #3060 

Example Metrics
```
# HELP proxy_inject_admission_requests_total A counter for number of admission requests to proxy injector
# TYPE proxy_inject_admission_requests_total counter
proxy_inject_admission_requests_total{namespace="emojivoto",owner_kind="deployment"} 4
proxy_inject_admission_requests_total{namespace="mem-example",owner_kind="pod"} 1
# HELP proxy_inject_admission_responses_total A counter for number of admission responses from proxy injector
# TYPE proxy_inject_admission_responses_total counter
proxy_inject_admission_responses_total{namespace="emojivoto",owner_kind="deployment",reason="",skip="false"} 4
proxy_inject_admission_responses_total{namespace="mem-example",owner_kind="pod",reason="injection_enable_annotation_absent",skip="true"} 1
```

@ihcsim @grampelberg 

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
