### PR TITLE
Fix Octopus graph with multiple nodes

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -1,4 +1,4 @@
-import { OctopusArms, baseHeight } from './util/OctopusArms.jsx';
+import { OctopusArms, inboundAlignment } from './util/OctopusArms.jsx';
 import { displayName, metricToFormatter } from './util/Utils.js';
 
 import Card from '@material-ui/core/Card';
@@ -6,14 +6,13 @@ import CardContent from '@material-ui/core/CardContent';
 import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
+import RootRef from '@material-ui/core/RootRef';
 import { StyledProgress } from './util/Progress.jsx';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
-import _ceil from 'lodash/ceil';
-import _floor from 'lodash/floor';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _isNil from 'lodash/isNil';
@@ -21,11 +20,8 @@ import _size from 'lodash/size';
 import _slice from 'lodash/slice';
 import _sortBy from 'lodash/sortBy';
 import _take from 'lodash/take';
-import _times from 'lodash/times';
 import { getSuccessRateClassification } from './util/MetricUtils.jsx';
 import { withStyles } from "@material-ui/core/styles";
-
-const maxNumNeighbors = 6; // max number of neighbor nodes to show in the octopus graph
 
 const styles = () => ({
   graphContainer: {
@@ -43,23 +39,38 @@ const styles = () => ({
   },
   neighborNode: {
     width: "220px"
-  }
+  },
+  collapsedNeighborName: {
+    paddingTop: "10px",
+  },
 });
 class Octopus extends React.Component {
   static defaultProps = {
     neighbors: {},
     resource: {},
-    unmeshedSources: []
+    unmeshedSources: [],
+    maxNumNeighbors: 6,
   }
 
   static propTypes = {
     classes: PropTypes.shape({}).isRequired,
+    maxNumNeighbors: PropTypes.number,
     neighbors: PropTypes.shape({}),
     resource: PropTypes.shape({}),
     unmeshedSources: PropTypes.arrayOf(PropTypes.shape({})),
   }
 
+  constructor(props) {
+    super(props);
+
+    this.upstreamsContainer = React.createRef();
+    this.downstreamsContainer = React.createRef();
+    this.upstreamsRefs = [];
+    this.downstreamsRefs = [];
+  }
+
   getNeighborDisplayData = neighbors => {
+    const { maxNumNeighbors } = this.props;
     // only display maxNumNeighbors neighboring nodes in the octopus graph,
     // otherwise it will be really tall
     // even though _sortBy is a stable sort, the order that this data is returned by the API
@@ -92,6 +103,16 @@ class Octopus extends React.Component {
     return display;
   }
 
+  refCallback = (element, index, isOutbound) => {
+    if (element) {
+      if (isOutbound) {
+        this.downstreamsRefs[index] = element;
+      } else {
+        this.upstreamsRefs[index] = element;
+      }
+    }
+  }
+
   linkedResourceTitle = (resource, display) => {
     // trafficsplit leaf resources cannot be linked
     return _isNil(resource.namespace) || resource.isLeafService ? display :
@@ -100,7 +121,7 @@ class Octopus extends React.Component {
       linkText={display} />;
   }
 
-  renderResourceCard(resource, type) {
+  renderResourceCard(resource, type, index, isOutbound) {
     const { classes } = this.props;
     let display = displayName(resource);
     let classification = getSuccessRateClassification(resource.successRate);
@@ -115,22 +136,24 @@ class Octopus extends React.Component {
     }
 
     return (
-      <Grid item key={resource.type + "-" + resource.name} >
-        <Card className={type === "neighbor" ? classes.neighborNode : classes.centerNode} title={display}>
-          <CardContent>
+      <RootRef rootRef={el => type === "neighbor" ? this.refCallback(el, index, isOutbound) : undefined} key={resource.type + "-" + resource.name}>
+        <Grid item>
+          <Card className={type === "neighbor" ? classes.neighborNode : classes.centerNode} title={display}>
+            <CardContent>
 
-            <Typography variant={type === "neighbor" ? "subtitle1" : "h6"} align="center">
-              { this.linkedResourceTitle(resource, display) }
-            </Typography>
+              <Typography variant={type === "neighbor" ? "subtitle1" : "h6"} align="center">
+                { this.linkedResourceTitle(resource, display) }
+              </Typography>
 
-            <Progress variant="determinate" value={resource.successRate * 100} />
+              <Progress variant="determinate" value={resource.successRate * 100} />
 
-            <Table padding="dense">
-              {showTcp ? this.renderTCPStats(resource) : this.renderHttpStats(resource)}
-            </Table>
-          </CardContent>
-        </Card>
-      </Grid>
+              <Table padding="dense">
+                {showTcp ? this.renderTCPStats(resource) : this.renderHttpStats(resource)}
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+      </RootRef>
     );
   }
 
@@ -181,75 +204,97 @@ class Octopus extends React.Component {
     );
   }
 
-  renderUnmeshedResources = unmeshedResources => {
+  renderUnmeshedResources = (unmeshedResources, index, isOutbound) => {
     const { classes } = this.props;
     return (
-      <Grid item>
-        <Card key="unmeshed-resources" className={classes.neighborNode}>
-          <CardContent>
-            <Typography variant="subtitle1">Unmeshed</Typography>
-            {
-              unmeshedResources.map(r => {
-                let display = displayName(r);
-                return <Typography key={display} variant="body2" title={display}>{display}</Typography>;
-              })
-            }
-          </CardContent>
-        </Card>
-      </Grid>
+      <RootRef rootRef={el => this.refCallback(el, index, isOutbound)}>
+        <Grid item>
+          <Card key="unmeshed-resources" className={classes.neighborNode}>
+            <CardContent>
+              <Typography variant="subtitle1">Unmeshed</Typography>
+              {
+                unmeshedResources.map(r => {
+                  let display = displayName(r);
+                  return <Typography key={display} variant="body2" title={display}>{display}</Typography>;
+                })
+              }
+            </CardContent>
+          </Card>
+        </Grid>
+      </RootRef>
     );
   }
 
-  renderCollapsedNeighbors = neighbors => {
+  renderCollapsedNeighbors = (neighbors, index, isOutbound) => {
     const { classes } = this.props;
+    let Progress = StyledProgress();
     return (
-      <Grid item>
-        <Card className={classes.neighborNode}>
-          <CardContent>
-            {
-              neighbors.map(r => {
-                let display = displayName(r);
-                return <Typography key={display}>{this.linkedResourceTitle(r, display)}</Typography>;
-              })
-            }
-          </CardContent>
-        </Card>
-      </Grid>
+      <RootRef rootRef={el => this.refCallback(el, index, isOutbound)}>
+        <Grid item>
+          <Card className={classes.neighborNode}>
+            <CardContent>
+              <Typography variant="subtitle1">
+                + { neighbors.length } more...
+              </Typography>
+              <Progress variant="determinate" value={100} />
+              {
+                neighbors.map(r => {
+                  let display = displayName(r);
+                  return <Typography key={display} className={classes.collapsedNeighborName}>{this.linkedResourceTitle(r, display)}</Typography>;
+                })
+              }
+            </CardContent>
+          </Card>
+        </Grid>
+      </RootRef>
     );
   }
 
-  renderArrowCol = (numNeighbors, isOutbound) => {
+  renderArrowCol = isOutbound => {
+    const container = !isOutbound ? this.upstreamsContainer : this.downstreamsContainer;
+    let refs = !isOutbound ? this.upstreamsRefs : this.downstreamsRefs;
+    if (refs.length === 0 || container.current === undefined) {
+      return null;
+    }
+
     let width = 80;
-    let showArrow = numNeighbors > 0;
-    let isEven = numNeighbors % 2 === 0;
-    let middleElementIndex = isEven ? ((numNeighbors - 1) / 2) : _floor(numNeighbors / 2);
+    let fullHeight = container.current.offsetHeight;
+    let arrowTypes = [];
+    arrowTypes = refs.map(element => {
+      const elementTop = element.offsetTop - container.current.offsetTop;
+      const elementHeight = element.offsetHeight;
+      const halfElement = elementHeight / 2;
 
-    let arrowTypes = _times(numNeighbors, i => i).map(i => {
-      if (i < middleElementIndex) {
-        let height = (_ceil(middleElementIndex - i) - 1) * baseHeight + (baseHeight / 2);
-        return { type: "up", inboundType: "down", height };
-      } else if (i === middleElementIndex) {
-        return { type: "flat", inboundType: "flat", height: baseHeight };
+      // Middle element
+      if (Math.round(fullHeight / 2) === elementTop + halfElement) {
+        const height = elementTop + halfElement;
+        return { type: "flat", inboundType: "flat", height: height };
+
+      // Elements underneath main element
+      } else if (elementTop + halfElement >= fullHeight / 2) {
+        const height = !isOutbound ? elementTop - fullHeight / 2 + halfElement - inboundAlignment : fullHeight - elementTop - halfElement + inboundAlignment;
+        return { type: "down", inboundType: "up", height: height, elementHeight: elementHeight };
+
+      // Elements over main element
       } else {
-        let height = (_ceil(i - middleElementIndex) - 1) * baseHeight + (baseHeight / 2);
-        return { type: "down", inboundType: "up", height };
+        const height = !isOutbound ? elementTop + halfElement + inboundAlignment : fullHeight / 2 - elementTop - halfElement - inboundAlignment;
+        return { type: "up", inboundType: "down", height: height, elementHeight: elementHeight };
       }
     });
 
-    let height = numNeighbors * baseHeight;
     let svg = (
-      <svg height={height} width={width} version="1.1" viewBox={`0 0 ${width} ${height}`}>
+      <svg height={fullHeight} width={width} version="1.1" viewBox={`0 0 ${width} ${fullHeight}`}>
         <defs />
         {
           arrowTypes.map(arrow => {
             let arrowType = isOutbound ? arrow.type : arrow.inboundType;
-            return OctopusArms[arrowType](width, height, arrow.height, isOutbound, isEven);
+            return OctopusArms[arrowType](width, fullHeight, arrow.height, isOutbound, arrow.elementHeight);
           })
         }
       </svg>
     );
 
-    return !showArrow ? null : svg;
+    return svg;
   }
 
   render() {
@@ -261,12 +306,6 @@ class Octopus extends React.Component {
 
     let display = this.getNeighborDisplayData(neighbors);
 
-    let numUpstreams = _size(display.upstreams.displayed) + (_isEmpty(unmeshedSources) ? 0 : 1) +
-      (_isEmpty(display.upstreams.collapsed) ? 0 : 1);
-
-    let numDownstreams = _size(display.downstreams.displayed) + (_isEmpty(display.downstreams.collapsed) ? 0 : 1);
-
-
     return (
       <div className={classes.graphContainer}>
         <div className={classes.graph}>
@@ -276,22 +315,23 @@ class Octopus extends React.Component {
             justify="center"
             alignItems="center">
 
-
-            <Grid
-              container
-              spacing={24}
-              direction="column"
-              justify="center"
-              alignItems="center"
-              item
-              xs={3}>
-              {display.upstreams.displayed.map(n => this.renderResourceCard(n, "neighbor"))}
-              {_isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources)}
-              {_isEmpty(display.upstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.upstreams.collapsed)}
-            </Grid>
+            <RootRef rootRef={this.upstreamsContainer}>
+              <Grid
+                container
+                spacing={24}
+                direction="column"
+                justify="center"
+                alignItems="center"
+                item
+                xs={3}>
+                {display.upstreams.displayed.map((n, index) => this.renderResourceCard(n, "neighbor", index, false))}
+                {_isEmpty(unmeshedSources) ? null : this.renderUnmeshedResources(unmeshedSources, display.upstreams.displayed.length, false)}
+                {_isEmpty(display.upstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.upstreams.collapsed, _isEmpty(unmeshedSources) ? display.upstreams.displayed.length : display.upstreams.displayed.length + 1, false)}
+              </Grid>
+            </RootRef>
 
             <Grid item xs={1}>
-              {this.renderArrowCol(numUpstreams, false)}
+              {this.renderArrowCol(false)}
             </Grid>
 
 
@@ -300,20 +340,22 @@ class Octopus extends React.Component {
             </Grid>
 
             <Grid item xs={1}>
-              {this.renderArrowCol(numDownstreams, true)}
+              {this.renderArrowCol(true)}
             </Grid>
 
-            <Grid
-              container
-              spacing={24}
-              direction="column"
-              justify="center"
-              alignItems="center"
-              item
-              xs={3}>
-              {display.downstreams.displayed.map(n => this.renderResourceCard(n, "neighbor"))}
-              {_isEmpty(display.downstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.downstreams.collapsed)}
-            </Grid>
+            <RootRef rootRef={this.downstreamsContainer}>
+              <Grid
+                container
+                spacing={24}
+                direction="column"
+                justify="center"
+                alignItems="center"
+                item
+                xs={3}>
+                {display.downstreams.displayed.map((n, index) => this.renderResourceCard(n, "neighbor", index, true))}
+                {_isEmpty(display.downstreams.collapsed) ? null : this.renderCollapsedNeighbors(display.downstreams.collapsed, display.downstreams.displayed.length, true)}
+              </Grid>
+            </RootRef>
           </Grid>
         </div>
       </div>

--- a/web/app/js/components/util/OctopusArms.jsx
+++ b/web/app/js/components/util/OctopusArms.jsx
@@ -4,10 +4,8 @@ import grey from '@material-ui/core/colors/grey';
 const strokeOpacity = "0.7";
 const arrowColor = grey[500];
 
-export const baseHeight = 220; // the height of the neighbor node box
-const halfBoxHeight = baseHeight / 2;
 const controlPoint = 10; // width and height of the control points for the bezier curves
-const inboundAlignment = controlPoint * 2;
+export const inboundAlignment = controlPoint * 2;
 
 const generateSvgComponents = (y1, width, height) => {
   let segmentWidth = width / 2 - controlPoint; // width of each horizontal arrow segment
@@ -71,15 +69,15 @@ const arrowG = (id, arm, transform) => {
   );
 };
 
-const up = (width, svgHeight, arrowHeight, isOutbound, isEven) => {
-  let height = arrowHeight + (isEven ? 0 : halfBoxHeight);
+const up = (width, svgHeight, arrowHeight, isOutbound) => {
+  let height = arrowHeight;
 
   // up arrows start and the center of the middle node for outbound arms,
   // and at the noce position for inbound arms
   let y1 = isOutbound ? svgHeight / 2 : arrowHeight;
   let arm = generateSvgComponents(y1, width, height);
 
-  let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + (isEven ? 0 : halfBoxHeight) + inboundAlignment})`;
+  let translate = isOutbound ? null : `translate(0, ${svgHeight / 2 + inboundAlignment})`;
 
   return arrowG(`up-arrow-${height}`, arm, translate);
 };
@@ -101,18 +99,18 @@ const flat = (width, height) => {
   );
 };
 
-const down = (width, svgHeight, arrowHeight, isOutbound) => {
+const down = (width, svgHeight, arrowHeight, isOutbound, elementHeight) => {
   // down outbound arrows start at the middle of the svg's height, and
   // have end of block n at (1/2 block height) + (block height * n-1)
   let height = (svgHeight / 2) - arrowHeight;
 
   // inbound arrows start at the offset of the card, and end in the center of the middle card
   // outbound arrows start in the center of the middle card, and end at the card's height
-  let y1 = isOutbound ? svgHeight / 2 : halfBoxHeight;
+  let y1 = isOutbound ? svgHeight / 2 : elementHeight / 2;
 
   let arm = generateSvgComponents(y1, width, height);
 
-  let translate = `translate(0, ${isOutbound ? svgHeight : svgHeight / 2 - height + halfBoxHeight - inboundAlignment})`;
+  let translate = `translate(0, ${isOutbound ? svgHeight : svgHeight / 2 - height + elementHeight / 2 - inboundAlignment})`;
   let reflect = "scale(1, -1)";
   let transform = `${translate} ${reflect}`;
 


### PR DESCRIPTION
This PR fixes issues with Octopus graphs components when some cards have different sizes: 
- Fix vertical position of arrows
- Improve collapsedNeighbors card title (based on #3047)
- Support for custom `maxNumNeighbors`, now we can use any neighbours number greater than or less than 6 passing it through prop (by default we are using 6) -> 8 is the result of 6 `resourceCard` + `unmeshedResources` card + `collapsedNeighbors` card
- Tested on Safari, Chrome, Firefox and Edge (for Mac)

Closes #3577

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>

![octopus_01](https://user-images.githubusercontent.com/1440981/68657703-853c9600-0534-11ea-937c-45469437a2a6.jpg)
![octopus_02](https://user-images.githubusercontent.com/1440981/68657705-85d52c80-0534-11ea-8ccd-24971288db66.jpg)
![octopus_03](https://user-images.githubusercontent.com/1440981/68657706-85d52c80-0534-11ea-8026-ca495638d02d.jpg)
![octopus_04](https://user-images.githubusercontent.com/1440981/68657707-85d52c80-0534-11ea-9907-4f00c1ad2ef2.jpg)
![octopus_05](https://user-images.githubusercontent.com/1440981/68657708-85d52c80-0534-11ea-8033-340d85d096b9.jpg)
