### PR TITLE
Fallback to defaults when config cannot be loaded

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -53,9 +53,8 @@ func Main(args []string) {
 	if *disableIdentity {
 		log.Info("Identity is disabled")
 	} else {
-		if err != nil {
-			trustDomain = global.GetIdentityContext().GetTrustDomain()
-		} else {
+		trustDomain = global.GetIdentityContext().GetTrustDomain()
+		if err != nil || trustDomain == "" {
 			trustDomain = "cluster.local"
 			log.Warnf("failed to load trust domain from global config: [%s] (falling back to %s)", err, trustDomain)
 		}

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -48,18 +48,24 @@ func Main(args []string) {
 	}
 
 	global, err := config.Global(consts.MountPathGlobalConfig)
-	if err != nil {
-		log.Fatalf("Failed to load global config: %s", err)
-	}
 
 	trustDomain := ""
 	if *disableIdentity {
 		log.Info("Identity is disabled")
 	} else {
-		trustDomain = global.GetIdentityContext().GetTrustDomain()
+		if err != nil {
+			trustDomain = global.GetIdentityContext().GetTrustDomain()
+		} else {
+			trustDomain = "cluster.local"
+			log.Warnf("failed to load trust domain from global config: [%s] (falling back to %s)", err, trustDomain)
+		}
 	}
 
 	clusterDomain := global.GetClusterDomain()
+	if err != nil || clusterDomain == "" {
+		clusterDomain = "cluster.local"
+		log.Warnf("failed to load cluster domain from global config: [%s] (falling back to %s)", err, clusterDomain)
+	}
 
 	server := destination.NewServer(
 		*addr,


### PR DESCRIPTION
When running the destination controller locally, the Linkerd config files which are typically mounted from a configmap are not available.  To facilitate local development, we fall back to default values in this case instead of failing to start up.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
