### PR TITLE
Make KillPodSandbox regex match broader

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -87,7 +87,7 @@ var (
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
 		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
 		`Failed to update endpoint .*-upgrade/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
-		`FailedKillPod .* error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: "rpc error: code = Unknown desc = failed to destroy network for sandbox \\".*\\": could not teardown ipv4 dnat: running \[/usr/sbin/iptables -t nat -X CNI-DN-.* --wait\]: exit status 1: iptables: No chain/target/match by that name\.\\n"`,
+		`FailedKillPod .* error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: .*`,
 	}, "|"))
 
 	injectionCases = []struct {


### PR DESCRIPTION
We're getting flakey `KillPodSandbox` events in the integration tests:
https://github.com/linkerd/linkerd2/runs/216505657#step:6:427
This is despite adding a regex for these events in #3380.

Modify the KillPodSandbox event regex to match on a broader set of
strings.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>
