### PR TITLE
Decrease proxy and web Docker image sizes

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -3,7 +3,7 @@
 # This means that all Linkerd containers share a common set of tools, and furthermore, they
 # are highly cacheable at runtime.
 
-FROM debian:stretch-20190204-slim
+FROM debian:stretch-20190812-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM gcr.io/linkerd-io/base:2019-02-19.01
+FROM gcr.io/linkerd-io/base:2019-09-04.01
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tcpdump \
     iproute2 \

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,7 +1,7 @@
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2019-02-19.01
+ARG RUNTIME_IMAGE=debian:stretch-20190812-slim
 
-FROM gcr.io/linkerd-io/base:2019-02-19.01 as fetch
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:stretch-20190812-slim as fetch
+RUN apt-get update && apt-get install -y ca-certificates curl
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy
 COPY .proxy-version proxy-version
@@ -16,13 +16,13 @@ COPY pkg/tls pkg/tls
 COPY pkg/version pkg/version
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly ./pkg/...
 COPY proxy-identity proxy-identity
-RUN CGO_ENABLED=0 GOOS=linux go install -mod=readonly ./proxy-identity
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity
 
 FROM $RUNTIME_IMAGE as runtime
 COPY --from=fetch /build/target/proxy/LICENSE /usr/lib/linkerd/LICENSE
 COPY --from=fetch /build/proxy-version /usr/lib/linkerd/linkerd2-proxy-version.txt
 COPY --from=fetch /build/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
-COPY --from=golang /go/bin/proxy-identity /usr/lib/linkerd/linkerd2-proxy-identity
+COPY --from=golang /out/proxy-identity /usr/lib/linkerd/linkerd2-proxy-identity
 COPY proxy-identity/run-proxy.sh /usr/bin/linkerd2-proxy-run
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -14,7 +14,7 @@ rootdir="$( cd $bindir/.. && pwd )"
 
 . $bindir/_docker.sh
 
-tag="2019-02-19.01"
+tag="2019-09-04.01"
 
 if (docker_pull base "${tag}"); then
     echo "$(docker_repo base):${tag}"

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -18,7 +18,6 @@ dockerfile=$rootdir/cli/Dockerfile-bin
 validate_go_deps_tag $dockerfile
 
 (
-    $bindir/docker-build-base
     $bindir/docker-build-go-deps
 ) >/dev/null
 

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -18,7 +18,6 @@ dockerfile=$rootdir/controller/Dockerfile
 validate_go_deps_tag $dockerfile
 
 (
-    $bindir/docker-build-base
     $bindir/docker-build-go-deps
 ) >/dev/null
 

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -18,7 +18,6 @@ dockerfile="$rootdir/Dockerfile-proxy"
 validate_go_deps_tag "$dockerfile"
 
 (
-    $bindir/docker-build-base
     $bindir/docker-build-go-deps
 ) >/dev/null
 

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -18,7 +18,6 @@ dockerfile=$rootdir/web/Dockerfile
 validate_go_deps_tag $dockerfile
 
 (
-    $bindir/docker-build-base
     $bindir/docker-build-go-deps
 ) >/dev/null
 

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_pull base       2019-02-19.01       || true
+docker_pull base       2019-09-04.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_push base         2019-02-19.01
+docker_push base         2019-09-04.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -6,7 +6,7 @@ COPY controller controller
 COPY cni-plugin cni-plugin
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/linkerd-cni -v -mod=readonly ./cni-plugin/
 
-FROM gcr.io/linkerd-io/base:2019-02-19.01
+FROM gcr.io/linkerd-io/base:2019-09-04.01
 WORKDIR /linkerd
 RUN curl -kL -o $(which jq) https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -29,10 +29,10 @@ COPY web/srv web/srv
 COPY controller controller
 COPY pkg pkg
 
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o web/web ./web
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o web/web -ldflags "-s -w" ./web
 
 ## package it all up
-FROM gcr.io/linkerd-io/base:2019-02-19.01
+FROM debian:stretch-20190812-slim
 WORKDIR /linkerd
 
 COPY LICENSE .


### PR DESCRIPTION
The `proxy` and `web` Docker images were 161MB and 186MB, respectively.
Most of the space was tools installed into the `linkerd.io/base` image.

Decrease `proxy` and `web` Docker images to 73MB and 90MB, respectively.
Switch these images to be based off of `debian:stretch-20190812-slim`.
Also set `-ldflags "-s -w"` for `proxy-identity` and `web`. Modify
`linkerd.io/base` to also be based off of
`debian:stretch-20190812-slim`, update tag to `2019-09-04.01`.

Fixes #3383

Signed-off-by: Andrew Seigner <siggy@buoyant.io>
