### PR TITLE
Fix issue with EdgesTable Grid wrapper

### DIFF
--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -380,15 +380,11 @@ export class ResourceDetailBase extends React.Component {
           isTcpTable={true}
           metrics={this.state.podMetrics} />
 
-        <Grid container direction="column" justify="center">
-          <Grid item>
-            <EdgesTable
-              api={this.api}
-              namespace={this.state.resource.namespace}
-              type={this.state.resource.type}
-              edges={edges} />
-          </Grid>
-        </Grid>
+        <EdgesTable
+          api={this.api}
+          namespace={this.state.resource.namespace}
+          type={this.state.resource.type}
+          edges={edges} />
 
       </div>
     );


### PR DESCRIPTION
Remove `Grid` wrapper around `EdgesTable` component in resource detail page.

  Fixes #3601

![image](https://user-images.githubusercontent.com/1440981/69135874-29d15180-0aba-11ea-9022-2f681456073b.png)


Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
