### PR TITLE
Update base docker image to debian latest stable: buster

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -3,7 +3,7 @@
 # This means that all Linkerd containers share a common set of tools, and furthermore, they
 # are highly cacheable at runtime.
 
-FROM debian:stretch-20190812-slim
+FROM debian:buster-20190910-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM gcr.io/linkerd-io/base:2019-09-04.01
+FROM gcr.io/linkerd-io/base:2019-09-17.01
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tcpdump \
     iproute2 \

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,4 +1,4 @@
-ARG RUNTIME_IMAGE=debian:stretch-20190812-slim
+ARG RUNTIME_IMAGE=debian:buster-20190910-slim
 
 FROM debian:stretch-20190812-slim as fetch
 RUN apt-get update && apt-get install -y ca-certificates curl

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -14,7 +14,7 @@ rootdir="$( cd $bindir/.. && pwd )"
 
 . $bindir/_docker.sh
 
-tag="2019-09-04.01"
+tag="2019-09-17.01"
 
 if (docker_pull base "${tag}"); then
     echo "$(docker_repo base):${tag}"

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_pull base       2019-09-04.01       || true
+docker_pull base       2019-09-17.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -7,5 +7,5 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . $bindir/_docker.sh
 . $bindir/_tag.sh
 
-docker_push base         2019-09-04.01
+docker_push base         2019-09-17.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -6,7 +6,7 @@ COPY controller controller
 COPY cni-plugin cni-plugin
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/linkerd-cni -v -mod=readonly ./cni-plugin/
 
-FROM gcr.io/linkerd-io/base:2019-09-04.01
+FROM gcr.io/linkerd-io/base:2019-09-17.01
 WORKDIR /linkerd
 RUN curl -kL -o $(which jq) https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 COPY --from=golang /go/bin/linkerd-cni /opt/cni/bin/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -32,7 +32,7 @@ COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o web/web -ldflags "-s -w" ./web
 
 ## package it all up
-FROM debian:stretch-20190812-slim
+FROM debian:buster-20190910-slim
 WORKDIR /linkerd
 
 COPY LICENSE .


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@buoyant.io>

Subject: Update the base linkerd image to the latest debian stable: buster

Problem: The current debian version used in the base image `stretch` is out of date

Solution: Update the base image to the latest stable supported debian version: buster

Validation: Built image and ran tests

Fixes #[GitHub issue ID]

