### PR TITLE
Check stats of deployed apps before and after linkerd upgrade

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -132,8 +132,14 @@ function install_stable() {
 
     local linkerd_path=$tmp/.linkerd2/bin/linkerd
     local stable_namespace="$1"
+    local test_app_namespace="$stable_namespace"-upgrade-test
     $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - > /dev/null 2>&1
     $linkerd_path check --linkerd-namespace="$stable_namespace" > /dev/null 2>&1
+
+    #Now we need to install the app that will be used to verify that upgrade does not break anything
+    kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1
+    kubectl --context=$k8s_context label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
+    $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - > /dev/null 2>&1
 }
 
 # Run the upgrade test by upgrading the most-recent stable release to the HEAD of

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -151,9 +151,8 @@ func TestCheckPreInstall(t *testing.T) {
 	}
 }
 
-// Gathers success stats from the app upgrade test app
-// Used to ensure upgrade process went smoothly
-func ensureUpgradedAppRunning(t *testing.T, namespace string) {
+// Gathers success stats from the test app
+func ensureTestAppRunning(t *testing.T, namespace string) {
 	args := []string{"stat", "deploy", "-n", namespace, "-t", "60s"}
 	err := TestHelper.RetryFor(60*time.Second, func() error {
 		out, stderr, err := TestHelper.LinkerdRun(args...)
@@ -185,7 +184,8 @@ func ensureUpgradedAppRunning(t *testing.T, namespace string) {
 	}
 }
 
-func deployUpgradeTestApp(t *testing.T, namespace string) {
+// deploys and meshes a simple test application
+func deployTestApp(t *testing.T, namespace string) {
 	out, _, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/upgrade_test.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s", out)
@@ -233,8 +233,8 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 			t.Fatalf("failed to create %s namespace: %s", upgradeNamespace, err)
 		}
 
-		deployUpgradeTestApp(t, upgradeNamespace)
-		ensureUpgradedAppRunning(t, upgradeNamespace)
+		deployTestApp(t, upgradeNamespace)
+		ensureTestAppRunning(t, upgradeNamespace)
 
 		cmd = "upgrade"
 		// test 2-stage install during upgrade
@@ -295,7 +295,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	}
 
 	if TestHelper.UpgradeFromVersion() != "" {
-		ensureUpgradedAppRunning(t, upgradeNamespace) // make sure apps a running after upgrade
+		ensureTestAppRunning(t, upgradeNamespace) // make sure apps a running after upgrade
 	}
 }
 

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -22,18 +22,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-type rowStat struct {
-	name               string
-	status             string
-	meshed             string
-	success            string
-	rps                string
-	p50Latency         string
-	p95Latency         string
-	p99Latency         string
-	tcpOpenConnections string
-}
-
 //////////////////////
 /// TEST EXECUTION ///
 //////////////////////
@@ -146,7 +134,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 				if tt.status != "" {
 					expectedColumnCount++
 				}
-				rowStats, err := parseRows(out, len(tt.expectedRows), expectedColumnCount)
+				rowStats, err := testutil.ParseRows(out, len(tt.expectedRows), expectedColumnCount)
 				if err != nil {
 					return err
 				}
@@ -166,112 +154,52 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	}
 }
 
-// check that expectedRowCount rows have been returned
-func checkRowCount(out string, expectedRowCount int) ([]string, error) {
-	rows := strings.Split(out, "\n")
-	if len(rows) < 2 {
-		return nil, fmt.Errorf(
-			"Error stripping header and trailing newline; full output:\n%s",
-			strings.Join(rows, "\n"),
-		)
-	}
-	rows = rows[1 : len(rows)-1] // strip header and trailing newline
-
-	if len(rows) != expectedRowCount {
-		return nil, fmt.Errorf(
-			"Expected [%d] rows in stat output, got [%d]; full output:\n%s",
-			expectedRowCount, len(rows), strings.Join(rows, "\n"))
-	}
-
-	return rows, nil
-}
-
-func parseRows(out string, expectedRowCount, expectedColumnCount int) (map[string]*rowStat, error) {
-	rows, err := checkRowCount(out, expectedRowCount)
-	if err != nil {
-		return nil, err
-	}
-
-	rowStats := make(map[string]*rowStat)
-	for _, row := range rows {
-		fields := strings.Fields(row)
-
-		if expectedColumnCount == 0 {
-			expectedColumnCount = 8
-		}
-		if len(fields) != expectedColumnCount {
-			return nil, fmt.Errorf(
-				"Expected [%d] columns in stat output, got [%d]; full output:\n%s",
-				expectedColumnCount, len(fields), row)
-		}
-
-		rowStats[fields[0]] = &rowStat{
-			name: fields[0],
-		}
-
-		i := 0
-		if expectedColumnCount == 9 {
-			rowStats[fields[0]].status = fields[1]
-			i = 1
-		}
-		rowStats[fields[0]].meshed = fields[1+i]
-		rowStats[fields[0]].success = fields[2+i]
-		rowStats[fields[0]].rps = fields[3+i]
-		rowStats[fields[0]].p50Latency = fields[4+i]
-		rowStats[fields[0]].p95Latency = fields[5+i]
-		rowStats[fields[0]].p99Latency = fields[6+i]
-		rowStats[fields[0]].tcpOpenConnections = fields[7+i]
-	}
-
-	return rowStats, nil
-}
-
-func validateRowStats(name, expectedMeshCount, expectedStatus string, rowStats map[string]*rowStat) error {
+func validateRowStats(name, expectedMeshCount, expectedStatus string, rowStats map[string]*testutil.RowStat) error {
 	stat, ok := rowStats[name]
 	if !ok {
 		return fmt.Errorf("No stats found for [%s]", name)
 	}
 
-	if stat.status != expectedStatus {
+	if stat.Status != expectedStatus {
 		return fmt.Errorf("Expected status '%s' for '%s', got '%s'",
-			expectedStatus, name, stat.status)
+			expectedStatus, name, stat.Status)
 	}
 
-	if stat.meshed != expectedMeshCount {
+	if stat.Meshed != expectedMeshCount {
 		return fmt.Errorf("Expected mesh count [%s] for [%s], got [%s]",
-			expectedMeshCount, name, stat.meshed)
+			expectedMeshCount, name, stat.Meshed)
 	}
 
 	expectedSuccessRate := "100.00%"
-	if stat.success != expectedSuccessRate {
+	if stat.Success != expectedSuccessRate {
 		return fmt.Errorf("Expected success rate [%s] for [%s], got [%s]",
-			expectedSuccessRate, name, stat.success)
+			expectedSuccessRate, name, stat.Success)
 	}
 
-	if !strings.HasSuffix(stat.rps, "rps") {
+	if !strings.HasSuffix(stat.Rps, "rps") {
 		return fmt.Errorf("Unexpected rps for [%s], got [%s]",
-			name, stat.rps)
+			name, stat.Rps)
 	}
 
-	if !strings.HasSuffix(stat.p50Latency, "ms") {
+	if !strings.HasSuffix(stat.P50Latency, "ms") {
 		return fmt.Errorf("Unexpected p50 latency for [%s], got [%s]",
-			name, stat.p50Latency)
+			name, stat.P50Latency)
 	}
 
-	if !strings.HasSuffix(stat.p95Latency, "ms") {
+	if !strings.HasSuffix(stat.P95Latency, "ms") {
 		return fmt.Errorf("Unexpected p95 latency for [%s], got [%s]",
-			name, stat.p95Latency)
+			name, stat.P95Latency)
 	}
 
-	if !strings.HasSuffix(stat.p99Latency, "ms") {
+	if !strings.HasSuffix(stat.P99Latency, "ms") {
 		return fmt.Errorf("Unexpected p99 latency for [%s], got [%s]",
-			name, stat.p99Latency)
+			name, stat.P99Latency)
 	}
 
-	if stat.tcpOpenConnections != "-" {
-		_, err := strconv.Atoi(stat.tcpOpenConnections)
+	if stat.TCPOpenConnections != "-" {
+		_, err := strconv.Atoi(stat.TCPOpenConnections)
 		if err != nil {
-			return fmt.Errorf("Error parsing number of TCP connections [%s]: %s", stat.tcpOpenConnections, err.Error())
+			return fmt.Errorf("Error parsing number of TCP connections [%s]: %s", stat.TCPOpenConnections, err.Error())
 		}
 	}
 

--- a/test/testdata/upgrade_test.yaml
+++ b/test/testdata/upgrade_test.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: server
+  template:
+    metadata:
+      labels:
+        app: server
+    spec:
+      containers:
+      - name: server
+        image: buoyantio/bb:v0.0.5
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=server"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-svc
+spec:
+  selector:
+    app: server
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: slow-cooker
+spec:
+  template:
+    metadata:
+      labels:
+        app: slow-cooker
+    spec:
+      containers:
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.1.1
+        command:
+        - "/bin/sh"
+        args:
+        - "-c"
+        - |
+          sleep 5 # wait for pods to start
+          slow_cooker -metric-addr 0.0.0.0:9999 http://server-svc:8080
+        ports:
+        - containerPort: 9999
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: slow-cooker
+spec:
+  selector:
+    app: slow-cooker
+  ports:
+  - name: metrics
+    port: 9999
+    targetPort: 9999

--- a/test/testdata/upgrade_test.yaml
+++ b/test/testdata/upgrade_test.yaml
@@ -1,72 +1,157 @@
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: emoji
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: voting
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: web
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: server
+  creationTimestamp: null
+  name: emoji
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: server
+      app: emoji-svc
+  strategy: {}
   template:
     metadata:
+      creationTimestamp: null
       labels:
-        app: server
+        app: emoji-svc
     spec:
+      serviceAccountName: emoji
       containers:
-      - name: server
-        image: buoyantio/bb:v0.0.5
-        args:
-        - terminus
-        - "--h1-server-port=8080"
-        - "--response-text=server"
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        image: buoyantio/emojivoto-emoji-svc:v8
+        name: emoji-svc
         ports:
         - containerPort: 8080
+          name: grpc
+        resources:
+          requests:
+            cpu: 100m
+status: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: server-svc
+  name: emoji-svc
 spec:
   selector:
-    app: server
+    app: emoji-svc
+  clusterIP: None
   ports:
-  - name: http
+  - name: grpc
     port: 8080
     targetPort: 8080
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: slow-cooker
+  creationTimestamp: null
+  name: voting
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: voting-svc
+  strategy: {}
   template:
     metadata:
+      creationTimestamp: null
       labels:
-        app: slow-cooker
+        app: voting-svc
     spec:
+      serviceAccountName: voting
       containers:
-      - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
-        command:
-        - "/bin/sh"
-        args:
-        - "-c"
-        - |
-          sleep 5 # wait for pods to start
-          slow_cooker -metric-addr 0.0.0.0:9999 http://server-svc:8080
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        image: buoyantio/emojivoto-voting-svc:v8
+        name: voting-svc
         ports:
-        - containerPort: 9999
-      restartPolicy: OnFailure
+        - containerPort: 8080
+          name: grpc
+        resources:
+          requests:
+            cpu: 100m
+status: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: slow-cooker
+  name: voting-svc
 spec:
   selector:
-    app: slow-cooker
+    app: voting-svc
+  clusterIP: None
   ports:
-  - name: metrics
-    port: 9999
-    targetPort: 9999
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: web-svc
+    spec:
+      serviceAccountName: web
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "8080"
+        - name: EMOJISVC_HOST
+          value: emoji-svc:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v8
+        name: web-svc
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  type: LoadBalancer
+  selector:
+    app: web-svc
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+---


### PR DESCRIPTION
This PR adds a stat checks to the upgrade integration test to ensure the deployed apps did not break. This is done by looking at the SuccessRate. 

Fixes #3544 
Signed-off-by: zaharidichev <zaharidichev@gmail.com>
