### PR TITLE
CLI command to fetch control plane metrics

### DIFF
--- a/cli/cmd/diagnostics.go
+++ b/cli/cmd/diagnostics.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	adminHTTPPortName string = "admin-http"
+)
+
+type diagnosticsResult struct {
+	pod       string
+	container string
+	metrics   []byte
+	err       error
+}
+type diagResult []diagnosticsResult
+
+func (s diagResult) Len() int {
+	return len(s)
+}
+func (s diagResult) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s diagResult) Less(i, j int) bool {
+	if s[i].pod != s[j].pod {
+		return s[i].pod < s[j].pod
+	}
+	return s[i].container < s[j].container
+}
+
+type diagnosticsOptions struct {
+	wait time.Duration
+}
+
+func newDiagnosticsOptions() *diagnosticsOptions {
+	return &diagnosticsOptions{
+		wait: 300 * time.Second,
+	}
+}
+
+func newCmdDiagnostics() *cobra.Command {
+	options := newDiagnosticsOptions()
+
+	cmd := &cobra.Command{
+		Use:   "diagnostics",
+		Short: "Fetch metrics directly from the Linkerd control plane containers",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			if err != nil {
+				return err
+			}
+
+			timeoutSeconds := int64(30)
+			deployments, err := k8sAPI.AppsV1().Deployments(controlPlaneNamespace).List(metav1.ListOptions{TimeoutSeconds: &timeoutSeconds})
+			if err != nil {
+				return err
+			}
+
+			// ensure we can connect to the public API before fetching the diagnostics.
+			checkPublicAPIClientOrRetryOrExit(time.Now().Add(options.wait), true)
+
+			resCount := 0
+			resultChan := make(chan diagnosticsResult)
+			for _, d := range deployments.Items {
+				pods, err := getPodsFor(k8sAPI, controlPlaneNamespace, "deploy/"+d.Name)
+				if err != nil {
+					fmt.Println(err)
+					continue
+				}
+
+				for _, pod := range pods {
+					containers, err := getNonProxyContainersForPod(pod)
+					if err != nil {
+						fmt.Println(err)
+						continue
+					}
+
+					for i := range containers {
+						resCount++
+						go func(container corev1.Container) {
+							bytes, err := getDiagnostics(k8sAPI, pod, container, verbose)
+
+							resultChan <- diagnosticsResult{
+								pod:       pod.GetName(),
+								container: container.Name,
+								metrics:   bytes,
+								err:       err,
+							}
+						}(containers[i])
+					}
+				}
+			}
+
+			var results []diagnosticsResult
+			timer := time.NewTimer(options.wait)
+			timedOut := false
+
+			for {
+				select {
+				case result := <-resultChan:
+					results = append(results, result)
+				case <-timer.C:
+					timedOut = true
+				}
+				if len(results) == resCount || timedOut {
+					break
+				}
+			}
+
+			sort.Sort(diagResult(results))
+			for i, result := range results {
+				fmt.Printf("#\n# POD %s (%d of %d)\n# CONTAINER %s (%d of %d)\n#\n", result.pod, i+1, len(results), result.container, i+1, len(results))
+				if result.err == nil {
+					fmt.Printf("%s", result.metrics)
+				} else {
+					fmt.Printf("# ERROR %s\n", result.err)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().DurationVarP(&options.wait, "wait", "w", options.wait, "Time allowed to fetch diagnostics")
+
+	return cmd
+}
+
+func getDiagnostics(
+	k8sAPI *k8s.KubernetesAPI,
+	pod corev1.Pod,
+	container corev1.Container,
+	emitLogs bool,
+) ([]byte, error) {
+	var port corev1.ContainerPort
+	for _, p := range container.Ports {
+		if p.Name == adminHTTPPortName {
+			port = p
+			break
+		}
+	}
+	if port.Name != adminHTTPPortName {
+		return nil, fmt.Errorf("no %s port found for container %s", adminHTTPPortName, container.Name)
+	}
+
+	portforward, err := k8s.NewPortForward(
+		k8sAPI,
+		pod.GetNamespace(),
+		pod.GetName(),
+		"localhost",
+		0,
+		int(port.ContainerPort),
+		emitLogs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	defer portforward.Stop()
+	if err = portforward.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+	}
+
+	metricsURL := portforward.URLFor("/metrics")
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+// getNonProxyContainersForPod returns all the containers of a pod except the proxy.
+func getNonProxyContainersForPod(
+	pod corev1.Pod,
+) ([]corev1.Container, error) {
+	var containers []corev1.Container
+
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil, fmt.Errorf("pod not running: %s", pod.GetName())
+	}
+
+	for _, c := range pod.Spec.Containers {
+		if c.Name != k8s.ProxyContainerName {
+			containers = append(containers, c)
+		}
+	}
+
+	return containers, nil
+}

--- a/cli/cmd/diagnostics.go
+++ b/cli/cmd/diagnostics.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"sort"
 	"time"
@@ -174,12 +172,7 @@ func getDiagnostics(
 	}
 
 	metricsURL := portforward.URLFor("/metrics")
-	resp, err := http.Get(metricsURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := GetResponse(metricsURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"sort"
 	"time"
@@ -166,12 +164,7 @@ func getMetrics(
 	}
 
 	metricsURL := portforward.URLFor("/metrics")
-	resp, err := http.Get(metricsURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := GetResponse(metricsURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/metrics_diagnostics_util.go
+++ b/cli/cmd/metrics_diagnostics_util.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+// GetResponse makes a http Get request to the passed url and returns the response/error
+func GetResponse(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -99,6 +99,7 @@ func init() {
 	RootCmd.AddCommand(newCmdCheck())
 	RootCmd.AddCommand(newCmdCompletion())
 	RootCmd.AddCommand(newCmdDashboard())
+	RootCmd.AddCommand(newCmdDiagnostics())
 	RootCmd.AddCommand(newCmdDoc())
 	RootCmd.AddCommand(newCmdEdges())
 	RootCmd.AddCommand(newCmdEndpoints())


### PR DESCRIPTION
The CLI command `diagnostics` will fetch the control plane metrics directly from containers.

Sample output: https://gist.github.com/srv-twry/8e5f649edfa8bd34dcee286cbf913d5d

Fixes #3116

Signed-off-by: Saurav Tiwary <srv.twry@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
