### PR TITLE
Adding "external link" icons to sidebar menu items if appropriate

### DIFF
--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,4 +1,5 @@
 import { githubIcon, linkerdWordLogo, slackIcon } from './util/SvgWrappers.jsx';
+
 import AppBar from '@material-ui/core/AppBar';
 import Badge from '@material-ui/core/Badge';
 import BreadcrumbHeader from './BreadcrumbHeader.jsx';
@@ -27,9 +28,11 @@ import Typography from '@material-ui/core/Typography';
 import Version from './Version.jsx';
 import _maxBy from 'lodash/maxBy';
 import classNames from 'classnames';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt';
 import { faMicroscope } from '@fortawesome/free-solid-svg-icons/faMicroscope';
 import { faRandom } from '@fortawesome/free-solid-svg-icons/faRandom';
 import { faStream } from '@fortawesome/free-solid-svg-icons/faStream';
+import grey from '@material-ui/core/colors/grey';
 import { withContext } from './util/AppContext.jsx';
 import { withStyles } from '@material-ui/core/styles';
 import yellow from '@material-ui/core/colors/yellow';
@@ -128,6 +131,10 @@ const styles = theme => {
       fontSize: "18px",
       paddingLeft: "3px",
       paddingRight: "3px",
+    },
+    // color is consistent with Octopus Graph coloring
+    externalLinkIcon: {
+      color: grey[500],
     },
     badge: {
       backgroundColor: yellow[500],
@@ -300,6 +307,7 @@ class NavigationBase extends React.Component {
             <MenuItem component="a" href="https://linkerd.io/2/overview/" target="_blank" className={classes.navMenuItem}>
               <ListItemIcon><LibraryBooksIcon className={classes.shrinkIcon} /></ListItemIcon>
               <ListItemText primary="Documentation" />
+              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
             </MenuItem>
             { this.menuItem("/community", "Community",
               <Badge
@@ -311,17 +319,20 @@ class NavigationBase extends React.Component {
               ) }
             <MenuItem component="a" href="https://lists.cncf.io/g/cncf-linkerd-users" target="_blank" className={classes.navMenuItem}>
               <ListItemIcon><EmailIcon className={classes.shrinkIcon} /></ListItemIcon>
-              <ListItemText primary="Join the Mailing List" />
+              <ListItemText primary="Mailing List" />
+              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
             </MenuItem>
 
             <MenuItem component="a" href="https://slack.linkerd.io" target="_blank" className={classes.navMenuItem}>
               <ListItemIcon>{slackIcon}</ListItemIcon>
-              <ListItemText primary="Join us on Slack" />
+              <ListItemText primary="Slack" />
+              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
             </MenuItem>
 
             <MenuItem component="a" href="https://github.com/linkerd/linkerd2/issues/new/choose" target="_blank" className={classes.navMenuItem}>
               <ListItemIcon>{githubIcon}</ListItemIcon>
               <ListItemText primary="File an Issue" />
+              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
             </MenuItem>
           </MenuList>
 

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,5 +1,4 @@
 import { githubIcon, linkerdWordLogo, slackIcon } from './util/SvgWrappers.jsx';
-
 import AppBar from '@material-ui/core/AppBar';
 import Badge from '@material-ui/core/Badge';
 import BreadcrumbHeader from './BreadcrumbHeader.jsx';


### PR DESCRIPTION
Fixes #2693. 

Adds an "external link" icon to sidebar menu items that take you out of the dashboard. For consistency, the link color is the same light grey as the Octopus graph arrows.

Because this icon increases the width of the menu item, `Join The Mailing List` is now `Mailing List` and `Join Us On Slack` is now `Slack`.

Original:

<img width="233" alt="Screen Shot 2019-09-03 at 6 28 44 PM" src="https://user-images.githubusercontent.com/2289389/64219016-b041a400-ce78-11e9-8ecf-8a4a00d8e8a2.png">

Now:

<img width="237" alt="Screen Shot 2019-09-03 at 6 24 42 PM" src="https://user-images.githubusercontent.com/2289389/64218878-3a3d3d00-ce78-11e9-91fd-fbd1b866b575.png">
