### PR TITLE
Stop using react-iframe library in dashboard

### DIFF
--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -1,15 +1,28 @@
-import Iframe from 'react-iframe';
+import PropTypes from 'prop-types';
 import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
 
-const Community = () => {
+const styles = () => ({
+  iframe: {
+    border: "0px",
+    height: "100vh",
+    width: "100%",
+    overflow: "hidden",
+  },
+});
+
+const Community = ({classes}) => {
   return (
-    <Iframe
-      url="https://linkerd.io/dashboard/"
-      position="inherit"
-      display="block"
-      height="100vh"
-      border="none" />
+    <iframe
+      title="Community"
+      src="https://linkerd.io/dashboard/"
+      scrolling="no"
+      className={classes.iframe} />
   );
 };
 
-export default Community;
+Community.propTypes = {
+  classes: PropTypes.shape({}).isRequired,
+};
+
+export default withStyles(styles)(Community);

--- a/web/app/js/components/Community.test.jsx
+++ b/web/app/js/components/Community.test.jsx
@@ -1,0 +1,16 @@
+import Community from './Community.jsx';
+import { routerWrap } from '../../test/testHelpers.jsx';
+import { mount } from 'enzyme';
+
+describe('Community', () => {
+  it('makes a iframe', () => {
+    let component = mount(routerWrap(Community));
+    expect(component.find("Community")).toHaveLength(1);
+
+    const src = component.find("iframe").props().src;
+    expect(src).toEqual("https://linkerd.io/dashboard/");
+    
+    const title = component.find("iframe").props().title;
+    expect(title).toEqual("Community");
+  });
+});

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -21,7 +21,6 @@
     "prop-types": "15.6.1",
     "react": "16.5.0",
     "react-dom": "16.5.0",
-    "react-iframe": "1.7.16",
     "react-linkify": "1.0.0-alpha",
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -7891,14 +7891,12 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
-react-iframe@1.7.16:
-  version "1.7.16"
-  resolved "https://registry.yarnpkg.com/react-iframe/-/react-iframe-1.7.16.tgz#820cae25a5342c3fb201dc02571763b73ee810c7"
-  integrity sha512-tMph5QOcCynSldusHnGU5LavVVakt0YHRubWm4yFPHXqEgWznSQLDxY8DfX5pEpiGNRMBpKlrlRTZ15UqfLInQ==
-  dependencies:
-    object-assign "^4.1.1"
+react-is@^16.5.2, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-is@^16.5.2, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.8.6:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==


### PR DESCRIPTION
`react-iframe` library is only rendering a normal `iframe`, so we can delete it.

Closes #2915 

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>