### PR TITLE
Dynamically get certificates from cert-manager

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -5,7 +5,12 @@
   "version": "{{.LinkerdVersion}}",
   "identityContext":{
     "trustDomain": "{{.Identity.TrustDomain}}",
+{{if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/cert-manager") -}}
+    "trustAnchorsPem": "REPLACE_ME",
+{{- end}}
+{{if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/tls") -}}
     "trustAnchorsPem": "{{required "Please provide the identity trust anchors" .Identity.TrustAnchorsPEM | trim | replace "\n" "\\n"}}",
+{{- end}}
     "issuanceLifeTime": "{{.Identity.Issuer.IssuanceLifeTime}}",
     "clockSkewAllowance": "{{.Identity.Issuer.ClockSkewAllowance}}",
     "scheme": "{{.Identity.Issuer.Scheme}}"

--- a/charts/linkerd2/templates/grafana.yaml
+++ b/charts/linkerd2/templates/grafana.yaml
@@ -26,7 +26,7 @@ data:
 
     [auth.anonymous]
     enabled = true
-    org_role = Editor
+    org_role = {{ .GrafanaUserRole | default "Editor" }}
 
     [auth.basic]
     enabled = false

--- a/charts/linkerd2/templates/hook-post-delete-remove-certs.yaml
+++ b/charts/linkerd2/templates/hook-post-delete-remove-certs.yaml
@@ -1,0 +1,130 @@
+{{ with .Values -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: linkerd-janitor
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: linkerd-janitor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - linkerd-config
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - linkerd-identity-issuer
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - {{ .Namespace }}
+  verbs:
+  - delete
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - issuers
+  resourceNames:
+  - linkerd-selfsigning-issuer
+  verbs:
+  - delete
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  resourceNames:
+  - linkerd-identity-issuer
+  verbs:
+  - delete
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - linkerd-{{ .Namespace }}-control-plane
+  verbs:
+  - use
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkerd-janitor
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: linkerd-janitor
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: linkerd-janitor
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: linkerd-janitor
+subjects:
+  - kind: ServiceAccount
+    name: linkerd-janitor
+    namespace: {{ .Namespace }}
+roleRef:
+  kind: Role
+  name: linkerd-janitor
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: linkerd-janitor
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: linkerd-janitor
+spec:
+  template:
+    spec:
+      serviceAccountName: linkerd-janitor
+      containers:
+      - name: janitor
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        command:
+        - /bin/sh
+        - -e
+        - -c
+        - >-
+          kubectl -n linkerd delete configmap linkerd-config;
+{{- if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/cert-manager") }}
+          kubectl -n linkerd delete issuer linkerd-selfsigning-issuer;
+          kubectl -n linkerd delete certificate linkerd-identity-issuer;
+          kubectl -n linkerd delete secret linkerd-identity-issuer;
+{{- end }}
+{{- if (.InstallNamespace) }}
+          kubectl delete ns {{ .Namespace }};
+{{- end }}
+      restartPolicy: Never
+  backoffLimit: 6
+{{- end -}}

--- a/charts/linkerd2/templates/hook-pre-install-identity-certs.yaml
+++ b/charts/linkerd2/templates/hook-pre-install-identity-certs.yaml
@@ -1,0 +1,41 @@
+{{with .Values -}}
+{{if .Identity -}}
+{{if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/cert-manager") -}}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: linkerd-selfsigning-issuer
+  namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+  annotations:
+    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+spec:
+  selfSigned: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: linkerd-identity-issuer
+  namespace: {{.Namespace}}
+  labels:
+    {{.ControllerComponentLabel}}: identity
+    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+  annotations:
+    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+spec:
+  secretName: linkerd-identity-issuer
+  commonName: identity.linkerd.{{.ClusterDomain}}
+  isCA: true
+  keyAlgorithm: ecdsa
+  issuerRef:
+    name: linkerd-selfsigning-issuer
+{{- end}}
+{{- end}}
+{{- end}}

--- a/charts/linkerd2/templates/hook-pre-install-linkerd-config.yaml
+++ b/charts/linkerd2/templates/hook-pre-install-linkerd-config.yaml
@@ -10,6 +10,8 @@ metadata:
     {{.ControllerNamespaceLabel}}: {{.Namespace}}
   annotations:
     {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-4"
 data:
   global: |
   {{- if .Configs -}}

--- a/charts/linkerd2/templates/hook-pre-install-namespace.yaml
+++ b/charts/linkerd2/templates/hook-pre-install-namespace.yaml
@@ -11,6 +11,8 @@ metadata:
   name: {{ .Namespace }}
   annotations:
     {{.ProxyInjectAnnotation}}: {{.ProxyInjectDisabled}}
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-10"
   labels:
     {{.LinkerdNamespaceLabel}}: "true"
     config.linkerd.io/admission-webhooks: disabled

--- a/charts/linkerd2/templates/hook-pre-install-update-config-with-cert-job.yaml
+++ b/charts/linkerd2/templates/hook-pre-install-update-config-with-cert-job.yaml
@@ -1,0 +1,123 @@
+{{with .Values -}}
+{{if .Identity -}}
+{{if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/cert-manager") -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: global-config-creator
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: global-config-creator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - linkerd-config
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - linkerd-identity-issuer
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - linkerd-{{ .Namespace }}-control-plane
+  verbs:
+  - "use"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: global-config-creator
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  namespace: {{ .Namespace }}
+  labels:
+    app: global-config-creator
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: global-config-creator
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: global-config-creator
+subjects:
+  - kind: ServiceAccount
+    name: global-config-creator
+    namespace: {{ .Namespace }}
+roleRef:
+  kind: Role
+  name: global-config-creator
+  namespace: {{ .Namespace }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: global-config-creator
+  namespace: {{ .Namespace }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  labels:
+    app: global-config-creator
+spec:
+  template:
+    spec:
+      serviceAccountName: global-config-creator
+      containers:
+      - name: global-config-creator
+        image: "quay.io/giantswarm/docker-kubectl:latest"
+        command:
+        - /bin/sh
+        - -e
+        - -x
+        - -c
+        - >-
+          while true; do 
+              export CERT=`kubectl -n linkerd get secret linkerd-identity-issuer -o jsonpath="{.data['ca\.crt']}" | base64 -d`;
+              if [ $? -eq 0 ] && [ ! -z "$CERT" ]; then 
+                  break; 
+              fi; 
+              echo \"waiting for cert\"; 
+              sleep 1; 
+          done; 
+          while true; do 
+              kubectl -n linkerd get cm linkerd-config -o yaml --export > /tmp/config.yaml; 
+              if [ $? -eq 0 ]; then 
+                  break; 
+              fi; 
+              echo "waiting for config"; 
+              sleep 1; 
+          done; 
+          awk -v CERT="$CERT" 'BEGIN{gsub("\n", "\\n", CERT)}; {gsub("REPLACE_ME", CERT);print $0}' /tmp/config.yaml > /tmp/config-out.yaml;
+          kubectl -n linkerd replace configmap linkerd-config -f /tmp/config-out.yaml;
+      restartPolicy: Never
+  backoffLimit: 6
+{{- end}}
+{{- end}}
+{{- end}}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -51,6 +51,7 @@ Identity:
 
 # grafana configuration
 GrafanaImage: gcr.io/linkerd-io/grafana
+GrafanaUserRole: Editor
 
 # heartbeat configuration
 DisableHeartBeat: false

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -39,8 +39,16 @@ env:
 - name: LINKERD2_PROXY_IDENTITY_DIR
   value: /var/run/linkerd/identity/end-entity
 - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+{{- if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/cert-manager") }}
+  valueFrom:
+    secretKeyRef:
+      name: linkerd-identity-issuer
+      key: ca.crt
+{{- end}}
+{{- if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/tls") }}
   value: |
   {{- required "Please provide the identity trust anchors" .Identity.TrustAnchorsPEM | trim | nindent 4 }}
+{{- end}}
 - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
   value: /var/run/secrets/kubernetes.io/serviceaccount/token
 - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR


### PR DESCRIPTION
Currently, a manual process is required when installing with Helm to get the certificates from `cert-manager`. This is sub-optimal, as `cert-managers`'s task is to provide certificates for applications automatically.

This PR changes Helm's templates and hooks to first request certificates from `cert-manager`, then embed them in linkerd's configs without any interaction from the user. 

*Note:* requires `cert-manager` to be already installed in the cluster.