### PR TITLE
Add helm version annotation to tap,injector and sp-validator

### DIFF
--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -25,6 +25,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if empty .CliVersion }}
+        linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
+        {{- end }}
         {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
         {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
       labels:

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -44,6 +44,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if empty .CliVersion }}
+        linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
+        {{- end }}
         {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
         {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
       labels:

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -49,6 +49,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if empty .CliVersion }}
+        linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
+        {{- end }}
         {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
         {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
       labels:

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2416,6 +2416,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
@@ -2642,6 +2643,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
@@ -2849,6 +2851,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -2568,6 +2568,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
@@ -2827,6 +2828,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
@@ -3067,6 +3069,7 @@ spec:
   template:
     metadata:
       annotations:
+        linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version


### PR DESCRIPTION
As described in #3497  tap, sp-validator and proxy injector are not restarted upon helm upgrade, causing them to use old certs. Initial suggestion was to use the hash of he rbac templates to drive the pod restart. There are two problems with that: 

1. It is not really worth it as this rbac template will effectively render twice producing different hash values, so we might as well use a random val here (correct me if I am wrong).
2. In order to use the *-rbac.yaml in such a way, we need to add it to the control plane install stage as it will be referenced from the main deployment yaml for the respective service. Since we want to have a separate `install config` and `install control-plane` stages, this is not really suitable.

The current solution is to add an annotation to the respective deployment spec templates that uses the `$.Release.Revision` as its value. you can validate the fix by doing: 

```
helm upgrade --install linkerd2 charts/linkerd2 --set-file Identity.TrustAnchorsPEM=<crt.pem> --set-file Identity.Issuer.TLS.KeyPEM=<key.pem> --set-file Identity.Issuer.TLS.CrtPEM=<crt.pem> --set Identity.Issuer.CrtExpiry=<crt-expiry-date>

#Check the value of `linkerd.io/helm-release-version` for tap, sp-validator 
#and proxy-injector pods.Make sure it equals 1.

helm upgrade --install linkerd2 charts/linkerd2 --set-file Identity.TrustAnchorsPEM=<crt.pem> --set-file Identity.Issuer.TLS.KeyPEM=<key.pem> --set-file Identity.Issuer.TLS.CrtPEM=<crt.pem> --set Identity.Issuer.CrtExpiry=<crt-expiry-date>

#Make sure the pods are restarted and the value equals 2
```

Fixes #3497 

Signed-off-by: zaharidichev <zaharidichev@gmail.com>