### PR TITLE
Update CHANGES.md for edge-19.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,15 @@
   * Added a new `json` output option to the `linkerd tap` command
 * Controller
   * Fixed proxy injector timeout during a large number of concurrent injections
-  * Separated the destination controller into its own separate pod
+  * Separated the destination controller into its own separate deployment
   * Updated Prometheus config to keep only needed `cadvisor` metrics,
     substantially reducing the number of time-series stored in most clusters
 * Web UI
   * Fixed bad request in the top routes tab on empty fields (thanks @pierDipi!)
 * Proxy
   * Fixes to the client's backoff logic
-  * Added 587 to the list of ports to disable protocol detection (thanks @brianstorti!)
+  * Added 587 (SMTP) to the list of ports to ignore in protocol detection (bound
+    to server-speaks-first protocols) (thanks @brianstorti!)
 
 ## edge-19.9.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## edge-19.9.3
+
+* Helm
+  * Allow disabling namespace creation during install (thanks @KIVagant!)
+* Controller
+  * Fixed proxy injector timeout during a large number of concurrent injections
+  * Separated the destination controller into its own separate pod
+  * Updated Prometheus config to keep only needed cadvisor metrics
+* Web UI
+  * Fixed bad request in the top routes tab on empty fields (thanks @pierDipi!)
+* Proxy
+  * Fixes to the client's backoff logic
+  * Add 587 to the list of ports to disable protocol detection
+
 ## edge-19.9.2
 
 Much of our effort has been focused on improving our build and test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## edge-19.9.3
 
 * Helm
-  * Allow disabling namespace creation during install (thanks @KIVagant!)
+  * Allowed disabling namespace creation during install (thanks @KIVagant!)
 * CLI
   * Added a new `json` output option to the `linkerd tap` command
 * Controller

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,18 @@
 
 * Helm
   * Allow disabling namespace creation during install (thanks @KIVagant!)
+* CLI
+  * Added a new `json` output option to the `linkerd tap` command
 * Controller
   * Fixed proxy injector timeout during a large number of concurrent injections
   * Separated the destination controller into its own separate pod
-  * Updated Prometheus config to keep only needed cadvisor metrics
+  * Updated Prometheus config to keep only needed `cadvisor` metrics,
+    substantially reducing the number of time-series stored in most clusters
 * Web UI
   * Fixed bad request in the top routes tab on empty fields (thanks @pierDipi!)
 * Proxy
   * Fixes to the client's backoff logic
-  * Add 587 to the list of ports to disable protocol detection
+  * Added 587 to the list of ports to disable protocol detection (thanks @brianstorti!)
 
 ## edge-19.9.2
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.9.2
+LinkerdVersion: &linkerd_version edge-19.9.3
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.9.3

* Helm
  * Allow disabling namespace creation during install (thanks @KIVagant!)
* CLI
  * Added a new `json` output option to the `linkerd tap` command
* Controller
  * Fixed proxy injector timeout during a large number of concurrent injections
  * Separated the destination controller into its own separate pod
  * Updated Prometheus config to keep only needed `cadvisor` metrics,
    substantially reducing the number of time-series stored in most clusters
* Web UI
  * Fixed bad request in the top routes tab on empty fields (thanks @pierDipi!)
* Proxy
  * Fixes to the client's backoff logic
  * Added 587 to the list of ports to disable protocol detection (thanks @brianstorti!)
