### PR TITLE
Fix bad request in the top routes tab on empty fields

### DIFF
--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -208,9 +208,7 @@ class TopRoutes extends React.Component {
               <Button
                 color="primary"
                 variant="outlined"
-                disabled={this.state.requestInProgress ||
-                  this.state.query.namespace === '' ||
-                  this.state.query.resource_type === ''}
+                disabled={this.state.requestInProgress || !this.state.query.namespace || !this.state.query.resource_type}
                 onClick={this.handleBtnClick(true)}>
               Start
               </Button>

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -208,7 +208,9 @@ class TopRoutes extends React.Component {
               <Button
                 color="primary"
                 variant="outlined"
-                disabled={this.state.requestInProgress}
+                disabled={this.state.requestInProgress ||
+                  this.state.query.namespace === '' ||
+                  this.state.query.resource_type === ''}
                 onClick={this.handleBtnClick(true)}>
               Start
               </Button>


### PR DESCRIPTION
When clicking on the start button on the top routes tab without
filling the namespace and resource dropdown buttons will cause
a bad request error.

Disabling the `Start` button if the `namespace` and the `resource type`
field of the query object of the state are empty strings will solve
the problem.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>