### PR TITLE
Add CronJobs and ReplicaSets to dashboard and CLI

### DIFF
--- a/charts/linkerd2/templates/controller-rbac.yaml
+++ b/charts/linkerd2/templates/controller-rbac.yaml
@@ -15,7 +15,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]

--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -24,7 +24,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -46,18 +46,22 @@ func newCmdEdges() *cobra.Command {
   The RESOURCETYPE argument specifies the type of resource to display edges within.
 
   Examples:
+  * cronjob
   * deploy
   * ds
   * job
   * po
   * rc
+  * rs
   * sts
 
   Valid resource types include:
+  * cronjobs
   * daemonsets
   * deployments
   * jobs
   * pods
+  * replicasets
   * replicationcontrollers
   * statefulsets`,
 		Example: `  # Get all edges between pods that either originate from or terminate in the demo namespace.

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -46,6 +46,7 @@ func TestRender(t *testing.T) {
 			ClockSkewAllowance: "20s",
 			IssuanceLifetime:   "86400s",
 		},
+		TrustAnchorsPEM: "test-trust-anchor",
 	})
 	metaConfig := metaOptions.configs(identityContext)
 	metaConfig.Global.LinkerdNamespace = "Namespace"

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -62,6 +62,7 @@ func newCmdMetrics() *cobra.Command {
   (TYPE/NAME)
 
   Examples:
+  * cronjob/my-cronjob
   * deploy/my-deploy
   * ds/my-daemonset
   * job/my-job
@@ -70,6 +71,7 @@ func newCmdMetrics() *cobra.Command {
   * sts/my-statefulset
 
   Valid resource types include:
+  * cronjobs
   * daemonsets
   * deployments
   * jobs
@@ -207,6 +209,23 @@ func getPodsFor(clientset kubernetes.Interface, namespace string, resource strin
 
 	var matchLabels map[string]string
 	switch res.GetType() {
+	case k8s.CronJob:
+		jobs, err := clientset.BatchV1().Jobs(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var pods []corev1.Pod
+		for _, job := range jobs.Items {
+			if isOwner(res.GetName(), job.GetOwnerReferences()) {
+				jobPods, err := getPodsFor(clientset, namespace, fmt.Sprintf("%s/%s", k8s.Job, job.GetName()))
+				if err != nil {
+					return nil, err
+				}
+				pods = append(pods, jobPods...)
+			}
+		}
+		return pods, nil
+
 	case k8s.DaemonSet:
 		ds, err := clientset.AppsV1().DaemonSets(namespace).Get(res.GetName(), metav1.GetOptions{})
 		if err != nil {
@@ -266,4 +285,13 @@ func getPodsFor(clientset kubernetes.Interface, namespace string, resource strin
 	}
 
 	return podList.Items, nil
+}
+
+func isOwner(resourceName string, ownerRefs []metav1.OwnerReference) bool {
+	for _, or := range ownerRefs {
+		if resourceName == or.Name {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -58,6 +58,7 @@ func newCmdStat() *cobra.Command {
   or (TYPE1/NAME1 TYPE2/NAME2...)
 
   Examples:
+  * cronjob/my-cronjob
   * deploy
   * deploy/my-deploy
   * deploy/ po/
@@ -67,6 +68,8 @@ func newCmdStat() *cobra.Command {
   * po/mypod1 rc/my-replication-controller
   * po mypod1 mypod2
   * rc/my-replication-controller
+  * rs
+  * rs/my-replicaset
   * sts/my-statefulset
   * ts/my-split
   * authority
@@ -74,11 +77,13 @@ func newCmdStat() *cobra.Command {
   * all
 
   Valid resource types include:
+  * cronjobs
   * daemonsets
   * deployments
   * namespaces
   * jobs
   * pods
+  * replicasets
   * replicationcontrollers
   * statefulsets
   * trafficsplits

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -134,21 +134,26 @@ func newCmdTap() *cobra.Command {
   (TYPE [NAME] | TYPE/NAME)
 
   Examples:
+  * cronjob/my-cronjob
   * deploy
   * deploy/my-deploy
   * deploy my-deploy
   * ds/my-daemonset
   * job/my-job
   * ns/my-ns
+  * rs
+  * rs/my-replicaset
   * sts
   * sts/my-statefulset
 
   Valid resource types include:
+  * cronjobs
   * daemonsets
   * deployments
   * jobs
   * namespaces
   * pods
+  * replicasets
   * replicationcontrollers
   * statefulsets
   * services (only supported as a --to resource)`,

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -680,173 +680,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:install-control-plane-version
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
-                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
-                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
-                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
-                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
-                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
-                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
-                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:install-control-plane-version
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -680,40 +680,173 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:install-control-plane-version
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1515,173 +1515,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:install-control-plane-version
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
-                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
-                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
-                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
-                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
-                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
-                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
-                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:install-control-plane-version
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1515,40 +1515,173 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:install-control-plane-version
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1614,185 +1614,47 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:install-control-plane-version
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
-                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
-                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
-                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
-                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
-                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
-                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
-                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 100m
-                memory: 20Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:install-control-plane-version
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            resources:
+              limits:
+                cpu: "1"
+                memory: "250Mi"
+              requests:
+                cpu: "100m"
+                memory: "50Mi"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1614,47 +1614,185 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:install-control-plane-version
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
             resources:
               limits:
                 cpu: "1"
-                memory: "250Mi"
+                memory: 250Mi
               requests:
-                cpu: "100m"
-                memory: "50Mi"
+                cpu: 100m
+                memory: 50Mi
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources:
+              limits:
+                cpu: "1"
+                memory: 250Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1614,47 +1614,185 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:install-control-plane-version
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
             resources:
               limits:
                 cpu: "1"
-                memory: "250Mi"
+                memory: 250Mi
               requests:
-                cpu: "100m"
-                memory: "50Mi"
+                cpu: 100m
+                memory: 50Mi
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources:
+              limits:
+                cpu: "1"
+                memory: 250Mi
+              requests:
+                cpu: 400m
+                memory: 300Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1614,185 +1614,47 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:install-control-plane-version
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
-                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
-                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
-                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
-                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
-                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
-                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
-                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 400m
-                memory: 300Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:install-control-plane-version
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            resources:
+              limits:
+                cpu: "1"
+                memory: "250Mi"
+              requests:
+                cpu: "100m"
+                memory: "50Mi"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -82,7 +82,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -473,7 +473,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -655,7 +655,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -82,7 +82,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -473,7 +473,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -655,7 +655,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1413,142 +1413,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:install-control-plane-version
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
-                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
-                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
-                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
-                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
-                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
-                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
-                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:install-control-plane-version
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1413,40 +1413,142 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:install-control-plane-version
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+                LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+                AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+                xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+                6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+                BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+                AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+                OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1512,40 +1512,164 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: Namespace
+  annotations:
+    CreatedByAnnotation: CliVersion
+  creationTimestamp: null
   labels:
     ControllerComponentLabel: heartbeat
     ControllerNamespaceLabel: Namespace
-  annotations:
-    CreatedByAnnotation: CliVersion
+  name: linkerd-heartbeat
+  namespace: Namespace
 spec:
-  schedule: ""
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            ControllerComponentLabel: heartbeat
           annotations:
             CreatedByAnnotation: CliVersion
+            linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: install-proxy-version
+          creationTimestamp: null
+          labels:
+            ControllerComponentLabel: heartbeat
+            linkerd.io/control-plane-ns: Namespace
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090
+            - -controller-namespace=Namespace
+            - -log-level=ControllerLogLevel
             image: ControllerImage:ControllerImageVersion
             imagePullPolicy: ImagePullPolicy
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090"
-            - "-controller-namespace=Namespace"
-            - "-log-level=ControllerLogLevel"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.Namespace.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                test-trust-anchor
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.Namespace.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: Namespace
+            - name: _l5d_trustdomain
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:install-proxy-version
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: ""
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1512,164 +1512,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    CreatedByAnnotation: CliVersion
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: Namespace
   labels:
     ControllerComponentLabel: heartbeat
     ControllerNamespaceLabel: Namespace
-  name: linkerd-heartbeat
-  namespace: Namespace
+  annotations:
+    CreatedByAnnotation: CliVersion
 spec:
+  schedule: ""
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            CreatedByAnnotation: CliVersion
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: install-proxy-version
-          creationTimestamp: null
           labels:
             ControllerComponentLabel: heartbeat
-            linkerd.io/control-plane-ns: Namespace
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            CreatedByAnnotation: CliVersion
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090
-            - -controller-namespace=Namespace
-            - -log-level=ControllerLogLevel
-            image: ControllerImage:ControllerImageVersion
-            imagePullPolicy: ImagePullPolicy
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.Namespace.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                test-trust-anchor
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.Namespace.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: Namespace
-            - name: _l5d_trustdomain
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:install-proxy-version
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: ""
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: ControllerImage:ControllerImageVersion
+            imagePullPolicy: ImagePullPolicy
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.Namespace.svc.cluster.local:9090"
+            - "-controller-namespace=Namespace"
+            - "-log-level=ControllerLogLevel"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1518,40 +1518,174 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
+                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
+                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
+                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
+                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
+                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
+                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
+                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
+                +U9K4WlbzA==
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1518,174 +1518,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
-                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
-                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
-                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
-                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
-                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
-                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
-                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
-                +U9K4WlbzA==
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1504,40 +1504,174 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
+            resources: {}
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
+                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
+                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
+                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
+                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
+                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
+                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
+                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
+                +U9K4WlbzA==
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -1504,174 +1504,40 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources: {}
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
-                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
-                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
-                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
-                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
-                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
-                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
-                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
-                +U9K4WlbzA==
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole
@@ -1617,47 +1617,186 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  creationTimestamp: null
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
+  name: linkerd-heartbeat
+  namespace: linkerd
 spec:
-  schedule: "1 2 3 4 5"
-  successfulJobsHistoryLimit: 0
   jobTemplate:
+    metadata:
+      creationTimestamp: null
     spec:
       template:
         metadata:
-          labels:
-            linkerd.io/control-plane-component: heartbeat
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
+            linkerd.io/identity-mode: default
+            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
+          creationTimestamp: null
+          labels:
+            linkerd.io/control-plane-component: heartbeat
+            linkerd.io/control-plane-ns: linkerd
+            linkerd.io/proxy-cronjob: linkerd-heartbeat
         spec:
-          nodeSelector:
-            beta.kubernetes.io/os: linux
-          serviceAccountName: linkerd-heartbeat
-          restartPolicy: Never
           containers:
-          - name: heartbeat
+          - args:
+            - heartbeat
+            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
+            - -controller-namespace=linkerd
+            - -log-level=info
             image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
             imagePullPolicy: IfNotPresent
-            args:
-            - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
-            - "-controller-namespace=linkerd"
-            - "-log-level=info"
+            name: heartbeat
             resources:
               limits:
                 cpu: "1"
-                memory: "250Mi"
+                memory: 250Mi
               requests:
-                cpu: "100m"
-                memory: "50Mi"
+                cpu: 100m
+                memory: 50Mi
             securityContext:
               runAsUser: 2103
+          - env:
+            - name: LINKERD2_PROXY_LOG
+              value: warn,linkerd2_proxy=info
+            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+              value: linkerd-dst.linkerd.svc.cluster.local:8086
+            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+              value: 0.0.0.0:4190
+            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+              value: 0.0.0.0:4191
+            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+              value: 127.0.0.1:4140
+            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+              value: 0.0.0.0:4143
+            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+              value: svc.cluster.local.
+            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+              value: 10000ms
+            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+              value: 10000ms
+            - name: _pod_ns
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+              value: ns:$(_pod_ns)
+            - name: LINKERD2_PROXY_IDENTITY_DIR
+              value: /var/run/linkerd/identity/end-entity
+            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+              value: |
+                -----BEGIN CERTIFICATE-----
+                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
+                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
+                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
+                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
+                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
+                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
+                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
+                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
+                +U9K4WlbzA==
+                -----END CERTIFICATE-----
+            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/kubernetes.io/serviceaccount/token
+            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+              value: linkerd-identity.linkerd.svc.cluster.local:8080
+            - name: _pod_sa
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: _l5d_ns
+              value: linkerd
+            - name: _l5d_trustdomain
+              value: cluster.local
+            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            - name: LINKERD2_PROXY_TAP_SVC_NAME
+              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /metrics
+                port: 4191
+              initialDelaySeconds: 10
+            name: linkerd-proxy
+            ports:
+            - containerPort: 4143
+              name: linkerd-proxy
+            - containerPort: 4191
+              name: linkerd-admin
+            readinessProbe:
+              httpGet:
+                path: /ready
+                port: 4191
+              initialDelaySeconds: 2
+            resources:
+              limits:
+                cpu: "1"
+                memory: 250Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              runAsUser: 2102
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - mountPath: /var/run/linkerd/identity/end-entity
+              name: linkerd-identity-end-entity
+          initContainers:
+          - args:
+            - --incoming-proxy-port
+            - "4143"
+            - --outgoing-proxy-port
+            - "4140"
+            - --proxy-uid
+            - "2102"
+            - --inbound-ports-to-ignore
+            - 4190,4191
+            image: gcr.io/linkerd-io/proxy-init:v1.2.0
+            imagePullPolicy: IfNotPresent
+            name: linkerd-init
+            resources:
+              limits:
+                cpu: 100m
+                memory: 50Mi
+              requests:
+                cpu: 10m
+                memory: 10Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: false
+              runAsUser: 0
+            terminationMessagePolicy: FallbackToLogsOnError
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          restartPolicy: Never
+          serviceAccountName: linkerd-heartbeat
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: linkerd-identity-end-entity
+  schedule: 1 2 3 4 5
+  successfulJobsHistoryLimit: 0
+status: {}
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1617,186 +1617,47 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  annotations:
-    linkerd.io/created-by: linkerd/cli dev-undefined
-  creationTimestamp: null
+  name: linkerd-heartbeat
+  namespace: linkerd
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
-  name: linkerd-heartbeat
-  namespace: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
+  schedule: "1 2 3 4 5"
+  successfulJobsHistoryLimit: 0
   jobTemplate:
-    metadata:
-      creationTimestamp: null
     spec:
       template:
         metadata:
-          annotations:
-            linkerd.io/created-by: linkerd/cli dev-undefined
-            linkerd.io/identity-mode: default
-            linkerd.io/proxy-version: UPGRADE-PROXY-VERSION
-          creationTimestamp: null
           labels:
             linkerd.io/control-plane-component: heartbeat
-            linkerd.io/control-plane-ns: linkerd
-            linkerd.io/proxy-cronjob: linkerd-heartbeat
+          annotations:
+            linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
-          containers:
-          - args:
-            - heartbeat
-            - -prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090
-            - -controller-namespace=linkerd
-            - -log-level=info
-            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
-            imagePullPolicy: IfNotPresent
-            name: heartbeat
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 100m
-                memory: 50Mi
-            securityContext:
-              runAsUser: 2103
-          - env:
-            - name: LINKERD2_PROXY_LOG
-              value: warn,linkerd2_proxy=info
-            - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-              value: linkerd-dst.linkerd.svc.cluster.local:8086
-            - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-              value: 0.0.0.0:4190
-            - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-              value: 0.0.0.0:4191
-            - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-              value: 127.0.0.1:4140
-            - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-              value: 0.0.0.0:4143
-            - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-              value: svc.cluster.local.
-            - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
-              value: 10000ms
-            - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
-              value: 10000ms
-            - name: _pod_ns
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-              value: ns:$(_pod_ns)
-            - name: LINKERD2_PROXY_IDENTITY_DIR
-              value: /var/run/linkerd/identity/end-entity
-            - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
-              value: |
-                -----BEGIN CERTIFICATE-----
-                MIIBgzCCASmgAwIBAgIBATAKBggqhkjOPQQDAjApMScwJQYDVQQDEx5pZGVudGl0
-                eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMTkwNDA0MjM1MzM3WhcNMjAwNDAz
-                MjM1MzU3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9j
-                YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAT+Sb5X4wi4XP0X3rJwMp23VBdg
-                EMMU8EU+KG8UI2LmC5Vjg5RWLOW6BJjBmjXViKM+b+1/oKAeOg6FrJk8qyFlo0Iw
-                QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
-                MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAKUFG3sYOS++bakW
-                YmJZU45iCdTLtaelMDSFiHoC9eBKAiBDWzzo+/CYLLmn33bAEn8pQnogP4Fx06aj
-                +U9K4WlbzA==
-                -----END CERTIFICATE-----
-            - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-              value: linkerd-identity.linkerd.svc.cluster.local:8080
-            - name: _pod_sa
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: _l5d_ns
-              value: linkerd
-            - name: _l5d_trustdomain
-              value: cluster.local
-            - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
-              value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
-              value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
-              value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            - name: LINKERD2_PROXY_TAP_SVC_NAME
-              value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-            image: gcr.io/linkerd-io/proxy:UPGRADE-PROXY-VERSION
-            imagePullPolicy: IfNotPresent
-            livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 4191
-              initialDelaySeconds: 10
-            name: linkerd-proxy
-            ports:
-            - containerPort: 4143
-              name: linkerd-proxy
-            - containerPort: 4191
-              name: linkerd-admin
-            readinessProbe:
-              httpGet:
-                path: /ready
-                port: 4191
-              initialDelaySeconds: 2
-            resources:
-              limits:
-                cpu: "1"
-                memory: 250Mi
-              requests:
-                cpu: 100m
-                memory: 20Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              runAsUser: 2102
-            terminationMessagePolicy: FallbackToLogsOnError
-            volumeMounts:
-            - mountPath: /var/run/linkerd/identity/end-entity
-              name: linkerd-identity-end-entity
-          initContainers:
-          - args:
-            - --incoming-proxy-port
-            - "4143"
-            - --outgoing-proxy-port
-            - "4140"
-            - --proxy-uid
-            - "2102"
-            - --inbound-ports-to-ignore
-            - 4190,4191
-            image: gcr.io/linkerd-io/proxy-init:v1.2.0
-            imagePullPolicy: IfNotPresent
-            name: linkerd-init
-            resources:
-              limits:
-                cpu: 100m
-                memory: 50Mi
-              requests:
-                cpu: 10m
-                memory: 10Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                add:
-                - NET_ADMIN
-                - NET_RAW
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: false
-              runAsUser: 0
-            terminationMessagePolicy: FallbackToLogsOnError
           nodeSelector:
             beta.kubernetes.io/os: linux
-          restartPolicy: Never
           serviceAccountName: linkerd-heartbeat
-          volumes:
-          - emptyDir:
-              medium: Memory
-            name: linkerd-identity-end-entity
-  schedule: 1 2 3 4 5
-  successfulJobsHistoryLimit: 0
-status: {}
+          restartPolicy: Never
+          containers:
+          - name: heartbeat
+            image: gcr.io/linkerd-io/controller:UPGRADE-CONTROL-PLANE-VERSION
+            imagePullPolicy: IfNotPresent
+            args:
+            - "heartbeat"
+            - "-prometheus-url=http://linkerd-prometheus.linkerd.svc.cluster.local:9090"
+            - "-controller-namespace=linkerd"
+            - "-log-level=info"
+            resources:
+              limits:
+                cpu: "1"
+                memory: "250Mi"
+              requests:
+                cpu: "100m"
+                memory: "50Mi"
+            securityContext:
+              runAsUser: 2103
 ---
 ###
 ### Web

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -76,7 +76,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 - apiGroups: [""]
   resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
@@ -451,7 +451,7 @@ rules:
   resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
@@ -629,7 +629,7 @@ rules:
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["extensions", "batch"]
-  resources: ["jobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["list" , "get", "watch"]
 ---
 kind: ClusterRole

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -283,21 +283,26 @@ func newCmdTop() *cobra.Command {
   (TYPE [NAME] | TYPE/NAME)
 
   Examples:
+  * cronjob/my-cronjob
   * deploy
   * deploy/my-deploy
   * deploy my-deploy
   * ds/my-daemonset
   * job/my-job
   * ns/my-ns
+  * rs
+  * rs/my-replicaset
   * sts
   * sts/my-statefulset
 
   Valid resource types include:
+  * cronjobs
   * daemonsets
   * deployments
   * jobs
   * namespaces
   * pods
+  * replicasets
   * replicationcontrollers
   * statefulsets
   * services (only supported as a --to resource)`,

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -1250,6 +1250,13 @@ status:
 								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
+											Rows: []*pb.StatTable_PodGroup_Row{},
+										},
+									},
+								},
+								{
+									Table: &pb.StatTable_PodGroup_{
+										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
 												{
 													Resource: &pb.Resource{
@@ -1305,6 +1312,24 @@ status:
 														Name:      "emojivoto-pod-2",
 													},
 													Status:          "Running",
+													TimeWindow:      "1m",
+													MeshedPodCount:  1,
+													RunningPodCount: 1,
+												},
+											},
+										},
+									},
+								},
+								{
+									Table: &pb.StatTable_PodGroup_{
+										PodGroup: &pb.StatTable_PodGroup{
+											Rows: []*pb.StatTable_PodGroup_Row{
+												{
+													Resource: &pb.Resource{
+														Namespace: "emojivoto",
+														Type:      pkgK8s.ReplicaSet,
+														Name:      "emojivoto-meshed_2",
+													},
 													TimeWindow:      "1m",
 													MeshedPodCount:  1,
 													RunningPodCount: 1,

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -30,11 +30,13 @@ var (
 	// destination resource on an outbound 'from' query
 	ValidTargets = []string{
 		k8s.Authority,
+		k8s.CronJob,
 		k8s.DaemonSet,
 		k8s.Deployment,
 		k8s.Job,
 		k8s.Namespace,
 		k8s.Pod,
+		k8s.ReplicaSet,
 		k8s.ReplicationController,
 		k8s.StatefulSet,
 	}
@@ -42,11 +44,13 @@ var (
 	// ValidTapDestinations specifies resource types allowed as a tap destination:
 	// destination resource on an outbound 'to' query
 	ValidTapDestinations = []string{
+		k8s.CronJob,
 		k8s.DaemonSet,
 		k8s.Deployment,
 		k8s.Job,
 		k8s.Namespace,
 		k8s.Pod,
+		k8s.ReplicaSet,
 		k8s.ReplicationController,
 		k8s.Service,
 		k8s.StatefulSet,

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -9,7 +9,7 @@ import (
 // Main executes the proxy-injector subcommand
 func Main(args []string) {
 	webhook.Launch(
-		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod},
+		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod, k8s.CJ},
 		9995,
 		injector.Inject,
 		"linkerd-proxy-injector",

--- a/controller/cmd/public-api/main.go
+++ b/controller/cmd/public-api/main.go
@@ -47,7 +47,7 @@ func Main(args []string) {
 
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath,
-		k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP, k8s.TS,
+		k8s.CJ, k8s.DS, k8s.Deploy, k8s.Job, k8s.NS, k8s.Pod, k8s.RC, k8s.RS, k8s.Svc, k8s.SS, k8s.SP, k8s.TS,
 	)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)

--- a/controller/cmd/tap/main.go
+++ b/controller/cmd/tap/main.go
@@ -42,6 +42,7 @@ func Main(args []string) {
 
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath,
+		k8s.CJ,
 		k8s.DS,
 		k8s.SS,
 		k8s.Deploy,

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,7 @@ import (
 	arinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	appv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
+	batchv1beta1informers "k8s.io/client-go/informers/batch/v1beta1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -40,7 +42,8 @@ type APIResource int
 
 // These constants enumerate Kubernetes resource types.
 const (
-	CM APIResource = iota
+	CJ APIResource = iota
+	CM
 	Deploy
 	DS
 	Endpoint
@@ -61,6 +64,7 @@ const (
 type API struct {
 	Client kubernetes.Interface
 
+	cj       batchv1beta1informers.CronJobInformer
 	cm       coreinformers.ConfigMapInformer
 	deploy   appv1informers.DeploymentInformer
 	ds       appv1informers.DaemonSetInformer
@@ -158,6 +162,9 @@ func NewAPI(
 
 	for _, resource := range resources {
 		switch resource {
+		case CJ:
+			api.cj = sharedInformers.Batch().V1beta1().CronJobs()
+			api.syncChecks = append(api.syncChecks, api.cj.Informer().HasSynced)
 		case CM:
 			api.cm = sharedInformers.Core().V1().ConfigMaps()
 			api.syncChecks = append(api.syncChecks, api.cm.Informer().HasSynced)
@@ -352,6 +359,14 @@ func (api *API) Node() coreinformers.NodeInformer {
 	return api.node
 }
 
+// CJ provides access to a shared informer and lister for CronJobs.
+func (api *API) CJ() batchv1beta1informers.CronJobInformer {
+	if api.cj == nil {
+		panic("CJ informer not configured")
+	}
+	return api.cj
+}
+
 // GetObjects returns a list of Kubernetes objects, given a namespace, type, and name.
 // If namespace is an empty string, match objects in all namespaces.
 // If name is an empty string, match all objects of the given type.
@@ -359,6 +374,8 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 	switch restype {
 	case k8s.Namespace:
 		return api.getNamespaces(name)
+	case k8s.CronJob:
+		return api.getCronjobs(namespace, name)
 	case k8s.DaemonSet:
 		return api.getDaemonsets(namespace, name)
 	case k8s.Deployment:
@@ -369,12 +386,13 @@ func (api *API) GetObjects(namespace, restype, name string) ([]runtime.Object, e
 		return api.getPods(namespace, name)
 	case k8s.ReplicationController:
 		return api.getRCs(namespace, name)
+	case k8s.ReplicaSet:
+		return api.getReplicasets(namespace, name)
 	case k8s.Service:
 		return api.getServices(namespace, name)
 	case k8s.StatefulSet:
 		return api.getStatefulsets(namespace, name)
 	default:
-		// TODO: ReplicaSet
 		return nil, status.Errorf(codes.Unimplemented, "unimplemented resource type: %s", restype)
 	}
 }
@@ -395,27 +413,39 @@ func (api *API) GetOwnerKindAndName(pod *corev1.Pod, retry bool) (string, string
 	}
 
 	parent := ownerRefs[0]
-	if parent.Kind == "ReplicaSet" {
-		var rs *appsv1.ReplicaSet
-		var err error
-		rs, err = api.RS().Lister().ReplicaSets(pod.Namespace).Get(parent.Name)
+	var parentObj metav1.Object
+	var err error
+	switch parent.Kind {
+	case "Job":
+		parentObj, err = api.Job().Lister().Jobs(pod.Namespace).Get(parent.Name)
+		if err != nil {
+			log.Warnf("failed to retrieve job from indexer %s/%s: %s", pod.Namespace, parent.Name, err)
+			if retry {
+				parentObj, err = api.Client.BatchV1().Jobs(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
+				if err != nil {
+					log.Warnf("failed to retrieve job from direct API call %s/%s: %s", pod.Namespace, parent.Name, err)
+				}
+			}
+		}
+	case "ReplicaSet":
+		parentObj, err = api.RS().Lister().ReplicaSets(pod.Namespace).Get(parent.Name)
 		if err != nil {
 			log.Warnf("failed to retrieve replicaset from indexer %s/%s: %s", pod.Namespace, parent.Name, err)
 			if retry {
-				rs, err = api.Client.AppsV1().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
+				parentObj, err = api.Client.AppsV1().ReplicaSets(pod.Namespace).Get(parent.Name, metav1.GetOptions{})
 				if err != nil {
 					log.Warnf("failed to retrieve replicaset from direct API call %s/%s: %s", pod.Namespace, parent.Name, err)
 				}
 			}
 		}
-
-		if err != nil || len(rs.GetOwnerReferences()) != 1 {
-			return strings.ToLower(parent.Kind), parent.Name
-		}
-		rsParent := rs.GetOwnerReferences()[0]
-		return strings.ToLower(rsParent.Kind), rsParent.Name
+	default:
+		return strings.ToLower(parent.Kind), parent.Name
 	}
 
+	if err == nil && len(parentObj.GetOwnerReferences()) == 1 {
+		grandParent := parentObj.GetOwnerReferences()[0]
+		return strings.ToLower(grandParent.Kind), grandParent.Name
+	}
 	return strings.ToLower(parent.Kind), parent.Name
 }
 
@@ -432,6 +462,24 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 	case *corev1.Namespace:
 		namespace = typed.Name
 		selector = labels.Everything()
+
+	case *batchv1beta1.CronJob:
+		namespace = typed.Namespace
+		selector = labels.Everything()
+		jobs, err := api.Job().Lister().Jobs(namespace).List(selector)
+		if err != nil {
+			return nil, err
+		}
+		for _, job := range jobs {
+			if isOwner(typed.UID, job.GetOwnerReferences()) {
+				jobPods, err := api.GetPodsFor(job, includeFailed)
+				if err != nil {
+					return nil, err
+				}
+				pods = append(pods, jobPods...)
+			}
+		}
+		return pods, nil
 
 	case *appsv1.DaemonSet:
 		namespace = typed.Namespace
@@ -509,9 +557,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 	allPods := []*corev1.Pod{}
 	for _, pod := range pods {
 		if isPendingOrRunning(pod) || (includeFailed && isFailed(pod)) {
-			if ownerUID == "" {
-				allPods = append(allPods, pod)
-			} else if isOwner(ownerUID, pod.GetOwnerReferences()) {
+			if ownerUID == "" || isOwner(ownerUID, pod.GetOwnerReferences()) {
 				allPods = append(allPods, pod)
 			}
 		}
@@ -533,6 +579,9 @@ func GetNameAndNamespaceOf(obj runtime.Object) (string, string, error) {
 	switch typed := obj.(type) {
 	case *corev1.Namespace:
 		return typed.Name, typed.Name, nil
+
+	case *batchv1beta1.CronJob:
+		return typed.Name, typed.Namespace, nil
 
 	case *appsv1.DaemonSet:
 		return typed.Name, typed.Namespace, nil
@@ -777,6 +826,56 @@ func (api *API) getServices(namespace, name string) ([]runtime.Object, error) {
 	objects := []runtime.Object{}
 	for _, svc := range services {
 		objects = append(objects, svc)
+	}
+
+	return objects, nil
+}
+
+func (api *API) getCronjobs(namespace, name string) ([]runtime.Object, error) {
+	var err error
+	var cronjobs []*batchv1beta1.CronJob
+
+	if namespace == "" {
+		cronjobs, err = api.CJ().Lister().List(labels.Everything())
+	} else if name == "" {
+		cronjobs, err = api.CJ().Lister().CronJobs(namespace).List(labels.Everything())
+	} else {
+		var cronjob *batchv1beta1.CronJob
+		cronjob, err = api.CJ().Lister().CronJobs(namespace).Get(name)
+		cronjobs = []*batchv1beta1.CronJob{cronjob}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	objects := []runtime.Object{}
+	for _, cronjob := range cronjobs {
+		objects = append(objects, cronjob)
+	}
+
+	return objects, nil
+}
+
+func (api *API) getReplicasets(namespace, name string) ([]runtime.Object, error) {
+	var err error
+	var replicasets []*appsv1.ReplicaSet
+
+	if namespace == "" {
+		replicasets, err = api.RS().Lister().List(labels.Everything())
+	} else if name == "" {
+		replicasets, err = api.RS().Lister().ReplicaSets(namespace).List(labels.Everything())
+	} else {
+		var replicaset *appsv1.ReplicaSet
+		replicaset, err = api.RS().Lister().ReplicaSets(namespace).Get(name)
+		replicasets = []*appsv1.ReplicaSet{replicaset}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	objects := []runtime.Object{}
+	for _, replicaset := range replicasets {
+		objects = append(objects, replicaset)
 	}
 
 	return objects, nil

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -16,6 +16,7 @@ func NewFakeAPI(configs ...string) (*API, error) {
 		clientSet,
 		spClientSet,
 		tsClientSet,
+		CJ,
 		CM,
 		Deploy,
 		DS,

--- a/controller/tap/handlers.go
+++ b/controller/tap/handlers.go
@@ -68,6 +68,7 @@ var (
 		{"replicasets", "rs", true},
 		{"statefulsets", "sts", true},
 		{"jobs", "", true},
+		{"cronjobs", "cj", true},
 	}
 )
 

--- a/grafana/dashboards/cronjob.json
+++ b/grafana/dashboards/cronjob.json
@@ -1,0 +1,2300 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "id": null,
+    "iteration": 1531763681685,
+    "links": [],
+    "panels": [
+      {
+        "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">cj/$cronjob</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 20,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#d44a3a",
+          "rgba(237, 129, 40, 0.89)",
+          "#299c46"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "percentunit",
+        "gauge": {
+          "maxValue": 1,
+          "minValue": 0,
+          "show": true,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 0,
+          "y": 2
+        },
+        "id": 5,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s]))",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "0.9,.99",
+        "title": "SUCCESS RATE",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 8,
+          "y": 2
+        },
+        "id": 4,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": " RPS",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s]))",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "REQUEST RATE",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 2
+        },
+        "id": 11,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "100%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "count(count(request_total{dst_namespace=\"$namespace\", cronjob!=\"\", dst_cronjob!=\"\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}) by (namespace, cronjob))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "INBOUND CRONJOBS",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 2
+        },
+        "id": 15,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "count(count(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}) by (namespace, dst_cronjob))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "OUTBOUND CRONJOBS",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND TRAFFIC</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 6
+        },
+        "id": 17,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 8
+        },
+        "id": 67,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) by (cronjob) / sum(irate(response_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) by (cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "cj/{{cronjob}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "SUCCESS RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "percentunit",
+            "label": "",
+            "logBase": 1,
+            "max": "1",
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 8
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\", tls=\"true\"}[30s])) by (cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "🔒cj/{{cronjob}}",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\", tls!=\"true\"}[30s])) by (cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "cj/{{cronjob}}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "REQUEST RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "rps",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 8
+        },
+        "id": 68,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) by (le, cronjob))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "p50 cj/{{cronjob}}",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) by (le, cronjob))",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "p95 cj/{{cronjob}}",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}[30s])) by (le, cronjob))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "p99 cj/{{cronjob}}",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "LATENCY",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "ms",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 15
+        },
+        "id": 148,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 16
+            },
+            "id": 167,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_close_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\",errno!=\"\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}} {{errno}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTION FAILURES",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 16
+            },
+            "id": 168,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_open_connections{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTIONS OPEN",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": "prometheus",
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 16
+            },
+            "heatmap": {},
+            "hideZeroBuckets": false,
+            "highlightCards": true,
+            "id": 169,
+            "legend": {
+              "show": false
+            },
+            "links": [],
+            "options": {},
+            "reverseYBuckets": false,
+            "targets": [
+              {
+                "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"inbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "refId": "A"
+              }
+            ],
+            "title": "TCP CONNECTION DURATION",
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "dtdurationms",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketBound": "auto",
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "title": "Inbound TCP Metrics",
+        "type": "row"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 152,
+        "panels": [],
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND CRONJOBS</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 76,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 59,
+        "panels": [
+          {
+            "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">cj/$inbound</span>\n</div>",
+            "gridPos": {
+              "h": 2,
+              "w": 24,
+              "x": 0,
+              "y": 22.2
+            },
+            "id": 39,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 24.2
+            },
+            "id": 36,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(response_total{classification=\"success\", cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (cronjob, pod) / sum(irate(response_total{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (cronjob, pod)",
+                "format": "time_series",
+                "instant": false,
+                "intervalFactor": 1,
+                "legendFormat": "po/{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "SUCCESS RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 24.2
+            },
+            "id": 22,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(request_total{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\", tls=\"true\"}[30s])) by (cronjob, pod)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "🔒po/{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(irate(request_total{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\", tls!=\"true\"}[30s])) by (cronjob, pod)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "po/{{pod}}",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "REQUEST RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "rps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 24.2
+            },
+            "id": 29,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (le, cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P50 cj/{{cronjob}}",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (le, cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P95 cj/{{cronjob}}",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{cronjob!=\"\", cronjob=\"$inbound\", dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (le, cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P99 cj/{{cronjob}}",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LATENCY",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": "inbound",
+        "title": "cj/$inbound",
+        "type": "row"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 34,
+        "panels": [],
+        "repeat": null,
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND TRAFFIC</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 21
+        },
+        "id": 32,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 23
+        },
+        "id": 77,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (dst_cronjob) / sum(irate(response_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (dst_cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "cj/{{dst_cronjob}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "SUCCESS RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "percentunit",
+            "label": "",
+            "logBase": 1,
+            "max": "1",
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 23
+        },
+        "id": 78,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "🔒cj/{{dst_cronjob}}",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_cronjob)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "cj/{{dst_cronjob}}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "REQUEST RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "rps",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 23
+        },
+        "id": 79,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}[30s])) by (le, dst_cronjob))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "P95 cj/{{dst_cronjob}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "P95 LATENCY",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 30
+        },
+        "id": 154,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 29
+            },
+            "id": 157,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_close_total{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\",errno!=\"\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}} {{errno}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTION FAILURES",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 29
+            },
+            "id": 166,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_open_connections{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTIONS OPEN",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": "prometheus",
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 29
+            },
+            "heatmap": {},
+            "hideZeroBuckets": false,
+            "highlightCards": true,
+            "id": 160,
+            "legend": {
+              "show": false
+            },
+            "links": [],
+            "options": {},
+            "reverseYBuckets": false,
+            "targets": [
+              {
+                "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", direction=\"outbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "refId": "A"
+              }
+            ],
+            "title": "TCP CONNECTION DURATION",
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "dtdurationms",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketBound": "auto",
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "title": "Outbound TCP Metrics",
+        "type": "row"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 31
+        },
+        "id": 156,
+        "panels": [],
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND CRONJOBS</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 32
+        },
+        "id": 80,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 34
+        },
+        "id": 27,
+        "panels": [
+          {
+            "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">cj/$outbound</span>\n</div>",
+            "gridPos": {
+              "h": 2,
+              "w": 24,
+              "x": 0,
+              "y": 36
+            },
+            "id": 40,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 38
+            },
+            "id": 28,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_cronjob) / sum(irate(response_total{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_cronjob)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "cj/{{dst_cronjob}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "SUCCESS RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 38
+            },
+            "id": 35,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_cronjob)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "🔒cj/{{dst_cronjob}}",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(irate(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_cronjob)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "cj/{{dst_cronjob}}",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "REQUEST RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "rps",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 38
+            },
+            "id": 41,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P50 cj/{{dst_cronjob}}",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P95 cj/{{dst_cronjob}}",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", cronjob=\"$cronjob\", dst_cronjob=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_cronjob))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P99 cj/{{dst_cronjob}}",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LATENCY",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": "outbound",
+        "title": "cj/$outbound",
+        "type": "row"
+      },
+      {
+        "content": "<div>\n  <div style=\"position: absolute; top: 0, left: 0\">\n    <a href=\"https://linkerd.io\" target=\"_blank\"><img src=\"https://linkerd.io/images/identity/svg/linkerd_primary_color_white.svg\" style=\"height: 30px;\"></a>\n  </div>\n  <div id=\"version\" style=\"position: absolute; top: 0; right: 0; font-size: 15px\">\n  </div>\n</div>\n<script type=\"text/javascript\">\nvar localReqURL =\n  window.location.href.substring(\n    0,\n    window.location.href.indexOf(\n    \"/grafana/\"\n    )\n  )+'/overview';\n\nfetch(localReqURL, {\n  credentials: 'include',\n  headers: {\n    \"Content-Type\": \"text/html; charset=utf-8\",\n  },\n})\n.then(response => response.text())\n.then(text => (new window.DOMParser()).parseFromString(text, \"text/html\"))\n.then(html => {\n  var main = html.getElementById('main');\n  var localVersion = main.getAttribute(\"data-release-version\");\n  var versionElem = document.getElementById('version');\n\n  var channel;\n  var parts = localVersion.split(\"-\", 2);\n  if (parts.length === 2) {\n    channel = parts[0];\n    versionElem.innerHTML += 'Running Linkerd ' + parts[1] + ' (' + parts[0] + ')' + '.<br>';\n  } else {\n    versionElem.innerHTML += 'Running Linkerd ' + localVersion + '.<br>';\n  }\n  var uuid = main.getAttribute(\"data-uuid\");\n\n  fetch('https://versioncheck.linkerd.io/version.json?version='+localVersion+'&uuid='+uuid+'&source=grafana', {\n    credentials: 'include',\n    headers: {\n      \"Content-Type\": \"application/json; charset=utf-8\",\n    },\n  })\n  .then(response => response.json())\n  .then(json => {\n    if (!channel || !json[channel]) {\n      versionElem.innerHTML += 'Version check failed.'\n    } else if (json[channel] === localVersion) {\n      versionElem.innerHTML += 'Linkerd is up to date.';\n    } else {\n      parts = json[channel].split(\"-\", 2);\n      if (parts.length === 2) {\n        versionElem.innerHTML += \"A new \"+parts[0]+\" version (\"+parts[1]+\") is available.\"\n      } else {\n        versionElem.innerHTML += \"A new version (\"+json[channel]+\") is available.\"\n      }\n      versionElem.innerHTML += \" <a href='https://versioncheck.linkerd.io/update' target='_blank'>Update now</a>.\";\n    }\n  });\n});\n</script>",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 35
+        },
+        "height": "1px",
+        "id": 171,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      }
+    ],
+    "refresh": "1m",
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [
+      "linkerd"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "prometheus",
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(process_start_time_seconds{cronjob!=\"\"}, namespace)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "prometheus",
+          "definition": "",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Deployment",
+          "multi": false,
+          "name": "cronjob",
+          "options": [],
+          "query": "label_values(process_start_time_seconds{namespace=\"$namespace\"}, cronjob)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "prometheus",
+          "definition": "",
+          "hide": 2,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "inbound",
+          "options": [],
+          "query": "label_values(request_total{dst_namespace=\"$namespace\", dst_cronjob=\"$cronjob\"}, cronjob)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "prometheus",
+          "definition": "",
+          "hide": 2,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "outbound",
+          "options": [],
+          "query": "label_values(request_total{namespace=\"$namespace\", cronjob=\"$cronjob\"}, dst_cronjob)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Linkerd CronJob",
+    "uid": "cronjob",
+    "version": 1
+  }
+  

--- a/grafana/dashboards/replicaset.json
+++ b/grafana/dashboards/replicaset.json
@@ -1,0 +1,2345 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "id": 16,
+    "iteration": 1573121539385,
+    "links": [],
+    "panels": [
+      {
+        "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">replicaset/$replicaset</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 20,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#d44a3a",
+          "rgba(237, 129, 40, 0.89)",
+          "#299c46"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "percentunit",
+        "gauge": {
+          "maxValue": 1,
+          "minValue": 0,
+          "show": true,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 0,
+          "y": 2
+        },
+        "id": 5,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) / sum(irate(response_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s]))",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "0.9,.99",
+        "title": "SUCCESS RATE",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 8,
+          "x": 8,
+          "y": 2
+        },
+        "id": 4,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": " RPS",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": true,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": true
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s]))",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "REQUEST RATE",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "decimals": null,
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 2
+        },
+        "id": 11,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "100%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "count(count(request_total{dst_namespace=\"$namespace\", replicaset!=\"\", dst_replicaset!=\"\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}) by (namespace, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "INBOUND REPLICASETS",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "#299c46",
+          "rgba(237, 129, 40, 0.89)",
+          "#d44a3a"
+        ],
+        "datasource": "prometheus",
+        "format": "none",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": false,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 2
+        },
+        "id": 15,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "options": {},
+        "postfix": "",
+        "postfixFontSize": "100%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "count(count(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}) by (namespace, dst_replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "thresholds": "",
+        "title": "OUTBOUND REPLICASETS",
+        "transparent": true,
+        "type": "singlestat",
+        "valueFontSize": "100%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "current"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND TRAFFIC</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 6
+        },
+        "id": 17,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 8
+        },
+        "id": 67,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) by (replicaset) / sum(irate(response_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) by (replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "rs/{{replicaset}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "SUCCESS RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "percentunit",
+            "label": "",
+            "logBase": 1,
+            "max": "1",
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 8
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\", tls=\"true\"}[30s])) by (replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "🔒rs/{{replicaset}}",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\", tls!=\"true\"}[30s])) by (replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "rs/{{replicaset}}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "REQUEST RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "rps",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 8
+        },
+        "id": 68,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "p50 rs/{{replicaset}}",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "hide": false,
+            "intervalFactor": 1,
+            "legendFormat": "p95 rs/{{replicaset}}",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "p99 rs/{{replicaset}}",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "LATENCY",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "ms",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 15
+        },
+        "id": 148,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 16
+            },
+            "id": 167,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_close_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\",errno!=\"\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}} {{errno}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTION FAILURES",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 16
+            },
+            "id": 168,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_open_connections{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTIONS OPEN",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": "prometheus",
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 16
+            },
+            "heatmap": {},
+            "hideZeroBuckets": false,
+            "highlightCards": true,
+            "id": 169,
+            "legend": {
+              "show": false
+            },
+            "links": [],
+            "options": {},
+            "reverseYBuckets": false,
+            "targets": [
+              {
+                "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"inbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "refId": "A"
+              }
+            ],
+            "title": "TCP CONNECTION DURATION",
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "dtdurationms",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketBound": "auto",
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "title": "Inbound TCP Metrics",
+        "type": "row"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 152,
+        "panels": [],
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>INBOUND REPLICASETS</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 76,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 59,
+        "panels": [],
+        "repeat": "inbound",
+        "scopedVars": {
+          "inbound": {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          }
+        },
+        "title": "rs/$inbound",
+        "type": "row"
+      },
+      {
+        "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">rs/$inbound</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 39,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "scopedVars": {
+          "inbound": {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          }
+        },
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 22
+        },
+        "id": 36,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "scopedVars": {
+          "inbound": {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (replicaset, pod) / sum(irate(response_total{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (replicaset, pod)",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "po/{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "SUCCESS RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "percentunit",
+            "label": null,
+            "logBase": 1,
+            "max": "1",
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 22
+        },
+        "id": 22,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "scopedVars": {
+          "inbound": {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\", tls=\"true\"}[30s])) by (replicaset, pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "🔒po/{{pod}}",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(irate(request_total{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\", tls!=\"true\"}[30s])) by (replicaset, pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "po/{{pod}}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "REQUEST RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "rps",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 22
+        },
+        "id": 29,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "scopedVars": {
+          "inbound": {
+            "selected": false,
+            "text": "web",
+            "value": "web"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "P50 rs/{{replicaset}}",
+            "refId": "A"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "P95 rs/{{replicaset}}",
+            "refId": "B"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{replicaset!=\"\", replicaset=\"$inbound\", dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (le, replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "P99 rs/{{replicaset}}",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "LATENCY",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 29
+        },
+        "id": 34,
+        "panels": [],
+        "repeat": null,
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND TRAFFIC</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 30
+        },
+        "id": 32,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 0,
+          "y": 32
+        },
+        "id": 77,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (dst_replicaset) / sum(irate(response_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (dst_replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "rs/{{dst_replicaset}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "SUCCESS RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "percentunit",
+            "label": "",
+            "logBase": 1,
+            "max": "1",
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 8,
+          "y": 32
+        },
+        "id": 78,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "🔒rs/{{dst_replicaset}}",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replicaset)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "rs/{{dst_replicaset}}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "REQUEST RATE",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "rps",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 7,
+          "w": 8,
+          "x": 16,
+          "y": 32
+        },
+        "id": 79,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}[30s])) by (le, dst_replicaset))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "P95 rs/{{dst_replicaset}}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "P95 LATENCY",
+        "tooltip": {
+          "shared": true,
+          "sort": 2,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "ms",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 39
+        },
+        "id": 154,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 29
+            },
+            "id": 157,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_close_total{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\",errno!=\"\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}} {{errno}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTION FAILURES",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "none",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 29
+            },
+            "id": 166,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "tcp_open_connections{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "{{peer}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "TCP CONNECTIONS OPEN",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "cards": {
+              "cardPadding": null,
+              "cardRound": null
+            },
+            "color": {
+              "cardColor": "#b4ff00",
+              "colorScale": "sqrt",
+              "colorScheme": "interpolateOranges",
+              "exponent": 0.5,
+              "mode": "spectrum"
+            },
+            "dataFormat": "timeseries",
+            "datasource": "prometheus",
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 29
+            },
+            "heatmap": {},
+            "hideZeroBuckets": false,
+            "highlightCards": true,
+            "id": 160,
+            "legend": {
+              "show": false
+            },
+            "links": [],
+            "options": {},
+            "reverseYBuckets": false,
+            "targets": [
+              {
+                "expr": "tcp_connection_duration_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", direction=\"outbound\"}",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "refId": "A"
+              }
+            ],
+            "title": "TCP CONNECTION DURATION",
+            "tooltip": {
+              "show": true,
+              "showHistogram": true
+            },
+            "type": "heatmap",
+            "xAxis": {
+              "show": true
+            },
+            "xBucketNumber": null,
+            "xBucketSize": null,
+            "yAxis": {
+              "decimals": null,
+              "format": "dtdurationms",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true,
+              "splitFactor": null
+            },
+            "yBucketBound": "auto",
+            "yBucketNumber": null,
+            "yBucketSize": null
+          }
+        ],
+        "title": "Outbound TCP Metrics",
+        "type": "row"
+      },
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 40
+        },
+        "id": 156,
+        "panels": [],
+        "title": "",
+        "type": "row"
+      },
+      {
+        "content": "<div class=\"text-center dashboard-header\">\n  <span>OUTBOUND REPLICASETS</span>\n</div>",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 41
+        },
+        "id": 80,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 43
+        },
+        "id": 27,
+        "panels": [
+          {
+            "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"baseline; height:30px;\"/>&nbsp;\n  <span style=\"font-size: 15px; border-image:none\">rs/$outbound</span>\n</div>",
+            "gridPos": {
+              "h": 2,
+              "w": 24,
+              "x": 0,
+              "y": 36
+            },
+            "id": 40,
+            "links": [],
+            "mode": "html",
+            "options": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 0,
+              "y": 38
+            },
+            "id": 28,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(response_total{classification=\"success\", namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replicaset) / sum(irate(response_total{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\"}[30s])) by (dst_replicaset)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "rs/{{dst_replicaset}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "SUCCESS RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": null,
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": "1",
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 8,
+              "y": 38
+            },
+            "id": 35,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_replicaset)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "🔒rs/{{dst_replicaset}}",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(irate(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\", tls!=\"true\"}[30s])) by (dst_replicaset)",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "rs/{{dst_replicaset}}",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "REQUEST RATE",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "rps",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "prometheus",
+            "fill": 1,
+            "gridPos": {
+              "h": 7,
+              "w": 8,
+              "x": 16,
+              "y": 38
+            },
+            "id": 41,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {},
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicaset))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P50 rs/{{dst_replicaset}}",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicaset))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P95 rs/{{dst_replicaset}}",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace=\"$namespace\", replicaset=\"$replicaset\", dst_replicaset=\"$outbound\", direction=\"outbound\"}[30s])) by (le, dst_replicaset))",
+                "format": "time_series",
+                "intervalFactor": 1,
+                "legendFormat": "P99 rs/{{dst_replicaset}}",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "LATENCY",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "repeat": "outbound",
+        "title": "rs/$outbound",
+        "type": "row"
+      },
+      {
+        "content": "<div>\n  <div style=\"position: absolute; top: 0, left: 0\">\n    <a href=\"https://linkerd.io\" target=\"_blank\"><img src=\"https://linkerd.io/images/identity/svg/linkerd_primary_color_white.svg\" style=\"height: 30px;\"></a>\n  </div>\n  <div id=\"version\" style=\"position: absolute; top: 0; right: 0; font-size: 15px\">\n  </div>\n</div>\n<script type=\"text/javascript\">\nvar localReqURL =\n  window.location.href.substring(\n    0,\n    window.location.href.indexOf(\n    \"/grafana/\"\n    )\n  )+'/overview';\n\nfetch(localReqURL, {\n  credentials: 'include',\n  headers: {\n    \"Content-Type\": \"text/html; charset=utf-8\",\n  },\n})\n.then(response => response.text())\n.then(text => (new window.DOMParser()).parseFromString(text, \"text/html\"))\n.then(html => {\n  var main = html.getElementById('main');\n  var localVersion = main.getAttribute(\"data-release-version\");\n  var versionElem = document.getElementById('version');\n\n  var channel;\n  var parts = localVersion.split(\"-\", 2);\n  if (parts.length === 2) {\n    channel = parts[0];\n    versionElem.innerHTML += 'Running Linkerd ' + parts[1] + ' (' + parts[0] + ')' + '.<br>';\n  } else {\n    versionElem.innerHTML += 'Running Linkerd ' + localVersion + '.<br>';\n  }\n  var uuid = main.getAttribute(\"data-uuid\");\n\n  fetch('https://versioncheck.linkerd.io/version.json?version='+localVersion+'&uuid='+uuid+'&source=grafana', {\n    credentials: 'include',\n    headers: {\n      \"Content-Type\": \"application/json; charset=utf-8\",\n    },\n  })\n  .then(response => response.json())\n  .then(json => {\n    if (!channel || !json[channel]) {\n      versionElem.innerHTML += 'Version check failed.'\n    } else if (json[channel] === localVersion) {\n      versionElem.innerHTML += 'Linkerd is up to date.';\n    } else {\n      parts = json[channel].split(\"-\", 2);\n      if (parts.length === 2) {\n        versionElem.innerHTML += \"A new \"+parts[0]+\" version (\"+parts[1]+\") is available.\"\n      } else {\n        versionElem.innerHTML += \"A new version (\"+json[channel]+\") is available.\"\n      }\n      versionElem.innerHTML += \" <a href='https://versioncheck.linkerd.io/update' target='_blank'>Update now</a>.\";\n    }\n  });\n});\n</script>",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 44
+        },
+        "height": "1px",
+        "id": 171,
+        "links": [],
+        "mode": "html",
+        "options": {},
+        "title": "",
+        "transparent": true,
+        "type": "text"
+      }
+    ],
+    "refresh": "1m",
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [
+      "linkerd"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "default",
+            "value": "default"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(process_start_time_seconds{replicaset!=\"\"}, namespace)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(process_start_time_seconds{replicaset!=\"\"}, namespace)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "rs1",
+            "value": "rs1"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(process_start_time_seconds{namespace=\"$namespace\"}, replicaset)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "ReplicaSet",
+          "multi": false,
+          "name": "replicaset",
+          "options": [],
+          "query": "label_values(process_start_time_seconds{namespace=\"$namespace\"}, replicaset)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(request_total{dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\"}, replicaset)",
+          "hide": 2,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "inbound",
+          "options": [],
+          "query": "label_values(request_total{dst_namespace=\"$namespace\", dst_replicaset=\"$replicaset\"}, replicaset)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "prometheus",
+          "definition": "label_values(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\"}, dst_replicaset)",
+          "hide": 2,
+          "includeAll": true,
+          "label": null,
+          "multi": false,
+          "name": "outbound",
+          "options": [],
+          "query": "label_values(request_total{namespace=\"$namespace\", replicaset=\"$replicaset\"}, dst_replicaset)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Linkerd ReplicaSet",
+    "uid": "replicaset",
+    "version": 1
+  }

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -35,6 +35,7 @@ const (
 // AllResources is a sorted list of all resources defined as constants above.
 var AllResources = []string{
 	Authority,
+	CronJob,
 	DaemonSet,
 	Deployment,
 	Job,
@@ -60,6 +61,8 @@ var StatAllResourceTypes = []string{
 	Service,
 	TrafficSplit,
 	Authority,
+	CronJob,
+	ReplicaSet,
 }
 
 // GetConfig returns kubernetes config based on the current environment.
@@ -84,6 +87,8 @@ func CanonicalResourceNameFromFriendlyName(friendlyName string) (string, error) 
 	switch friendlyName {
 	case "au", "authority", "authorities":
 		return Authority, nil
+	case "cj", "cronjob", "cronjobs":
+		return CronJob, nil
 	case "ds", "daemonset", "daemonsets":
 		return DaemonSet, nil
 	case "deploy", "deployment", "deployments":
@@ -119,6 +124,8 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 	switch canonicalName {
 	case Authority:
 		return "au"
+	case CronJob:
+		return "cj"
 	case DaemonSet:
 		return "ds"
 	case Deployment:

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -34,6 +34,8 @@ func TestCanonicalResourceNameFromFriendlyName(t *testing.T) {
 			"deployments": Deployment,
 			"au":          Authority,
 			"authorities": Authority,
+			"cj":          CronJob,
+			"cronjob":     CronJob,
 		}
 
 		for input, expectedName := range expectations {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -58,6 +58,10 @@ const (
 	// StatefulSet that this proxy belongs to.
 	ProxyStatefulSetLabel = Prefix + "/proxy-statefulset"
 
+	// ProxyCronJobLabel is injected into mesh-enabled apps, identifying the
+	// CronJob that this proxy belongs to.
+	ProxyCronJobLabel = Prefix + "/proxy-cronjob"
+
 	/*
 	 * Annotations
 	 */

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -156,6 +156,8 @@ class Namespaces extends React.Component {
             {this.renderResourceSection("statefulset", metrics.statefulset)}
             {this.renderResourceSection("job", metrics.job)}
             {this.renderResourceSection("trafficsplit", metrics.trafficsplit)}
+            {this.renderResourceSection("cronjob", metrics.cronjob)}
+            {this.renderResourceSection("replicaset", metrics.replicaset)}
 
             {
               noMetrics ? null :

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,4 +1,4 @@
-import { daemonsetIcon, deploymentIcon, githubIcon, jobIcon, linkerdWordLogo, namespaceIcon, podIcon, replicaSetIcon, slackIcon, statefulSetIcon } from './util/SvgWrappers.jsx';
+import { cronJobIcon, daemonsetIcon, deploymentIcon, githubIcon, jobIcon, linkerdWordLogo, namespaceIcon, podIcon, replicaSetIcon, slackIcon, statefulSetIcon } from './util/SvgWrappers.jsx';
 import AppBar from '@material-ui/core/AppBar';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import Badge from '@material-ui/core/Badge';
@@ -456,6 +456,8 @@ class NavigationBase extends React.Component {
                 Workloads
           </Typography>
 
+          { this.menuItem(`/namespaces/${selectedNamespace}/cronjobs`, "Cron Jobs", cronJobIcon) }
+
           { this.menuItem(`/namespaces/${selectedNamespace}/daemonsets`, "Daemon Sets", daemonsetIcon) }
 
           { this.menuItem(`/namespaces/${selectedNamespace}/deployments`, "Deployments", deploymentIcon) }
@@ -463,6 +465,8 @@ class NavigationBase extends React.Component {
           { this.menuItem(`/namespaces/${selectedNamespace}/jobs`, "Jobs", jobIcon) }
 
           { this.menuItem(`/namespaces/${selectedNamespace}/pods`, "Pods", podIcon) }
+
+          { this.menuItem(`/namespaces/${selectedNamespace}/replicasets`, "Replica Sets", replicaSetIcon) }
 
           { this.menuItem(`/namespaces/${selectedNamespace}/replicationcontrollers`, "Replication Controllers", replicaSetIcon) }
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -28,7 +28,7 @@ import { withContext } from './util/AppContext.jsx';
 // if there has been no traffic for some time, show a warning
 const showNoTrafficMsgDelayMs = 6000;
 // resource types supported when querying API for edge data
-const edgeDataAvailable = ["daemonset", "deployment", "job", "pod", "replicationcontroller", "statefulset"];
+const edgeDataAvailable = ["cronjob", "daemonset", "deployment", "job", "pod", "replicaset", "replicationcontroller", "statefulset"];
 
 const getResourceFromUrl = (match, pathPrefix) => {
   let resource = {

--- a/web/app/js/components/util/SvgWrappers.jsx
+++ b/web/app/js/components/util/SvgWrappers.jsx
@@ -953,3 +953,82 @@ export const statefulSetIcon = (
     </g>
   </svg>
 );
+
+export const cronJobIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24px"
+    height="24px"
+    version="1.1"
+    viewBox="0 0 18.035 17.5">
+    <g fillOpacity="1">
+      <g
+        stroke="none"
+        strokeDasharray="none"
+        strokeMiterlimit="4"
+        strokeWidth="0">
+        <path
+          fill="#757575"
+          strokeOpacity="1"
+          d="M-6.85 4.272a1.12 1.11 0 00-.428.109l-5.852 2.796a1.12 1.11 0 00-.606.753l-1.444 6.282a1.12 1.11 0 00.152.85 1.12 1.11 0 00.064.089l4.05 5.037a1.12 1.11 0 00.876.417l6.496-.001a1.12 1.11 0 00.875-.417l4.049-5.038a1.12 1.11 0 00.216-.939L.152 7.93a1.12 1.11 0 00-.605-.753L-6.307 4.38a1.12 1.11 0 00-.542-.109z"
+          transform="translate(-.993 -1.174) matrix(1.01489 0 0 1.01489 16.902 -2.699)" />
+        <path
+          fill="#fff"
+          fillRule="nonzero"
+          d="M-6.852 3.818a1.181 1.172 0 00-.452.115l-6.18 2.951a1.181 1.172 0 00-.638.795l-1.524 6.63a1.181 1.172 0 00.16.9 1.181 1.172 0 00.067.093l4.276 5.317a1.181 1.172 0 00.924.44h6.858a1.181 1.172 0 00.923-.44L1.837 15.3a1.181 1.172 0 00.228-.99L.54 7.677a1.181 1.172 0 00-.64-.795l-6.178-2.95a1.181 1.172 0 00-.573-.115zm.003.455a1.12 1.11 0 01.542.108l5.853 2.795a1.12 1.11 0 01.606.753l1.446 6.281a1.12 1.11 0 01-.216.94l-4.05 5.037a1.12 1.11 0 01-.875.417l-6.496.001a1.12 1.11 0 01-.875-.417l-4.05-5.037a1.12 1.11 0 01-.064-.088 1.12 1.11 0 01-.152-.851l1.444-6.281a1.12 1.11 0 01.605-.753l5.853-2.797a1.12 1.11 0 01.429-.108z"
+          baselineShift="baseline"
+          color="#000"
+          direction="ltr"
+          display="inline"
+          enableBackground="accumulate"
+          fontFamily="Sans"
+          fontSize="medium"
+          fontStretch="normal"
+          fontStyle="normal"
+          fontVariant="normal"
+          fontWeight="normal"
+          letterSpacing="normal"
+          overflow="visible"
+          textAnchor="start"
+          textDecoration="none"
+          transform="translate(-.993 -1.174) matrix(1.01489 0 0 1.01489 16.902 -2.699)"
+          style={{
+            lineHeight: "normal",
+            InkscapeFontSpecification: "Sans",
+            WebkitTextIndent: "0",
+            textIndent: "0",
+            WebkitTextAlign: "start",
+            textAlign: "start",
+            WebkitTextDecorationLine: "none",
+            textDecorationLine: "none",
+            WebkitTextTransform: "none",
+            textTransform: "none",
+            marker: "none"
+          }}
+          visibility="visible"
+          wordSpacing="normal"
+          writingMode="lr-tb" />
+      </g>
+      <g fill="#fff">
+        <path
+          fillRule="nonzero"
+          stroke="none"
+          strokeDasharray="1.418, 1.418"
+          strokeDashoffset="23.045"
+          strokeLinecap="butt"
+          strokeLinejoin="round"
+          strokeMiterlimit="10"
+          strokeOpacity="1"
+          strokeWidth="0.709"
+          d="M11.673 3.96v2.143h2.202V3.96zm0 3.084v.546c.258-.06.526-.097.803-.097.497 0 .97.106 1.4.295v-.744zm-6.284.033V9.22h2.203V7.077zm3.142 0V9.22h.928c.31-.52.75-.955 1.275-1.258v-.885zm-3.163 3.117v2.143h2.203v-2.143zm3.152 0v2.143h.707c-.17-.411-.265-.86-.265-1.33 0-.28.037-.551.1-.813z"
+          opacity="1"
+          transform="translate(-.993 -1.174) translate(-.578 .775)" />
+        <path
+          strokeWidth="0.32"
+          d="M12.608 7.94a3.21 3.21 0 00-3.2 3.2c0 1.76 1.44 3.2 3.2 3.2 1.76 0 3.2-1.44 3.2-3.2 0-1.76-1.44-3.2-3.2-3.2zm1.344 4.543l-1.664-1.024V9.54h.48v1.664l1.44.864z"
+          clipPath="url(#b)"
+          transform="translate(-.993 -1.174) translate(-.578 .775)" />
+      </g>
+    </g>
+  </svg>
+);

--- a/web/app/js/components/util/TapUtils.jsx
+++ b/web/app/js/components/util/TapUtils.jsx
@@ -38,7 +38,9 @@ export const tapResourceTypes = [
   "pod",
   "replicationcontroller",
   "statefulset",
-  "job"
+  "job",
+  "replicaset",
+  "cronjob"
 ];
 
 // use a generator to get this object, to prevent it from being overwritten

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -139,6 +139,10 @@ export const friendlyTitle = singularOrPluralResource => {
     titleCase = _startCase("stateful set");
   } else if (resource === "trafficsplit") {
     titleCase = _startCase("traffic split");
+  } else if (resource === "cronjob") {
+    titleCase = _startCase("cron job");
+  } else if (resource === "replicaset") {
+    titleCase = _startCase("replica set");
   }
 
   let titles = { singular: titleCase };
@@ -168,7 +172,8 @@ const camelCaseLookUp = {
   "replicationcontroller": "replicationController",
   "statefulset": "statefulSet",
   "trafficsplit": "trafficSplit",
-  "daemonset": "daemonSet"
+  "daemonset": "daemonSet",
+  "cronjob": "cronJob",
 };
 
 export const resourceTypeToCamelCase = resource => camelCaseLookUp[resource] || resource;
@@ -187,7 +192,8 @@ export const shortNameLookup = {
   "statefulset": "sts",
   "trafficsplit": "ts",
   "job": "job",
-  "authority": "au"
+  "authority": "au",
+  "cronjob": "cj",
 };
 
 export const podOwnerLookup = {
@@ -196,6 +202,7 @@ export const podOwnerLookup = {
   "replicationcontroller": "rc",
   "replicaset": "rs",
   "statefulset": "sts",
+  "cronjob": "cj",
 };
 
 export const toShortResourceName = name => shortNameLookup[name] || name;

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -149,6 +149,18 @@ function AppHTML() {
                 path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers`}
                 render={props => <Navigation {...props} ChildComponent={ResourceList} resource="replicationcontroller" />} />
               <Route
+                path={`${pathPrefix}/namespaces/:namespace/cronjobs/:cronjob`}
+                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+              <Route
+                path={`${pathPrefix}/namespaces/:namespace/cronjobs`}
+                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="cronjob" />} />
+              <Route
+                path={`${pathPrefix}/namespaces/:namespace/replicasets/:replicaset`}
+                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+              <Route
+                path={`${pathPrefix}/namespaces/:namespace/replicasets`}
+                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="replicaset" />} />
+              <Route
                 path={`${pathPrefix}/tap`}
                 render={props => <Navigation {...props} ChildComponent={Tap} />} />
               <Route

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -130,6 +130,8 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/deployments", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/replicationcontrollers", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/pods", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/cronjobs", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/replicasets", handler.handleIndex)
 
 	// legacy paths that are deprecated but should not 404
 	server.router.GET("/overview", handler.handleIndex)
@@ -150,6 +152,8 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/deployments/:deployment", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/jobs/:job", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/replicationcontrollers/:replicationcontroller", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/cronjobs/:cronjob", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/replicasets/:replicaset", handler.handleIndex)
 
 	// tools and community paths
 	server.router.GET("/tap", handler.handleIndex)


### PR DESCRIPTION
CronJobs and ReplicaSets are now visible in the dashboard (please see screenshots attached). A new entry for each workload has been added to the navigation menu. From there it's possible to open the view listing each kind of resource and accessing their details as with any other workload. It's also possible to use the tap/top tools in the dashboard on CronJobs and ReplicaSets.

Some other points addressed: 

- A new Grafana dashboard has been added for each kind of resource
- CLI tools like metrics/tap/top can now work with CronJobs
- Update CLI help to include CronJobs (and ReplicaSets where missing)
- Inject now supports CronJobs
- Add support for CronJobs and ReplicaSets in K8S API
- Allow access to CronJobs in RBAC templates

Closes #3614 
Closes #3630
Closes #3584 
Closes #3585

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>

<img width="2001" alt="rs1" src="https://user-images.githubusercontent.com/1213902/68392409-088f6d80-016a-11ea-8182-8c3e3bbb433c.png">

<img width="2001" alt="rs2" src="https://user-images.githubusercontent.com/1213902/68392417-0cbb8b00-016a-11ea-97f7-8d61b09ab3b2.png">

<img width="2001" alt="cj1" src="https://user-images.githubusercontent.com/1213902/68392424-0fb67b80-016a-11ea-85a8-7b9a8e1461ef.png">

<img width="2001" alt="cj2" src="https://user-images.githubusercontent.com/1213902/68392431-12b16c00-016a-11ea-8f8d-8bf0e5d6a6b7.png">

<img width="2001" alt="tap_cj" src="https://user-images.githubusercontent.com/1213902/68392438-180eb680-016a-11ea-9706-affe0f6df57d.png">

<img width="2001" alt="top_cj" src="https://user-images.githubusercontent.com/1213902/68392445-1b09a700-016a-11ea-84e6-9e677b8ff07d.png">

<img width="2001" alt="tap_rs" src="https://user-images.githubusercontent.com/1213902/68392450-1e9d2e00-016a-11ea-9018-a1c8fc1f65ad.png">

<img width="2001" alt="top_rs" src="https://user-images.githubusercontent.com/1213902/68392455-21981e80-016a-11ea-886e-3a6ebbc9dec2.png">

<img width="2001" alt="grafana_rs" src="https://user-images.githubusercontent.com/1213902/68392473-265cd280-016a-11ea-8c95-510a757fab44.png">

<img width="2001" alt="grafana_cronjob" src="https://user-images.githubusercontent.com/1213902/68392488-2ceb4a00-016a-11ea-815b-5be80709ccd8.png">



