### PR TITLE
Add integration test for custom cluster domain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -277,7 +277,7 @@ jobs:
   kind_setup:
     strategy:
       matrix:
-        integration_test: [deep, upgrade, helm]
+        integration_test: [deep, upgrade, helm, custom_domain]
     name: Cluster setup (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04
     needs: [download_src]
@@ -311,15 +311,22 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        export CUSTOM_DOMAIN_CONFIG="test/testdata/custom_cluster_domain_config.yaml"
         # retry cluster creation once in case of port conflict or kubeadm failure
-        bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
+        if [ "${{ matrix.integration_test }}" == "custom_domain" ]
+        then
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG
+        else
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
+        fi
         scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) github@$DOCKER_ADDRESS:/tmp
 
   kind_integration:
     strategy:
       matrix:
-        integration_test: [deep, upgrade, helm]
+        integration_test: [deep, upgrade, helm, custom_domain]
     needs: [docker_pull, docker_build, kind_setup]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04
@@ -406,7 +413,7 @@ jobs:
     strategy:
       fail-fast: false # always attempt to cleanup all clusters
       matrix:
-        integration_test: [deep, upgrade, helm]
+        integration_test: [deep, upgrade, helm, custom_domain]
     needs: [kind_integration]
     name: Cluster cleanup (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -64,6 +64,11 @@ function deep_integration_tests() {
     exit_on_err "error during deep tests"
 }
 
+function custom_domain_integration_tests() {
+    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace --cluster-domain="custom.domain"
+    exit_on_err "error during install"
+}
+
 #
 # Helper functions.
 #

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -165,6 +165,10 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 	)
 
+	if TestHelper.GetClusterDomain() != "" {
+		args = append(args, "--cluster-domain", TestHelper.GetClusterDomain())
+	}
+
 	if TestHelper.UpgradeFromVersion() != "" {
 		cmd = "upgrade"
 

--- a/test/testdata/custom_cluster_domain_config.yaml
+++ b/test/testdata/custom_cluster_domain_config.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kubeadmConfigPatches:
+- |
+  apiVersion: kubeadm.k8s.io/v1beta2
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  networking:
+    dnsDomain: "custom.domain"

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -21,6 +21,7 @@ type TestHelper struct {
 	version            string
 	namespace          string
 	upgradeFromVersion string
+	clusterDomain      string
 	httpClient         http.Client
 	KubernetesHelper
 	helm
@@ -49,6 +50,7 @@ func NewTestHelper() *TestHelper {
 	helmReleaseName := flag.String("helm-release", "", "install linkerd via Helm using this release name")
 	tillerNs := flag.String("tiller-ns", "kube-system", "namespace under which Tiller will be installed")
 	upgradeFromVersion := flag.String("upgrade-from-version", "", "when specified, the upgrade test uses it as the base version of the upgrade")
+	clusterDomain := flag.String("cluster-domain", "", "when specified, the install test uses a custom cluster domain")
 	runTests := flag.Bool("integration-tests", false, "must be provided to run the integration tests")
 	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	flag.Parse()
@@ -86,6 +88,7 @@ func NewTestHelper() *TestHelper {
 			releaseName: *helmReleaseName,
 			tillerNs:    *tillerNs,
 		},
+		clusterDomain: *clusterDomain,
 	}
 
 	version, _, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -134,6 +137,11 @@ func (h *TestHelper) GetHelmReleaseName() string {
 // UpgradeFromVersion returns the base version of the upgrade test.
 func (h *TestHelper) UpgradeFromVersion() string {
 	return h.upgradeFromVersion
+}
+
+// GetClusterDomain returns the custom cluster domain that needs to be used during linkerd installation
+func (h *TestHelper) GetClusterDomain() string {
+	return h.clusterDomain
 }
 
 // LinkerdRun executes a linkerd command appended with the --linkerd-namespace


### PR DESCRIPTION
This pr adds logic for creating a custom domain kind cluster and then exercising the install_test.go logic while supplying a `--cluster-domain` flag to the `linkerd install` command.

Fixes: #3517 

Signed-off-by: zaharidichev <zaharidichev@gmail.com>