### PR TITLE
Introduce Tracing Annotations

### DIFF
--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -74,6 +74,9 @@ Proxy:
     Memory:
       Limit: ""
       Request: ""
+  Trace:
+    CollectorSvcAddr: ""
+    CollectorSvcAccount: default
   UID: 2102
 
 # proxy-init configuration

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -68,6 +68,14 @@ env:
 - name: LINKERD2_PROXY_TAP_SVC_NAME
   value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
+{{ if .Proxy.Trace -}}
+{{ if .Proxy.Trace.CollectorSvcAddr -}}
+- name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
+  value: {{ .Proxy.Trace.CollectorSvcAddr }}
+- name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME
+  value: {{ .Proxy.Trace.CollectorSvcAccount }}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+{{ end -}}
+{{ end -}}
 image: {{.Proxy.Image.Name}}:{{.Proxy.Image.Version}}
 imagePullPolicy: {{.Proxy.Image.PullPolicy}}
 livenessProbe:

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -658,8 +658,7 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*cha
 				Request: options.proxyMemoryRequest,
 			},
 		},
-		Trace: &charts.Trace{},
-		UID:   options.proxyUID,
+		UID: options.proxyUID,
 	}
 
 	inboundPortStrs := []string{}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -658,7 +658,8 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*cha
 				Request: options.proxyMemoryRequest,
 			},
 		},
-		UID: options.proxyUID,
+		Trace: &charts.Trace{},
+		UID:   options.proxyUID,
 	}
 
 	inboundPortStrs := []string{}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -20,6 +20,7 @@ import (
 const (
 	eventTypeSkipped  = "InjectionSkipped"
 	eventTypeInjected = "Injected"
+	eventTypeTracing  = "Tracing"
 )
 
 // Inject returns an AdmissionResponse containing the patch, if any, to apply
@@ -108,6 +109,9 @@ func Inject(api *k8s.API,
 
 	if parent != nil {
 		recorder.Event(*parent, v1.EventTypeNormal, eventTypeInjected, "Linkerd sidecar proxy injected")
+		if report.TracingEnabled {
+			recorder.Event(*parent, v1.EventTypeNormal, eventTypeTracing, "Tracing Enabled")
+		}
 	}
 	log.Infof("patch generated for: %s", report.ResName())
 	log.Debugf("patch: %s", patchJSON)

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -85,6 +85,7 @@ type (
 		SAMountPath            *SAMountPath
 		Ports                  *Ports
 		Resources              *Resources
+		Trace                  *Trace
 		UID                    int64
 	}
 
@@ -180,6 +181,12 @@ type (
 	// Helm templates
 	TLS struct {
 		KeyPEM, CrtPEM string
+	}
+
+	// Trace has all the tracing-related Helm variables
+	Trace struct {
+		CollectorSvcAddr    string
+		CollectorSvcAccount string
 	}
 )
 

--- a/pkg/charts/values_test.go
+++ b/pkg/charts/values_test.go
@@ -85,6 +85,10 @@ func TestNewValues(t *testing.T) {
 					Request: "",
 				},
 			},
+			Trace: &Trace{
+				CollectorSvcAddr:    "",
+				CollectorSvcAccount: "default",
+			},
 			UID: 2102,
 		},
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -556,19 +556,19 @@ func (conf *ResourceConfig) trace() *charts.Trace {
 		return nil
 	}
 
-	splits := strings.Split(svcAddr, ".")
-	if len(splits) <= 1 {
-		log.Errorf("fail to enable tracing due to malformed collector service address %s. Expected service address to use the <svc-name>:<ns> format", svcAddr)
-		return nil
-	}
+	hostAndPort := strings.Split(svcAddr, ":")
+	hostname := strings.Split(hostAndPort[0], ".")
 
-	if delimiter := strings.Index(splits[1], ":"); delimiter != -1 {
-		splits[1] = splits[1][:delimiter]
+	var ns string
+	if len(hostname) == 1 {
+		ns = conf.workload.Meta.Namespace
+	} else {
+		ns = hostname[1]
 	}
 
 	return &charts.Trace{
 		CollectorSvcAddr:    svcAddr,
-		CollectorSvcAccount: fmt.Sprintf("%s.%s", svcAccount, splits[1]),
+		CollectorSvcAccount: fmt.Sprintf("%s.%s", svcAccount, ns),
 	}
 }
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -28,6 +28,8 @@ const (
 	proxyInitResourceRequestMemory = "10Mi"
 	proxyInitResourceLimitCPU      = "100m"
 	proxyInitResourceLimitMemory   = "50Mi"
+
+	traceDefaultSvcAccount = "default"
 )
 
 var (
@@ -554,6 +556,10 @@ func (conf *ResourceConfig) trace() *charts.Trace {
 
 	if svcAddr == "" {
 		return nil
+	}
+
+	if svcAccount == "" {
+		svcAccount = traceDefaultSvcAccount
 	}
 
 	hostAndPort := strings.Split(svcAddr, ":")

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -558,7 +558,7 @@ func (conf *ResourceConfig) trace() *charts.Trace {
 
 	splits := strings.Split(svcAddr, ".")
 	if len(splits) <= 1 {
-		log.Errorf("Fail to start tracing due to malformed collector service address %s. Expected service address to use the <svc-name>:<ns> format", svcAddr)
+		log.Errorf("fail to enable tracing due to malformed collector service address %s. Expected service address to use the <svc-name>:<ns> format", svcAddr)
 		return nil
 	}
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -501,7 +501,7 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 	values.AddRootVolumes = len(conf.pod.spec.Volumes) == 0
 
 	if trace := conf.trace(); trace != nil {
-		log.Infof("tracing enabled for %s/%s: service name=%s, service account=%s", conf.workload.metaType.Kind, conf.workload.Meta.Name, trace.CollectorSvcAddr, trace.CollectorSvcAccount)
+		log.Infof("tracing enabled for %s/%s: remote service=%s, service account=%s", conf.workload.ownerRef.Kind, conf.workload.ownerRef.Name, trace.CollectorSvcAddr, trace.CollectorSvcAccount)
 		values.Proxy.Trace = trace
 	}
 }

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -503,7 +503,7 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 	values.AddRootVolumes = len(conf.pod.spec.Volumes) == 0
 
 	if trace := conf.trace(); trace != nil {
-		log.Infof("tracing enabled for %s/%s: remote service=%s, service account=%s", conf.workload.ownerRef.Kind, conf.workload.ownerRef.Name, trace.CollectorSvcAddr, trace.CollectorSvcAccount)
+		log.Infof("tracing enabled: remote service=%s, service account=%s", trace.CollectorSvcAddr, trace.CollectorSvcAccount)
 		values.Proxy.Trace = trace
 	}
 }

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -31,6 +31,7 @@ type expectedProxyConfigs struct {
 	initVersion          string
 	inboundSkipPorts     string
 	outboundSkipPorts    string
+	trace                *charts.Trace
 }
 
 func TestConfigAccessors(t *testing.T) {
@@ -103,7 +104,10 @@ func TestConfigAccessors(t *testing.T) {
 							k8s.ProxyUIDAnnotation:                    "8500",
 							k8s.ProxyLogLevelAnnotation:               "debug,linkerd2_proxy=debug",
 							k8s.ProxyEnableExternalProfilesAnnotation: "false",
-							k8s.ProxyVersionOverrideAnnotation:        proxyVersionOverride},
+							k8s.ProxyVersionOverrideAnnotation:        proxyVersionOverride,
+							k8s.ProxyTraceCollectorSvcAddr:            "oc-collector.tracing:55678",
+							k8s.ProxyTraceCollectorSvcAccount:         "default",
+						},
 					},
 					Spec: corev1.PodSpec{},
 				},
@@ -133,6 +137,10 @@ func TestConfigAccessors(t *testing.T) {
 				initVersion:         version.ProxyInitVersion,
 				inboundSkipPorts:    "4222,6222",
 				outboundSkipPorts:   "8079,8080",
+				trace: &charts.Trace{
+					CollectorSvcAddr:    "oc-collector.tracing:55678",
+					CollectorSvcAccount: "default.tracing",
+				},
 			},
 		},
 		{id: "use defaults",
@@ -189,7 +197,10 @@ func TestConfigAccessors(t *testing.T) {
 				k8s.ProxyUIDAnnotation:                    "8500",
 				k8s.ProxyLogLevelAnnotation:               "debug,linkerd2_proxy=debug",
 				k8s.ProxyEnableExternalProfilesAnnotation: "false",
-				k8s.ProxyVersionOverrideAnnotation:        proxyVersionOverride},
+				k8s.ProxyVersionOverrideAnnotation:        proxyVersionOverride,
+				k8s.ProxyTraceCollectorSvcAddr:            "oc-collector.tracing:55678",
+				k8s.ProxyTraceCollectorSvcAccount:         "default",
+			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{},
@@ -220,6 +231,10 @@ func TestConfigAccessors(t *testing.T) {
 				initVersion:         version.ProxyInitVersion,
 				inboundSkipPorts:    "4222,6222",
 				outboundSkipPorts:   "8079,8080",
+				trace: &charts.Trace{
+					CollectorSvcAddr:    "oc-collector.tracing:55678",
+					CollectorSvcAccount: "default.tracing",
+				},
 			},
 		},
 	}
@@ -346,6 +361,20 @@ func TestConfigAccessors(t *testing.T) {
 				expected := testCase.expected.outboundSkipPorts
 				if actual := resourceConfig.proxyOutboundSkipPorts(); expected != actual {
 					t.Errorf("Expected: %v Actual: %v", expected, actual)
+				}
+			})
+
+			t.Run("proxyTraceCollectorService", func(t *testing.T) {
+				var expected *charts.Trace
+				if testCase.expected.trace != nil {
+					expected = &charts.Trace{
+						CollectorSvcAddr:    testCase.expected.trace.CollectorSvcAddr,
+						CollectorSvcAccount: testCase.expected.trace.CollectorSvcAccount,
+					}
+				}
+
+				if actual := resourceConfig.trace(); !reflect.DeepEqual(expected, actual) {
+					t.Errorf("Expected: %+v Actual: %+v", expected, actual)
 				}
 			})
 		})

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -42,6 +42,7 @@ type Report struct {
 	InjectDisabled       bool
 	InjectDisabledReason string
 	InjectAnnotationAt   string
+	TracingEnabled       bool
 
 	// Uninjected consists of two boolean flags to indicate if a proxy and
 	// proxy-init containers have been uninjected in this report
@@ -77,6 +78,7 @@ func newReport(conf *ResourceConfig) *Report {
 		report.HostNetwork = conf.pod.spec.HostNetwork
 		report.Sidecar = healthcheck.HasExistingSidecars(conf.pod.spec)
 		report.UDP = checkUDPPorts(conf.pod.spec)
+		report.TracingEnabled = conf.pod.meta.Annotations[k8s.ProxyTraceCollectorSvcAddr] != "" || conf.nsAnnotations[k8s.ProxyTraceCollectorSvcAddr] != ""
 	} else {
 		report.UnsupportedResource = true
 	}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -169,6 +169,16 @@ const (
 	// injected.
 	ProxyEnableDebugAnnotation = ProxyConfigAnnotationsPrefix + "/enable-debug-sidecar"
 
+	// ProxyTraceCollectorSvcAddr can be used to enable tracing on a proxy.
+	// It takes the collector service name (e.g. oc-collector.tracing:55678) as
+	// its value.
+	ProxyTraceCollectorSvcAddr = ProxyConfigAnnotationsPrefix + "/trace-collector"
+
+	// ProxyTraceCollectorSvcAccount is used to specify the service account
+	// associated with the trace collector. It is used to create the service's
+	// mTLS identity.
+	ProxyTraceCollectorSvcAccount = "config.alpha.linkerd.io/trace-collector-service-account"
+
 	// IdentityModeDefault is assigned to IdentityModeAnnotation to
 	// use the control plane's default identity scheme.
 	IdentityModeDefault = "default"


### PR DESCRIPTION
This PR introduces two proxy config annotations named `config.linkerd.io/trace-collector` and `config.alpha.linkerd.io/trace-collector-service-account`, to support per-pod tracing. These annotations are translated into two new proxy environment variables.

Note that these annotations work on both the pod template and namespace levels.

The proxy injector logs and events have been updated to include `tracing enabled` events.
```
linkerd-proxy-injector-667958849d-pkvkn proxy-injector time="2019-09-26T04:32:23Z" level=info msg="patch generated for: pod/voting-855d545684-"
linkerd-proxy-injector-667958849d-pkvkn proxy-injector time="2019-09-26T04:32:23Z" level=info msg="received admission review request 93017758-75b4-4aac-8721-c9c37d11b043"
linkerd-proxy-injector-667958849d-pkvkn proxy-injector time="2019-09-26T04:32:23Z" level=info msg="received pod/web-79694f4896-"
linkerd-proxy-injector-667958849d-pkvkn proxy-injector time="2019-09-26T04:32:23Z" level=info msg="tracing enabled for deployment/web: remote service=oc-collector.tracing:55678, service account=tracing.tracing"


Events:
  Type    Reason             Age   From                    Message
  ----    ------             ----  ----                    -------
  Normal  ScalingReplicaSet  83s   deployment-controller   Scaled up replica set emoji-697b575bd9 to 1
  Normal  Injected           83s   linkerd-proxy-injector  Linkerd sidecar proxy injected
  Normal  Tracing            83s   linkerd-proxy-injector  Tracing Enabled
```

Fixes https://github.com/linkerd/linkerd2/issues/3472.