### PR TITLE
Add --disable-heartbeat flag for linkerd install|upgrade

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -42,6 +42,7 @@ type (
 		highAvailability            bool
 		controllerUID               int64
 		disableH2Upgrade            bool
+		disableHeartbeat            bool
 		noInitContainer             bool
 		skipChecks                  bool
 		omitWebhookSideEffects      bool
@@ -163,6 +164,7 @@ func newInstallOptionsWithDefaults() (*installOptions, error) {
 		highAvailability:            defaults.HighAvailability,
 		controllerUID:               defaults.ControllerUID,
 		disableH2Upgrade:            !defaults.EnableH2Upgrade,
+		disableHeartbeat:            defaults.DisableHeartBeat,
 		noInitContainer:             defaults.NoInitContainer,
 		omitWebhookSideEffects:      defaults.OmitWebhookSideEffects,
 		restrictDashboardPrivileges: defaults.RestrictDashboardPrivileges,
@@ -430,6 +432,10 @@ func (options *installOptions) recordableFlagSet() *pflag.FlagSet {
 		&options.disableH2Upgrade, "disable-h2-upgrade", options.disableH2Upgrade,
 		"Prevents the controller from instructing proxies to perform transparent HTTP/2 upgrading (default false)",
 	)
+	flags.BoolVar(
+		&options.disableHeartbeat, "disable-heartbeat", options.disableHeartbeat,
+		"Disables the heartbeat cronjob (default false)",
+	)
 	flags.DurationVar(
 		&options.identityOptions.issuanceLifetime, "identity-issuance-lifetime", options.identityOptions.issuanceLifetime,
 		"The amount of time for which the Identity issuer should certify identity",
@@ -626,6 +632,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*cha
 	installValues.PrometheusLogLevel = toPromLogLevel(strings.ToLower(options.controllerLogLevel))
 	installValues.HeartbeatSchedule = options.heartbeatSchedule()
 	installValues.RestrictDashboardPrivileges = options.restrictDashboardPrivileges
+	installValues.DisableHeartBeat = options.disableHeartbeat
 	installValues.UUID = configs.GetInstall().GetUuid()
 	installValues.WebImage = fmt.Sprintf("%s/web", options.dockerRegistry)
 

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -70,7 +70,7 @@ func newCmdUpgradeConfig(options *upgradeOptions) *cobra.Command {
 
 Note that this command should be followed by "linkerd upgrade control-plane".`,
 		Example: `  # Default upgrade.
-  linkerd upgrade config | kubectl apply -f -`,
+  linkerd upgrade config | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeRunE(options, configStage, options.recordableFlagSet())
 		},
@@ -95,7 +95,7 @@ Note that the default flag values for this command come from the Linkerd control
 plane. The default values displayed in the Flags section below only apply to the
 install command. It should be run after "linkerd upgrade config".`,
 		Example: `  # Default upgrade.
-  linkerd upgrade control-plane | kubectl apply -f -`,
+  linkerd upgrade control-plane | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeRunE(options, controlPlaneStage, flags)
 		},
@@ -126,7 +126,7 @@ plane. The default values displayed in the Flags section below only apply to the
 install command.`,
 
 		Example: `  # Default upgrade.
-  linkerd upgrade | kubectl apply -f -
+  linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
 
   # Similar to install, upgrade may also be broken up into two stages, by user
   # privilege.`,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -539,7 +539,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-sa",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.checkServiceAccounts(true)
+						return hc.checkServiceAccounts(false)
 					},
 				},
 				{
@@ -586,6 +586,14 @@ func (hc *HealthChecker) allCategories() []category {
 					check: func(context.Context) (err error) {
 						hc.linkerdConfig, err = hc.checkLinkerdConfigConfigMap()
 						return
+					},
+				},
+				{
+					description: "control plane ServiceAccounts exist",
+					hintAnchor:  "l5d-existence-sa",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkServiceAccounts(true)
 					},
 				},
 				{
@@ -1033,11 +1041,13 @@ func (hc *HealthChecker) expectedRBACNames() []string {
 	}
 }
 
-func expectedServiceAccountNames() []string {
+func expectedServiceAccountNames(onlyHeartbeat bool) []string {
+	if onlyHeartbeat {
+		return []string{"linkerd-heartbeat"}
+	}
 	return []string{
 		"linkerd-controller",
 		"linkerd-grafana",
-		"linkerd-heartbeat",
 		"linkerd-identity",
 		"linkerd-prometheus",
 		"linkerd-proxy-injector",
@@ -1093,7 +1103,7 @@ func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 	return checkResources("ClusterRoleBindings", objects, hc.expectedRBACNames(), shouldExist)
 }
 
-func (hc *HealthChecker) checkServiceAccounts(shouldExist bool) error {
+func (hc *HealthChecker) checkServiceAccounts(onlyHeartbeat bool) error {
 	options := metav1.ListOptions{
 		LabelSelector: k8s.ControllerNSLabel,
 	}
@@ -1108,7 +1118,20 @@ func (hc *HealthChecker) checkServiceAccounts(shouldExist bool) error {
 		objects = append(objects, &item)
 	}
 
-	return checkResources("ServiceAccounts", objects, expectedServiceAccountNames(), shouldExist)
+	if onlyHeartbeat {
+		heartbeatDisabled := false
+		for _, flag := range hc.linkerdConfig.GetInstall().GetFlags() {
+			if flag.GetName() == "disable-heartbeat" && flag.GetValue() == "true" {
+				heartbeatDisabled = true
+				break
+			}
+		}
+		if heartbeatDisabled {
+			return nil
+		}
+	}
+
+	return checkResources("ServiceAccounts", objects, expectedServiceAccountNames(onlyHeartbeat), true)
 }
 
 func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error {

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -22,7 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
-√ control plane ServiceAccounts exist
+√ heartbeat ServiceAccount exist
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -22,6 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
+√ control plane ServiceAccounts exist
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -22,7 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
-√ control plane ServiceAccounts exist
+√ heartbeat ServiceAccount exist
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -22,6 +22,7 @@ linkerd-config
 linkerd-existence
 -----------------
 √ 'linkerd-config' config map exists
+√ control plane ServiceAccounts exist
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running


### PR DESCRIPTION
Fixes #3386

Add `linkerd install|upgrade --disable-heartbeat` flag, and have
`linkerd check` check for the heartbeat's SA only if it's enabled.

Also added those flags into the `linkerd upgrade -h` examples.
