### PR TITLE
Add changes for edge-19.9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,10 +23,10 @@ and workloads.
 * Controller
   * Instrumented the proxy-injector to provide additional metrics about
     injection (thanks @Pothulapati!)
-  * Added support for `config.linkerd.io/skip-webhook` annotation on namespaces
-    to prevent control plane components from being installed to specific
-    namespaces; this fixes situations in HA deployments where the proxy-injector
-    is installed in `kube-system` (thanks @hasheddan!)
+  * Added support for `config.linkerd.io/skip-webhooks: disabled` label on
+    namespaces so that the pods creation events in these namespaces are ignored
+    by the proxy injector. namespaces; this fixes situations in HA deployments
+    where the proxy-injector is installed in `kube-system` (thanks @hasheddan!)
   * Introduced `config.linkerd.io/trace-collector` and
     `config.alpha.linkerd.io/trace-collector-service-account` pod spec
     annotations to support per-pod tracing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,39 @@
+## edge-19.9.4
+
+This edge release introduces support for distributed tracing as well as a
+redesigned sidebar in the Web UI!
+
+Support for distributed tracing means that Linkerd data plane proxies can now
+emit trace spans, allowing you to see the exact amount of time spent in the
+Linkerd proxy for traced requests. The new `config.linkerd.io/trace-collector`
+and `config.alpha.linkerd.io/trace-collector-service-account` tracing
+annotations allow specifying which pods should emit trace spans.
+
+The goal of dashboard's sidebar redesign was to reduce load on Prometheus and
+simplify navigation by providing top-level views centered around namespaces and
+workloads.
+
+* CLI
+  * Introduced a new `--cluster-domain` flag to the `linkerd install` command
+    that allows setting a custom cluster domain (thanks @arminbuerkle!)
+  * Added `--disable-heartbeat` flag for `linkerd` `install|upgrade` commands
+* Controller
+  * Instrumented the proxy-injector to provide additional metrics about
+    injection (thanks @Pothulapati!)
+  * Added selectors to MWC that allow skipping namespaces; this fixes `--ha`
+    deployments where components are installed in `kube-system` (thanks
+    @hasheddan!)
+  * Introduced `config.linkerd.io/trace-collector` and
+    `config.alpha.linkerd.io/trace-collector-service-account` to support per-pod
+    tracing
+* Web UI
+  * Workloads are now viewed by namespace
+  * Individual resources are no longer listed on the sidebar
+  * Navigation between namespaces no longer changes the current page view
+* Proxy
+  * Added distributed tracing support
+  * Added http metadata to spans as annotations
+
 ## edge-19.9.3
 
 * Helm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,10 +23,10 @@ and workloads.
 * Controller
   * Instrumented the proxy-injector to provide additional metrics about
     injection (thanks @Pothulapati!)
-  * Added support for `config.linkerd.io/skip-webhooks: disabled` label on
+  * Added support for `config.linkerd.io/admission-webhooks: disabled` label on
     namespaces so that the pods creation events in these namespaces are ignored
-    by the proxy injector. namespaces; this fixes situations in HA deployments
-    where the proxy-injector is installed in `kube-system` (thanks @hasheddan!)
+    by the proxy injector; this fixes situations in HA deployments where the
+    proxy-injector is installed in `kube-system` (thanks @hasheddan!)
   * Introduced `config.linkerd.io/trace-collector` and
     `config.alpha.linkerd.io/trace-collector-service-account` pod spec
     annotations to support per-pod tracing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,14 @@
 ## edge-19.9.4
 
-This edge release introduces support for distributed tracing as well as a
-redesigned sidebar in the Web UI!
+This edge release introduces experimental support for distributed tracing as
+well as a redesigned sidebar in the Web UI!
 
-Support for distributed tracing means that Linkerd data plane proxies can now
-emit trace spans, allowing you to see the exact amount of time spent in the
-Linkerd proxy for traced requests. The new `config.linkerd.io/trace-collector`
-and `config.alpha.linkerd.io/trace-collector-service-account` tracing
-annotations allow specifying which pods should emit trace spans.
+Experimental support for distributed tracing means that Linkerd data plane
+proxies can now emit trace spans, allowing you to see the exact amount of time
+spent in the Linkerd proxy for traced requests. The new
+`config.linkerd.io/trace-collector` and
+`config.alpha.linkerd.io/trace-collector-service-account` tracing annotations
+allow specifying which pods should emit trace spans.
 
 The goal of the dashboard's sidebar redesign was to reduce load on Prometheus
 and simplify navigation by providing top-level views centered around namespaces
@@ -33,7 +34,7 @@ and workloads.
   * Workloads are now viewed by namespace, with an "All Namespaces" option, to
     improve dashboard performance
 * Proxy
-  * Added distributed tracing support
+  * Added experimental distributed tracing support
 
 ## edge-19.9.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,30 +9,31 @@ Linkerd proxy for traced requests. The new `config.linkerd.io/trace-collector`
 and `config.alpha.linkerd.io/trace-collector-service-account` tracing
 annotations allow specifying which pods should emit trace spans.
 
-The goal of dashboard's sidebar redesign was to reduce load on Prometheus and
-simplify navigation by providing top-level views centered around namespaces and
-workloads.
+The goal of the dashboard's sidebar redesign was to reduce load on Prometheus
+and simplify navigation by providing top-level views centered around namespaces
+and workloads.
 
 * CLI
   * Introduced a new `--cluster-domain` flag to the `linkerd install` command
     that allows setting a custom cluster domain (thanks @arminbuerkle!)
+  * Fixed the `linkerd endpoints` command to use the correct Destination API
+    address (thanks @Pothulapati!)
   * Added `--disable-heartbeat` flag for `linkerd` `install|upgrade` commands
 * Controller
   * Instrumented the proxy-injector to provide additional metrics about
     injection (thanks @Pothulapati!)
-  * Added selectors to MWC that allow skipping namespaces; this fixes `--ha`
-    deployments where components are installed in `kube-system` (thanks
-    @hasheddan!)
+  * Added support for `config.linkerd.io/skip-webhook` annotation on namespaces
+    to prevent control plane components from being installed to specific
+    namespaces; this fixes situations in HA deployments where the proxy-injector
+    is installed in `kube-system` (thanks @hasheddan!)
   * Introduced `config.linkerd.io/trace-collector` and
-    `config.alpha.linkerd.io/trace-collector-service-account` to support per-pod
-    tracing
+    `config.alpha.linkerd.io/trace-collector-service-account` pod spec
+    annotations to support per-pod tracing
 * Web UI
-  * Workloads are now viewed by namespace
-  * Individual resources are no longer listed on the sidebar
-  * Navigation between namespaces no longer changes the current page view
+  * Workloads are now viewed by namespace, with an "All Namespaces" option, to
+    improve dashboard performance
 * Proxy
   * Added distributed tracing support
-  * Added http metadata to spans as annotations
 
 ## edge-19.9.3
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.9.3
+LinkerdVersion: &linkerd_version edge-19.9.4
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.9.4

This edge release introduces a redesigned sidebar in dashboard! The goal of the
redesign was to reduce load on Prometheus and simplify navigation by providing
top-level views centered around namespaces and workloads.

* CLI
  * Introduced a new `--cluster-domain` flag to the `linkerd install` command
    that allows setting a custom cluster domain (thanks @arminbuerkle!)
  * Fixed the `linkerd endpoints` command to use the correct Destination API
    address (thanks @Pothulapati!)
  * Added `--disable-heartbeat` flag for `linkerd` `install|upgrade` commands
* Controller
  * Instrumented the proxy-injector to provide additional metrics about
    injection (thanks @Pothulapati!)
  * Added support for `config.linkerd.io/admission-webhooks: disabled` label on
    namespaces so that the pods creation events in these namespaces are ignored
    by the proxy injector; this fixes situations in HA deployments where the
    proxy-injector is installed in `kube-system` (thanks @hasheddan!)
* Web UI
  * Workloads are now viewed by namespace, with an "All Namespaces" option, to
    improve dashboard performance
* Proxy
  * Added experimental distributed tracing support

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
