### PR TITLE
Added the ability to define Identity.External in order to use an external secret for issuer certs

### DIFF
--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -4,7 +4,7 @@
 ###
 ### Identity Controller Service
 ###
-{{ if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/tls") -}}
+{{ if and (not .Identity.External) (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/tls") -}}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -25,6 +25,8 @@ Dashboard:
 
 # identity configuration
 Identity:
+  # enabling this flag behaves like using --identitiy-external-issuer flag
+  External: false
   Issuer:
     Scheme: linkerd.io/tls
 


### PR DESCRIPTION
Let me know if further clarifications are needed here, this is pretty straight forward.

The use case here is the need to define the issuer secret using certs-manager / other way.