### PR TITLE
edge-19.11.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,8 @@
   * Fixed a bug causing the `Run Linkerd Check` button to be incorrectly
     positioned after being clicked
 * Internal
-  * Fixed an issue causing some control plane components to continue
-    using old certificates 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+    old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
     

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## edge-19.11.3
+
+* CLI
+  * Added a check that ensures using `--namespace` and `--all-namespaces`
+    results in an error as they are mutually exclusive
+* Web UI
+  * Fixed a bug causing the `Run Linkerd Check` button to be incorrectly
+    positioned after being clicked
+* Internal
+  * Fixed an issue causing some control plane components to continue
+    using old certificates 
+  * Fixed incomplete Swagger definition of the tap api, causing benign
+    error logging in the kube-apiserver
+    
 ## edge-19.11.2
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,6 @@
 * CLI
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
-* Web UI
-  * Fixed a bug causing the `Run Linkerd Check` button to be incorrectly
-    positioned after being clicked
 * Internal
   * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
     old certificates after `helm upgrade` due to not being restarted

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.11.2
+LinkerdVersion: &linkerd_version edge-19.11.3
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.11.3

* CLI
  * Added a check that ensures using `--namespace` and `--all-namespaces`
    results in an error as they are mutually exclusive
* Web UI
  * Fixed a bug causing the `Run Linkerd Check` button to be incorrectly
    positioned after being clicked
* Internal
  * Fixed an issue causing some control plane components to continue
    using old certificates 
  * Fixed incomplete Swagger definition of the tap api, causing benign
    error logging in the kube-apiserver
    


Signed-off-by: zaharidichev <zaharidichev@gmail.com>
