### PR TITLE
Add conntrack and netstat to debug container

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -3,6 +3,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tcpdump \
     iproute2 \
     lsof \
+    net-tools \
+    conntrack \
     tshark && \
     rm -rf /var/lib/apt/lists/*
 ENTRYPOINT [ "tshark", "-i", "any" ]

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -3,7 +3,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tcpdump \
     iproute2 \
     lsof \
-    net-tools \
     conntrack \
     tshark && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: Charles Pretzer <charles@buoyant.io>

Fixes #3671 