### PR TITLE
fetch-proxy: Make POSIX compatible

### DIFF
--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # If the first argument to this script is "latest" or unset, it fetches the
-# latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt. If it's set to
+# latest proxy binary from the linkerd2-proxy github releases. If it's set to
 # a commit sha from the master branch of the linkerd2-proxy repo, it will fetch
 # the binary matching that sha instead.
 

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -2,8 +2,8 @@
 
 # If the first argument to this script is "latest" or unset, it fetches the
 # latest proxy binary from the linkerd2-proxy github releases. If it's set to
-# a commit sha from the master branch of the linkerd2-proxy repo, it will fetch
-# the binary matching that sha instead.
+# a linkerd2-proxy version number (such as v2.76.0), it will fetch the binary
+# matching that version number instead.
 
 set -eu
 

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # If the first argument to this script is "latest" or unset, it fetches the
 # latest proxy binary via build.l5d.io/linkerd2-proxy/latest.txt. If it's set to
@@ -7,12 +7,12 @@
 
 set -eu
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 builddir="$rootdir/target/proxy"
 
-version="${1:-latest}"
-if [ "$version" == "latest" ]; then
+version=${1:-latest}
+if [ "$version" = latest ]; then
   version=$(curl -sL https://api.github.com/repos/linkerd/linkerd2-proxy/releases/latest |jq -r .tag_name | sed 's,^release/,,')
 fi
 
@@ -30,7 +30,7 @@ tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
 computed=$(sha256sum "$pkgfile" | awk '{print $1}')
 if [ "$computed" != "$expected" ]; then
-  echo "sha mismatch" >&2
+  echo 'sha mismatch' >&2
   exit 1
 fi
 


### PR DESCRIPTION
Getting the directory where the script resides can easily be done
without bash-specific functionality, and hence the script can be POSIX
compatible.

Change-Id: I30bd69dccbc950bdce3dc5da4bea279305a7b1f9
Signed-off-by: Joakim Roubert <joakimr@axis.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
