### PR TITLE
Add direct edges integration test

### DIFF
--- a/test/edges/edges_test.go
+++ b/test/edges/edges_test.go
@@ -3,8 +3,10 @@ package edges
 import (
 	"bytes"
 	"html/template"
+	"io/ioutil"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/linkerd/linkerd2/testutil"
@@ -43,5 +45,92 @@ func TestEdges(t *testing.T) {
 	r := regexp.MustCompile(b.String())
 	if !r.MatchString(out) {
 		t.Errorf("Expected output:\n%s\nactual:\n%s", b.String(), out)
+	}
+}
+
+// TestDirectEdges deploys a terminus and then generates a load generator which
+// sends traffic directly to the pod ip of the terminus pod. Traffic which is
+// addressed this way (as opposed to using the service name) does not show up
+// in the `linkerd edges` command. This test should be updated once
+// `linkerd edges` is updated to support this kind of traffic.
+func TestDirectEdges(t *testing.T) {
+
+	// setup
+
+	testNamespace := TestHelper.GetTestNamespace("direct-edges-test")
+	err := TestHelper.CreateNamespaceIfNotExists(testNamespace, nil)
+	if err != nil {
+		t.Fatalf("failed to create %s namespace: %s", testNamespace, err)
+	}
+
+	// inject terminus
+
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/terminus.yaml")
+	if err != nil {
+		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
+	}
+
+	// deploy terminus
+
+	out, err = TestHelper.KubectlApply(out, testNamespace)
+	if err != nil {
+		t.Fatalf("kubectl apply command failed\n%s", out)
+	}
+
+	if err := TestHelper.CheckPods(testNamespace, "terminus", 1); err != nil {
+		t.Error(err)
+	}
+
+	if err := TestHelper.CheckDeployment(testNamespace, "terminus", 1); err != nil {
+		t.Errorf("Error validating deployment [%s]:\n%s", "terminus", err)
+	}
+
+	// get terminus pod ip
+
+	ip, err := TestHelper.Kubectl("", "-n", testNamespace, "get", "pod", "-ojsonpath=\"{.items[*].status.podIP}\"")
+	if err != nil {
+		t.Error(err)
+	}
+	ip = strings.Trim(ip, "\"") // strip quotes
+
+	bytes, err := ioutil.ReadFile("testdata/slow-cooker.yaml")
+	if err != nil {
+		t.Error(err)
+	}
+
+	slowcooker := string(bytes)
+	slowcooker = strings.ReplaceAll(slowcooker, "___TERMINUS_POD_IP___", ip)
+
+	// inject slow cooker
+
+	out, stderr, err = TestHelper.PipeToLinkerdRun(slowcooker, "inject", "--manual", "-")
+	if err != nil {
+		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "inject", err.Error(), stderr)
+	}
+
+	// deploy slow cooker
+
+	out, err = TestHelper.KubectlApply(out, testNamespace)
+	if err != nil {
+		t.Fatalf("kubectl apply command failed\n%s", out)
+	}
+
+	if err := TestHelper.CheckPods(testNamespace, "slow-cooker", 1); err != nil {
+		t.Error(err)
+	}
+
+	if err := TestHelper.CheckDeployment(testNamespace, "slow-cooker", 1); err != nil {
+		t.Errorf("Error validating deployment [%s]:\n%s", "terminus", err)
+	}
+
+	// check edges
+
+	_, stderr, err = TestHelper.LinkerdRun("-n", testNamespace, "edges", "pods")
+	if err != nil {
+		t.Fatalf("'linkerd %s' command failed with %s: %s\n", "edges", err.Error(), stderr)
+	}
+	stderr = strings.TrimSpace(stderr)
+	if stderr != "No edges found." {
+		t.Fatalf("Expected: \"%s\" Got: \"%s\"", "No edges found.", stderr)
 	}
 }

--- a/test/edges/testdata/slow-cooker.yaml
+++ b/test/edges/testdata/slow-cooker.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slow-cooker
+  template:
+    metadata:
+      labels:
+        app: slow-cooker
+    spec:
+      containers:
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.1.1
+        command:
+        - "/bin/sh"
+        args:
+        - "-c"
+        - |
+          sleep 15 # wait for pods to start
+          slow_cooker -metric-addr 0.0.0.0:9999 http://___TERMINUS_POD_IP___:8080
+        ports:
+        - containerPort: 9999

--- a/test/edges/testdata/terminus.yaml
+++ b/test/edges/testdata/terminus.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terminus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: terminus
+  template:
+    metadata:
+      labels:
+        app: terminus
+    spec:
+      containers:
+      - name: terminus
+        image: buoyantio/bb:v0.0.5
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=pong"
+        ports:
+        - containerPort: 8080


### PR DESCRIPTION
Add an integration test which exercises the behavior when one meshed pod connects to another meshed pod by pod ip address.

The current behavior is that the Linkerd proxy will not do any lookup against the destination service for this kind of connection and will proxy directly to the SO_ORIG_DST.  This means that it will not have the identity metadata necessary to TLS the connection, and the connection will not be present in the `linkerd edges` command output.  This test validates that behavior.

The purpose of this test is to set the stage for future work which will allow the Linkerd proxy to TLS this type of connection and display it in `linkerd edges`.  The assertions in this test will be updated as part of that work.

This test will be run as part of the integration test suite.  It can also be run directly:

```
go test --failfast --mod=readonly test/install_test.go   --linkerd=(pwd)"/bin/linkerd" --k8s-context="$CTX" --integration-tests
go test -v --mod=readonly test/edges/edges_test.go  --linkerd=(pwd)"/bin/linkerd" --k8s-context="$CTX" --integration-tests
```

Signed-off-by: Alex Leong <alex@buoyant.io>

