### PR TITLE
rename `edge-19.10.5` to `edge-19.11.1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## edge-19.10.5
+## edge-19.11.1
 
 This edge release adds support for integrating Linkerd's PKI with an external
 certificate issuer such as [`cert-manager`], adds distributed tracing support to


### PR DESCRIPTION
The intention was to release `edge-19.10.5` yesterday, but due to CI
issues, the release had to be delayed until today. Since yesterday was
October 31st, the release's version would have been `edge-19.10.5`;
however, today is November 1st, so the version number is now
`edge-19.11.1`. Unfortunately, I only realised this *immediately after*
I merged #3658...

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
