### PR TITLE
Add filter to namespace select button

### DIFF
--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -75,7 +75,7 @@ class BaseTable extends React.Component {
   };
 
   handleFilterInputChange = event => {
-    this.setState({ filterBy: event.target.value });
+    this.setState({ filterBy: regexFilterString(event.target.value) });
   }
 
   handleFilterToggle = () => {
@@ -95,11 +95,12 @@ class BaseTable extends React.Component {
       let filteredRows = rows.filter(row => {
         return columnsToFilter.some(col => {
           let rowText = col.filter(row);
-          return rowText.match(regexFilterString(filterBy));
+          return rowText.match(filterBy);
         });
       });
       rows = filteredRows;
     }
+
     return rows;
   }
 

--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -20,6 +20,7 @@ import _get from 'lodash/get';
 import _isNil from 'lodash/isNil';
 import _orderBy from 'lodash/orderBy';
 import classNames from 'classnames';
+import { regexFilterString } from './util/Utils.js';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
@@ -74,9 +75,7 @@ class BaseTable extends React.Component {
   };
 
   handleFilterInputChange = e => {
-    let input = e.target.value.replace(/[^A-Z0-9/.\-_]/gi, "").toLowerCase();
-    let swapWildCard = /[*]/g; // replace "*" in input with wildcard
-    let filterBy = new RegExp(input.replace(swapWildCard, ".+"), "i");
+    let filterBy = regexFilterString(e.target.value);
     if (filterBy !== this.state.filterBy) {
       this.setState({ filterBy });
     }

--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -90,15 +90,16 @@ class BaseTable extends React.Component {
     if (orderBy && col.sorter) {
       rows = _orderBy(rows, row => col.sorter(row), order);
     }
-    let columnsToFilter = tableColumns.filter(col => col.filter);
-    let filteredRows = rows.filter(row => {
-      return columnsToFilter.some(col => {
-        let rowText = col.filter(row);
-        return rowText.match(regexFilterString(filterBy));
+    if (filterBy) {
+      let columnsToFilter = tableColumns.filter(col => col.filter);
+      let filteredRows = rows.filter(row => {
+        return columnsToFilter.some(col => {
+          let rowText = col.filter(row);
+          return rowText.match(regexFilterString(filterBy));
+        });
       });
-    });
-    rows = filteredRows;
-
+      rows = filteredRows;
+    }
     return rows;
   }
 

--- a/web/app/js/components/BaseTable.jsx
+++ b/web/app/js/components/BaseTable.jsx
@@ -74,11 +74,8 @@ class BaseTable extends React.Component {
     this.setState({ order, orderBy });
   };
 
-  handleFilterInputChange = e => {
-    let filterBy = regexFilterString(e.target.value);
-    if (filterBy !== this.state.filterBy) {
-      this.setState({ filterBy });
-    }
+  handleFilterInputChange = event => {
+    this.setState({ filterBy: event.target.value });
   }
 
   handleFilterToggle = () => {
@@ -93,16 +90,14 @@ class BaseTable extends React.Component {
     if (orderBy && col.sorter) {
       rows = _orderBy(rows, row => col.sorter(row), order);
     }
-    if (filterBy) {
-      let columnsToFilter = tableColumns.filter(col => col.filter);
-      let filteredRows = rows.filter(row => {
-        return columnsToFilter.some(col => {
-          let rowText = col.filter(row);
-          return rowText.match(filterBy);
-        });
+    let columnsToFilter = tableColumns.filter(col => col.filter);
+    let filteredRows = rows.filter(row => {
+      return columnsToFilter.some(col => {
+        let rowText = col.filter(row);
+        return rowText.match(regexFilterString(filterBy));
       });
-      rows = filteredRows;
-    }
+    });
+    rows = filteredRows;
 
     return rows;
   }

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -167,7 +167,7 @@ class NavigationBase extends React.Component {
       namespaceMenuOpen: false,
       newNamespace: '',
       namespaceFilter: '',
-      namespaceFilterInput: "",
+      namespaceFilterInput: '',
       hideUpdateBadge: true,
       latestVersion: '',
       isLatest: true,
@@ -337,7 +337,7 @@ class NavigationBase extends React.Component {
   handleNamespaceMenuClick = event => {
     // ensure that mobile drawer will not close on click
     event.stopPropagation();
-    this.setState({ anchorEl: event.currentTarget, namespaceFilterInput: "", namespaceFilter: "" });
+    this.setState({ anchorEl: event.currentTarget, namespaceFilterInput: '', namespaceFilter: '' });
     this.setState(state => ({ namespaceMenuOpen: !state.namespaceMenuOpen }));
   }
 
@@ -369,7 +369,7 @@ class NavigationBase extends React.Component {
   render() {
     const { api, classes, selectedNamespace, ChildComponent, ...otherProps } = this.props;
     let { namespaces, namespaceFilter, namespaceFilterInput, anchorEl, showNamespaceChangeDialog, newNamespace, mobileSidebarOpen } = this.state;
-    if (namespaceFilter !== "") {
+    if (namespaceFilter !== '') {
       namespaces = namespaces.filter(ns => {
         return ns.name.match(namespaceFilter);
       });

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -167,6 +167,7 @@ class NavigationBase extends React.Component {
       namespaceMenuOpen: false,
       newNamespace: '',
       namespaceFilter: '',
+      formattedNamespaceFilter: '',
       hideUpdateBadge: true,
       latestVersion: '',
       isLatest: true,
@@ -302,7 +303,8 @@ class NavigationBase extends React.Component {
   }
 
   handleFilterInputChange = event => {
-    this.setState({ namespaceFilter: event.target.value });
+    this.setState({ namespaceFilter: event.target.value,
+      formattedNamespaceFilter: regexFilterString(event.target.value) });
   }
 
   handleNamespaceChange = (event, namespace) => {
@@ -333,7 +335,8 @@ class NavigationBase extends React.Component {
   handleNamespaceMenuClick = event => {
     // ensure that mobile drawer will not close on click
     event.stopPropagation();
-    this.setState({ anchorEl: event.currentTarget, namespaceFilter: '' });
+    this.setState({ anchorEl: event.currentTarget, namespaceFilter: '',
+      formattedNamespaceFilter: '' });
     this.setState(state => ({ namespaceMenuOpen: !state.namespaceMenuOpen }));
   }
 
@@ -364,10 +367,10 @@ class NavigationBase extends React.Component {
 
   render() {
     const { api, classes, selectedNamespace, ChildComponent, ...otherProps } = this.props;
-    let { namespaces, namespaceFilter, anchorEl, showNamespaceChangeDialog,
-      newNamespace, mobileSidebarOpen } = this.state;
+    let { namespaces, namespaceFilter, formattedNamespaceFilter, anchorEl,
+      showNamespaceChangeDialog, newNamespace, mobileSidebarOpen } = this.state;
     namespaces = namespaces.filter(ns => {
-      return ns.name.match(regexFilterString(namespaceFilter));
+      return ns.name.match(formattedNamespaceFilter);
     });
     let formattedNamespaceName = selectedNamespace;
     if (formattedNamespaceName === "_all") {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -167,7 +167,6 @@ class NavigationBase extends React.Component {
       namespaceMenuOpen: false,
       newNamespace: '',
       namespaceFilter: '',
-      namespaceFilterInput: '',
       hideUpdateBadge: true,
       latestVersion: '',
       isLatest: true,
@@ -302,11 +301,8 @@ class NavigationBase extends React.Component {
     this.props.history.push(`/namespaces/${this.state.newNamespace}`);
   }
 
-  handleFilterInputChange = e => {
-    let namespaceFilter = regexFilterString(e.target.value);
-    if (namespaceFilter !== this.state.namespaceFilter) {
-      this.setState({ namespaceFilter, namespaceFilterInput: e.target.value });
-    }
+  handleFilterInputChange = event => {
+    this.setState({ namespaceFilter: event.target.value });
   }
 
   handleNamespaceChange = (event, namespace) => {
@@ -337,7 +333,7 @@ class NavigationBase extends React.Component {
   handleNamespaceMenuClick = event => {
     // ensure that mobile drawer will not close on click
     event.stopPropagation();
-    this.setState({ anchorEl: event.currentTarget, namespaceFilterInput: '', namespaceFilter: '' });
+    this.setState({ anchorEl: event.currentTarget, namespaceFilter: '' });
     this.setState(state => ({ namespaceMenuOpen: !state.namespaceMenuOpen }));
   }
 
@@ -368,12 +364,11 @@ class NavigationBase extends React.Component {
 
   render() {
     const { api, classes, selectedNamespace, ChildComponent, ...otherProps } = this.props;
-    let { namespaces, namespaceFilter, namespaceFilterInput, anchorEl, showNamespaceChangeDialog, newNamespace, mobileSidebarOpen } = this.state;
-    if (namespaceFilter !== '') {
-      namespaces = namespaces.filter(ns => {
-        return ns.name.match(namespaceFilter);
-      });
-    }
+    let { namespaces, namespaceFilter, anchorEl, showNamespaceChangeDialog,
+      newNamespace, mobileSidebarOpen } = this.state;
+    namespaces = namespaces.filter(ns => {
+      return ns.name.match(regexFilterString(namespaceFilter));
+    });
     let formattedNamespaceName = selectedNamespace;
     if (formattedNamespaceName === "_all") {
       formattedNamespaceName = "All Namespaces";
@@ -422,7 +417,7 @@ class NavigationBase extends React.Component {
             <MenuItem>
               <InputBase
                 id="namespace-filter-textfield"
-                value={namespaceFilterInput}
+                value={namespaceFilter}
                 onChange={this.handleFilterInputChange}
                 placeholder="Select namespace..."
                 autoFocus />

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -119,9 +119,10 @@ export const toClassName = name => {
  Create regex string from user input for a filter
 */
 export const regexFilterString = input => {
+  // make input lower case and strip out unwanted characters
   input = input.replace(/[^A-Z0-9/.\-_*]/gi, "").toLowerCase();
-  let swapWildCard = /[*]/g; // replace "*" in input with wildcard
-  return new RegExp(input.replace(swapWildCard, ".+"), "i");
+  // replace "*" in input with wildcard
+  return new RegExp(input.replace(/[*]/g, ".+"));
 };
 
 /*

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -116,6 +116,15 @@ export const toClassName = name => {
 };
 
 /*
+ Create regex string from user input for a filter
+*/
+export const regexFilterString = input => {
+  input = input.replace(/[^A-Z0-9/.\-_]/gi, "").toLowerCase();
+  let swapWildCard = /[*]/g; // replace "*" in input with wildcard
+  return new RegExp(input.replace(swapWildCard, ".+"), "i");
+};
+
+/*
   Nicely readable names for the stat resources
 */
 export const friendlyTitle = singularOrPluralResource => {

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -119,7 +119,7 @@ export const toClassName = name => {
  Create regex string from user input for a filter
 */
 export const regexFilterString = input => {
-  input = input.replace(/[^A-Z0-9/.\-_]/gi, "").toLowerCase();
+  input = input.replace(/[^A-Z0-9/.\-_*]/gi, "").toLowerCase();
   let swapWildCard = /[*]/g; // replace "*" in input with wildcard
   return new RegExp(input.replace(swapWildCard, ".+"), "i");
 };


### PR DESCRIPTION
Fixes #3610 

Adds a text input to the namespace selection button of the dashboard to allow users to filter the list of namespaces.

Moved some filter logic to `Utils.js` since it is now used by both `BaseTable` and `Navigation` components.

Fixed a bug where using `*` as a wildcard in the filter input, as in `li*kerd`, was not returning `linkerd` as a match.

Namespace select button before:
![Screen Shot 2019-11-01 at 1 04 50 PM](https://user-images.githubusercontent.com/2289389/68053051-41ca6800-fca8-11e9-876d-452a89c93046.png)

Namespace select button after:
![Screen Shot 2019-11-01 at 1 03 59 PM](https://user-images.githubusercontent.com/2289389/68053054-44c55880-fca8-11e9-8a68-426906060d8a.png)
![Screen Shot 2019-11-01 at 1 04 09 PM](https://user-images.githubusercontent.com/2289389/68053107-5dce0980-fca8-11e9-877c-17e48c4d0105.png)
