### PR TITLE
Fix sorting of metricsResult

### DIFF
--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -37,7 +37,7 @@ func (s byResult) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s byResult) Less(i, j int) bool {
-	return s[i].pod < s[i].pod
+	return s[i].pod < s[j].pod
 }
 
 func newMetricsOptions() *metricsOptions {


### PR DESCRIPTION
Fix sorting of metricsResult. Currently element with index i never sorts before the element with index j.
 