### PR TITLE
If tap source IP matches many running pods then only show the IP

### DIFF
--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -569,7 +569,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -569,7 +569,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -543,7 +543,7 @@ metadata:
     ControllerNamespaceLabel: Namespace
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -543,7 +543,7 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "replicationcontrollers", "namespaces"]
+  resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -49,6 +49,7 @@ func Main(args []string) {
 		k8s.RC,
 		k8s.Svc,
 		k8s.RS,
+		k8s.Node,
 	)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -54,6 +54,7 @@ const (
 	SS
 	Svc
 	TS
+	Node
 )
 
 // API provides shared informers for all Kubernetes objects
@@ -74,6 +75,7 @@ type API struct {
 	ss       appv1informers.StatefulSetInformer
 	svc      coreinformers.ServiceInformer
 	ts       tsinformers.TrafficSplitInformer
+	node     coreinformers.NodeInformer
 
 	syncChecks        []cache.InformerSynced
 	sharedInformers   informers.SharedInformerFactory
@@ -198,6 +200,9 @@ func NewAPI(
 		case TS:
 			api.ts = tsSharedInformers.Split().V1alpha1().TrafficSplits()
 			api.syncChecks = append(api.syncChecks, api.ts.Informer().HasSynced)
+		case Node:
+			api.node = sharedInformers.Core().V1().Nodes()
+			api.syncChecks = append(api.syncChecks, api.node.Informer().HasSynced)
 		}
 	}
 
@@ -337,6 +342,14 @@ func (api *API) TS() tsinformers.TrafficSplitInformer {
 		panic("TS informer not configured")
 	}
 	return api.ts
+}
+
+// Node provides access to a shared informer and lister for Nodes.
+func (api *API) Node() coreinformers.NodeInformer {
+	if api.node == nil {
+		panic("Node informer not configured")
+	}
+	return api.node
 }
 
 // GetObjects returns a list of Kubernetes objects, given a namespace, type, and name.

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -30,6 +30,7 @@ func NewFakeAPI(configs ...string) (*API, error) {
 		SS,
 		Svc,
 		TS,
+		Node,
 	), nil
 }
 

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -23,11 +23,12 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 )
 
 const requireIDHeader = "l5d-require-id"
-const podIPIndex = "ip"
+const ipIndex = "ip"
 const defaultMaxRps = 100.0
 
 // GRPCTapServer describes the gRPC server implementing pb.TapServer
@@ -510,7 +511,8 @@ func NewGrpcTapServer(
 	clusterDomain string,
 	k8sAPI *k8s.API,
 ) *GRPCTapServer {
-	k8sAPI.Pod().Informer().AddIndexers(cache.Indexers{podIPIndex: indexPodByIP})
+	k8sAPI.Pod().Informer().AddIndexers(cache.Indexers{ipIndex: indexByIP})
+	k8sAPI.Node().Informer().AddIndexers(cache.Indexers{ipIndex: indexByIP})
 
 	return newGRPCTapServer(tapPort, controllerNamespace, clusterDomain, k8sAPI)
 }
@@ -534,11 +536,21 @@ func newGRPCTapServer(
 	return srv
 }
 
-func indexPodByIP(obj interface{}) ([]string, error) {
-	if pod, ok := obj.(*corev1.Pod); ok {
-		return []string{pod.Status.PodIP}, nil
+func indexByIP(obj interface{}) ([]string, error) {
+	switch v := obj.(type) {
+	case *corev1.Pod:
+		return []string{v.Status.PodIP}, nil
+	case *corev1.Node:
+		addresses := make([]string, 0)
+		for _, address := range v.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP {
+				log.Debugf("Indexing node address: %s", address.Address)
+				addresses = append(addresses, address.Address)
+			}
+		}
+		return addresses, nil
 	}
-	return []string{""}, fmt.Errorf("object is not a pod")
+	return []string{""}, fmt.Errorf("object is not a pod nor a node")
 }
 
 // hydrateEventLabels attempts to hydrate the metadata labels for an event's
@@ -568,60 +580,71 @@ func (s *GRPCTapServer) hydrateEventLabels(ev *public.TapEvent) {
 // hydrateIPMeta attempts to determine the metadata labels for `ip` and, if
 // successful, adds them to `labels`.
 func (s *GRPCTapServer) hydrateIPLabels(ip *public.IPAddress, labels map[string]string) error {
-	pod, err := s.podForIP(ip)
-	switch {
-	case err != nil:
+	res, err := s.resourceForIP(ip)
+	if err != nil {
 		return err
-	case pod == nil:
-		log.Debugf("no pod for IP %s", addr.PublicIPToString(ip))
-		return nil
-	default:
-		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(pod, false)
-		podLabels := pkgK8s.GetPodLabels(ownerKind, ownerName, pod)
+	}
+
+	switch v := res.(type) {
+	case *corev1.Pod:
+		if v == nil {
+			log.Debugf("no pod found for IP %s", addr.PublicIPToString(ip))
+			return nil
+		}
+		ownerKind, ownerName := s.k8sAPI.GetOwnerKindAndName(v, false)
+		podLabels := pkgK8s.GetPodLabels(ownerKind, ownerName, v)
 		for key, value := range podLabels {
 			labels[key] = value
 		}
-		labels[pkgK8s.Namespace] = pod.Namespace
-		return nil
+		labels[pkgK8s.Namespace] = v.Namespace
+	case *corev1.Node:
+		labels[pkgK8s.Node] = v.Name
 	}
+	return nil
 }
 
-// podForIP returns the pod corresponding to a given IP address, if one exists.
+// resourceForIP returns the pod or node corresponding to a given IP address.
 //
 // If multiple pods exist with the same IP address, this may be because some
 // are terminating and the IP has been assigned to a new pod. In this case, we
-// select the running pod, if one currently exists. If there is a single pod
-// which is not running, we return that pod. Otherwise we return `nil`, as we
-// cannot easily determine which pod sent a given request.
+// select the running pod, if only one currently exists. If multiple exist, then
+// we return the node whose internal IP matches (if there's only one).
 //
-// If no pods were found for the provided IP address, it returns nil. Errors are
-// returned only in the event of an error indexing the pods list.
-func (s *GRPCTapServer) podForIP(ip *public.IPAddress) (*corev1.Pod, error) {
+// If no pods or nodes were found for the provided IP address, it returns nil. Errors are
+// returned only in the event of an error searching the indices.
+func (s *GRPCTapServer) resourceForIP(ip *public.IPAddress) (runtime.Object, error) {
 	ipStr := addr.PublicIPToString(ip)
-	objs, err := s.k8sAPI.Pod().Informer().GetIndexer().ByIndex(podIPIndex, ipStr)
-
+	pods, err := s.k8sAPI.Pod().Informer().GetIndexer().ByIndex(ipIndex, ipStr)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(objs) == 1 {
+	if len(pods) == 1 {
 		log.Debugf("found one pod at IP %s", ipStr)
 		// It's safe to cast elements of `objs` to a `Pod`s here (and in the
 		// loop below). If the object wasn't a pod, it should never have been
 		// indexed by the indexing func in the first place.
-		return objs[0].(*corev1.Pod), nil
+		return pods[0].(*corev1.Pod), nil
 	}
 
 	var singleRunningPod *corev1.Pod
-	for _, obj := range objs {
+	for _, obj := range pods {
 		pod := obj.(*corev1.Pod)
 		if pod.Status.Phase == corev1.PodRunning {
 			if singleRunningPod != nil {
 				log.Warnf(
 					"could not uniquely identify pod at %s (found %d pods)",
 					ipStr,
-					len(objs),
+					len(pods),
 				)
+
+				nodes, err := s.k8sAPI.Node().Informer().GetIndexer().ByIndex(ipIndex, ipStr)
+				if err != nil {
+					return nil, err
+				}
+				if len(nodes) == 1 {
+					return nodes[0].(*corev1.Node), nil
+				}
 				return nil, nil
 			}
 			singleRunningPod = pod

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -22,6 +22,7 @@ const (
 	ServiceProfile        = "serviceprofile"
 	StatefulSet           = "statefulset"
 	TrafficSplit          = "trafficsplit"
+	Node                  = "node"
 
 	ServiceProfileAPIVersion = "linkerd.io/v1alpha2"
 	ServiceProfileKind       = "ServiceProfile"

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -113,6 +113,11 @@ export const processNeighborData = (source, labels, resourceAgg, resourceType) =
       name: labels.pod,
       namespace: labels.namespace
     };
+  } else if (_has(labels, "node")) {
+    neighb = {
+      type: "node",
+      name: labels.node,
+    };
   } else {
     neighb = {
       type: "ip",


### PR DESCRIPTION
When an unmeshed source ip matched more than one running pod, tap was
showing the names for all those pods, even though they didn't necessary
originate the connection. This could be reproduced when using a pod
network add-on such as Calico.

With this change, if more than one running pod matches the source, only
use the IP as source without attaching any of the pods' metadata.

Fixes #3103 

#### Tested using GKE with Network Policy enabled (Calico), with emojivoto without vote-bot, but the readiness probe hitting the web deployment:

Before:
![Screenshot from 2019-10-02 08-22-02](https://user-images.githubusercontent.com/554287/66066655-8c24c180-e50f-11e9-8c8d-57f25185d934.png)

After:
![Screenshot from 2019-10-02 12-12-25](https://user-images.githubusercontent.com/554287/66066694-a2328200-e50f-11e9-9af4-a40c915e0185.png)
