### PR TITLE
Classify some gRPC status codes as non-errors

### DIFF
--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -21,6 +21,7 @@ import (
 	termbox "github.com/nsf/termbox-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
 )
 
 type topOptions struct {
@@ -534,7 +535,16 @@ func newRow(req topRequest) (tableRow, error) {
 	if success {
 		switch eos := req.rspEnd.GetEos().GetEnd().(type) {
 		case *pb.Eos_GrpcStatusCode:
-			success = eos.GrpcStatusCode == 0
+			switch codes.Code(eos.GrpcStatusCode) {
+			case codes.Unknown,
+				codes.DeadlineExceeded,
+				codes.Internal,
+				codes.Unavailable,
+				codes.DataLoss:
+				success = false
+			default:
+				success = true
+			}
 
 		case *pb.Eos_ResetErrorCode:
 			success = false

--- a/web/app/js/components/TopModule.jsx
+++ b/web/app/js/components/TopModule.jsx
@@ -9,6 +9,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _each from 'lodash/each';
 import _get from 'lodash/get';
 import _has from 'lodash/has';
+import _includes from 'lodash/includes';
 import _isEmpty from 'lodash/isEmpty';
 import _isEqual from 'lodash/isEqual';
 import _isNil from 'lodash/isNil';
@@ -18,6 +19,9 @@ import _take from 'lodash/take';
 import _throttle from 'lodash/throttle';
 import _values from 'lodash/values';
 import { withContext } from './util/AppContext.jsx';
+
+// https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+const grpcErrorStatusCodes = [2, 4, 13, 14, 15];
 
 class TopModule extends React.Component {
   static propTypes = {
@@ -306,7 +310,7 @@ class TopModule extends React.Component {
     if (success) {
       let grpcStatusCode = _get(d, "responseEnd.http.responseEnd.eos.grpcStatusCode");
       if (!_isNil(grpcStatusCode)) {
-        success = grpcStatusCode === 0;
+        success = !_includes(grpcErrorStatusCodes, grpcStatusCode);
       } else if (!_isNil(_get(d, "responseEnd.http.responseEnd.eos.resetErrorCode"))) {
         success = false;
       }


### PR DESCRIPTION
Linkerd classifies all gRPC status codes except `OK` as errors. This can negatively affect a gRPC server's success rate, even when it is only returning things like `NOT_FOUND` or `INVALID_ARGUMENT`.

This change narrows down the list of gRPC status codes that are considered an error to:

* UNKNOWN (2)
* DEADLINE_EXCEEDED (4)
* INTERNAL (13)
* UNAVAILABLE (14)
* DATA_LOSS (15)

Please see [this linkerd2 issue](https://github.com/linkerd/linkerd2/issues/3729) for more details.

This PR depends on https://github.com/linkerd/linkerd2-proxy/pull/395.

Closes #3729 

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>

