### PR TITLE
Add missing package to proxy Dockerfile

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -14,6 +14,7 @@ WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls
 COPY pkg/version pkg/version
+COPY pkg/identity pkg/identity
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly ./pkg/...
 COPY proxy-identity proxy-identity
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1238,7 +1238,7 @@ func (hc *HealthChecker) checkDataPlaneProxiesCertificate() error {
 				if envVar.Name != identity.EnvTrustAnchors {
 					continue
 				}
-				if envVar.Value != trustAnchorsPem {
+				if strings.TrimSpace(envVar.Value) != strings.TrimSpace(trustAnchorsPem) {
 					if hc.DataPlaneNamespace == "" {
 						offendingPods = append(offendingPods, fmt.Sprintf("%s/%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name))
 					} else {

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -49,5 +49,6 @@ linkerd-data-plane
 √ data plane proxy metrics are present in Prometheus
 √ data plane is up-to-date
 √ data plane and cli versions match
+√ data plane proxies certificate match CA
 
 Status check results are √


### PR DESCRIPTION
PR #3524 added a new import path to [`proxy-indentity/main.go`](https://github.com/linkerd/linkerd2/commit/ba14dc3fc76b3e2e0851515827d703379eef2133#diff-52a2a4df64b3fc136dcfdd6135264104R16). The `Dockerfile-proxy` needs to be updated to include this change, to resolve the [current build failure](https://github.com/linkerd/linkerd2/runs/261255032).

Signed-off-by: Ivan Sim <ivan@buoyant.io>