### PR TITLE
docker*: POSIX compatible and whitespace path handling

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -1,20 +1,18 @@
 set -eu
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-. $bindir/_log.sh
+. "$bindir"/_log.sh
 
 # TODO this should be set to the canonical public docker registry; we can override this
 # docker regsistry in, for instance, CI.
-export DOCKER_REGISTRY="${DOCKER_REGISTRY:-gcr.io/linkerd-io}"
+export DOCKER_REGISTRY=${DOCKER_REGISTRY:-gcr.io/linkerd-io}
 
 # When set, causes docker's build output to be emitted to stderr.
-export DOCKER_TRACE="${DOCKER_TRACE:-}"
+export DOCKER_TRACE=${DOCKER_TRACE:-}
 
 docker_repo() {
-    repo="$1"
+    repo=$1
 
-    name="$repo"
+    name=$repo
     if [ -n "${DOCKER_REGISTRY:-}" ]; then
         name="$DOCKER_REGISTRY/$name"
     fi
@@ -26,23 +24,23 @@ docker_build() {
     repo=$(docker_repo "$1")
     shift
 
-    tag="$1"
+    tag=$1
     shift
 
-    file="$1"
+    file=$1
     shift
 
     extra="$@"
 
-    output="/dev/null"
+    output=/dev/null
     if [ -n "$DOCKER_TRACE" ]; then
-        output="/dev/stderr"
+        output=/dev/stderr
     fi
 
-    rootdir="$( cd $bindir/.. && pwd )"
+    rootdir=$( cd "$bindir"/.. && pwd )
 
     log_debug "  :; docker build $rootdir -t $repo:$tag -f $file $extra"
-    docker build $rootdir \
+    docker build "$rootdir" \
         -t "$repo:$tag" \
         -f "$file" \
         $extra \
@@ -53,22 +51,22 @@ docker_build() {
 
 docker_pull() {
     repo=$(docker_repo "$1")
-    tag="$2"
+    tag=$2
     log_debug "  :; docker pull $repo:$tag"
     docker pull "$repo:$tag"
 }
 
 docker_push() {
     repo=$(docker_repo "$1")
-    tag="$2"
+    tag=$2
     log_debug "  :; docker push $repo:$tag"
     docker push "$repo:$tag"
 }
 
 docker_retag() {
     repo=$(docker_repo "$1")
-    from="$2"
-    to="$3"
+    from=$2
+    to=$3
     log_debug "  :; docker tag $repo:$from $repo:$to"
     docker tag "$repo:$from" "$repo:$to"
     echo "$repo:$to"

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -1,15 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
+
+bindir=$( cd "${0%/*}" && pwd )
 
 git_sha_head() {
     git rev-parse --short=8 HEAD
 }
 
 go_deps_sha() {
-    bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    rootdir="$( cd $bindir/.. && pwd )"
-    cat $rootdir/go.mod $rootdir/Dockerfile-go-deps | shasum - | awk '{print $1}' |cut -c 1-8
+    rootdir=$( cd "$bindir"/.. && pwd )
+    cat "$rootdir"/go.mod "$rootdir"/Dockerfile-go-deps | shasum - | awk '{print $1}' |cut -c 1-8
 }
 
 clean_head() {
@@ -24,37 +25,37 @@ head_root_tag() {
     if clean_head ; then
         clean_head_root_tag
     else
-        name="$(echo $USER | sed "s/[^[:alnum:].-]//g")"
+        name=$(echo $USER | sed 's/[^[:alnum:].-]//g')
         echo "dev-$(git_sha_head)-$name"
     fi
 }
 
 clean_head_root_tag() {
     if clean_head ; then
-        if [ "$(named_tag)" != "undefined" ]; then
+        if [ "$(named_tag)" != undefined ]; then
             echo "$(named_tag)"
         else
             echo "git-$(git_sha_head)"
         fi
     else
-        echo "Commit unstaged changes." >&2
+        echo 'Commit unstaged changes.' >&2
         exit 3
     fi
 }
 
 validate_tag() {
-    file="$1"
+    file=$1
     shift
 
-    image="$1"
+    image=$1
     shift
 
-    sha="$1"
+    sha=$1
     shift
 
-    dockerfile_tag=$(grep -oe $image':[^ ]*' $file) || true
+    dockerfile_tag=$(grep -oe $image':[^ ]*' "$file") || true
     deps_tag="$image:$sha"
-    if [ "$dockerfile_tag" != "" ] && [ "$dockerfile_tag" != "$deps_tag" ]; then
+    if [ -n "$dockerfile_tag" ] && [ "$dockerfile_tag" != "$deps_tag" ]; then
         echo "Tag in "$file" does not match source tree:"
         echo $dockerfile_tag" ("$file")"
         echo $deps_tag" (source)"
@@ -68,6 +69,6 @@ validate_tag() {
 # $ grep -ER 'docker-build-go-deps' .
 
 validate_go_deps_tag() {
-    file="$1"
-    validate_tag "$file" "gcr.io/linkerd-io/go-deps" "$(go_deps_sha)"
+    file=$1
+    validate_tag "$file" gcr.io/linkerd-io/go-deps "$(go_deps_sha)"
 }

--- a/bin/docker
+++ b/bin/docker
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 dockerversion=19.03.1
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-targetbin="$( cd $bindir/.. && pwd )"/target/bin
+bindir=$( cd "${0%/*}" && pwd )
+targetbin=$( cd "$bindir"/.. && pwd )/target/bin
 dockerbin="${targetbin}/.docker-${dockerversion}"
 
 if [ ! -f "$dockerbin" ]; then
-  if [ "$(uname -s)" = "Darwin" ]; then
+  if [ "$(uname -s)" = Darwin ]; then
     os=mac
     filename="docker-$dockerversion.tgz"
   else
@@ -22,11 +22,11 @@ if [ ! -f "$dockerbin" ]; then
   mkdir -p "$targetbin"
   (
       cd "$tmp"
-      curl -Lsf -o "./docker.tar.gz" "$url"
-      tar zf "./docker.tar.gz" -x docker/docker
+      curl -Lsf -o ./docker.tar.gz "$url"
+      tar zf ./docker.tar.gz -x docker/docker
   )
   mv "$tmp/docker/docker" "$dockerbin"
   rm -rf "$tmp"
 fi
 
-$dockerbin "$@"
+"$dockerbin" "$@"

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,22 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-$bindir/docker-build-proxy
-$bindir/docker-build-controller
-$bindir/docker-build-web
-$bindir/docker-build-cni-plugin
-$bindir/docker-build-debug
+"$bindir"/docker-build-proxy
+"$bindir"/docker-build-controller
+"$bindir"/docker-build-web
+"$bindir"/docker-build-cni-plugin
+"$bindir"/docker-build-debug
 if [ -z "${LINKERD_LOCAL_BUILD_CLI:-}" ]; then
-    $bindir/docker-build-cli-bin
+    "$bindir"/docker-build-cli-bin
 else
-    $bindir/build-cli-bin
+    "$bindir"/build-cli-bin
 fi
-$bindir/docker-build-grafana
+"$bindir"/docker-build-grafana

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -1,23 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 # Builds (or pulls) our base runtime docker image.
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir="$( cd "$bindir"/.. && pwd )"
 
-. $bindir/_docker.sh
+. "$bindir"/_docker.sh
 
-tag="2019-09-04.01"
+tag=2019-09-04.01
 
-if (docker_pull base "${tag}"); then
-    echo "$(docker_repo base):${tag}"
+if (docker_pull base $tag); then
+    echo "$(docker_repo base):$tag"
 else
-    docker_build base "${tag}" $rootdir/Dockerfile-base
+    docker_build base $tag "$rootdir/Dockerfile-base"
 fi

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -1,28 +1,28 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
-dockerfile=$rootdir/cli/Dockerfile-bin
+dockerfile="$rootdir"/cli/Dockerfile-bin
 
-validate_go_deps_tag $dockerfile
+validate_go_deps_tag "$dockerfile"
 
 (
-    $bindir/docker-build-go-deps
+    "$bindir"/docker-build-go-deps
 ) >/dev/null
 
-tag="$(head_root_tag)"
-docker_build cli-bin $tag $dockerfile --build-arg LINKERD_VERSION=$tag
+tag=$(head_root_tag)
+docker_build cli-bin $tag "$dockerfile" --build-arg LINKERD_VERSION=$tag
 IMG=$(docker_repo cli-bin):$tag
 ID=$(docker create "$IMG")
 

--- a/bin/docker-build-cni-plugin
+++ b/bin/docker-build-cni-plugin
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename "$0"), given: $*" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
 . "$bindir"/_docker.sh
 . "$bindir"/_tag.sh
 
-dockerfile=$rootdir/cni-plugin/Dockerfile
+dockerfile="$rootdir"/cni-plugin/Dockerfile
 
 validate_go_deps_tag "$dockerfile"
 
@@ -22,4 +22,4 @@ validate_go_deps_tag "$dockerfile"
     "$bindir"/docker-build-go-deps
 ) >/dev/null
 
-docker_build cni-plugin "$(head_root_tag)" "$dockerfile"
+docker_build cni-plugin $(head_root_tag) "$dockerfile"

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -1,25 +1,25 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
-dockerfile=$rootdir/controller/Dockerfile
+dockerfile="$rootdir"/controller/Dockerfile
 
-validate_go_deps_tag $dockerfile
+validate_go_deps_tag "$dockerfile"
 
 (
-    $bindir/docker-build-go-deps
+    "$bindir"/docker-build-go-deps
 ) >/dev/null
 
-tag="$(head_root_tag)"
-docker_build controller $tag $dockerfile --build-arg LINKERD_VERSION=$tag
+tag=$(head_root_tag)
+docker_build controller $tag "$dockerfile" --build-arg LINKERD_VERSION=$tag

--- a/bin/docker-build-debug
+++ b/bin/docker-build-debug
@@ -1,24 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
-dockerfile=$rootdir/Dockerfile-debug
+dockerfile="$rootdir"/Dockerfile-debug
 
 (
     "$bindir"/docker-build-base
 ) >/dev/null
 
-tag="$(head_root_tag)"
-
-docker_build debug $tag $dockerfile
+docker_build debug $(head_root_tag) "$dockerfile"

--- a/bin/docker-build-go-deps
+++ b/bin/docker-build-go-deps
@@ -1,24 +1,23 @@
-#!/bin/bash
+#!/bin/sh
 
 # Builds (or pulls) our go-deps docker image.
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+bindir=$( cd "${0%/*}" && pwd )
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
 tag=$(go_deps_sha)
 
-if (docker_pull go-deps "${tag}"); then
-    echo "$(docker_repo go-deps):${tag}"
+if (docker_pull go-deps "$tag"); then
+    echo "$(docker_repo go-deps):$tag"
 else
-    rootdir="$( cd $bindir/.. && pwd )"
-    docker_build go-deps "${tag}" $rootdir/Dockerfile-go-deps
+    rootdir=$( cd "$bindir"/.. && pwd )
+    docker_build go-deps "$tag" "$rootdir/Dockerfile-go-deps"
 fi

--- a/bin/docker-build-grafana
+++ b/bin/docker-build-grafana
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
-dockerfile=$rootdir/grafana/Dockerfile
+dockerfile="$rootdir/grafana/Dockerfile"
 
-docker_build grafana "$(head_root_tag)" $dockerfile
+docker_build grafana $(head_root_tag) "$dockerfile"

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -1,26 +1,25 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
 dockerfile="$rootdir/Dockerfile-proxy"
 
 validate_go_deps_tag "$dockerfile"
 
 (
-    $bindir/docker-build-go-deps
+    "$bindir"/docker-build-go-deps
 ) >/dev/null
 
-tag="$(head_root_tag)"
-docker_build proxy "$tag" "$dockerfile" \
-  --build-arg "LINKERD_VERSION=$tag"
+tag=$(head_root_tag)
+docker_build proxy $tag "$dockerfile" --build-arg LINKERD_VERSION=$tag

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -1,25 +1,25 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 0 ]; then
-    echo "no arguments allowed for $(basename $0), given: $@" >&2
+    echo "no arguments allowed for ${0##*/}, given: $@" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
-dockerfile=$rootdir/web/Dockerfile
+dockerfile="$rootdir"/web/Dockerfile
 
-validate_go_deps_tag $dockerfile
+validate_go_deps_tag "$dockerfile"
 
 (
-    $bindir/docker-build-go-deps
+    "$bindir"/docker-build-go-deps
 ) >/dev/null
 
-tag="$(head_root_tag)"
-docker_build web $tag $dockerfile --build-arg LINKERD_VERSION=$tag
+tag=$(head_root_tag)
+docker_build web $tag "$dockerfile" --build-arg LINKERD_VERSION=$tag

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
 docker_image() {
-    repo="$(docker_repo "$1")"
+    repo=$(docker_repo "$1")
     docker image ls \
         --format "{{printf \"%-16s %-10s\" \"$1\" \"${2}\"}} {{.Size | printf \"%6s\"}}  {{.ID}}  {{.CreatedAt}}" \
         "${repo}:${2}"
@@ -16,8 +16,8 @@ docker_image() {
 
 tag=$(head_root_tag)
 
-for img in cli-bin cni-plugin controller debug grafana proxy web  ; do
-    docker_image "$img" "$tag"
+for img in cli-bin cni-plugin controller debug grafana proxy web ; do
+    docker_image $img $tag
 done
 
-docker_image go-deps      "$(go_deps_sha)"
+docker_image go-deps "$(go_deps_sha)"

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -eq 1 ]; then
-    tag="${1:-}"
+    tag=${1:-}
 else
-    echo "usage: $(basename $0) tag" >&2
+    echo "usage: ${0##*/} tag" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
+. "$bindir"/_docker.sh
 
-for img in cli-bin cni-plugin controller debug grafana proxy web  ; do
-    docker_pull "$img" "$tag"
+for img in cli-bin cni-plugin controller debug grafana proxy web ; do
+    docker_pull $img "$tag"
 done

--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -1,34 +1,32 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -eq 1 ]; then
-    tag="${1:-}"
+    tag=${1:-}
 else
-    echo "usage: $(basename $0) tag" >&2
+    echo "usage: ${0##*/} tag" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir="$( cd "$bindir"/.. && pwd )"
 
-. $bindir/_docker.sh
+. "$bindir"/_docker.sh
 
 workdir="$rootdir/target/release"
 mkdir -p "$workdir"
 
-shorttag="$tag"
-if [ "${tag:0:1}" == "v" ]; then
-  shorttag="${tag:1}"
-fi
+# create shorttag where eventual initial v in tag is stripped
+shorttag=${tag#v}
 
 # create the cli-bin container in order to extract the binaries
 id=$(docker create "$(docker_repo cli-bin):$tag")
 
 for os in darwin linux windows ; do
-  ext="$os"
-  if [ "$os" == "windows" ]; then
-    ext="windows.exe"
+  ext=$os
+  if [ "$os" = windows ]; then
+    ext=windows.exe
   fi
   filepath="$workdir/linkerd2-cli-$shorttag-$ext"
   docker cp "$id:/out/linkerd-$os" "$filepath"

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
 docker_pull base       2019-09-04.01       || true
 docker_pull go-deps    "$(go_deps_sha)"    || true

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -eq 1 ]; then
     tag="${1:-}"
 else
-    echo "usage: $(basename $0) tag" >&2
+    echo "usage: ${0##*/} tag" >&2
     exit 64
 fi
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
+. "$bindir"/_docker.sh
 
-for img in cli-bin cni-plugin controller debug grafana proxy web  ; do
-    docker_push "$img" "$tag"
+for img in cli-bin cni-plugin controller debug grafana proxy web ; do
+    docker_push $img "$tag"
 done

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
-. $bindir/_tag.sh
+. "$bindir"/_docker.sh
+. "$bindir"/_tag.sh
 
 docker_push base         2019-09-04.01
 docker_push go-deps      "$(go_deps_sha)"

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 if [ $# -ne 2 ]; then
-    echo "usage: $0 from-tag to-tag" >&2
+    echo "usage: ${0##*/} from-tag to-tag" >&2
     exit 64
 fi
-from="${1}"
-to="${2}"
+from=$1
+to=$2
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
 
-. $bindir/_docker.sh
+. "$bindir"/_docker.sh
 
-for img in cli-bin cni-plugin controller debug grafana proxy web  ; do
-    docker_retag "$img" "$from" "$to"
+for img in cli-bin cni-plugin controller debug grafana proxy web ; do
+    docker_retag $img "$from" "$to"
 done

--- a/bin/docker-test-proxy
+++ b/bin/docker-test-proxy
@@ -1,26 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 # When set, causes docker's build output to be emitted to stderr.
-export DOCKER_TRACE="${DOCKER_TRACE:-}"
-export RUST_LOG="${RUST_LOG:-}"
+export DOCKER_TRACE=${DOCKER_TRACE:-}
+export RUST_LOG=${RUST_LOG:-}
 
-bindir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-rootdir="$( cd $bindir/.. && pwd )"
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
 
-output="/dev/null"
 if [ -n "$DOCKER_TRACE" ]; then
-    output="/dev/stderr"
+	output=/dev/stderr
+else
+	output=/dev/null
 fi
 
-output="/dev/null"
-if [ -n "$DOCKER_TRACE" ]; then
-    output="/dev/stderr"
-fi
-
-docker build -f $rootdir/proxy/Dockerfile . \
+docker build -f "$rootdir/proxy/Dockerfile" . \
     --target build \
     -t proxy-build \
-    --build-arg=PROXY_UNOPTIMIZED=1 > "$output"
+    --build-arg=PROXY_UNOPTIMIZED=1 > $output
 docker run --rm -it proxy-build env RUST_LOG="$RUST_LOG" cargo test "$@"


### PR DESCRIPTION
Make docker scripts POSIX compatible and handle paths with whitespaces.

Change-Id: I58707a28d42723bc8782e1a8d72487ac4f3080c3
Signed-off-by: Joakim Roubert <joakimr@axis.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
