### PR TITLE
Add validation to ensure stat time window is at least 15s

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -169,7 +169,7 @@ If no resource name is specified, displays stats about all resources of the spec
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the specified resource")
-	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\")")
+	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\"). Needs to be more than 10 seconds.")
 	cmd.PersistentFlags().StringVar(&options.toResource, "to", options.toResource, "If present, restricts outbound stats to the specified resource name")
 	cmd.PersistentFlags().StringVar(&options.toNamespace, "to-namespace", options.toNamespace, "Sets the namespace used to lookup the \"--to\" resource; by default the current \"--namespace\" is used")
 	cmd.PersistentFlags().StringVar(&options.fromResource, "from", options.fromResource, "If present, restricts outbound stats from the specified resource name")

--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -169,7 +169,7 @@ If no resource name is specified, displays stats about all resources of the spec
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the specified resource")
-	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\"). Needs to be more than 10 seconds.")
+	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"15s\", \"1m\", \"10m\", \"1h\"). Needs to be at least 15s.")
 	cmd.PersistentFlags().StringVar(&options.toResource, "to", options.toResource, "If present, restricts outbound stats to the specified resource name")
 	cmd.PersistentFlags().StringVar(&options.toNamespace, "to-namespace", options.toNamespace, "Sets the namespace used to lookup the \"--to\" resource; by default the current \"--namespace\" is used")
 	cmd.PersistentFlags().StringVar(&options.fromResource, "from", options.fromResource, "If present, restricts outbound stats from the specified resource name")

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -178,6 +178,18 @@ func TestStat(t *testing.T) {
 			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
 		}
 	})
+
+	t.Run("Returns an error if --time-window is not more than 10s", func(t *testing.T) {
+		options := newStatOptions()
+		options.timeWindow = "10s"
+		args := []string{"ns/bar"}
+		expectedError := "metrics time window needs to be > 10s"
+
+		_, err := buildStatSummaryRequests(args, options)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error [%s] instead got [%s]", expectedError, err)
+		}
+	})
 }
 
 func testStatCall(exp paramsExp, resourceType string, t *testing.T) {

--- a/cli/cmd/stat_test.go
+++ b/cli/cmd/stat_test.go
@@ -179,11 +179,11 @@ func TestStat(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns an error if --time-window is not more than 10s", func(t *testing.T) {
+	t.Run("Returns an error if --time-window is not more than 15s", func(t *testing.T) {
 		options := newStatOptions()
 		options.timeWindow = "10s"
 		args := []string{"ns/bar"}
-		expectedError := "metrics time window needs to be > 10s"
+		expectedError := "metrics time window needs to be at least 15s"
 
 		_, err := buildStatSummaryRequests(args, options)
 		if err == nil || err.Error() != expectedError {

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	defaultMetricTimeWindow    = "1m"
-	metricTimeWindowLowerBound = time.Second * 10 //the window value needs to be larger than that
+	metricTimeWindowLowerBound = time.Second * 15 //the window value needs to equal or larger than that
 
 	// ValidTargets specifies resource types allowed as a target:
 	// target resource on an inbound query
@@ -151,8 +151,8 @@ func BuildStatSummaryRequest(p StatsSummaryRequestParams) (*pb.StatSummaryReques
 			return nil, err
 		}
 
-		if w <= metricTimeWindowLowerBound {
-			return nil, errors.New("metrics time window needs to be > 10s")
+		if w < metricTimeWindowLowerBound {
+			return nil, errors.New("metrics time window needs to be at least 15s")
 		}
 
 		window = p.TimeWindow

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -21,7 +21,8 @@ import (
 */
 
 var (
-	defaultMetricTimeWindow = "1m"
+	defaultMetricTimeWindow    = "1m"
+	metricTimeWindowLowerBound = time.Second * 10 //the window value needs to be larger than that
 
 	// ValidTargets specifies resource types allowed as a target:
 	// target resource on an inbound query
@@ -145,10 +146,15 @@ func GRPCError(err error) error {
 func BuildStatSummaryRequest(p StatsSummaryRequestParams) (*pb.StatSummaryRequest, error) {
 	window := defaultMetricTimeWindow
 	if p.TimeWindow != "" {
-		_, err := time.ParseDuration(p.TimeWindow)
+		w, err := time.ParseDuration(p.TimeWindow)
 		if err != nil {
 			return nil, err
 		}
+
+		if w <= metricTimeWindowLowerBound {
+			return nil, errors.New("metrics time window needs to be > 10s")
+		}
+
 		window = p.TimeWindow
 	}
 


### PR DESCRIPTION
This pr adds a check ensuring that the time window of stat is at least 15s

Fixes #3715

Signed-off-by: zaharidichev <zaharidichev@gmail.com>
