### PR TITLE
Keep old releases in Helm repo index

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -519,12 +519,12 @@ jobs:
     - name: Edge Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/edge')
       run: |
-        gsutil rsync cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
+        gsutil cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
         bin/helm-build package
         gsutil rsync target/helm gs://helm.linkerd.io/edge
     - name: Stable Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/stable')
       run: |
-        gsutil rsync cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
+        gsutil cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
         bin/helm-build package
         gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -516,15 +516,15 @@ jobs:
           set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
         )
         . "$dir/path.bash.inc"
-    - name: Helm chart creation
-      if: startsWith(github.ref, 'refs/tags')
-      run: |
-        bin/helm-build package
-    - name: Edge Helm chart upload
+    - name: Edge Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/edge')
       run: |
+        gsutil rsync cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
+        bin/helm-build package
         gsutil rsync target/helm gs://helm.linkerd.io/edge
-    - name: Stable Helm chart upload
+    - name: Stable Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/stable')
       run: |
+        gsutil rsync cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
+        bin/helm-build package
         gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -516,6 +516,7 @@ jobs:
           set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
         )
         . "$dir/path.bash.inc"
+        mkdir -p target/helm
     - name: Edge Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/edge')
       run: |

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -27,6 +27,7 @@ if [ "$1" == "package" ]; then
     repo=${BASH_REMATCH[1]}
     version=${BASH_REMATCH[2]}
     mkdir -p $rootdir/target/helm
-    $bindir/helm --version $version --app-version $tag -d $rootdir/target/helm package $rootdir/charts/linkerd2 \
-      && $bindir/helm repo index --url "https://helm.linkerd.io/$repo/" $rootdir/target/helm
+    $bindir/helm --version $version --app-version $tag -d $rootdir/target/helm package $rootdir/charts/linkerd2
+    mv $rootdir/target/helm/index-pre.yaml $rootdir/target/helm/index-pre-$version.yaml
+    $bindir/helm repo index --url "https://helm.linkerd.io/$repo/" --merge $rootdir/target/helm/index-pre-$version.yaml $rootdir/target/helm
 fi;

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -14,6 +14,7 @@ $bindir/helm dep up $rootdir/charts/linkerd2
 $bindir/helm dep up $rootdir/charts/patch
 $bindir/helm lint --set Identity.TrustAnchorsPEM="fake-trust" --set Identity.Issuer.TLS.CrtPEM="fake-cert" --set Identity.Issuer.TLS.KeyPEM="fake-key" --set Identity.Issuer.CrtExpiry="fake-expiry-date" $rootdir/charts/linkerd2
 
+# `bin/helm-build package` assumes the presence of $rootdir/target/helm/index-pre.yaml which is downloaded in the chart_deploy CI job
 if [ "$1" == "package" ]; then
     . $bindir/_tag.sh
     tag=$(named_tag)
@@ -26,7 +27,6 @@ if [ "$1" == "package" ]; then
     fi;
     repo=${BASH_REMATCH[1]}
     version=${BASH_REMATCH[2]}
-    mkdir -p $rootdir/target/helm
     $bindir/helm --version $version --app-version $tag -d $rootdir/target/helm package $rootdir/charts/linkerd2
     mv $rootdir/target/helm/index-pre.yaml $rootdir/target/helm/index-pre-$version.yaml
     $bindir/helm repo index --url "https://helm.linkerd.io/$repo/" --merge $rootdir/target/helm/index-pre-$version.yaml $rootdir/target/helm


### PR DESCRIPTION
When building the Helm repo index file, keep the references to the old
releases. Also rename and keep the old index file in case
something goes wrong when generating the new one.

Fixes #3561