### PR TITLE
Introduce healthcheck dependencies

### DIFF
--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1672,6 +1672,18 @@ metadata:
 	}
 }
 
+func TestDependencies(t *testing.T) {
+	hc := NewHealthChecker(
+		[]CategoryID{KubernetesVersionChecks},
+		&Options{},
+	)
+	for _, c := range hc.categories {
+		if c.id == KubernetesAPIChecks && !c.enabled {
+			t.Fatal("Expecting KubernetesAPIChecks to be executed when KubernetesVersionChecks is specified because of dependencies but it's not enabled")
+		}
+	}
+}
+
 func TestValidateControlPlanePods(t *testing.T) {
 	pod := func(name string, phase corev1.PodPhase, ready bool) corev1.Pod {
 		return corev1.Pod{


### PR DESCRIPTION
Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>

Submitted based on discussion with @siggy 

Currently HealthChecking code has few flaws that make it hard to use - one of them is that there is implicit dependencies between checks that might cause HC to be initialized in a way that a check would always fail e.g. because kubernetes client was not initialized by running a different check before.

This PR proposes a way how to make those dependencies explicit.
