### PR TITLE
Faster `linkerd install --ignore-cluster`

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -250,13 +250,15 @@ resources for the Linkerd control plane. This command should be followed by
   # Install Linkerd into a non-default namespace.
   linkerd install config -l linkerdtest | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options); err != nil && !options.ignoreCluster {
-				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
-					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				} else {
-					fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
+			if !options.ignoreCluster {
+				if err := errAfterRunningChecks(options); err != nil {
+					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
+						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
+					} else {
+						fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
+					}
+					os.Exit(1)
 				}
-				os.Exit(1)
 			}
 
 			return installRunE(options, configStage, parentFlags)
@@ -289,20 +291,24 @@ control plane. It should be run after "linkerd install config".`,
   # Install Linkerd into a non-default namespace.
   linkerd install control-plane -l linkerdtest | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// check if global resources exist to determine if the `install config`
-			// stage succeeded
-			if err := errAfterRunningChecks(options); err == nil && !options.skipChecks {
-				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
-					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				} else {
-					fmt.Fprintf(os.Stderr, errMsgGlobalResourcesMissing, controlPlaneNamespace)
+			if !options.skipChecks {
+				// check if global resources exist to determine if the `install config`
+				// stage succeeded
+				if err := errAfterRunningChecks(options); err == nil {
+					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
+						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
+					} else {
+						fmt.Fprintf(os.Stderr, errMsgGlobalResourcesMissing, controlPlaneNamespace)
+					}
+					os.Exit(1)
 				}
-				os.Exit(1)
 			}
 
-			if err := errIfLinkerdConfigConfigMapExists(); err != nil && !options.ignoreCluster {
-				fmt.Fprintf(os.Stderr, errMsgLinkerdConfigConfigMapNotFound, controlPlaneNamespace, err.Error())
-				os.Exit(1)
+			if !options.ignoreCluster {
+				if err := errIfLinkerdConfigConfigMapExists(); err != nil {
+					fmt.Fprintf(os.Stderr, errMsgLinkerdConfigConfigMapNotFound, controlPlaneNamespace, err.Error())
+					os.Exit(1)
+				}
 			}
 
 			return installRunE(options, controlPlaneStage, flags)
@@ -350,13 +356,15 @@ control plane.`,
   # Installation may also be broken up into two stages by user privilege, via
   # subcommands.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := errAfterRunningChecks(options); err != nil && !options.ignoreCluster {
-				if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
-					fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-				} else {
-					fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
+			if !options.ignoreCluster {
+				if err := errAfterRunningChecks(options); err != nil {
+					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
+						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
+					} else {
+						fmt.Fprintf(os.Stderr, errMsgGlobalResourcesExist, err)
+					}
+					os.Exit(1)
 				}
-				os.Exit(1)
 			}
 
 			return installRunE(options, "", flags)


### PR DESCRIPTION
The `linkerd install` `--ignore-cluster` and `--skip-checks` flags
enable generating install manifests without a connection to a k8s
cluster. Unfortunately these flags were only checked after attempted
connections to a k8s cluster were made. This satisfied the use case of
`linkerd install` "ignoring" the state of the cluster, but for
environments not connected to a cluster, the user would have to wait for
30s timeouts before getting the manifests.

Modify `linkerd install` and its subcommands to pre-emptively check for
`--ignore-cluster` and `--skip-checks`. This decreases `linkerd install
--ignore-cluster` from ~30s to ~1s, and `linkerd install control-plane
--ignore-cluster --skip-checks` from ~60s to ~1s.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

## before

```
$ time bin/go-run cli install --ignore-cluster > /dev/null

real	0m35.948s
user	0m5.518s
sys	0m2.085s

$ time bin/go-run cli install control-plane --ignore-cluster --skip-checks > /dev/null

real	1m3.408s
user	0m2.723s
sys	0m1.979s
```

## after

```
$ time bin/go-run cli install --ignore-cluster > /dev/null

real	0m4.140s
user	0m3.887s
sys	0m2.027s

$ time bin/go-run cli install control-plane --ignore-cluster --skip-checks > /dev/null

real	0m3.237s
user	0m2.631s
sys	0m1.938s
```