### PR TITLE
Remove destination container from controller

### DIFF
--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -23,25 +23,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: {{.Namespace}}
-  labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-  annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-spec:
-  type: ClusterIP
-  selector:
-    {{.ControllerComponentLabel}}: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 {{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
 {{ $_ := set .Proxy "Component" "linkerd-controller" -}}
 {{ include "linkerd.proxy.validation" .Proxy -}}
@@ -105,38 +86,6 @@ spec:
             port: 9995
         {{- if .PublicAPIResources -}}
         {{- include "partials.resources" .PublicAPIResources | nindent 8 }}
-        {{- end }}
-        securityContext:
-          runAsUser: {{.ControllerUID}}
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace={{.Namespace}}
-        - -enable-h2-upgrade={{.EnableH2Upgrade}}
-        - -log-level={{.ControllerLogLevel}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
-        {{- if .DestinationResources -}}
-        {{- include "partials.resources" .DestinationResources | nindent 8 }}
         {{- end }}
         securityContext:
           runAsUser: {{.ControllerUID}}

--- a/cli/cmd/testdata/install-sp_default.golden
+++ b/cli/cmd/testdata/install-sp_default.golden
@@ -41,7 +41,7 @@ spec:
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: linkerd-destination.linkerd.svc.cluster.local
+  name: linkerd-dst.linkerd.svc.cluster.local
   namespace: linkerd
 spec:
   routes:

--- a/cli/cmd/testdata/install-sp_output.golden
+++ b/cli/cmd/testdata/install-sp_output.golden
@@ -41,7 +41,7 @@ spec:
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: linkerd-destination.NAMESPACE.svc.CLUSTERDOMAIN
+  name: linkerd-dst.NAMESPACE.svc.CLUSTERDOMAIN
   namespace: NAMESPACE
 spec:
   routes:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -270,25 +270,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -344,35 +325,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:install-control-plane-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1028,25 +1028,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1102,35 +1083,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:install-control-plane-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1061,25 +1061,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1155,42 +1136,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources:
-          limits:
-            cpu: "1"
-            memory: "250Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:install-control-plane-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         resources:
           limits:
             cpu: "1"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1061,25 +1061,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1155,42 +1136,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources:
-          limits:
-            cpu: "1"
-            memory: "250Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:install-control-plane-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         resources:
           limits:
             cpu: "1"

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1104,25 +1104,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/helm linkerd-version
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1178,35 +1159,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:linkerd-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1137,25 +1137,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/helm linkerd-version
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1231,42 +1212,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources:
-          limits:
-            cpu: "1"
-            memory: "250Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:linkerd-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         resources:
           limits:
             cpu: "1"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -992,25 +992,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1066,35 +1047,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:install-control-plane-version
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1027,25 +1027,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: Namespace
-  labels:
-    ControllerComponentLabel: controller
-    ControllerNamespaceLabel: Namespace
-  annotations:
-    CreatedByAnnotation: CliVersion
-spec:
-  type: ClusterIP
-  selector:
-    ControllerComponentLabel: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1101,35 +1082,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=Namespace
-        - -enable-h2-upgrade=true
-        - -log-level=ControllerLogLevel
-        image: ControllerImage:ControllerImageVersion
-        imagePullPolicy: ImagePullPolicy
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1029,25 +1029,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1103,35 +1084,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -1015,25 +1015,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1089,35 +1070,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         securityContext:
           runAsUser: 2103
         volumeMounts:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1062,25 +1062,6 @@ spec:
     port: 8085
     targetPort: 8085
 ---
-kind: Service
-apiVersion: v1
-metadata:
-  name: linkerd-destination
-  namespace: linkerd
-  labels:
-    linkerd.io/control-plane-component: controller
-    linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-spec:
-  type: ClusterIP
-  selector:
-    linkerd.io/control-plane-component: controller
-  ports:
-  - name: grpc
-    port: 8086
-    targetPort: 8086
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -1156,42 +1137,6 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        resources:
-          limits:
-            cpu: "1"
-            memory: "250Mi"
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
-        securityContext:
-          runAsUser: 2103
-        volumeMounts:
-        - mountPath: /var/run/linkerd/config
-          name: config
-      - args:
-        - destination
-        - -addr=:8086
-        - -controller-namespace=linkerd
-        - -enable-h2-upgrade=true
-        - -log-level=info
-        image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /ping
-            port: 9996
-          initialDelaySeconds: 10
-        name: destination
-        ports:
-        - containerPort: 8086
-          name: grpc
-        - containerPort: 9996
-          name: admin-http
-        readinessProbe:
-          failureThreshold: 7
-          httpGet:
-            path: /ready
-            port: 9996
         resources:
           limits:
             cpu: "1"

--- a/cli/installsp/template.go
+++ b/cli/installsp/template.go
@@ -44,7 +44,7 @@ spec:
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: linkerd-destination.{{.Namespace}}.svc.{{.ClusterDomain}}
+  name: linkerd-dst.{{.Namespace}}.svc.{{.ClusterDomain}}
   namespace: {{.Namespace}}
 spec:
   routes:

--- a/test/endpoints/endpoints_test.go
+++ b/test/endpoints/endpoints_test.go
@@ -24,7 +24,6 @@ func TestGoodEndpoints(t *testing.T) {
 	cmd := []string{
 		"endpoints",
 		fmt.Sprintf("linkerd-controller-api.%s.svc.cluster.local:8085", ns),
-		fmt.Sprintf("linkerd-destination.%s.svc.cluster.local:8086", ns),
 		fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", ns),
 		fmt.Sprintf("linkerd-grafana.%s.svc.cluster.local:3000", ns),
 		fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", ns),

--- a/test/endpoints/testdata/linkerd_endpoints.golden
+++ b/test/endpoints/testdata/linkerd_endpoints.golden
@@ -10,13 +10,6 @@
     "namespace": "{{.Ns}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8086,
-    "pod": "linkerd\-controller\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-destination\.{{.Ns}}"
-  \},
-  \{
-    "namespace": "{{.Ns}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 8086,
     "pod": "linkerd\-destination\-[a-f0-9]+\-[a-z0-9]+",
     "service": "linkerd\-dst\.{{.Ns}}"
   \},

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 var (
 	linkerdSvcs = []string{
 		"linkerd-controller-api",
-		"linkerd-destination",
+		"linkerd-dst",
 		"linkerd-grafana",
 		"linkerd-identity",
 		"linkerd-prometheus",

--- a/test/routes/routes_test.go
+++ b/test/routes/routes_test.go
@@ -39,7 +39,8 @@ func TestRoutes(t *testing.T) {
 		c int
 	}{
 		{"linkerd-controller-api", 9},
-		{"linkerd-destination", 4},
+		{"linkerd-destination", 1},
+		{"linkerd-dst", 3},
 		{"linkerd-grafana", 12},
 		{"linkerd-identity", 2},
 		{"linkerd-prometheus", 5},


### PR DESCRIPTION
Now that we are going to release 2.7, we can remove the destination container from the controller again. 

Fixes: #3543 

Signed-off-by: zaharidichev <zaharidichev@gmail.com>
