### PR TITLE
Dockerfile-base - remove explicit apt cache clean up

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -11,5 +11,4 @@ RUN apt-get update \
         dnsutils \
         iptables \
         jq \
-        nghttp2 \
-    && rm -rf /var/lib/apt/lists/*
+        nghttp2


### PR DESCRIPTION
Proposing removing the explicit apt cache clean up in `Dockerfile-base` - it already happens automatically!

From the [official Dockerfile best practices](https://docs.docker.com/v17.09/engine/userguide/eng-image/dockerfile_best-practices/#run) (scroll down a bit):
> The official Debian and Ubuntu images automatically run apt-get clean, so explicit invocation is not required.