### PR TITLE
Fix integration test event regex matching

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -87,7 +87,7 @@ var (
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
 		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
 		`Failed to update endpoint .*-upgrade/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
-		`FailedKillPod .* error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: .*`,
+		`error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: "rpc error: code = Unknown desc = failed to destroy network for sandbox \\".*\\": could not teardown ipv4 dnat: running \[/usr/sbin/iptables -t nat -X CNI-DN-.* --wait\]: exit status 1: iptables: No chain/target/match by that name\.\\n"`,
 	}, "|"))
 
 	injectionCases = []struct {
@@ -595,7 +595,7 @@ func TestEvents(t *testing.T) {
 			continue
 		}
 
-		evtStr := fmt.Sprintf("%s %s %s", e.Reason, e.InvolvedObject.Name, e.Message)
+		evtStr := fmt.Sprintf("Reason: [%s] Object: [%s] Message: [%s]", e.Reason, e.InvolvedObject.Name, e.Message)
 		if knownEventWarningsRegex.MatchString(e.Message) {
 			t.Logf("Found known warning event: %s", evtStr)
 		} else {


### PR DESCRIPTION
The integration tests check for known k8s events using a regex. This
regex included an incorrect pattern that prepended a failure reason and
object, rather than simply the event message we were trying to match on.
This resulted in failures such as:
https://github.com/linkerd/linkerd2/runs/217872818#step:6:476

Fix the regex to only check for the event message. Also explicitly
differentiate reason, object, and message in the log output.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

