### PR TITLE
Allow to disable Namespace installation with Helm (#3412)

### DIFF
--- a/charts/linkerd2/templates/namespace.yaml
+++ b/charts/linkerd2/templates/namespace.yaml
@@ -1,4 +1,5 @@
 {{with .Values -}}
+{{- if (.InstallNamespace) -}}
 ---
 ###
 ### Linkerd Namespace
@@ -13,3 +14,4 @@ metadata:
   labels:
     {{.LinkerdNamespaceLabel}}: "true"
 {{ end -}}
+{{- end -}}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -125,3 +125,10 @@ ProxyInjectDisabled: disabled
 ControllerComponentLabel: linkerd.io/control-plane-component
 ControllerNamespaceLabel: linkerd.io/control-plane-ns
 LinkerdNamespaceLabel: linkerd.io/is-control-plane
+
+# If the namespace is controlled by an external tool or can't be installed with Helm
+# you can disable its installation. In this case:
+# - The namespace created by the external tool must match the Namespace value above
+# - The external tool needs to create the namespace with the label:
+#     linkerd.io/is-control-plane: "true"
+InstallNamespace: true

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -75,6 +75,7 @@ func TestRender(t *testing.T) {
 		WebhookFailurePolicy:        "WebhookFailurePolicy",
 		OmitWebhookSideEffects:      false,
 		RestrictDashboardPrivileges: false,
+		InstallNamespace:            true,
 		Configs: charts.ConfigJSONs{
 			Global:  "GlobalConfig",
 			Proxy:   "ProxyConfig",

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -49,6 +49,7 @@ type (
 		RestrictDashboardPrivileges bool
 		DisableHeartBeat            bool
 		HeartbeatSchedule           string
+		InstallNamespace            bool
 		Configs                     ConfigJSONs
 		Identity                    *Identity
 		ProxyInjector               *ProxyInjector

--- a/pkg/charts/values_test.go
+++ b/pkg/charts/values_test.go
@@ -45,6 +45,7 @@ func TestNewValues(t *testing.T) {
 		RestrictDashboardPrivileges: false,
 		DisableHeartBeat:            false,
 		HeartbeatSchedule:           "0 0 * * *",
+		InstallNamespace:            true,
 
 		Identity: &Identity{
 			TrustDomain: "cluster.local",


### PR DESCRIPTION
If the namespace is controlled by an external tool or can't be installed
with Helm, disable its installation
Fixes #3412

Signed-off-by: Eugene Glotov <kivagant@gmail.com>
