### PR TITLE
Responsive dashboard sidebar behavior and refactoring Navigation component

### DIFF
--- a/web/app/css/svg-wrappers.css
+++ b/web/app/css/svg-wrappers.css
@@ -17,17 +17,15 @@
 .linkerd-word-logo .st0{fill:#FF576B;}
 .linkerd-word-logo .st1{fill:#6D6E71;}
 .linkerd-word-logo .st2{fill:#FFFFFF;}
-/* blue gradient; hard-coding #2BEDA7 for Safari browsers */
-.linkerd-word-logo .st3{fill:url(#SVGID_1_) #2BEDA7;}
-.linkerd-word-logo .st4{fill:url(#SVGID_2_) #2BEDA7;}
+.linkerd-word-logo .st3{fill:url(#SVGID_1_);}
+.linkerd-word-logo .st4{fill:url(#SVGID_2_);}
 .linkerd-word-logo .st5{fill:#2BEDA7;}
-.linkerd-word-logo .st6{fill:url(#SVGID_3_) #2BEDA7;}
-.linkerd-word-logo .st7{fill:url(#SVGID_4_) #2BEDA7;}
-.linkerd-word-logo .st8{fill:url(#SVGID_5_) #2BEDA7;}
-.linkerd-word-logo .st9{fill:url(#SVGID_6_) #2BEDA7;}
-.linkerd-word-logo .st10{fill:url(#SVGID_7_) #2BEDA7;}
-.linkerd-word-logo .st11{fill:url(#SVGID_8_) #2BEDA7;}
-/* end gradient */
+.linkerd-word-logo .st6{fill:url(#SVGID_3_);}
+.linkerd-word-logo .st7{fill:url(#SVGID_4_);}
+.linkerd-word-logo .st8{fill:url(#SVGID_5_);}
+.linkerd-word-logo .st9{fill:url(#SVGID_6_);}
+.linkerd-word-logo .st10{fill:url(#SVGID_7_);}
+.linkerd-word-logo .st11{fill:url(#SVGID_8_);}
 .linkerd-word-logo .st12{fill:url(#SVGID_9_);}
 .linkerd-word-logo .st13{fill:url(#SVGID_10_);}
 .linkerd-word-logo .st14{fill:url(#SVGID_11_);}

--- a/web/app/css/svg-wrappers.css
+++ b/web/app/css/svg-wrappers.css
@@ -17,15 +17,17 @@
 .linkerd-word-logo .st0{fill:#FF576B;}
 .linkerd-word-logo .st1{fill:#6D6E71;}
 .linkerd-word-logo .st2{fill:#FFFFFF;}
-.linkerd-word-logo .st3{fill:url(#SVGID_1_);}
-.linkerd-word-logo .st4{fill:url(#SVGID_2_);}
+/* blue gradient; hard-coding #2BEDA7 for Safari browsers */
+.linkerd-word-logo .st3{fill:url(#SVGID_1_) #2BEDA7;}
+.linkerd-word-logo .st4{fill:url(#SVGID_2_) #2BEDA7;}
 .linkerd-word-logo .st5{fill:#2BEDA7;}
-.linkerd-word-logo .st6{fill:url(#SVGID_3_);}
-.linkerd-word-logo .st7{fill:url(#SVGID_4_);}
-.linkerd-word-logo .st8{fill:url(#SVGID_5_);}
-.linkerd-word-logo .st9{fill:url(#SVGID_6_);}
-.linkerd-word-logo .st10{fill:url(#SVGID_7_);}
-.linkerd-word-logo .st11{fill:url(#SVGID_8_);}
+.linkerd-word-logo .st6{fill:url(#SVGID_3_) #2BEDA7;}
+.linkerd-word-logo .st7{fill:url(#SVGID_4_) #2BEDA7;}
+.linkerd-word-logo .st8{fill:url(#SVGID_5_) #2BEDA7;}
+.linkerd-word-logo .st9{fill:url(#SVGID_6_) #2BEDA7;}
+.linkerd-word-logo .st10{fill:url(#SVGID_7_) #2BEDA7;}
+.linkerd-word-logo .st11{fill:url(#SVGID_8_) #2BEDA7;}
+/* end gradient */
 .linkerd-word-logo .st12{fill:url(#SVGID_9_);}
 .linkerd-word-logo .st13{fill:url(#SVGID_10_);}
 .linkerd-word-logo .st14{fill:url(#SVGID_11_);}

--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -87,17 +87,13 @@ class BreadcrumbHeader extends React.Component {
 
   render() {
     let prefix = this.props.pathPrefix;
-    let PrefixedLink = this.api.PrefixedLink;
     let breadcrumbs = this.convertURLToBreadcrumbs(this.props.location.pathname.replace(prefix, ""));
     let shouldPluralizeFirstSegment = breadcrumbs.length === 1;
 
     return breadcrumbs.map((pathSegment, index) => {
       return (
-        <span key={pathSegment.segment} className="breadcrumb-link">
-          <PrefixedLink
-            to={pathSegment.link}>
-            {this.renderBreadcrumbSegment(pathSegment.segment, shouldPluralizeFirstSegment && index === 0)}
-          </PrefixedLink>
+        <span key={pathSegment.segment}>
+          {this.renderBreadcrumbSegment(pathSegment.segment, shouldPluralizeFirstSegment && index === 0)}
           { index < breadcrumbs.length - 1 ? " > " : null }
         </span>
       );

--- a/web/app/js/components/BreadcrumbHeader.test.jsx
+++ b/web/app/js/components/BreadcrumbHeader.test.jsx
@@ -23,7 +23,7 @@ describe('Tests for <BreadcrumbHeader>', () => {
       </BrowserRouter>
     );
 
-    const crumbs = component.find("a");
+    const crumbs = component.find("span");
     expect(crumbs).toHaveLength(3);
   });
 });

--- a/web/app/js/components/NamespaceConfirmationModal.jsx
+++ b/web/app/js/components/NamespaceConfirmationModal.jsx
@@ -1,0 +1,50 @@
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class NamespaceConfirmationModal extends React.Component {
+
+  render() {
+    const { open, selectedNamespace, newNamespace, handleConfirmNamespaceChange, handleDialogCancel } = this.props;
+
+    return (
+      <React.Fragment>
+        <Dialog
+          open={open}
+          onClose={this.handleClose}>
+          <DialogTitle>
+            Change namespace?
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              The resource you are viewing is in a different namespace than the namespace you have selected. Do you want to change the namespace from { selectedNamespace } to { newNamespace }?
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleConfirmNamespaceChange} color="primary">
+              Yes
+            </Button>
+            <Button onClick={handleDialogCancel} variant="text">
+              No
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </React.Fragment>
+    );
+  }
+}
+
+NamespaceConfirmationModal.propTypes = {
+  handleConfirmNamespaceChange: PropTypes.func.isRequired,
+  handleDialogCancel: PropTypes.func.isRequired,
+  newNamespace: PropTypes.string.isRequired,
+  open: PropTypes.bool.isRequired,
+  selectedNamespace: PropTypes.string.isRequired
+};
+
+export default NamespaceConfirmationModal;

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -4,16 +4,11 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import Badge from '@material-ui/core/Badge';
 import BreadcrumbHeader from './BreadcrumbHeader.jsx';
 import Button from '@material-ui/core/Button';
-import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import Divider from '@material-ui/core/Divider';
 import Drawer from '@material-ui/core/Drawer';
 import EmailIcon from '@material-ui/icons/Email';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Hidden from '@material-ui/core/Hidden';
 import IconButton from '@material-ui/core/IconButton';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
 import { Link } from 'react-router-dom';
@@ -22,6 +17,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
+import NamespaceConfirmationModal from './NamespaceConfirmationModal.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
@@ -29,7 +25,6 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Version from './Version.jsx';
 import _maxBy from 'lodash/maxBy';
-import classNames from 'classnames';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { faCloud } from '@fortawesome/free-solid-svg-icons/faCloud';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons/faExternalLinkAlt';
@@ -49,8 +44,7 @@ const localStorageKey = "linkerd-updates-last-clicked";
 const minBrowserWidth = 960;
 
 const styles = theme => {
-  const drawerWidth = theme.spacing.unit * 36;
-  const drawerWidthClosed = theme.spacing.unit * 9;
+  const drawerWidth = theme.spacing.unit * 38;
   const navLogoWidth = theme.spacing.unit * 22.5;
   const contentPadding = theme.spacing.unit * 3;
 
@@ -71,34 +65,23 @@ const styles = theme => {
       display: 'flex',
     },
     appBar: {
-      position: "absolute",
+      alignItems: "center",
+      position: "permanent",
       color: 'white',
       transition: leaving,
     },
-    appBarShift: {
-      width: `calc(100% - ${drawerWidth}px)`,
-      transition: entering,
+    bars: {
+      color: 'white',
+      position: "fixed",
+      left: theme.spacing.unit * 2.5,
+    },
+    breadcrumbs: {
+      color: 'white',
+      marginLeft: `${drawerWidth}px`
     },
     drawer: {
       width: drawerWidth,
       transition: entering,
-    },
-    drawerClose: {
-      width: drawerWidthClosed,
-      transition: leaving,
-    },
-    drawerPaper: {
-      overflowX: 'hidden',
-      whiteSpace: 'nowrap',
-      width: drawerWidth,
-      transition: entering,
-    },
-    drawerPaperClose: {
-      transition: leaving,
-      width: drawerWidthClosed,
-      [theme.breakpoints.up('sm')]: {
-        width: drawerWidthClosed,
-      },
     },
     toolbar: theme.mixins.toolbar,
     navToolbar: {
@@ -116,18 +99,13 @@ const styles = theme => {
       padding: contentPadding,
       transition: entering,
     },
-    contentDrawerClose: {
-      width: `calc(100% - ${drawerWidthClosed}px)`,
-      transition: leaving,
-    },
     linkerdNavLogo: {
-      minWidth: `${navLogoWidth}px`,
+      margin: 'auto',
+      width: `${navLogoWidth}px`,
       transition: enteringFn(['margin', 'opacity']),
     },
-    linkerdNavLogoClose: {
-      opacity: "0",
-      marginLeft: `-${navLogoWidth+theme.spacing.unit/2}px`,
-      transition: leavingFn(['margin', 'opacity']),
+    linkerdMobileLogo: {
+      width: `${navLogoWidth}px`,
     },
     namespaceChangeButton: {
       marginLeft: `${drawerWidth * .075}px`,
@@ -158,9 +136,6 @@ const styles = theme => {
       paddingBottom: "9px",
       marginLeft: `${drawerWidth * .09}px`,
     },
-    toggleDrawerButton: {
-      marginRight: `${contentPadding}px`,
-    },
     badge: {
       backgroundColor: yellow[500],
     }
@@ -185,8 +160,9 @@ class NavigationBase extends React.Component {
   getInitialState() {
     return {
       anchorEl: null,
-      drawerOpen: true,
+      mobileSidebarOpen: false,
       namespaceMenuOpen: false,
+      newNamespace: '',
       hideUpdateBadge: true,
       latestVersion: '',
       isLatest: true,
@@ -300,7 +276,7 @@ class NavigationBase extends React.Component {
   }
 
   handleDrawerClick = () => {
-    this.setState(state => ({ drawerOpen: !state.drawerOpen }));
+    this.setState(state => ({ mobileSidebarOpen: !state.mobileSidebarOpen }));
   };
 
   handleConfirmNamespaceChange = () => {
@@ -357,209 +333,214 @@ class NavigationBase extends React.Component {
 
   updateWindowDimensions() {
     let browserWidth = window.innerWidth;
-    if (browserWidth < minBrowserWidth) {
-      this.setState({ drawerOpen: false });
-    } else {
-      this.setState({ drawerOpen: true });
+    if (browserWidth > minBrowserWidth) {
+      this.setState({ mobileSidebarOpen: false });
     }
   }
 
   render() {
     const { api, classes, selectedNamespace, ChildComponent, ...otherProps } = this.props;
-    const { namespaces, anchorEl, drawerOpen, showNamespaceChangeDialog, newNamespace } = this.state;
+    const { namespaces, anchorEl, showNamespaceChangeDialog, newNamespace, mobileSidebarOpen } = this.state;
     let formattedNamespaceName = selectedNamespace;
     if (formattedNamespaceName === "_all") {
       formattedNamespaceName = "All Namespaces";
     }
 
-    return (
-      <div className={classes.root}>
-        <AppBar
-          className={classNames(classes.appBar, {[classes.appBarShift]: drawerOpen} )}>
-          <Toolbar>
-            <Typography variant="h6" color="inherit" noWrap>
-              { !drawerOpen &&
-              <IconButton className={classes.toggleDrawerButton}>
-                <FontAwesomeIcon icon={faBars} onClick={this.handleDrawerClick} />
-              </IconButton>
-              }
-              <BreadcrumbHeader {...this.props} />
-            </Typography>
-          </Toolbar>
-        </AppBar>
-
-        <Drawer
-          className={classNames(classes.drawer, {[classes.drawerClose]: !drawerOpen} )}
-          variant="persistent"
-          classes={{
-            paper: classNames(classes.drawerPaper, {[classes.drawerPaperClose]: !drawerOpen} ),
-          }}
-          open={drawerOpen}>
-          <div className={classNames(classes.navToolbar)}>
-            <div className={classNames(classes.linkerdNavLogo, {[classes.linkerdNavLogoClose]: !drawerOpen} )}>
-              <Link to="/namespaces">{linkerdWordLogo}</Link>
-            </div>
-            <IconButton className="drawer-toggle-btn" onClick={this.handleDrawerClick}>
-              <ChevronLeftIcon />
-            </IconButton>
+    const drawer = (
+      <div>
+        { !mobileSidebarOpen &&
+        <div className={classes.navToolbar}>
+          <div className={classes.linkerdNavLogo}>
+            <Link to="/namespaces">{linkerdWordLogo}</Link>
           </div>
-
-          <Divider />
-          <MenuList>
-            <Typography variant="button" className={classes.sidebarHeading}>
+        </div>
+        }
+        <Divider />
+        <MenuList>
+          <Typography variant="button" className={classes.sidebarHeading}>
                 Cluster
-            </Typography>
+          </Typography>
 
-            { this.menuItem("/namespaces", "Namespaces", namespaceIcon) }
+          { this.menuItem("/namespaces", "Namespaces", namespaceIcon) }
 
 
-            { this.menuItem("/controlplane", "Control Plane",
-              <FontAwesomeIcon icon={faCloud} className={classes.shrinkCloudIcon} />) }
+          { this.menuItem("/controlplane", "Control Plane",
+            <FontAwesomeIcon icon={faCloud} className={classes.shrinkCloudIcon} />) }
 
-          </MenuList>
+        </MenuList>
 
-          <Divider />
+        <Divider />
 
-          <MenuList>
-            <Button
-              variant="contained"
-              className={classes.namespaceChangeButton}
-              size="large"
-              onClick={this.handleNamespaceMenuClick}>
-              { formattedNamespaceName }
-              <ArrowDropDownIcon />
-            </Button>
-            <Menu
-              anchorEl={anchorEl}
-              open={this.state.namespaceMenuOpen}
-              keepMounted
-              onClose={this.handleNamespaceMenuClick}>
-              <MenuItem
-                value="all"
-                onClick={() => this.handleNamespaceChange("_all")}>
+        <MenuList>
+          <Button
+            variant="contained"
+            className={classes.namespaceChangeButton}
+            size="large"
+            onClick={this.handleNamespaceMenuClick}>
+            { formattedNamespaceName }
+            <ArrowDropDownIcon />
+          </Button>
+          <Menu
+            anchorEl={anchorEl}
+            open={this.state.namespaceMenuOpen}
+            keepMounted
+            onClose={this.handleNamespaceMenuClick}>
+            <MenuItem
+              value="all"
+              onClick={() => this.handleNamespaceChange("_all")}>
                   All Namespaces
+            </MenuItem>
+
+            <Divider />
+
+            {namespaces.map(ns => (
+              <MenuItem
+                onClick={() => this.handleNamespaceChange(ns.name)}
+                key={ns.name}>
+                {ns.name}
               </MenuItem>
-
-              <Divider />
-
-              {namespaces.map(ns => (
-                <MenuItem
-                  onClick={() => this.handleNamespaceChange(ns.name)}
-                  key={ns.name}>
-                  {ns.name}
-                </MenuItem>
               ))}
-            </Menu>
-            <Dialog
-              open={showNamespaceChangeDialog}
-              onClose={this.handleClose}
-              aria-labelledby="form-dialog-title">
-              <DialogTitle id="form-dialog-title">
-                Change namespace?
-              </DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-              The resource you are viewing is in a different namespace than the namespace you have selected. Do you want to change the namespace from { selectedNamespace } to { newNamespace }?
-                </DialogContentText>
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={this.handleConfirmNamespaceChange} color="primary">
-                    Yes
-                </Button>
-                <Button onClick={this.handleDialogCancel} variant="text">
-                  No
-                </Button>
-              </DialogActions>
-            </Dialog>
-          </MenuList>
+          </Menu>
+          <NamespaceConfirmationModal
+            open={showNamespaceChangeDialog}
+            selectedNamespace={selectedNamespace}
+            newNamespace={newNamespace}
+            handleDialogCancel={this.handleDialogCancel}
+            handleConfirmNamespaceChange={this.handleConfirmNamespaceChange} />
 
-          <MenuList>
-            <Typography variant="button" className={classes.sidebarHeading}>
+        </MenuList>
+
+        <MenuList>
+          <Typography variant="button" className={classes.sidebarHeading}>
                 Workloads
-            </Typography>
+          </Typography>
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/daemonsets`, "Daemon Sets", daemonsetIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/daemonsets`, "Daemon Sets", daemonsetIcon) }
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/deployments`, "Deployments", deploymentIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/deployments`, "Deployments", deploymentIcon) }
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/jobs`, "Jobs", jobIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/jobs`, "Jobs", jobIcon) }
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/pods`, "Pods", podIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/pods`, "Pods", podIcon) }
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/replicationcontrollers`, "Replication Controllers", replicaSetIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/replicationcontrollers`, "Replication Controllers", replicaSetIcon) }
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/statefulsets`, "Stateful Sets", statefulSetIcon) }
-          </MenuList>
+          { this.menuItem(`/namespaces/${selectedNamespace}/statefulsets`, "Stateful Sets", statefulSetIcon) }
+        </MenuList>
 
-          <MenuList>
-            <Typography variant="button" className={classes.sidebarHeading}>
+        <MenuList>
+          <Typography variant="button" className={classes.sidebarHeading}>
                 Configuration
-            </Typography>
+          </Typography>
 
-            { this.menuItem(`/namespaces/${selectedNamespace}/trafficsplits`, "Traffic Splits", <FontAwesomeIcon icon={faFilter} className={classes.shrinkIcon} />) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/trafficsplits`, "Traffic Splits", <FontAwesomeIcon icon={faFilter} className={classes.shrinkIcon} />) }
 
-          </MenuList>
-          <Divider />
-          <MenuList >
-            <Typography variant="button" className={classes.sidebarHeading}>
+        </MenuList>
+        <Divider />
+        <MenuList >
+          <Typography variant="button" className={classes.sidebarHeading}>
                 Tools
-            </Typography>
+          </Typography>
 
-            { this.menuItem("/tap", "Tap", <FontAwesomeIcon icon={faMicroscope} className={classes.shrinkIcon} />) }
-            { this.menuItem("/top", "Top", <FontAwesomeIcon icon={faStream} className={classes.shrinkIcon} />) }
-            { this.menuItem("/routes", "Routes", <FontAwesomeIcon icon={faRandom} className={classes.shrinkIcon} />) }
+          { this.menuItem("/tap", "Tap", <FontAwesomeIcon icon={faMicroscope} className={classes.shrinkIcon} />) }
+          { this.menuItem("/top", "Top", <FontAwesomeIcon icon={faStream} className={classes.shrinkIcon} />) }
+          { this.menuItem("/routes", "Routes", <FontAwesomeIcon icon={faRandom} className={classes.shrinkIcon} />) }
 
-          </MenuList>
-          <Divider />
-          <MenuList>
-            { this.menuItem("/community", "Community",
-              <Badge
-                classes={{ badge: classes.badge }}
-                invisible={this.state.hideUpdateBadge}
-                badgeContent="1">
-                <FontAwesomeIcon icon={faSmile} className={classes.shrinkIcon} />
-              </Badge>, this.handleCommunityClick
+        </MenuList>
+        <Divider />
+        <MenuList>
+          { this.menuItem("/community", "Community",
+            <Badge
+              classes={{ badge: classes.badge }}
+              invisible={this.state.hideUpdateBadge}
+              badgeContent="1">
+              <FontAwesomeIcon icon={faSmile} className={classes.shrinkIcon} />
+            </Badge>, this.handleCommunityClick
               ) }
 
-            <MenuItem component="a" href="https://linkerd.io/2/overview/" target="_blank" className={classes.navMenuItem}>
-              <ListItemIcon><LibraryBooksIcon className={classes.shrinkIcon} /></ListItemIcon>
-              <ListItemText primary="Documentation" />
-              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
-            </MenuItem>
+          <MenuItem component="a" href="https://linkerd.io/2/overview/" target="_blank" className={classes.navMenuItem}>
+            <ListItemIcon><LibraryBooksIcon className={classes.shrinkIcon} /></ListItemIcon>
+            <ListItemText primary="Documentation" />
+            <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
+          </MenuItem>
 
-            <MenuItem component="a" href="https://github.com/linkerd/linkerd2/issues/new/choose" target="_blank" className={classes.navMenuItem}>
-              <ListItemIcon>{githubIcon}</ListItemIcon>
-              <ListItemText primary="GitHub" />
-              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
-            </MenuItem>
+          <MenuItem component="a" href="https://github.com/linkerd/linkerd2/issues/new/choose" target="_blank" className={classes.navMenuItem}>
+            <ListItemIcon>{githubIcon}</ListItemIcon>
+            <ListItemText primary="GitHub" />
+            <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
+          </MenuItem>
 
-            <MenuItem component="a" href="https://lists.cncf.io/g/cncf-linkerd-users" target="_blank" className={classes.navMenuItem}>
-              <ListItemIcon><EmailIcon className={classes.shrinkIcon} /></ListItemIcon>
-              <ListItemText primary="Mailing List" />
-              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
-            </MenuItem>
+          <MenuItem component="a" href="https://lists.cncf.io/g/cncf-linkerd-users" target="_blank" className={classes.navMenuItem}>
+            <ListItemIcon><EmailIcon className={classes.shrinkIcon} /></ListItemIcon>
+            <ListItemText primary="Mailing List" />
+            <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
+          </MenuItem>
 
-            <MenuItem component="a" href="https://slack.linkerd.io" target="_blank" className={classes.navMenuItem}>
-              <ListItemIcon>{slackIcon}</ListItemIcon>
-              <ListItemText primary="Slack" />
-              <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
-            </MenuItem>
+          <MenuItem component="a" href="https://slack.linkerd.io" target="_blank" className={classes.navMenuItem}>
+            <ListItemIcon>{slackIcon}</ListItemIcon>
+            <ListItemText primary="Slack" />
+            <FontAwesomeIcon icon={faExternalLinkAlt} className={classes.externalLinkIcon} size="xs" />
+          </MenuItem>
 
-          </MenuList>
+          <Version
+            isLatest={this.state.isLatest}
+            latestVersion={this.state.latestVersion}
+            releaseVersion={this.props.releaseVersion}
+            error={this.state.error}
+            uuid={this.props.uuid} />
 
-          {
-            !drawerOpen ? null : <Version
-              isLatest={this.state.isLatest}
-              latestVersion={this.state.latestVersion}
-              releaseVersion={this.props.releaseVersion}
-              error={this.state.error}
-              uuid={this.props.uuid} />
-          }
-        </Drawer>
+        </MenuList>
 
-        <main className={classNames(classes.content, {[classes.contentDrawerClose]: !drawerOpen})}>
+      </div>
+    );
+
+    return (
+      <div className={classes.root}>
+
+        <Hidden smDown>
+          <Drawer
+            className={classes.drawer}
+            variant="permanent">
+            {drawer}
+          </Drawer>
+          <AppBar >
+            <Toolbar>
+              <Typography variant="h6" color="inherit"  className={classes.breadcrumbs} noWrap>
+                <BreadcrumbHeader  {...this.props} />
+              </Typography>
+            </Toolbar>
+          </AppBar>
+        </Hidden>
+
+        <Hidden mdUp>
+          <AppBar className={classes.appBar}>
+            <Toolbar>
+              <div className={classes.linkerdMobileLogo}>
+                {linkerdWordLogo}
+              </div>
+              { !mobileSidebarOpen && // mobile view but no sidebar
+              <React.Fragment>
+                <IconButton onClick={this.handleDrawerClick} className={classes.bars}>
+                  <FontAwesomeIcon icon={faBars}  />
+                </IconButton>
+              </React.Fragment>
+              }
+            </Toolbar>
+          </AppBar>
+          <Drawer
+            className={classes.drawer}
+            variant="temporary"
+            onClose={this.handleDrawerClick}
+            open={mobileSidebarOpen}>
+            {drawer}
+          </Drawer>
+        </Hidden>
+
+        <main className={classes.content}>
           <div className={classes.toolbar} />
-          <div className="main-content"><ChildComponent {...otherProps} /></div>
+          <div>
+            <ChildComponent {...otherProps} />
+          </div>
         </main>
       </div>
     );

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -279,10 +279,15 @@ class NavigationBase extends React.Component {
     if (!this.state.mobileSidebarOpen) {
       this.setState({ mobileSidebarOpen: true });
     } else {
-      // due to a bug in Safari that renders the SVG gradient incorrectly when
-      // the mobile sidebar is closed, perform a hard reload of the page to
-      // ensure the logo renders correctly.
-      window.location.reload();
+      this.setState({ mobileSidebarOpen: false });
+      window.setTimeout(function() {
+        let linkerdHash = document.querySelector(".linkerd-word-logo #linkerd-hash");
+        linkerdHash.style.display='none';
+        window.setTimeout(function() {
+          linkerdHash.offsetHeight;
+          linkerdHash.style.display='';
+        }, 15);
+      }, 300);
     }
   };
 

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -276,7 +276,14 @@ class NavigationBase extends React.Component {
   }
 
   handleDrawerClick = () => {
-    this.setState(state => ({ mobileSidebarOpen: !state.mobileSidebarOpen }));
+    if (!this.state.mobileSidebarOpen) {
+      this.setState({ mobileSidebarOpen: true });
+    } else {
+      // due to a bug in Safari that renders the SVG gradient incorrectly when
+      // the mobile sidebar is closed, perform a hard reload of the page to
+      // ensure the logo renders correctly.
+      window.location.reload();
+    }
   };
 
   handleConfirmNamespaceChange = () => {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -297,7 +297,9 @@ class NavigationBase extends React.Component {
     this.props.history.push(`/namespaces/${this.state.newNamespace}`);
   }
 
-  handleNamespaceChange = namespace => {
+  handleNamespaceChange = (event, namespace) => {
+    // ensure that mobile drawer will not close on click
+    event.stopPropagation();
     this.setState({ namespaceMenuOpen: false });
     if (namespace === this.props.selectedNamespace) {
       return;
@@ -321,6 +323,8 @@ class NavigationBase extends React.Component {
   }
 
   handleNamespaceMenuClick = event => {
+    // ensure that mobile drawer will not close on click
+    event.stopPropagation();
     this.setState({ anchorEl: event.currentTarget });
     this.setState(state => ({ namespaceMenuOpen: !state.namespaceMenuOpen }));
   }
@@ -399,7 +403,7 @@ class NavigationBase extends React.Component {
             onClose={this.handleNamespaceMenuClick}>
             <MenuItem
               value="all"
-              onClick={() => this.handleNamespaceChange("_all")}>
+              onClick={e => this.handleNamespaceChange(e, "_all")}>
                   All Namespaces
             </MenuItem>
 
@@ -407,7 +411,7 @@ class NavigationBase extends React.Component {
 
             {namespaces.map(ns => (
               <MenuItem
-                onClick={() => this.handleNamespaceChange(ns.name)}
+                onClick={e => this.handleNamespaceChange(e, ns.name)}
                 key={ns.name}>
                 {ns.name}
               </MenuItem>
@@ -542,6 +546,7 @@ class NavigationBase extends React.Component {
           <Drawer
             className={classes.drawer}
             variant="temporary"
+            onClick={this.handleDrawerClick}
             onClose={this.handleDrawerClick}
             open={mobileSidebarOpen}>
             {drawer}

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -19,6 +19,7 @@ const loc = {
 describe('Navigation', () => {
   let curVer = "edge-1.2.3";
   let newVer = "edge-2.3.4";
+  let selectedNamespace = "emojivoto"
 
   let component, fetchStub;
   let apiHelpers = ApiHelpers("");
@@ -37,38 +38,6 @@ describe('Navigation', () => {
     window.fetch.restore();
   });
 
-  const expandSidebar = component => {
-    // click trigger to expand the sidebar
-    component.find("button.drawer-toggle-btn").simulate('click', () => {});
-  };
-
-  it('is hidden when the sidebar is collapsed', () => {
-    fetchStub.resolves({
-      ok: true,
-      json: () => Promise.resolve({ edge: curVer })
-    });
-
-    component = mount(
-      <BrowserRouter>
-        <Navigation
-          ChildComponent={childComponent}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={apiHelpers}
-          releaseVersion={curVer}
-          pathPrefix=""
-          uuid="fakeuuid" />
-      </BrowserRouter>
-    );
-
-    return withPromise(() => {
-      expect(component).toIncludeText("Linkerd is up to date");
-      expandSidebar(component);
-      expect(component).not.toIncludeText("Linkerd is up to date");
-    });
-  });
-
   it('renders up to date message when versions match', () => {
     fetchStub.resolves({
       ok: true,
@@ -84,6 +53,7 @@ describe('Navigation', () => {
           location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          selectedNamespace={selectedNamespace}
           pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>
@@ -109,6 +79,7 @@ describe('Navigation', () => {
           location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          selectedNamespace={selectedNamespace}
           pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>
@@ -139,6 +110,7 @@ describe('Navigation', () => {
           location={loc}
           api={apiHelpers}
           releaseVersion={curVer}
+          selectedNamespace={selectedNamespace}
           pathPrefix=""
           uuid="fakeuuid" />
       </BrowserRouter>

--- a/web/app/js/components/util/SvgWrappers.jsx
+++ b/web/app/js/components/util/SvgWrappers.jsx
@@ -190,7 +190,7 @@ export const linkerdWordLogo = (
       <path
         className="st2"
         d="M951.7,164.6V68.9c0-5.8,3.2-9,9.2-9h31.4c35.5,0,59,24.2,59,57c0,32.9-23.5,56.8-59,56.8h-31.4 C954.9,173.6,951.7,170.4,951.7,164.6z M992.3,158.6c26.3,0,41.4-18.8,41.4-41.8c0-23.4-14.7-41.9-41.4-41.9h-23.5v83.7H992.3z" />
-      <g>
+      <g id="linkerd-hash">
         <linearGradient
           id="SVGID_1_"
           gradientUnits="userSpaceOnUse"

--- a/web/app/js/components/util/theme.js
+++ b/web/app/js/components/util/theme.js
@@ -23,7 +23,17 @@ const status = {
 
 export const dashboardTheme = {
   palette: {
-    primary: green
+    primary: {
+      main: '#001443',
+    },
+  },
+  // substituting default Material breakpoints with Bootstrap breakpoints
+  breakpoints: {
+    values: {
+      sm: 576,
+      md: 992,
+      lg: 1200,
+    },
   },
   typography: {
     useNextVariants: true,


### PR DESCRIPTION
This PR fixes #3467 with browser routing tests coming in a separate PR. It only focuses on the sidebar behavior for mobile, tablet and desktop views, and changes navbar color to the color of the linkerd.io website as suggested by @grampelberg.
Works in the latest Chrome, Safari and Firefox.

**Testing Instructions**

Clone @grampelberg's repo here: https://github.com/grampelberg/linkerd2-mockups
Run the mockups demo, note behavior when browser window is in desktop, mobile and tablet size
Compare to behavior in this branch

**New and Old Screenshots**

This Branch:
Dashboard desktop, mobile size and mobile size w/sidebar
![Screen Shot 2019-10-16 at 11 55 37 AM](https://user-images.githubusercontent.com/2289389/66949941-43d7ca00-f00c-11e9-9ef3-062f4a81c50c.png)


![Screen Shot 2019-10-16 at 11 55 52 AM](https://user-images.githubusercontent.com/2289389/66949942-44706080-f00c-11e9-9901-d52ff73b37cf.png)


![Screen Shot 2019-10-16 at 11 56 00 AM](https://user-images.githubusercontent.com/2289389/66949943-44706080-f00c-11e9-9161-b5fcb7226987.png)

Previous Branch:
Dashboard desktop, mobile size and mobile size w/sidebar
![Screen Shot 2019-10-16 at 11 57 09 AM](https://user-images.githubusercontent.com/2289389/66949955-49cdab00-f00c-11e9-9719-ff06634294b9.png)


![Screen Shot 2019-10-16 at 11 57 17 AM](https://user-images.githubusercontent.com/2289389/66949956-49cdab00-f00c-11e9-910d-23abcd85c3ab.png)


![Screen Shot 2019-10-16 at 11 57 24 AM](https://user-images.githubusercontent.com/2289389/66949958-49cdab00-f00c-11e9-9989-13110ad41f09.png)
