### PR TITLE
edge-19.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ variety of other improvements.
   * Added support for disabling the heartbeat cronjob (thanks @kevtaylor!)
 * Proxy
   * Decreased proxy Docker image size by removing bundled debug tools
+  * Fixed an issue where the incorrect content-length could be set for GET
+    requests with bodies
 * Web UI
   * Added trafficsplits as a resource to the dashboard, including a trafficsplit
     detail page

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ variety of other improvements.
     @alenkacz!)
   * Added `--address` flag to `linkerd dashboard` (thanks @bmcstdio!)
 * Controller
-  * Fixed an issue where the proxy-injector has insufficient RBAC permissions
+  * Fixed an issue where the proxy-injector had insufficient RBAC permissions
   * Added support for disabling the heartbeat cronjob (thanks @kevtaylor!)
 * Proxy
   * Decreased proxy Docker image size by removing bundled debug tools

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+## edge-19.9.1
+
+This edge release adds traffic splits into the Linkerd dashboard as well as a
+variety of other improvements.
+
+* CLI
+  * Improved the error message when the CLI cannot connect to Kubernetes (thanks
+    @alenkacz!)
+  * Added `--address` flag to `linkerd dashboard` (thanks @bmcstdio!)
+* Controller
+  * Fixed an issue where the proxy-injector has insufficient RBAC permissions
+  * Added support for disabling the heartbeat cronjob (thanks @kevtaylor!)
+* Web UI
+  * Added trafficsplits as a resource to the dashboard, including a trafficsplit
+    detail page
+* Internal
+  * Added support for Kubernetes 1.16
+
+
 ## edge-19.8.7
 
 * Controller

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,13 @@ variety of other improvements.
 * Controller
   * Fixed an issue where the proxy-injector has insufficient RBAC permissions
   * Added support for disabling the heartbeat cronjob (thanks @kevtaylor!)
+* Proxy
+  * Decreased proxy Docker image size by removing bundled debug tools
 * Web UI
   * Added trafficsplits as a resource to the dashboard, including a trafficsplit
     detail page
 * Internal
   * Added support for Kubernetes 1.16
-
 
 ## edge-19.8.7
 

--- a/charts/linkerd2/Chart.yaml
+++ b/charts/linkerd2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: "v1"
-appVersion: edge-19.8.7
+appVersion: edge-19.9.1
 description: Linkerd gives you observability, reliability, and security for your microservices — with no code change required.
 home: https://linkerd.io
 keywords:

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.8.7
+LinkerdVersion: &linkerd_version edge-19.9.1
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
This edge release adds traffic splits into the Linkerd dashboard as well as a
variety of other improvements.

* CLI
  * Improved the error message when the CLI cannot connect to Kubernetes (thanks
    @alenkacz!)
  * Added `--address` flag to `linkerd dashboard` (thanks @bmcstdio!)
* Controller
  * Fixed an issue where the proxy-injector has insufficient RBAC permissions
  * Added support for disabling the heartbeat cronjob (thanks @kevtaylor!)
* Web UI
  * Added trafficsplits as a resource to the dashboard, including a trafficsplit
    detail page
* Internal
  * Added support for Kubernetes 1.16

Signed-off-by: Alex Leong <alex@buoyant.io>