### PR TITLE
The linkerd proxy does not work with headless services

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -421,7 +421,7 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 				continue
 			}
 			if endpoint.TargetRef == nil {
-				id := PodID{
+				id := ServiceID{
 					Name: strings.Join([]string{
 						endpoints.ObjectMeta.Name,
 						endpoint.IP,

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -420,7 +421,18 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) PodSe
 				continue
 			}
 			if endpoint.TargetRef == nil {
-				pp.log.Warnf("Endpoint missing TargetRef: %+v", endpoint)
+				id := PodID{
+					Name: strings.Join([]string{
+						endpoints.ObjectMeta.Name,
+						endpoint.IP,
+						fmt.Sprint(resolvedPort),
+					}, "-"),
+					Namespace: endpoints.ObjectMeta.Namespace,
+				}
+				pods[id] = Address{
+					IP:   endpoint.IP,
+					Port: resolvedPort,
+				}
 				continue
 			}
 			if endpoint.TargetRef.Kind == "Pod" {

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -138,6 +138,7 @@ status:
 				"172.17.0.12:8989",
 				"172.17.0.19:8989",
 				"172.17.0.20:8989",
+				"172.17.0.21:8989",
 			},
 			expectedNoEndpoints:              false,
 			expectedNoEndpointsServiceExists: false,


### PR DESCRIPTION
The linkerd proxy does not work with headless services (i.e. endpoints not referencing a pod).

Changed endpoints_watcher to also return endpoints with no targetref. Changed endpoint_translator to handle addresses with no associated pod.

Fixes #3308

Ran tests in minikube verifying that the proxy handles headless services correctly both in cases with and without port-remapping.

Signed-of-by: Johannes Hansen <johannesh1980@gmail.com>
