### PR TITLE
Make config mount path configurable

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -201,11 +201,17 @@ Linkerd2's control plane is composed of several Go microservices. You can run
 these components in a Kubernetes (or Minikube) cluster, or even locally.
 
 To run an individual component locally, you can use the `go-run` command, and
-pass in valid Kubernetes credentials via the `-kubeconfig` flag. For instance,
-to run the destination service locally, run:
+pass in valid Kubernetes credentials via the `-kubeconfig` flag. Some components
+also require config files which are typically mounted from a ConfigMap when
+the component is running in Kubernetes.  To run locally, you will need to
+provide these config files via the `-config-mount-path` flag.  If you already
+have Linkerd installed on a Kubernetes cluster, you can use the
+`bin/fetch-config` script to download Linkerd's config files for local use.
+For instance, to run the destination service locally, run:
 
 ```bash
-bin/go-run controller/cmd/destination -kubeconfig ~/.kube/config -log-level debug
+bin/fetch-config
+bin/go-run controller/cmd/destination -kubeconfig ~/.kube/config -log-level debug -config-mount-path .
 ```
 
 You can send test requests to the destination service using the
@@ -213,11 +219,6 @@ You can send test requests to the destination service using the
 
 ```bash
 bin/go-run controller/script/destination-client -path hello.default.svc.cluster.local:80
-```
-
-You can also send test requests to the destination's discovery interface:
-```bash
-bin/go-run controller/script/discovery-client
 ```
 
 ##### Running the Tap APIService for development

--- a/bin/fetch-config
+++ b/bin/fetch-config
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p config
+for cfg in global install proxy ; do
+    kubectl -n linkerd get cm/linkerd-config -ojsonpath="{.data.$cfg}" > config/$cfg
+done

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -67,6 +67,7 @@ func newGrpcServer(
 	controllerNamespace string,
 	clusterDomain string,
 	ignoredNamespaces []string,
+	configMountPath string,
 ) *grpcServer {
 
 	grpcServer := &grpcServer{
@@ -77,8 +78,8 @@ func newGrpcServer(
 		controllerNamespace:   controllerNamespace,
 		clusterDomain:         clusterDomain,
 		ignoredNamespaces:     ignoredNamespaces,
-		mountPathGlobalConfig: pkgK8s.MountPathGlobalConfig,
-		mountPathProxyConfig:  pkgK8s.MountPathProxyConfig,
+		mountPathGlobalConfig: pkgK8s.GlobalConfig(configMountPath),
+		mountPathProxyConfig:  pkgK8s.ProxyConfig(configMountPath),
 	}
 
 	pb.RegisterApiServer(prometheus.NewGrpcServer(), grpcServer)

--- a/controller/api/public/grpc_server_test.go
+++ b/controller/api/public/grpc_server_test.go
@@ -404,6 +404,7 @@ status:
 				"linkerd",
 				"mycluster.local",
 				[]string{},
+				"",
 			)
 
 			k8sAPI.Sync()
@@ -507,6 +508,7 @@ metadata:
 				"linkerd",
 				"mycluster.local",
 				[]string{},
+				"",
 			)
 
 			k8sAPI.Sync()
@@ -538,6 +540,7 @@ func TestConfig(t *testing.T) {
 			"linkerd",
 			"mycluster.local",
 			[]string{},
+			"",
 		)
 		fakeGrpcServer.mountPathGlobalConfig = "testdata/global.conf.json"
 		fakeGrpcServer.mountPathProxyConfig = "testdata/proxy.conf.json"

--- a/controller/api/public/http_server.go
+++ b/controller/api/public/http_server.go
@@ -324,6 +324,7 @@ func NewServer(
 	controllerNamespace string,
 	clusterDomain string,
 	ignoredNamespaces []string,
+	configMountPath string,
 ) *http.Server {
 	baseHandler := &handler{
 		grpcServer: newGrpcServer(
@@ -334,6 +335,7 @@ func NewServer(
 			controllerNamespace,
 			clusterDomain,
 			ignoredNamespaces,
+			configMountPath,
 		),
 	}
 

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1395,6 +1395,7 @@ status:
 				"linkerd",
 				"mycluster.local",
 				[]string{},
+				"",
 			)
 
 			_, err := fakeGrpcServer.StatSummary(context.TODO(), &exp.req)
@@ -1421,6 +1422,7 @@ status:
 			"linkerd",
 			"mycluster.local",
 			[]string{},
+			"",
 		)
 
 		invalidRequests := []statSumExpected{

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -551,6 +551,7 @@ func newMockGrpcServer(exp expectedStatRPC) (*MockProm, *grpcServer, error) {
 		"linkerd",
 		"cluster.local",
 		[]string{},
+		"",
 	)
 
 	k8sAPI.Sync()

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -26,6 +26,7 @@ func Main(args []string) {
 	enableH2Upgrade := cmd.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
 	disableIdentity := cmd.Bool("disable-identity", false, "Disable identity configuration")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	configMountPath := cmd.String("config-mount-path", consts.DefaultMouthPathBase, "Path where Linkerd configs are mounted")
 
 	flags.ConfigureAndParse(cmd, args)
 
@@ -47,7 +48,7 @@ func Main(args []string) {
 		log.Fatalf("Failed to listen on %s: %s", *addr, err)
 	}
 
-	global, err := config.Global(consts.MountPathGlobalConfig)
+	global, err := config.Global(consts.GlobalConfig(*configMountPath))
 	if err != nil {
 		log.Fatalf("Failed to load global config: %s", err)
 	}

--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -36,10 +36,11 @@ func Main(args []string) {
 	issuerPath := cmd.String("issuer",
 		"/var/run/linkerd/identity/issuer",
 		"path to directory containing issuer credentials")
+	configMountPath := cmd.String("config-mount-path", consts.DefaultMouthPathBase, "Path where Linkerd configs are mounted")
 
 	flags.ConfigureAndParse(cmd, args)
 
-	cfg, err := config.Global(consts.MountPathGlobalConfig)
+	cfg, err := config.Global(consts.GlobalConfig(*configMountPath))
 	if err != nil {
 		log.Fatalf("Failed to load config: %s", err.Error())
 	}

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -31,6 +31,7 @@ func Main(args []string) {
 	destinationAPIAddr := cmd.String("destination-addr", "127.0.0.1:8086", "address of destination service")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	ignoredNamespaces := cmd.String("ignore-namespaces", "kube-system", "comma separated list of namespaces to not list pods from")
+	configMountPath := cmd.String("config-mount-path", pkgK8s.DefaultMouthPathBase, "Path where Linkerd configs are mounted")
 
 	flags.ConfigureAndParse(cmd, args)
 
@@ -62,7 +63,7 @@ func Main(args []string) {
 		log.Fatal(err.Error())
 	}
 
-	globalConfig, err := config.Global(pkgK8s.MountPathGlobalConfig)
+	globalConfig, err := config.Global(pkgK8s.GlobalConfig(*configMountPath))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -81,6 +82,7 @@ func Main(args []string) {
 		*controllerNamespace,
 		clusterDomain,
 		strings.Split(*ignoredNamespaces, ","),
+		*configMountPath,
 	)
 
 	k8sAPI.Sync() // blocks until caches are synced

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -26,9 +26,10 @@ func Main(args []string) {
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	tapPort := cmd.Uint("tap-port", 4190, "proxy tap port to connect to")
-	tlsCertPath := cmd.String("tls-cert", pkgK8s.MountPathTLSCrtPEM, "path to TLS Cert PEM")
-	tlsKeyPath := cmd.String("tls-key", pkgK8s.MountPathTLSKeyPEM, "path to TLS Key PEM")
+	tlsCertPath := cmd.String("tls-cert", pkgK8s.TLSCrtPEM(pkgK8s.DefaultMouthPathBase), "path to TLS Cert PEM")
+	tlsKeyPath := cmd.String("tls-key", pkgK8s.TLSKeyPEM(pkgK8s.DefaultMouthPathBase), "path to TLS Key PEM")
 	disableCommonNames := cmd.Bool("disable-common-names", false, "disable checks for Common Names (for development)")
+	configMountPath := cmd.String("config-mount-path", pkgK8s.DefaultMouthPathBase, "Path where Linkerd configs are mounted")
 
 	flags.ConfigureAndParse(cmd, args)
 
@@ -51,7 +52,7 @@ func Main(args []string) {
 		log.Fatalf("Failed to initialize K8s API: %s", err)
 	}
 
-	globalConfig, err := config.Global(pkgK8s.MountPathGlobalConfig)
+	globalConfig, err := config.Global(pkgK8s.GlobalConfig(*configMountPath))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -28,15 +28,16 @@ const (
 func Inject(api *k8s.API,
 	request *admissionv1beta1.AdmissionRequest,
 	recorder record.EventRecorder,
+	configMountPath string,
 ) (*admissionv1beta1.AdmissionResponse, error) {
 	log.Debugf("request object bytes: %s", request.Object.Raw)
 
-	globalConfig, err := config.Global(pkgK8s.MountPathGlobalConfig)
+	globalConfig, err := config.Global(pkgK8s.GlobalConfig(configMountPath))
 	if err != nil {
 		return nil, err
 	}
 
-	proxyConfig, err := config.Proxy(pkgK8s.MountPathProxyConfig)
+	proxyConfig, err := config.Proxy(pkgK8s.ProxyConfig(configMountPath))
 	if err != nil {
 		return nil, err
 	}

--- a/controller/sp-validator/webhook.go
+++ b/controller/sp-validator/webhook.go
@@ -11,7 +11,7 @@ import (
 // AdmitSP verifies that the received Admission Request contains a valid
 // Service Profile definition
 func AdmitSP(
-	_ *k8s.API, request *admissionv1beta1.AdmissionRequest, _ record.EventRecorder,
+	_ *k8s.API, request *admissionv1beta1.AdmissionRequest, _ record.EventRecorder, _ string,
 ) (*admissionv1beta1.AdmissionResponse, error) {
 	admissionResponse := &admissionv1beta1.AdmissionResponse{Allowed: true}
 	if err := profiles.Validate(request.Object.Raw); err != nil {

--- a/controller/webhook/server.go
+++ b/controller/webhook/server.go
@@ -19,18 +19,19 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type handlerFunc func(*k8s.API, *admissionv1beta1.AdmissionRequest, record.EventRecorder) (*admissionv1beta1.AdmissionResponse, error)
+type handlerFunc func(*k8s.API, *admissionv1beta1.AdmissionRequest, record.EventRecorder, string) (*admissionv1beta1.AdmissionResponse, error)
 
 // Server describes the https server implementing the webhook
 type Server struct {
 	*http.Server
-	api      *k8s.API
-	handler  handlerFunc
-	recorder record.EventRecorder
+	api             *k8s.API
+	handler         handlerFunc
+	recorder        record.EventRecorder
+	configMountPath string
 }
 
 // NewServer returns a new instance of Server
-func NewServer(api *k8s.API, addr string, cred *pkgTls.Cred, handler handlerFunc, component string) (*Server, error) {
+func NewServer(api *k8s.API, addr string, cred *pkgTls.Cred, handler handlerFunc, component string, configMountPath string) (*Server, error) {
 	var (
 		certPEM = cred.EncodePEM()
 		keyPEM  = cred.EncodePrivateKeyPEM()
@@ -56,7 +57,7 @@ func NewServer(api *k8s.API, addr string, cred *pkgTls.Cred, handler handlerFunc
 	})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: component})
 
-	s := &Server{server, api, handler, recorder}
+	s := &Server{server, api, handler, recorder, configMountPath}
 	s.Handler = http.HandlerFunc(s.serve)
 	return s, nil
 }
@@ -119,7 +120,7 @@ func (s *Server) processReq(data []byte) *admissionv1beta1.AdmissionReview {
 	log.Infof("received admission review request %s", admissionReview.Request.UID)
 	log.Debugf("admission request: %+v", admissionReview.Request)
 
-	admissionResponse, err := s.handler(s.api, admissionReview.Request, s.recorder)
+	admissionResponse, err := s.handler(s.api, admissionReview.Request, s.recorder, s.configMountPath)
 	if err != nil {
 		log.Error("failed to inject sidecar. Reason: ", err)
 		admissionReview.Response = &admissionv1beta1.AdmissionResponse{

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -18,7 +18,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		testServer := &Server{nil, k8sAPI, nil, nil}
+		testServer := &Server{nil, k8sAPI, nil, nil, ""}
 
 		in := bytes.NewReader(nil)
 		request := httptest.NewRequest(http.MethodGet, "/", in)
@@ -38,7 +38,7 @@ func TestServe(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	server := &http.Server{Addr: ":0"}
-	testServer := &Server{server, nil, nil, nil}
+	testServer := &Server{server, nil, nil, nil, ""}
 
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -241,41 +241,48 @@ const (
 	TapServiceName = "linkerd-tap"
 
 	/*
-	 * Mount paths
+	 * Account tokens
 	 */
-
-	// MountPathBase is the base directory of the mount path.
-	MountPathBase = "/var/run/linkerd"
 
 	// MountPathServiceAccount is the default path where Kuberenetes stores
 	// the service account token
 	MountPathServiceAccount = "/var/run/secrets/kubernetes.io/serviceaccount"
-
-	// MountPathGlobalConfig is the path at which the global config file is mounted.
-	MountPathGlobalConfig = MountPathBase + "/config/global"
-
-	// MountPathProxyConfig is the path at which the global config file is mounted.
-	MountPathProxyConfig = MountPathBase + "/config/proxy"
-
-	// MountPathInstallConfig is the path at which the install config file is mounted.
-	MountPathInstallConfig = MountPathBase + "/config/install"
-
-	// MountPathEndEntity is the path at which a tmpfs directory is mounted to
-	// store identity credentials.
-	MountPathEndEntity = MountPathBase + "/identity/end-entity"
-
-	// MountPathTLSKeyPEM is the path at which the TLS key PEM file is mounted.
-	MountPathTLSKeyPEM = MountPathBase + "/tls/key.pem"
-
-	// MountPathTLSCrtPEM is the path at which the TLS cert PEM file is mounted.
-	MountPathTLSCrtPEM = MountPathBase + "/tls/crt.pem"
 
 	// IdentityServiceAccountTokenPath is the path to the kubernetes service
 	// account token used by proxies to provision identity.
 	//
 	// In the future, this should be changed to a time- and audience-scoped secret.
 	IdentityServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	/*
+	 * Mount path
+	 */
+
+	DefaultMouthPathBase = "/var/run/linkerd"
 )
+
+/*
+ * Mount paths
+ */
+
+// GlobalConfig is the path at which the global config file is mounted.
+func GlobalConfig(mountPathBase string) string { return mountPathBase + "/config/global" }
+
+// ProxyConfig is the path at which the proxy config file is mounted.
+func ProxyConfig(mountPathBase string) string { return mountPathBase + "/config/proxy" }
+
+// InstallConfig is the path at which the install config file is mounted.
+func InstallConfig(mountPathBase string) string { return mountPathBase + "/config/install" }
+
+// EndEntity is the path at which a tmpfs directory is mounted to store identity
+// credentials.
+func EndEntity(mountPathBase string) string { return mountPathBase + "/identity/end-entity" }
+
+// TLSKeyPEM is the path at which the TLS key PEM file is mounted.
+func TLSKeyPEM(mountPathBase string) string { return mountPathBase + "/tls/key.pem" }
+
+// MountPathTLSCrtPEM is the path at which the TLS cert PEM file is mounted.
+func TLSCrtPEM(mountPathBase string) string { return mountPathBase + "/tls/crt.pem" }
 
 // CreatedByAnnotationValue returns the value associated with
 // CreatedByAnnotation.

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -258,6 +258,8 @@ const (
 	 * Mount path
 	 */
 
+	// DefaultMouthPathBase is the default filesystem path where config files
+	// will be read from.
 	DefaultMouthPathBase = "/var/run/linkerd"
 )
 
@@ -281,7 +283,7 @@ func EndEntity(mountPathBase string) string { return mountPathBase + "/identity/
 // TLSKeyPEM is the path at which the TLS key PEM file is mounted.
 func TLSKeyPEM(mountPathBase string) string { return mountPathBase + "/tls/key.pem" }
 
-// MountPathTLSCrtPEM is the path at which the TLS cert PEM file is mounted.
+// TLSCrtPEM is the path at which the TLS cert PEM file is mounted.
 func TLSCrtPEM(mountPathBase string) string { return mountPathBase + "/tls/crt.pem" }
 
 // CreatedByAnnotationValue returns the value associated with

--- a/web/main.go
+++ b/web/main.go
@@ -31,6 +31,7 @@ func main() {
 	reload := cmd.Bool("reload", true, "reloading set to true or false")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
+	configMountPath := cmd.String("config-mount-path", pkgK8s.DefaultMouthPathBase, "Path where Linkerd configs are mounted")
 
 	flags.ConfigureAndParse(cmd, os.Args[1:])
 
@@ -43,7 +44,7 @@ func main() {
 		log.Fatalf("failed to construct client for API server URL %s", *apiAddr)
 	}
 
-	globalConfig, err := config.Global(pkgK8s.MountPathGlobalConfig)
+	globalConfig, err := config.Global(pkgK8s.GlobalConfig(*configMountPath))
 	clusterDomain := globalConfig.GetClusterDomain()
 	if err != nil || clusterDomain == "" {
 		clusterDomain = "cluster.local"
@@ -55,7 +56,7 @@ func main() {
 		log.Fatalf("failed to construct Kubernetes API client: [%s]", err)
 	}
 
-	installConfig, err := config.Install(pkgK8s.MountPathInstallConfig)
+	installConfig, err := config.Install(pkgK8s.InstallConfig(*configMountPath))
 	if err != nil {
 		log.Warnf("failed to load uuid from install config: [%s] (disregard warning if running in development mode)", err)
 	}


### PR DESCRIPTION
The base config mount path where Linkerd will look for config files is hardcoded.  This makes it very difficult to run the control plane locally since you need to create or download the Linkerd configmap files to that specific location in your local filesystem.

We make this configurable with a `-config-mount-path` flag which indicates where the config files should be loaded from.  We also add a `fetch-config` script which uses kubectl to download the config files from your cluster to your local filesystem for local development.