### PR TITLE
Upgrade go to 1.13.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [download_src]
     container:
-      image: golang:1.12.9
+      image: golang:1.13.4
     steps:
     - name: Download .git artifact
       uses: actions/download-artifact@v1
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [download_src]
     container:
-      image: golang:1.12.9
+      image: golang:1.13.4
     steps:
     - name: Download .git artifact
       uses: actions/download-artifact@v1
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [download_src]
     container:
-      image: golang:1.12.9
+      image: golang:1.13.4
     steps:
     - name: Download .git artifact
       uses: actions/download-artifact@v1

--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.12.9
+FROM golang:1.13.4
 
 WORKDIR /linkerd-build
 

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:f4c3ddf4 as golang
+FROM gcr.io/linkerd-io/go-deps:1c6a29b8 as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.17.1
+lintversion=1.19.1
 
 cd "$(pwd -P)"
 

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:f4c3ddf4 as golang
+FROM gcr.io/linkerd-io/go-deps:1c6a29b8 as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:f4c3ddf4 as golang
+FROM gcr.io/linkerd-io/go-deps:1c6a29b8 as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller service
-FROM gcr.io/linkerd-io/go-deps:f4c3ddf4 as golang
+FROM gcr.io/linkerd-io/go-deps:1c6a29b8 as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.12.9
+go 1.13.4
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0
@@ -84,3 +84,7 @@ require (
 )
 
 replace github.com/wercker/stern => github.com/linkerd/stern v0.0.0-20190907020106-201e8ccdff9c
+
+replace k8s.io/apimachinery v0.0.0-20181127105237-2b1284ed4c93 => k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
+
+replace k8s.io/code-generator v0.0.0-20181116203124-c2090bec4d9b => k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,7 @@ k8s.io/api v0.0.0-20190620084959-7cf5895f2711 h1:BblVYz/wE5WtBsD/Gvu54KyBUTJMflo
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476 h1:Ws9zfxsgV19Durts9ftyTG7TO0A/QLhmu98VqNWLiH8=
 k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
+k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20181127105237-2b1284ed4c93 h1:x873ep9UWnh1yHdUVf9HMu95fsDVRausPvGFAe++vx8=
 k8s.io/apimachinery v0.0.0-20181127105237-2b1284ed4c93/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719 h1:uV4S5IB5g4Nvi+TBVNf3e9L4wrirlwYJ6w88jUQxTUw=
@@ -504,6 +505,7 @@ k8s.io/client-go v0.0.0-20181213151034-8d9ed539ba31/go.mod h1:7vJpHMYJwNQCWgzmNV
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/code-generator v0.0.0-20181116203124-c2090bec4d9b/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
+k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
 k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b/go.mod h1:G8bQwmHm2eafm5bgtX67XDZQ8CWKSGu9DekI+yN4Y5I=
 k8s.io/component-base v0.0.0-20190620085130-185d68e6e6ea/go.mod h1:VLedAFwENz2swOjm0zmUXpAP2mV55c49xgaOzPBI/QQ=
 k8s.io/gengo v0.0.0-20190116091435-f8a0810f38af/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -309,7 +309,7 @@ spec:
               min: 1`,
 		},
 		{
-			err: errors.New("failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into Go struct field Range.min of type uint32"),
+			err: errors.New("failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into Go struct field Range.spec.routes.responseClasses.condition.all.not.status.min of type uint32"),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
@@ -388,7 +388,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number -5 into Go struct field RetryBudget.minRetriesPerSecond of type uint32"),
+			err: errors.New("failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number -5 into Go struct field RetryBudget.spec.retryBudget.minRetriesPerSecond of type uint32"),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:f4c3ddf4 as golang
+FROM gcr.io/linkerd-io/go-deps:1c6a29b8 as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
Fixes #3566

As explained in #3566, as of go 1.13 there's a strict check that ensures a dependency's timestamp matches it's sha (as declared in `go.mod`). Our smi-sdk dependency has a problem with that that got resolved later on, but more work would be required to upgrade that dependency. In the meantime a quick pair of `replace` statements at the bottom of `go.mod` fix the issue.