### PR TITLE
Add support for k8s 1.16

### DIFF
--- a/cli/cmd/testdata/inject_contour.input.yml
+++ b/cli/cmd/testdata/inject_contour.input.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -163,7 +163,7 @@ spec:
         name: linkerd-identity-end-entity
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -328,7 +328,7 @@ spec:
         name: linkerd-identity-end-entity
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -493,7 +493,7 @@ spec:
         name: linkerd-identity-end-entity
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -37,7 +37,7 @@ spec:
         name: linkerd-proxy
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -74,7 +74,7 @@ spec:
       - name: linkerd-proxy
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -113,7 +113,7 @@ spec:
         name: linkerd-init
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -163,7 +163,7 @@ spec:
         name: linkerd-identity-end-entity
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -34,7 +34,7 @@ spec:
         resources: {}
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.input.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_istio.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_istio.input.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 items:
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null
@@ -164,7 +164,7 @@ items:
             medium: Memory
           name: linkerd-identity-end-entity
   status: {}
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_list.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.input.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 items:
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null
@@ -35,7 +35,7 @@ items:
             name: http
           resources: {}
   status: {}
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 items:
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null
@@ -164,7 +164,7 @@ items:
             medium: Memory
           name: linkerd-identity-end-entity
   status: {}
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     creationTimestamp: null

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.input.yml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 items:
-  - apiVersion: apps/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       creationTimestamp: null
@@ -36,7 +36,7 @@ items:
                   name: http
               resources: {}
     status: {}
-  - apiVersion: apps/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       creationTimestamp: null

--- a/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
   template:
@@ -19,7 +19,7 @@ spec:
         ports:
         - containerPort: 9090
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: get-test-deploy-injected-2

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -1,9 +1,10 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: get-test-deploy-injected-1
 spec:
+  selector: null
   strategy: {}
   template:
     metadata:
@@ -165,12 +166,13 @@ spec:
         name: linkerd-identity-end-entity
 status: {}
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   name: get-test-deploy-injected-2
 spec:
+  selector: null
   strategy: {}
   template:
     metadata:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: get-test-deploy-injected-1
@@ -21,7 +21,7 @@ spec:
         ports:
         - containerPort: 9090
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: get-test-deploy-injected-2

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -147,7 +147,7 @@ data:
 # This manifest installs the linkerd CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: linkerd-cni
   namespace: linkerd

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -147,7 +147,7 @@ data:
 # This manifest installs the linkerd CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: linkerd-cni
   namespace: other

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -147,7 +147,7 @@ data:
 # This manifest installs the linkerd CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: linkerd-cni
   namespace: other

--- a/cli/install/cni-template.go
+++ b/cli/install/cni-template.go
@@ -169,7 +169,7 @@ data:
 # This manifest installs the linkerd CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: linkerd-cni
   namespace: {{.Namespace}}

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -97,7 +97,7 @@ metadata:
   labels:
     pod-template-hash: hash-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: ReplicaSet
     name: rs-emojivoto-meshed
 status:
@@ -112,20 +112,20 @@ metadata:
   labels:
     pod-template-hash: hash-not-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: ReplicaSet
     name: rs-emojivoto-not-meshed
 status:
   phase: Pending
   podIP: 4.3.2.1
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: rs-emojivoto-meshed
   namespace: emojivoto
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: meshed-deployment
 spec:
@@ -133,13 +133,13 @@ spec:
     matchLabels:
       pod-template-hash: hash-meshed
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: rs-emojivoto-not-meshed
   namespace: emojivoto
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: not-meshed-deployment
 spec:
@@ -244,7 +244,7 @@ metadata:
   labels:
     pod-template-hash: hash-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: meshed-deployment
 status:
@@ -280,7 +280,7 @@ metadata:
   labels:
     pod-template-hash: hash-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: meshed-deployment
 status:
@@ -327,7 +327,7 @@ metadata:
   labels:
     pod-template-hash: hash-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: meshed-deployment
 status:
@@ -371,7 +371,7 @@ metadata:
   labels:
     pod-template-hash: hash-meshed
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     name: meshed-deployment
 status:

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -294,7 +294,7 @@ status:
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emoji
@@ -310,7 +310,7 @@ spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: a1b2c3d4
@@ -1123,7 +1123,7 @@ status:
 				expectedStatRPC: expectedStatRPC{
 					err: nil,
 					k8sConfigs: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emoji-deploy
@@ -1139,7 +1139,7 @@ spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: a1b2c3d4
@@ -1572,7 +1572,7 @@ status:
 					expectedStatRPC: expectedStatRPC{
 						err: nil,
 						k8sConfigs: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emoji
@@ -1588,7 +1588,7 @@ spec:
       containers:
       - image: buoyantio/emojivoto-emoji-svc:v3
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: a1b2c3d4

--- a/controller/api/public/top_routes_test.go
+++ b/controller/api/public/top_routes_test.go
@@ -14,7 +14,7 @@ import (
 
 // deployment/books
 var booksDeployConfig = []string{`kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: books
   namespace: default
@@ -33,7 +33,7 @@ spec:
       containers:
       - image: buoyantio/booksapp:v0.0.2
 `, `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: a1b2c3d4

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +28,6 @@ import (
 	"k8s.io/client-go/informers"
 	arinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	appv1informers "k8s.io/client-go/informers/apps/v1"
-	appv1beta2informers "k8s.io/client-go/informers/apps/v1beta2"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -63,7 +61,7 @@ type API struct {
 	Client kubernetes.Interface
 
 	cm       coreinformers.ConfigMapInformer
-	deploy   appv1beta2informers.DeploymentInformer
+	deploy   appv1informers.DeploymentInformer
 	ds       appv1informers.DaemonSetInformer
 	endpoint coreinformers.EndpointsInformer
 	job      batchv1informers.JobInformer
@@ -71,7 +69,7 @@ type API struct {
 	ns       coreinformers.NamespaceInformer
 	pod      coreinformers.PodInformer
 	rc       coreinformers.ReplicationControllerInformer
-	rs       appv1beta2informers.ReplicaSetInformer
+	rs       appv1informers.ReplicaSetInformer
 	sp       spinformers.ServiceProfileInformer
 	ss       appv1informers.StatefulSetInformer
 	svc      coreinformers.ServiceInformer
@@ -162,7 +160,7 @@ func NewAPI(
 			api.cm = sharedInformers.Core().V1().ConfigMaps()
 			api.syncChecks = append(api.syncChecks, api.cm.Informer().HasSynced)
 		case Deploy:
-			api.deploy = sharedInformers.Apps().V1beta2().Deployments()
+			api.deploy = sharedInformers.Apps().V1().Deployments()
 			api.syncChecks = append(api.syncChecks, api.deploy.Informer().HasSynced)
 		case DS:
 			api.ds = sharedInformers.Apps().V1().DaemonSets()
@@ -186,7 +184,7 @@ func NewAPI(
 			api.rc = sharedInformers.Core().V1().ReplicationControllers()
 			api.syncChecks = append(api.syncChecks, api.rc.Informer().HasSynced)
 		case RS:
-			api.rs = sharedInformers.Apps().V1beta2().ReplicaSets()
+			api.rs = sharedInformers.Apps().V1().ReplicaSets()
 			api.syncChecks = append(api.syncChecks, api.rs.Informer().HasSynced)
 		case SP:
 			api.sp = spSharedInformers.Linkerd().V1alpha2().ServiceProfiles()
@@ -231,7 +229,7 @@ func (api *API) NS() coreinformers.NamespaceInformer {
 }
 
 // Deploy provides access to a shared informer and lister for Deployments.
-func (api *API) Deploy() appv1beta2informers.DeploymentInformer {
+func (api *API) Deploy() appv1informers.DeploymentInformer {
 	if api.deploy == nil {
 		panic("Deploy informer not configured")
 	}
@@ -255,7 +253,7 @@ func (api *API) SS() appv1informers.StatefulSetInformer {
 }
 
 // RS provides access to a shared informer and lister for ReplicaSets.
-func (api *API) RS() appv1beta2informers.ReplicaSetInformer {
+func (api *API) RS() appv1informers.ReplicaSetInformer {
 	if api.rs == nil {
 		panic("RS informer not configured")
 	}
@@ -385,10 +383,10 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, skipCache bool) (string, st
 
 	parent := ownerRefs[0]
 	if parent.Kind == "ReplicaSet" {
-		var rs *appsv1beta2.ReplicaSet
+		var rs *appsv1.ReplicaSet
 		var err error
 		if skipCache {
-			rs, err = api.Client.AppsV1beta2().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
+			rs, err = api.Client.AppsV1().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
 			if err != nil {
 				log.Warnf("failed to retrieve replicaset from indexer %s/%s: %s", pod.Namespace, parent.Name, err)
 			}
@@ -428,7 +426,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
 		ownerUID = typed.UID
 
-	case *appsv1beta2.Deployment:
+	case *appsv1.Deployment:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
 		ret, err := api.RS().Lister().ReplicaSets(namespace).List(selector)
@@ -446,7 +444,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 		}
 		return pods, nil
 
-	case *appsv1beta2.ReplicaSet:
+	case *appsv1.ReplicaSet:
 		namespace = typed.Namespace
 		selector = labels.Set(typed.Spec.Selector.MatchLabels).AsSelector()
 		ownerUID = typed.UID
@@ -527,13 +525,13 @@ func GetNameAndNamespaceOf(obj runtime.Object) (string, string, error) {
 	case *appsv1.DaemonSet:
 		return typed.Name, typed.Namespace, nil
 
-	case *appsv1beta2.Deployment:
+	case *appsv1.Deployment:
 		return typed.Name, typed.Namespace, nil
 
 	case *batchv1.Job:
 		return typed.Name, typed.Namespace, nil
 
-	case *appsv1beta2.ReplicaSet:
+	case *appsv1.ReplicaSet:
 		return typed.Name, typed.Namespace, nil
 
 	case *corev1.ReplicationController:
@@ -600,16 +598,16 @@ func (api *API) getNamespaces(name string) ([]runtime.Object, error) {
 
 func (api *API) getDeployments(namespace, name string) ([]runtime.Object, error) {
 	var err error
-	var deploys []*appsv1beta2.Deployment
+	var deploys []*appsv1.Deployment
 
 	if namespace == "" {
 		deploys, err = api.Deploy().Lister().List(labels.Everything())
 	} else if name == "" {
 		deploys, err = api.Deploy().Lister().Deployments(namespace).List(labels.Everything())
 	} else {
-		var deploy *appsv1beta2.Deployment
+		var deploy *appsv1.Deployment
 		deploy, err = api.Deploy().Lister().Deployments(namespace).Get(name)
-		deploys = []*appsv1beta2.Deployment{deploy}
+		deploys = []*appsv1.Deployment{deploy}
 	}
 
 	if err != nil {

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -124,14 +124,14 @@ metadata:
 				resType:   k8s.Deployment,
 				name:      "",
 				k8sResResults: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-deploy
   namespace: my-ns`,
 				},
 				k8sResMisc: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-deploy
@@ -394,7 +394,7 @@ func TestGetPodsFor(t *testing.T) {
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emoji
@@ -506,7 +506,7 @@ status:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: emoji
@@ -591,7 +591,7 @@ status:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -621,7 +621,7 @@ status:
   phase: Running`,
 				},
 				k8sResMisc: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: deploymentRS
@@ -640,7 +640,7 @@ spec:
     matchLabels:
       app: emoji-svc
       pod-template-hash: deploymentPod`,
-					`apiVersion: apps/v1beta2
+					`apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: deploymentRSOld
@@ -665,7 +665,7 @@ spec:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -681,7 +681,7 @@ spec:
       app: emoji-svc`,
 				k8sResResults: []string{},
 				k8sResMisc: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: AnotherRS
@@ -706,7 +706,7 @@ spec:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -749,7 +749,7 @@ status:
   phase: Running`,
 				},
 				k8sResMisc: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: RS1
@@ -768,7 +768,7 @@ spec:
     matchLabels:
       app: emoji-svc
       pod-template-hash: pod1`,
-					`apiVersion: apps/v1beta2
+					`apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: RS2
@@ -793,7 +793,7 @@ spec:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -822,7 +822,7 @@ status:
   phase: Running`,
 				},
 				k8sResMisc: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   uid: validRS
@@ -905,17 +905,17 @@ metadata:
   name: t2-5f79f964bc-d5jvf
   namespace: default
   ownerReferences:
-  - apiVersion: apps/v1beta2
+  - apiVersion: apps/v1
     kind: ReplicaSet
     name: t2-5f79f964bc`,
 			extraConfigs: []string{`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
   name: t2-5f79f964bc
   namespace: default
   ownerReferences:
-  - apiVersion: apps/v1beta2
+  - apiVersion: apps/v1
     kind: Deployment
     name: t2`,
 			},
@@ -930,7 +930,7 @@ metadata:
   name: t1-b4f55d87f-98dbz
   namespace: default
   ownerReferences:
-  - apiVersion: apps/v1beta2
+  - apiVersion: apps/v1
     kind: ReplicaSet
     name: t1-b4f55d87f`,
 		},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -393,7 +393,7 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "can create Deployments",
 					hintAnchor:  "pre-k8s",
 					check: func(context.Context) error {
-						return hc.checkCanCreate(hc.ControlPlaneNamespace, "extensions", "v1beta1", "deployments")
+						return hc.checkCanCreate(hc.ControlPlaneNamespace, "apps", "v1", "deployments")
 					},
 				},
 				{

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -322,7 +322,7 @@ func TestHealthChecker(t *testing.T) {
 }
 
 func TestCheckCanCreate(t *testing.T) {
-	exp := fmt.Errorf("not authorized to access deployments.extensions")
+	exp := fmt.Errorf("not authorized to access deployments.apps")
 
 	hc := NewHealthChecker(
 		[]CategoryID{},
@@ -333,7 +333,7 @@ func TestCheckCanCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
-	err = hc.checkCanCreate("", "extensions", "v1beta1", "deployments")
+	err = hc.checkCanCreate("", "apps", "v1", "deployments")
 	if err == nil ||
 		err.Error() != exp.Error() {
 		t.Fatalf("Unexpected error (Expected: %s, Got: %s)", exp, err)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -15,7 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,15 +216,15 @@ func (conf *ResourceConfig) GetPatch(injectProxy bool) ([]byte, error) {
 func (conf *ResourceConfig) getFreshWorkloadObj() runtime.Object {
 	switch strings.ToLower(conf.workload.metaType.Kind) {
 	case k8s.Deployment:
-		return &v1beta1.Deployment{}
+		return &appsv1.Deployment{}
 	case k8s.ReplicationController:
 		return &corev1.ReplicationController{}
 	case k8s.ReplicaSet:
-		return &v1beta1.ReplicaSet{}
+		return &appsv1.ReplicaSet{}
 	case k8s.Job:
 		return &batchv1.Job{}
 	case k8s.DaemonSet:
-		return &v1beta1.DaemonSet{}
+		return &appsv1.DaemonSet{}
 	case k8s.StatefulSet:
 		return &appsv1.StatefulSet{}
 	case k8s.Pod:
@@ -279,7 +278,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 	obj := conf.getFreshWorkloadObj()
 
 	switch v := obj.(type) {
-	case *v1beta1.Deployment:
+	case *appsv1.Deployment:
 		if err := yaml.Unmarshal(bytes, v); err != nil {
 			return err
 		}
@@ -299,7 +298,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		conf.pod.labels[k8s.ProxyReplicationControllerLabel] = v.Name
 		conf.complete(v.Spec.Template)
 
-	case *v1beta1.ReplicaSet:
+	case *appsv1.ReplicaSet:
 		if err := yaml.Unmarshal(bytes, v); err != nil {
 			return err
 		}
@@ -319,7 +318,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 		conf.pod.labels[k8s.ProxyJobLabel] = v.Name
 		conf.complete(&v.Spec.Template)
 
-	case *v1beta1.DaemonSet:
+	case *appsv1.DaemonSet:
 		if err := yaml.Unmarshal(bytes, v); err != nil {
 			return err
 		}

--- a/pkg/k8s/authz_test.go
+++ b/pkg/k8s/authz_test.go
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cr-test
 rules:
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["list"]`,
 				`
@@ -37,7 +37,7 @@ subjects:
   name: system:unauthenticated
   apiGroup: rbac.authorization.k8s.io`,
 			},
-			errors.New("not authorized to access deployments.extensions"),
+			errors.New("not authorized to access deployments.apps"),
 		},
 	}
 
@@ -48,7 +48,7 @@ subjects:
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
-			err = ResourceAuthz(k8sClient, "", "list", "extensions", "v1beta1", "deployments", "")
+			err = ResourceAuthz(k8sClient, "", "list", "apps", "v1", "deployments", "")
 			if err != nil || test.err != nil {
 				if (err == nil && test.err != nil) ||
 					(err != nil && test.err == nil) ||

--- a/pkg/k8s/fake_test.go
+++ b/pkg/k8s/fake_test.go
@@ -16,7 +16,7 @@ func TestNewFakeAPI(t *testing.T) {
 
 	k8sConfigs := []string{
 		`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dep-name
@@ -44,13 +44,13 @@ spec:
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	deploy, err := api.AppsV1beta2().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
+	deploy, err := api.AppsV1().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   "apps",
-		Version: "v1beta2",
+		Version: "v1",
 		Kind:    "Deployment",
 	}
 	if !reflect.DeepEqual(deploy.GroupVersionKind(), gvk) {
@@ -74,7 +74,7 @@ spec:
 func TestNewFakeAPIFromManifests(t *testing.T) {
 	k8sConfigs := []string{
 		`
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dep-name
@@ -107,13 +107,13 @@ spec:
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	deploy, err := api.AppsV1beta2().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
+	deploy, err := api.AppsV1().Deployments("dep-ns").Get("dep-name", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 	gvk := schema.GroupVersionKind{
 		Group:   "apps",
-		Version: "v1beta2",
+		Version: "v1",
 		Kind:    "Deployment",
 	}
 	if !reflect.DeepEqual(deploy.GroupVersionKind(), gvk) {

--- a/test/egress/testdata/proxy.yaml
+++ b/test/egress/testdata/proxy.yaml
@@ -1,6 +1,6 @@
 #POST
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: egress-test-https-post
@@ -40,7 +40,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: egress-test-http-post
@@ -81,7 +81,7 @@ spec:
     targetPort: 8080
 #GET
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: egress-test-https-get
@@ -121,7 +121,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: egress-test-http-get
@@ -162,7 +162,7 @@ spec:
     targetPort: 8080
 ## Non www domains
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: egress-test-not-www-get

--- a/test/get/testdata/not_to_be_injected_application.yaml
+++ b/test/get/testdata/not_to_be_injected_application.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-get-test-not-injected-d1
@@ -25,7 +25,7 @@ spec:
         ports:
         - containerPort: 90
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-get-test-not-injected-d2

--- a/test/get/testdata/to_be_injected_application.yaml
+++ b/test/get/testdata/to_be_injected_application.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-get-test-d1
@@ -25,7 +25,7 @@ spec:
         ports:
         - containerPort: 90
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-get-test-d2

--- a/test/inject/testdata/inject_test.yaml
+++ b/test/inject/testdata/inject_test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inject-test-terminus

--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/test/serviceprofiles/testdata/hello_world.yaml
+++ b/test/serviceprofiles/testdata/hello_world.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
@@ -35,7 +35,7 @@ spec:
     port: 8888
     targetPort: 8888
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: world

--- a/test/serviceprofiles/testdata/tap_application.yaml
+++ b/test/serviceprofiles/testdata/tap_application.yaml
@@ -5,7 +5,7 @@
 
 ### t1 terminates gRPC requests
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t1
@@ -43,7 +43,7 @@ spec:
 
 ### t2 terminates gRPC requests and always fails
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t2
@@ -82,7 +82,7 @@ spec:
 
 # t3 terminates HTTP/1.1 requests
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t3
@@ -121,7 +121,7 @@ spec:
 
 ### gateway broadcasts requests to t1, t2, and t3
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gateway

--- a/test/tap/testdata/tap_application.yaml
+++ b/test/tap/testdata/tap_application.yaml
@@ -6,7 +6,7 @@
 
 ### t1 terminates gRPC requests
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t1
@@ -44,7 +44,7 @@ spec:
 
 ### t2 terminates gRPC requests and always fails
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t2
@@ -83,7 +83,7 @@ spec:
 
 # t3 terminates HTTP/1.1 requests
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t3
@@ -121,7 +121,7 @@ spec:
 
 # t4 terminates HTTP/1.1 requests, but tap is disabled
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: t4
@@ -161,7 +161,7 @@ spec:
 
 ### gateway broadcasts requests to t1, t2, t3 and t4
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gateway

--- a/test/testdata/smoke_test.yaml
+++ b/test/testdata/smoke_test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: smoke-test-terminus
@@ -32,7 +32,7 @@ spec:
     port: 9090
     targetPort: 9090
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: smoke-test-gateway

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -102,7 +102,7 @@ func (h *KubernetesHelper) Kubectl(stdin string, arg ...string) (string, error) 
 // getDeployments gets all deployments with a count of their ready replicas in
 // the specified namespace.
 func (h *KubernetesHelper) getDeployments(namespace string) (map[string]int, error) {
-	deploys, err := h.clientset.AppsV1beta2().Deployments(namespace).List(metav1.ListOptions{})
+	deploys, err := h.clientset.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (h *KubernetesHelper) GetPods(namespace string, podLabels map[string]string
 
 // GetPodsForDeployment returns all pods for the given deployment
 func (h *KubernetesHelper) GetPodsForDeployment(namespace string, deploymentName string) ([]corev1.Pod, error) {
-	deploy, err := h.clientset.AppsV1beta2().Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
+	deploy, err := h.clientset.AppsV1().Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #3356

1.16 removes some api groups that were already deprecated. From k8s blog
post (https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/):

```
- PodSecurityPolicy: will no longer be served from extensions/v1beta1 in
v1.16.
    Migrate to the policy/v1beta1 API, available since v1.10. Existing
    persisted data can be retrieved/updated via the policy/v1beta1 API.
- DaemonSet, Deployment, StatefulSet, and ReplicaSet: will no longer be
served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16.
    Migrate to the apps/v1 API, available since v1.9. Existing persisted
    data can be retrieved/updated via the apps/v1 API.
```

Previous PRs had already made this change at the Helm templates level,
but we still needed to do it at the API calls and tests.

The integration tests ran fine for k8s 1.12 and 1.15. They fail on 1.16
because the upgrade integration test tries to install linkerd 2.5 which is not
compatible with 1.16.
