### PR TITLE
GitHub Actions, kind, integration test logs fixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -131,7 +131,9 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
-        bin/kind create cluster --name=$KIND_CLUSTER --wait=1m
+        # retry cluster creation once in case of port conflict or kubeadm failure
+        bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
         scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) github@$DOCKER_ADDRESS:/tmp
 
   kind_integration:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,9 @@ jobs:
         - |
           # create kind cluster
           export KIND_CLUSTER=travis-$TRAVIS_BUILD_ID-$INTEGRATION_TEST
-          bin/kind create cluster --name=$KIND_CLUSTER
+          # retry cluster creation once in case of port conflict or kubeadm failure
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
         - |
           # Save kubeconfig to remote docker host for kind integration test stages.
           scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) $USER@$REMOTE_DOCKER:/tmp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Linkerd][logo]
 
 [![Build Status][ci-badge]][ci]
+[![GitHub Actions Status][github-actions-badge]][github-actions]
 [![GitHub license][license-badge]](LICENSE)
 [![Go Report Card][go-report-card-badge]][go-report-card]
 [![Slack Status][slack-badge]][slack]
@@ -75,6 +76,8 @@ specific language governing permissions and limitations under the License.
 <!-- refs -->
 [ci]: https://travis-ci.org/linkerd/linkerd2
 [ci-badge]: https://travis-ci.org/linkerd/linkerd2.svg?branch=master
+[github-actions]: https://github.com/linkerd/linkerd2/actions
+[github-actions-badge]: https://github.com/linkerd/linkerd2/workflows/CI/badge.svg
 [cncf]: https://www.cncf.io/
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [getting-started]: https://linkerd.io/2/getting-started/

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -533,7 +533,12 @@ func TestLogs(t *testing.T) {
 				// does not return 10,000 after 2 seconds. We don't need 10,000 log lines.
 				outputLines, _ := outputStream.ReadUntil(10000, 2*time.Second)
 				if len(outputLines) == 0 {
-					t.Errorf("No logs found for %s", name)
+					// Retry one time for 30 more seconds, in case the cluster is slow to
+					// produce log lines.
+					outputLines, _ = outputStream.ReadUntil(10000, 30*time.Second)
+					if len(outputLines) == 0 {
+						t.Errorf("No logs found for %s", name)
+					}
 				}
 
 				for _, line := range outputLines {


### PR DESCRIPTION
PR #3339 introduced a GitHub Actions CI workflow. Booting 6 clusters
simultaneously (3x Github Actions + 3x Travis) exhibits some transient
failures.

Implement fixes in GitHub Actions and integration tests to address kind
cluster creation and testing:
- Retry kind cluster creation once.
- Retry log reading from integration k8s clusters once.
- Add kind cluster creation debug logging.
- Add a GitHub Actions status badge to the top of `README.md`.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

![Screen Shot 2019-09-03 at 6 31 27 PM](https://user-images.githubusercontent.com/236915/64219143-11697780-ce79-11e9-9134-a31276daa92a.png)
