### PR TITLE
Added goimports lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
   - deadcode
   - depguard
   - goconst
+  - goimports
   - golint
   - gosimple
   - govet


### PR DESCRIPTION
Catches nonconformant import ordering, like in
https://github.com/linkerd/linkerd2/pull/3652#discussion_r340712146

@zaharidichev Please let me know if this clashes with your IDE of choice :wink: 