### PR TITLE
Increase the comprehensiveness of check --pre

### DIFF
--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -26,15 +26,6 @@ pre-kubernetes-capability
 √ has NET_ADMIN capability
 √ has NET_RAW capability
 
-pre-linkerd-global-resources
-----------------------------
-√ no ClusterRoles exist
-√ no ClusterRoleBindings exist
-√ no CustomResourceDefinitions exist
-√ no MutatingWebhookConfigurations exist
-√ no ValidatingWebhookConfigurations exist
-√ no PodSecurityPolicies exist
-
 linkerd-version
 ---------------
 √ can determine the latest version

--- a/test/testdata/check.pre.golden
+++ b/test/testdata/check.pre.golden
@@ -11,11 +11,7 @@ kubernetes-version
 pre-kubernetes-setup
 --------------------
 √ control plane namespace does not already exist
-√ can create Namespaces
-√ can create ClusterRoles
-√ can create ClusterRoleBindings
-√ can create CustomResourceDefinitions
-√ can create PodSecurityPolicies
+√ can create non-namespaced resources
 √ can create ServiceAccounts
 √ can create Services
 √ can create Deployments


### PR DESCRIPTION
A new check called `can create non-namespaced resources` has been added to replace the individual `can create <RESOURCE>` checks related to non-namespaced resources. 

Before, each of those `can create` checks was asking k8s (`SelfSubjectAccessReview`) if the user was authorized to create the given resource. Now, the non-namespaced resources are actually created but using the `DryRun` option so that objects are not persisted. This way we should be able to catch more details about potential problems preventing the installation to proceed successfully.

This check is fed from the generated installation manifest using default options. This means that as new non-namespaced resources are added to the installation, this check will test if it's possible to create them automatically without requiring additional modifications.

Closes #3224

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>

<img width="398" alt="Screenshot 2019-11-13 at 10 43 00" src="https://user-images.githubusercontent.com/1213902/68754636-5cd19c00-0607-11ea-8f6f-3e8111deb4de.png">
