### PR TITLE
Remove confusing edge version from Chart.yaml

### DIFF
--- a/charts/linkerd2/Chart.yaml
+++ b/charts/linkerd2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 # this version will be updated by the CI before publishing the Helm tarball
-appVersion: edge-19.9.2
+appVersion: edge-XX.X.X
 description: Linkerd gives you observability, reliability, and security for your microservices — with no code change required.
 home: https://linkerd.io
 keywords:


### PR DESCRIPTION
Chart.yaml includes an appVersion field which is overwritten by CI when a helm tarball is published.  Therefore, the value of this field is irrelevant.  It can be confusing that it appears that the field contains a valid, out-of-date edge version.

This change makes it more obvious that the field should not be considered to be a valid and current edge version.

Signed-off-by: Alex Leong <alex@buoyant.io>
