### PR TITLE
Add script to load images into kind cluster

### DIFF
--- a/bin/kind-load
+++ b/bin/kind-load
@@ -2,12 +2,8 @@
 
 set -eu
 
-if [ $# -eq 1 ]; then
-    cluster="${1:-}"
-else
-    echo "usage: $(basename $0) cluster-name" >&2
-    exit 64
-fi
+# If cluster name is unset or null, default to $USER.
+cluster="${1:-$USER}"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -16,10 +12,6 @@ bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tag="$(head_root_tag)"
 org_repo="gcr.io/linkerd-io"
 
-kind load docker-image $org_repo/proxy:$tag --name $cluster
-kind load docker-image $org_repo/controller:$tag --name $cluster
-kind load docker-image $org_repo/web:$tag --name $cluster
-kind load docker-image $org_repo/cni-plugin:$tag --name $cluster
-kind load docker-image $org_repo/debug:$tag --name $cluster
-kind load docker-image $org_repo/cli-bin:$tag --name $cluster
-kind load docker-image $org_repo/grafana:$tag --name $cluster
+for img in proxy controller web grafana ; do
+    kind load docker-image $org_repo/$img:$tag --name $cluster
+done

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -eq 1 ]; then
+    cluster="${1:-}"
+else
+    echo "usage: $(basename $0) cluster-name" >&2
+    exit 64
+fi
+
+bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $bindir/_tag.sh
+
+tag="$(head_root_tag)"
+org_repo="gcr.io/linkerd-io"
+
+kind load docker-image $org_repo/proxy:$tag --name $cluster
+kind load docker-image $org_repo/controller:$tag --name $cluster
+kind load docker-image $org_repo/web:$tag --name $cluster
+kind load docker-image $org_repo/cni-plugin:$tag --name $cluster
+kind load docker-image $org_repo/debug:$tag --name $cluster
+kind load docker-image $org_repo/cli-bin:$tag --name $cluster
+kind load docker-image $org_repo/grafana:$tag --name $cluster

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -7,14 +7,11 @@ cluster="${1:-$USER}"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Ensure kind is installed
-$bindir/kind
-
 . $bindir/_tag.sh
 
 tag="$(head_root_tag)"
 org_repo="gcr.io/linkerd-io"
 
 for img in proxy controller web grafana ; do
-    kind load docker-image $org_repo/$img:$tag --name $cluster
+    $bindir/kind load docker-image $org_repo/$img:$tag --name $cluster
 done

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -7,6 +7,9 @@ cluster="${1:-$USER}"
 
 bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Ensure kind is installed
+$bindir/kind
+
 . $bindir/_tag.sh
 
 tag="$(head_root_tag)"


### PR DESCRIPTION
## Summary

[kind](https://github.com/kubernetes-sigs/kind) has been a helpful tool for running local Kubernetes clusters and
testing linkerd builds. Once images are built with `bin/docker-build`, the
images must be loaded into the kind cluster.

This script should be run after `bin/docker-build` and will load the images into
the specified kind cluster.

Example:
```
$ bin/docker-build
$ kind get clusters # show available clusters to load images on to
kleimkuhler
$ bin/kind-load kleimkuhler
$ ./target/cli/linux/linkerd install | kubectl apply -f -
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
