### PR TITLE
Add preinstall checks for deletion and creation of secrets

### DIFF
--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -21,6 +21,8 @@ pre-kubernetes-setup
 √ can create Deployments
 √ can create CronJobs
 √ can create ConfigMaps
+√ can create Secrets
+√ can read Secrets
 √ no clock skew detected
 
 pre-kubernetes-capability


### PR DESCRIPTION
The pr adds checks that ensure the k8s client used for installation is able to create/get secrets. This is needed for the identity service.

Fixes #3638 

Signed-off-by: zaharidichev <zaharidichev@gmail.com>
