### PR TITLE
Increase the Grafana dashboards refresh interval

### DIFF
--- a/grafana/dashboards/authority.json
+++ b/grafana/dashboards/authority.json
@@ -1171,7 +1171,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/authority.json
+++ b/grafana/dashboards/authority.json
@@ -1171,7 +1171,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/daemonset.json
+++ b/grafana/dashboards/daemonset.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/daemonset.json
+++ b/grafana/dashboards/daemonset.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -2224,7 +2224,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/health.json
+++ b/grafana/dashboards/health.json
@@ -2224,7 +2224,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/job.json
+++ b/grafana/dashboards/job.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/job.json
+++ b/grafana/dashboards/job.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/kubernetes.json
+++ b/grafana/dashboards/kubernetes.json
@@ -2176,7 +2176,7 @@
       "type": "row"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/namespace.json
+++ b/grafana/dashboards/namespace.json
@@ -884,7 +884,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/namespace.json
+++ b/grafana/dashboards/namespace.json
@@ -884,7 +884,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -2112,7 +2112,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/pod.json
+++ b/grafana/dashboards/pod.json
@@ -2112,7 +2112,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/replicationcontroller.json
+++ b/grafana/dashboards/replicationcontroller.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/replicationcontroller.json
+++ b/grafana/dashboards/replicationcontroller.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -1171,7 +1171,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/service.json
+++ b/grafana/dashboards/service.json
@@ -1171,7 +1171,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/statefulset.json
+++ b/grafana/dashboards/statefulset.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "10s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/statefulset.json
+++ b/grafana/dashboards/statefulset.json
@@ -2165,7 +2165,7 @@
       "type": "text"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -990,7 +990,7 @@
       }
     }
   ],
-  "refresh": "5s",
+  "refresh": "1m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [


### PR DESCRIPTION
This PR increases the refresh interval of all workload dashboards from 5s to 10s. For dashboards that query for cluster-level or non-Linkerd resources, I set the refresh interval to 1m, following the default of the Prometheus and Prometheus benchmark dashboards.

See Grafana [docs](https://grafana.com/docs/reference/dashboard/#json-fields) for field description.

Fixes #3456.

Signed-off-by: Ivan Sim <ivan@buoyant.io>