### PR TITLE
Add Responses to path items to satisfy kube apiserver

### DIFF
--- a/controller/tap/handlers.go
+++ b/controller/tap/handlers.go
@@ -314,6 +314,18 @@ func mkPathItem(desc string) spec.PathItem {
 					Description: desc,
 					Consumes:    []string{"application/json"},
 					Produces:    []string{"application/json"},
+					Responses: &spec.Responses{
+						ResponsesProps: spec.ResponsesProps{
+							StatusCodeResponses: map[int]spec.Response{
+								200: spec.Response{
+									Refable: spec.Refable{Ref: spec.MustCreateRef("n/a")},
+									ResponseProps: spec.ResponseProps{
+										Description: "OK response",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Adds a `Responses` field to the `/openapi/v2` endpoints to satisfy kubernetes and avoid errors being logged in kube-apiserver.

Fixes: #3361

Signed-off-by: zaharidichev <zaharidichev@gmail.com>