### PR TITLE
update changelog for edge-19.10.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,6 @@ CLI.
   * Added a new `--identity-external-issuer` flag to `linkerd install` that
     configures Linkerd to use certificates issued by an external certificate
     issuer (such as `cert-manager`)
-  * Added new `--trace-collector` and `--trace-collector-svc-account` flags to
-    `linkerd inject` that configures the OpenCensus trace collector used by
-    proxies in the injected workload (thanks @Pothulapati!)
-  * Added a new `--control-plane-tracing` flag to `linkerd install` that enables
-    distributed tracing in the control plane (thanks @Pothulapati!)
   * Added support for injecting a namespace to `linkerd inject` (thanks
     @mayankshah1607!)
   * Added checks to `linkerd check --preinstall` ensuring Kubernetes Secrets
@@ -22,13 +17,19 @@ CLI.
   * Fixed `linkerd tap` sometimes displaying incorrect pod names for unmeshed
     IPs that match multiple running pods
 * Controller
-  * Added distributed tracing support to the control plane (thanks
-    @Pothulapati!)
   * Added support for using trust anchors from an external certificate issuer
     (such as `cert-mananger`) to the `linkerd-identity` service
 * Web UI
   * Added `Host:` header validation to the `linkerd-web` service, to protect
     against DNS rebinding attacks
+* Internal
+  * Added new `--trace-collector` and `--trace-collector-svc-account` flags to
+    `linkerd inject` that configures the OpenCensus trace collector used by
+    proxies in the injected workload (thanks @Pothulapati!)
+  * Added a new `--control-plane-tracing` flag to `linkerd install` that enables
+    distributed tracing in the control plane (thanks @Pothulapati!)
+  * Added distributed tracing support to the control plane (thanks
+    @Pothulapati!)
 
 Also, thanks to @joakimr-axis for several fixes and improvements to internal
 build scripts!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,47 @@
+## edge-19.10.5
+
+This edge release adds support for integrating Linkerd's PKI with an external
+certificate issuer such as [`cert-manager`], adds distributed tracing support to
+the Linkerd control plane, and adds protection against DNS rebinding attacks to
+the web dashboard. In addition, it includes several improvements to the Linkerd
+CLI.
+
+* CLI
+  * Added a new `--identity-external-issuer` flag to `linkerd install` that
+    configures Linkerd to use certificates issued by an external certificate
+    issuer (such as `cert-manager`)
+  * Added new `--trace-collector` and `--trace-collector-svc-account` flags to
+    `linkerd inject` that configures the OpenCensus trace collector used by
+    proxies in the injected workload (thanks @ Pothulapati!)
+  * Added a new `--control-plane-tracing` flag to `linkerd install` that enables
+    distributed tracing in the control plane (thanks @Pothulapati!)
+  * Added support for injecting a namespace to `linkerd inject` (thanks
+    @mayankshah1607!)
+  * Added checks to `linkerd check --preinstall` ensuring Kubernetes Secrets
+    can be created and accessed
+  * Fixed `linkerd tap` sometimes not displaying incorrect pod names for
+    unmeshed IPs that match multiple running pods
+* Controller
+  * Added distributed tracing support to the control plane (thanks
+    @Pothulapati!)
+  * Added support for using trust anchors from an external certificate issuer
+    (such as `cert-mananger`) to the `linkerd-identity` service
+* Web UI
+  * Added `Host:` header validation to the `linkerd-web` service, to protect
+    against DNS rebinding attacks
+
+Also, thanks to @joakimr-axis for several fixes and improvements to internal
+build scripts!
+
+[`cert-manager`]: https://github.com/jetstack/cert-manager
+
 ## edge-19.10.4
 
 This edge release adds dashboard UX enhancements, and improves the speed of the CLI.
 
 * CLI
   * Made `linkerd install --ignore-cluster` and `--skip-checks` faster
-  * Fixed a bug causing `linkerd upgrade` to fail when used with 
+  * Fixed a bug causing `linkerd upgrade` to fail when used with
   `--from-manifest`
 * Web UI
   * Made the dashboard sidebar component responsive

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,15 +12,15 @@ CLI.
     issuer (such as `cert-manager`)
   * Added new `--trace-collector` and `--trace-collector-svc-account` flags to
     `linkerd inject` that configures the OpenCensus trace collector used by
-    proxies in the injected workload (thanks @ Pothulapati!)
+    proxies in the injected workload (thanks @Pothulapati!)
   * Added a new `--control-plane-tracing` flag to `linkerd install` that enables
     distributed tracing in the control plane (thanks @Pothulapati!)
   * Added support for injecting a namespace to `linkerd inject` (thanks
     @mayankshah1607!)
   * Added checks to `linkerd check --preinstall` ensuring Kubernetes Secrets
     can be created and accessed
-  * Fixed `linkerd tap` sometimes not displaying incorrect pod names for
-    unmeshed IPs that match multiple running pods
+  * Fixed `linkerd tap` sometimes displaying incorrect pod names for unmeshed
+    IPs that match multiple running pods
 * Controller
   * Added distributed tracing support to the control plane (thanks
     @Pothulapati!)

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.10.4
+LinkerdVersion: &linkerd_version edge-19.10.5
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.10.5

This edge release adds support for integrating Linkerd's public-key
infrastructure with an external certificate issuer such as [`cert-manager`],
adds distributed tracing support to the Linkerd control plane, and adds
protection against DNS rebinding attacks to the web dashboard. In addition, it
includes several improvements to the Linkerd CLI.

* CLI
  * Added a new `--identity-external-issuer` flag to `linkerd install` that
    configures Linkerd to use certificates issued by an external certificate
    issuer (such as `cert-manager`)
  * Added support for injecting a namespace to `linkerd inject` (thanks
    @mayankshah1607!)
  * Added checks to `linkerd check --preinstall` ensuring Kubernetes Secrets
    can be created and accessed
  * Fixed `linkerd tap` sometimes displaying incorrect pod names for unmeshed
    IPs that match multiple running pods
* Controller
  * Added support for using trust anchors from an external certificate issuer
    (such as `cert-mananger`) to the `linkerd-identity` service
* Web UI
  * Added `Host:` header validation to the `linkerd-web` service, to protect
    against DNS rebinding attacks
* Internal
  * Added new `--trace-collector` and `--trace-collector-svc-account` flags to
    `linkerd inject` that configures the OpenCensus trace collector used by
    proxies in the injected workload (thanks @Pothulapati!)
  * Added a new `--control-plane-tracing` flag to `linkerd install` that enables
    distributed tracing in the control plane (thanks @Pothulapati!)
  * Added distributed tracing support to the control plane (thanks
    @Pothulapati!)

Also, thanks to @joakimr-axis for several fixes and improvements to internal
build scripts!