### PR TITLE
Removed 'no invalid service profiles' from linkerd check test fixtures

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -409,6 +409,7 @@ jobs:
         )
 
   kind_cleanup:
+    if: always()
     strategy:
       fail-fast: false # always attempt to cleanup all clusters
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -409,7 +409,6 @@ jobs:
         )
 
   kind_cleanup:
-    if: always()
     strategy:
       fail-fast: false # always attempt to cleanup all clusters
       matrix:

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -120,7 +120,8 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	} {
 		tt := tt // pin
 		t.Run("linkerd "+strings.Join(tt.args, " "), func(t *testing.T) {
-			err := TestHelper.RetryFor(20*time.Second, func() error {
+			// TODO: move this back to 20s once #3595 lands
+			err := TestHelper.RetryFor(40*time.Second, func() error {
 				// Use a short time window so that transient errors at startup
 				// fall out of the window.
 				tt.args = append(tt.args, "-t", "30s")

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -35,7 +35,6 @@ linkerd-api
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
-√ no invalid service profiles
 
 linkerd-version
 ---------------

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -35,7 +35,6 @@ linkerd-api
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
 √ [prometheus] control plane can talk to Prometheus
-√ no invalid service profiles
 
 linkerd-version
 ---------------


### PR DESCRIPTION
Followup to #3718