### PR TITLE
Check extension apiserver authentication

### DIFF
--- a/controller/tap/apiserver.go
+++ b/controller/tap/apiserver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/linkerd/linkerd2/controller/gen/controller/tap"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	k8sutils "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,15 +121,13 @@ func (a *apiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // kubectl -n kube-system get cm/extension-apiserver-authentication
 // accessible via the extension-apiserver-authentication-reader role
 func apiServerAuth(k8sAPI *k8s.API) (string, []string, string, string, error) {
-	cmName := "extension-apiserver-authentication"
-
 	cm, err := k8sAPI.Client.CoreV1().
-		ConfigMaps("kube-system").
-		Get(cmName, metav1.GetOptions{})
+		ConfigMaps(metav1.NamespaceSystem).
+		Get(k8sutils.ExtensionAPIServerAuthenticationConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, "", "", fmt.Errorf("failed to load [%s] config: %s", cmName, err)
+		return "", nil, "", "", fmt.Errorf("failed to load [%s] config: %s", k8sutils.ExtensionAPIServerAuthenticationConfigMapName, err)
 	}
-	clientCAPem, ok := cm.Data["requestheader-client-ca-file"]
+	clientCAPem, ok := cm.Data[k8sutils.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey]
 	if !ok {
 		return "", nil, "", "", fmt.Errorf("no client CA cert available for apiextension-server")
 	}

--- a/controller/tap/apiserver_test.go
+++ b/controller/tap/apiserver_test.go
@@ -2,12 +2,12 @@ package tap
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	k8sutils "github.com/linkerd/linkerd2/pkg/k8s"
 )
 
 func TestNewAPIServer(t *testing.T) {
@@ -16,24 +16,19 @@ func TestNewAPIServer(t *testing.T) {
 		err    error
 	}{
 		{
-			err: errors.New("failed to load [extension-apiserver-authentication] config: configmaps \"extension-apiserver-authentication\" not found"),
+			err: fmt.Errorf("failed to load [%s] config: configmaps %q not found", k8sutils.ExtensionAPIServerAuthenticationConfigMapName, k8sutils.ExtensionAPIServerAuthenticationConfigMapName),
 		},
 		{
 			err: nil,
-			k8sRes: []string{`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: extension-apiserver-authentication
-  namespace: kube-system
-data:
-  client-ca-file: 'client-ca-file'
-  requestheader-allowed-names: '["name1", "name2"]'
-  requestheader-client-ca-file: 'requestheader-client-ca-file'
-  requestheader-extra-headers-prefix: '["X-Remote-Extra-"]'
-  requestheader-group-headers: '["X-Remote-Group"]'
-  requestheader-username-headers: '["X-Remote-User"]'
-`,
+			k8sRes: []string{
+				k8sutils.ExtensionAPIServerConfigMapResource(map[string]string{
+					"client-ca-file":                     `'client-ca-file'`,
+					"requestheader-allowed-names":        `'["name1", "name2"]'`,
+					"requestheader-extra-headers-prefix": `'["X-Remote-Extra-"]'`,
+					"requestheader-group-headers":        `'["X-Remote-Group"]'`,
+					"requestheader-username-headers":     `'["X-Remote-User"]'`,
+					k8sutils.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey: `'requestheader-client-ca-file'`,
+				}),
 			},
 		},
 	}
@@ -67,23 +62,18 @@ func TestAPIServerAuth(t *testing.T) {
 		err            error
 	}{
 		{
-			err: errors.New("failed to load [extension-apiserver-authentication] config: configmaps \"extension-apiserver-authentication\" not found"),
+			err: fmt.Errorf("failed to load [%s] config: configmaps \"%s\" not found", k8sutils.ExtensionAPIServerAuthenticationConfigMapName, k8sutils.ExtensionAPIServerAuthenticationConfigMapName),
 		},
 		{
-			k8sRes: []string{`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: extension-apiserver-authentication
-  namespace: kube-system
-data:
-  client-ca-file: 'client-ca-file'
-  requestheader-allowed-names: '["name1", "name2"]'
-  requestheader-client-ca-file: 'requestheader-client-ca-file'
-  requestheader-extra-headers-prefix: '["X-Remote-Extra-"]'
-  requestheader-group-headers: '["X-Remote-Group"]'
-  requestheader-username-headers: '["X-Remote-User"]'
-`,
+			k8sRes: []string{
+				k8sutils.ExtensionAPIServerConfigMapResource(map[string]string{
+					"client-ca-file":                     `'client-ca-file'`,
+					"requestheader-allowed-names":        `'["name1", "name2"]'`,
+					"requestheader-extra-headers-prefix": `'["X-Remote-Extra-"]'`,
+					"requestheader-group-headers":        `'["X-Remote-Group"]'`,
+					"requestheader-username-headers":     `'["X-Remote-User"]'`,
+					k8sutils.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey: `'requestheader-client-ca-file'`,
+				}),
 			},
 			clientCAPem:    "requestheader-client-ca-file",
 			allowedNames:   []string{"name1", "name2"},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -116,15 +116,6 @@ const (
 	// The value is expected to be "true", "false" or "", where "false" and
 	// "" are equal, making "false" the default
 	linkerdCniResourceLabel = "linkerd.io/cni-resource"
-
-	// extensionAPIServerAuthenticationConfigMapName is the name of the
-	// ConfigMap where authentication data for extension API servers is
-	// placed.
-	extensionAPIServerAuthenticationConfigMapName = "extension-apiserver-authentication"
-	// extensionAPIServerAuthenticationRequestHeaderClientCAFileKey is
-	// the key that contains the value of the "--requestheader-client-ca-file"
-	// flag.
-	extensionAPIServerAuthenticationRequestHeaderClientCAFileKey = "requestheader-client-ca-file"
 )
 
 // HintBaseURL is the base URL on the linkerd.io website that all check hints
@@ -1361,12 +1352,12 @@ func (hc *HealthChecker) checkExtensionAPIServerAuthentication() error {
 	if hc.kubeAPI == nil {
 		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
 	}
-	m, err := hc.kubeAPI.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(extensionAPIServerAuthenticationConfigMapName, metav1.GetOptions{})
+	m, err := hc.kubeAPI.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(k8s.ExtensionAPIServerAuthenticationConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	if v, exists := m.Data[extensionAPIServerAuthenticationRequestHeaderClientCAFileKey]; !exists || v == "" {
-		return fmt.Errorf("--%s is not configured", extensionAPIServerAuthenticationRequestHeaderClientCAFileKey)
+	if v, exists := m.Data[k8s.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey]; !exists || v == "" {
+		return fmt.Errorf("--%s is not configured", k8s.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey)
 	}
 	return nil
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -392,34 +392,27 @@ status:
 }
 
 func TestCheckExtensionAPIServerAuthentication(t *testing.T) {
-	configMap := func(key, value string) string {
-		return fmt.Sprintf(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: %s
-  namespace: %s
-data:
-  %s: %s
-`, extensionAPIServerAuthenticationConfigMapName, metav1.NamespaceSystem, key, value)
-	}
 	tests := []struct {
 		k8sConfigs []string
 		err        error
 	}{
 		{
 			[]string{},
-			fmt.Errorf("configmaps %q not found", extensionAPIServerAuthenticationConfigMapName),
+			fmt.Errorf("configmaps %q not found", k8s.ExtensionAPIServerAuthenticationConfigMapName),
 		},
 		{
 			[]string{
-				configMap("foo", "bar"),
+				k8s.ExtensionAPIServerConfigMapResource(map[string]string{
+					"foo": "bar",
+				}),
 			},
-			fmt.Errorf("--%s is not configured", extensionAPIServerAuthenticationRequestHeaderClientCAFileKey),
+			fmt.Errorf("--%s is not configured", k8s.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey),
 		},
 		{
 			[]string{
-				configMap(extensionAPIServerAuthenticationRequestHeaderClientCAFileKey, "bar"),
+				k8s.ExtensionAPIServerConfigMapResource(map[string]string{
+					k8s.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey: "bar",
+				}),
 			},
 			nil,
 		},

--- a/pkg/k8s/constants.go
+++ b/pkg/k8s/constants.go
@@ -1,0 +1,8 @@
+package k8s
+
+const (
+	// ExtensionAPIServerAuthenticationConfigMapName is the name of the ConfigMap where authentication data for extension API servers is placed.
+	ExtensionAPIServerAuthenticationConfigMapName = "extension-apiserver-authentication"
+	// ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey is the key that contains the value of the "--requestheader-client-ca-file" flag.
+	ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey = "requestheader-client-ca-file"
+)

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -1,0 +1,24 @@
+package k8s
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ExtensionAPIServerConfigMapResource returns the string representation of a ConfigMap resource, meant to be used in unit tests.
+func ExtensionAPIServerConfigMapResource(data map[string]string) string {
+	r := fmt.Sprintf(
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+data:
+`, ExtensionAPIServerAuthenticationConfigMapName, metav1.NamespaceSystem)
+	for k, v := range data {
+		r = fmt.Sprintf("%s\n  %s: %s", r, k, v)
+	}
+	return r
+}


### PR DESCRIPTION
This PR closes #3343 by implementing a check for `--requestheader-client-ca-file` than runs as part of `linkerd check --pre`. I am also taking on this opportunity to reduce code duplication a bit. 🙂