### PR TITLE
Correct link syntax in ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,7 +13,7 @@
 - [In Loco](https://inloco.com.br/en/)
 - [LeadIQ](https://leadiq.com)
 - [Facelift](https://www.facelift-bbt.com/en)
-- [Mulligan Funding] (https://www.mulliganfunding.com/)
+- [Mulligan Funding](https://www.mulliganfunding.com/)
 
 If you're using Linkerd 2.x and aren't on this list, please [submit a pull
 request](https://github.com/linkerd/linkerd2/pulls)!


### PR DESCRIPTION
There was an unintended space in ADOPTERS.md for _Mulligan Funding_, which led the link to not render properly.

Just fixed that by removing the space.