### PR TITLE
Health check: check if proxies trust anchors match configuration

### DIFF
--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -20,6 +20,10 @@ const (
 	// DefaultIssuanceLifetime is the default lifetime of certificates issued by
 	// the identity service.
 	DefaultIssuanceLifetime = 24 * time.Hour
+
+	// EnvTrustAnchors is the environment variable holding the trust anchors for
+	// the proxy identity.
+	EnvTrustAnchors = "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS"
 )
 
 type (

--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -13,13 +13,13 @@ import (
 	"path/filepath"
 
 	"github.com/linkerd/linkerd2/pkg/flags"
+	"github.com/linkerd/linkerd2/pkg/identity"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	envDisabled     = "LINKERD2_PROXY_IDENTITY_DISABLED"
-	envTrustAnchors = "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS"
+	envDisabled = "LINKERD2_PROXY_IDENTITY_DISABLED"
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 		log.Fatalf("Invalid end-entity directory: %s", err)
 	}
 
-	if _, err := loadVerifier(os.Getenv(envTrustAnchors)); err != nil {
+	if _, err := loadVerifier(os.Getenv(identity.EnvTrustAnchors)); err != nil {
 		log.Fatalf("Failed to load trust anchors: %s", err)
 	}
 
@@ -56,7 +56,7 @@ func main() {
 
 func loadVerifier(pem string) (verify x509.VerifyOptions, err error) {
 	if pem == "" {
-		err = fmt.Errorf("'%s' must be set", envTrustAnchors)
+		err = fmt.Errorf("'%s' must be set", identity.EnvTrustAnchors)
 		return
 	}
 


### PR DESCRIPTION
If Linkerd is reinstalled or if the trust anchors are modified while
proxies are running on the cluster, they will contain an outdated
`LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS` certificate.

This changeset adds support for `linkerd check`, so it checks if there
is any proxy running on the cluster, and performing the check against
the configuration trust anchor. If there's a failure (considered non
fatal), `linkerd check` will notify the user about what pods are the
offenders (and in what namespace each one is), and also a way to
remediate the issue (restarting the pods).

Fixes #3344

Signed-off-by: Rafael Fernández López <ereslibre@ereslibre.es>