### PR TITLE
Error on conflicting stat options (--namespace and --all-namespaces)

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -711,6 +711,10 @@ func (o *statOptions) validateConflictingFlags() error {
 		return fmt.Errorf("--to-namespace and --from-namespace flags are mutually exclusive")
 	}
 
+	if o.allNamespaces && o.namespace != "default" {
+		return fmt.Errorf("--all-namespaces and --namespace flags are mutually exclusive")
+	}
+
 	return nil
 }
 

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -155,6 +155,19 @@ func TestStat(t *testing.T) {
 		}
 	})
 
+	t.Run("Rejects commands with both --all-namespaces and --namespace flags", func(t *testing.T) {
+		options := newStatOptions()
+		options.allNamespaces = true
+		options.namespace = "ns"
+		args := []string{"po"}
+		expectedError := "--all-namespaces and --namespace flags are mutually exclusive"
+
+		_, err := buildStatSummaryRequests(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
+
 	t.Run("Rejects --to-namespace flag when the target is a namespace", func(t *testing.T) {
 		options := newStatOptions()
 		options.toNamespace = "bar"


### PR DESCRIPTION
This PR adds a check that ensures that `--namespace` and `--all-namespaces` options are conflicting when using `stat`

Fixes #3714

Signed-off-by: zaharidichev <zaharidichev@gmail.com>
