### PR TITLE
build-cli-bin: POSIX compatible & handle whitespace paths

### DIFF
--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
@@ -6,9 +6,9 @@ set -eu
 # Note: This script is used by Brew when running `brew install linkerd`:
 # https://github.com/Homebrew/homebrew-core/pull/36957
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
-. $bindir/_tag.sh
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+. "$bindir"/_tag.sh
 
 current_platform=$(uname)
 host_platform="windows"
@@ -19,10 +19,11 @@ elif [ "${current_platform}" = 'Linux' ]; then
 fi
 
 (
-    cd $rootdir
+    cd "$rootdir"
     cd "$(pwd -P)"
     target="target/cli/${host_platform}/linkerd"
     GO111MODULE=on go generate -mod=readonly ./pkg/charts/static # TODO: `go generate` does not honor -mod=readonly
-    GO111MODULE=on CGO_ENABLED=0 go build -o $target -tags prod -mod=readonly -ldflags "-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=$($bindir/root-tag)" ./cli
+    root_tag=$("$bindir"/root-tag)
+    GO111MODULE=on CGO_ENABLED=0 go build -o $target -tags prod -mod=readonly -ldflags "-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=$root_tag" ./cli
     echo "$target"
 )

--- a/bin/root-tag
+++ b/bin/root-tag
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_tag.sh
+. "$bindir"/_tag.sh
 
 head_root_tag


### PR DESCRIPTION
Getting the directory where the script resides can easily be done
without bash-specific functionality, and hence the script can be POSIX
compatible. Also adding the missing pieces for handling paths with
whitespaces.

Change-Id: Ie2e867929be0322e476342438d9cf4a3d36f58f1
Signed-off-by: Joakim Roubert <joakimr@axis.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
