### PR TITLE
move t.Fatalf out of goroutine in server_test.go

### DIFF
--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -353,12 +353,17 @@ status:
 			}
 
 			// TODO: mock out the underlying grpc tap events
+			errChan := make(chan error, 1)
 			go func() {
-				err := s.Serve(lis)
-				if err != nil {
+				errChan <- s.Serve(lis)
+			}()
+
+			defer func() {
+				if err := <-errChan; err != nil {
 					t.Fatalf("Failed to serve on %+v: %s", lis, err)
 				}
 			}()
+
 			defer s.GracefulStop()
 
 			_, port, err := net.SplitHostPort(lis.Addr().String())
@@ -390,6 +395,7 @@ status:
 					t.Fatalf("Unexpected l5d-require-id header [%+v] expected [%+v]", md.Get(requireIDHeader), []string{exp.requireID})
 				}
 			}
+
 		})
 	}
 }


### PR DESCRIPTION
Subject
t.Fataf should not be called in goroutine

Problem

Solution
move t.Fatalf into testing func instead of its goroutine

Validation
unit test passed on my env