### PR TITLE
[POC] Service mirror

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -117,6 +117,8 @@ func init() {
 	RootCmd.AddCommand(newCmdUninject())
 	RootCmd.AddCommand(newCmdUpgrade())
 	RootCmd.AddCommand(newCmdVersion())
+	RootCmd.AddCommand(newCmdInstallServiceMirror())
+
 }
 
 type statOptionsBase struct {

--- a/cli/cmd/service-mirror.go
+++ b/cli/cmd/service-mirror.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"text/template"
+
+	"github.com/linkerd/linkerd2/cli/install"
+	"github.com/linkerd/linkerd2/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+type installServiceMirrorOptions struct {
+	Namespace string
+	LinkerdVersion string
+}
+
+func newServiceMirrorOptions() *installServiceMirrorOptions {
+	return &installServiceMirrorOptions{
+		Namespace: "srv-mirror",
+		LinkerdVersion:  version.Version,
+	}
+}
+
+func newCmdInstallServiceMirror() *cobra.Command {
+	options := newServiceMirrorOptions()
+
+	cmd := &cobra.Command{
+		Use:   "install-service-mirror [flags]",
+		Short: "Output Kubernetes configs to install Linkerd Service Mirror",
+		Long:  "Output Kubernetes configs to install Linkerd Service Mirror",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return renderServiceMirror(os.Stdout, options)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.LinkerdVersion, "linkerd-version", "v", options.LinkerdVersion, "Version")
+	cmd.PersistentFlags().StringVarP(&options.Namespace, "namespace", "n", options.Namespace, "Namespace")
+	return cmd
+}
+
+
+func renderServiceMirror(w io.Writer, config *installServiceMirrorOptions) error {
+	template, err := template.New("linkerd-service-mirror").Parse(install.ServiceMirrorTemplate)
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	err = template.Execute(buf, config)
+	if err != nil {
+		return err
+	}
+
+	w.Write(buf.Bytes())
+	w.Write([]byte("---\n"))
+
+	return nil
+}

--- a/cli/install/service-mirror-template.go
+++ b/cli/install/service-mirror-template.go
@@ -1,0 +1,96 @@
+package install
+
+
+const (
+	// CNITemplate provides the base template for the `linkerd install-cni-plugin` command.
+	ServiceMirrorTemplate = `### Namespace ###
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{.Namespace}}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Namespace}}-service-mirror
+  labels:
+    ControllerComponentLabel: service-mirror
+    ControllerNamespaceLabel: {{.Namespace}}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "endpoints", "services", "secrets", "namespaces"]
+  verbs: ["list", "get", "watch", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Namespace}}-service-mirror
+  labels:
+    ControllerComponentLabel: service-mirror
+    ControllerNamespaceLabel: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-{{.Namespace}}-service-mirror
+subjects:
+- kind: ServiceAccount
+  name: linkerd-service-mirror
+  namespace: {{.Namespace}}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-service-mirror
+  namespace: {{.Namespace}}
+  labels:
+    ControllerComponentLabel: service-mirror
+    ControllerNamespaceLabel: {{.Namespace}}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: linkerd-service-mirror
+  namespace: {{.Namespace}}
+spec:
+  type: ClusterIP
+  selector:
+    ControllerComponentLabel: service-mirror
+  ports:
+  - name: grpc
+    port: 8086
+    targetPort: 8086
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ControllerComponentLabel: service-mirror
+  name: linkerd-service-mirror
+  namespace: {{.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ControllerComponentLabel: service-mirror
+      ControllerNamespaceLabel: {{.Namespace}}
+  template:
+    metadata:
+      labels:
+        ControllerComponentLabel: service-mirror
+        ControllerNamespaceLabel: {{.Namespace}}
+    spec:
+      containers:
+      - args:
+        - service-mirror
+        image: gcr.io/linkerd-io/controller:{{.LinkerdVersion}}
+        name: service-mirror
+        ports:
+        - containerPort: 8086
+          name: grpc
+        - containerPort: 9996
+          name: admin-http
+        securityContext:
+          runAsUser: 2103
+      serviceAccountName: linkerd-service-mirror
+`
+)

--- a/controller/cmd/main.go
+++ b/controller/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	servicemirror "github.com/linkerd/linkerd2/controller/cmd/service-mirror"
 	"os"
 
 	"github.com/linkerd/linkerd2/controller/cmd/destination"
@@ -34,6 +35,8 @@ func main() {
 		spvalidator.Main(os.Args[2:])
 	case "tap":
 		tap.Main(os.Args[2:])
+	case "service-mirror":
+		servicemirror.Main(os.Args[2:])
 	default:
 		fmt.Printf("unknown subcommand: %s", os.Args[1])
 		os.Exit(1)

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -1,0 +1,241 @@
+package servicemirror
+
+import (
+	"flag"
+	"fmt"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/linkerd/linkerd2/pkg/flags"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const (
+	mirrorSecretType = "mirror.linkerd.io/kubeconfig"
+	mirrorServiceLabel = "linkerd.io/mirror-service"
+	configKeyName = "config"
+)
+
+type RemoteClusterGatewayService  struct {
+	name string
+	namespace string
+	gatewayAddress string
+	gatewayPort string
+}
+
+type RemoteClusterServiceWatcher struct {
+	clusterName string
+	apiClient *k8s.API
+	localApiClient *k8s.API
+	gatewayService *RemoteClusterGatewayService
+}
+
+func NewRemoteClusterServiceWatcher(localApi *k8s.API, cfg *rest.Config, clusterName string) (*RemoteClusterServiceWatcher, error) {
+	remoteApi, err := k8s.InitializeAPIForConfig(cfg, k8s.Svc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize remote api for cluster %s: %s", clusterName, err)
+	}
+	remoteApi.Sync()
+	return &RemoteClusterServiceWatcher{ clusterName: clusterName,localApiClient:localApi, apiClient:remoteApi}, nil
+}
+
+
+func (sw *RemoteClusterServiceWatcher) mirrorRemoteService(obj interface{}) {
+	// we need to create a service and an endpoint
+	svc := obj.(*corev1.Service)
+
+	lbls := map[string]string{mirrorServiceLabel: "true"}
+
+	_, err := sw.localApiClient.Client.CoreV1().Namespaces().Get(svc.Namespace, metav1.GetOptions{})
+
+	if err != nil {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      lbls,
+				Name:        svc.Namespace,
+			},
+		}
+		_, err = sw.localApiClient.Client.CoreV1().Namespaces().Create(ns)
+
+		if err != nil {
+			log.Errorf("could not create mirror namespace: %s", err)
+		}
+	}
+
+
+
+	serviceToCreate := &corev1.Service {
+		ObjectMeta: metav1.ObjectMeta {
+			Name: svc.Name,
+			Namespace: svc.Namespace,
+			Labels: lbls,
+		},
+		Spec:       corev1.ServiceSpec {
+			Ports:                    []corev1.ServicePort {{
+				Protocol:   corev1.ProtocolTCP,
+				Port:       80,
+				TargetPort: intstr.IntOrString{IntVal: 30080},
+			}},
+
+		},
+	}
+
+	s, err := sw.localApiClient.Client.CoreV1().Services(svc.Namespace).Create(serviceToCreate)
+	if err != nil {
+		log.Errorf("could not create mirror service: %s", err)
+	} else {
+		log.Infof("Created mirror service %s", s.Name)
+	}
+
+
+	// now we need to create an endpoint....
+
+		endpoints := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+			},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							IP: sw.gatewayService.gatewayAddress,
+						},
+					},
+					Ports: []corev1.EndpointPort{{
+						Port:     30080,
+					}},
+				},
+			},
+		}
+
+		endp, err := sw.localApiClient.Client.CoreV1().Endpoints(svc.Namespace).Create(endpoints)
+		if err != nil {
+			log.Errorf("could not create mirror service: %s", err)
+		} else {
+			log.Infof("Created mirror service %s", endp.Name)
+		}
+
+}
+
+
+
+func (sw *RemoteClusterServiceWatcher) Initialize() error {
+
+	// 1.We find the nginx ingress load balancer, in the case of docker for mac, the NodePort
+	gatewaySelector, _ := 	labels.Parse("component=controller")
+
+	gatewayServices, err := sw.apiClient.Svc().Lister().List(gatewaySelector)
+	if err != nil {
+		return fmt.Errorf("cannot obtain gateway services: %s", err)
+	}
+
+
+	gatewayService := gatewayServices[0]
+
+	if gatewayService.Spec.Type != corev1.ServiceTypeNodePort {
+		return fmt.Errorf("identity gateway service needs to be of type %s ", corev1.ServiceTypeNodePort)
+	}
+
+	// hacky as hell due to kind not supporting loadbalancers...
+	endpoints, err := net.LookupHost("docker.for.mac.host.internal")
+	if err != nil {
+		return err
+	}
+
+	sw.gatewayService = &RemoteClusterGatewayService{
+		gatewayService.Name,
+		gatewayService.Namespace,
+		endpoints[0],
+		"30080",
+	}
+
+	sw.apiClient.Svc().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    sw.mirrorRemoteService,
+			DeleteFunc: func(_ interface{}) {},
+			UpdateFunc: func(_, obj interface{}) {},
+		}, )
+
+	return nil
+}
+
+type RemoteClusterConfigWatcher struct {
+	k8sAPI *k8s.API
+}
+
+func NewRemoteClusterConfigWatcher(k8sAPI *k8s.API) *RemoteClusterConfigWatcher {
+	rcw := &RemoteClusterConfigWatcher{
+		k8sAPI: k8sAPI,
+	}
+	k8sAPI.Secret().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    rcw.registerRemoteCluster,
+			DeleteFunc: func(_ interface{}) {},
+			UpdateFunc: func(_, obj interface{}) {},
+		},
+	)
+	return rcw
+}
+
+func (ew *RemoteClusterConfigWatcher) registerRemoteCluster(obj interface{}) {
+	secret := obj.(*corev1.Secret)
+
+	if secret.Type == mirrorSecretType {
+		if val, ok := secret.Data[configKeyName]; ok {
+			clientConfig, err := clientcmd.RESTConfigFromKubeConfig(val)
+			if err != nil {
+				log.Error(err)
+			}
+			if err != nil {
+				log.Fatal("Error parsing kube config: %s", err)
+			}
+
+			watcher, err := NewRemoteClusterServiceWatcher(ew.k8sAPI, clientConfig, "remote")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			err = watcher.Initialize()
+			if err != nil {
+				log.Fatal("Could not initialize %s ", err)
+			}
+			log.Infof("Registered remote cluster: %s", clientConfig.Host)
+
+		}
+	}
+}
+
+func Main(args []string) {
+	cmd := flag.NewFlagSet("service-mirror", flag.ExitOnError)
+
+	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
+
+	flags.ConfigureAndParse(cmd, args)
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	k8sAPI, err := k8s.InitializeAPI(
+		*kubeConfigPath,
+		k8s.SC,
+	)
+
+	if err != nil {
+		log.Fatalf("Failed to initialize K8s API: %s", err)
+	}
+
+	_ = NewRemoteClusterConfigWatcher(k8sAPI)
+	k8sAPI.Sync()
+	time.Sleep(100 * time.Hour) // wait forever... for now :)
+}

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/rest"
 	"strings"
 	"time"
 
@@ -55,6 +56,7 @@ const (
 	Svc
 	TS
 	Node
+	SC
 )
 
 // API provides shared informers for all Kubernetes objects
@@ -76,6 +78,7 @@ type API struct {
 	svc      coreinformers.ServiceInformer
 	ts       tsinformers.TrafficSplitInformer
 	node     coreinformers.NodeInformer
+	sc     coreinformers.SecretInformer
 
 	syncChecks        []cache.InformerSynced
 	sharedInformers   informers.SharedInformerFactory
@@ -83,15 +86,11 @@ type API struct {
 	tsSharedInformers ts.SharedInformerFactory
 }
 
-// InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
-func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
-	k8sClient, err := k8s.NewAPI(kubeConfig, "", "", 0)
-	if err != nil {
-		return nil, err
-	}
 
+
+func initApi(k8sClient *k8s.KubernetesAPI,kubeConfig *rest.Config, resources ...APIResource) (*API, error) {
 	// check for cluster-wide access
-	err = k8s.ClusterAccess(k8sClient)
+	err  := k8s.ClusterAccess(k8sClient)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +126,34 @@ func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
 		}
 	}
 	return NewAPI(k8sClient, spClient, tsClient, resources...), nil
+
 }
+
+// InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
+func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
+	config, err := k8s.GetConfig(kubeConfig, "")
+	if err != nil {
+		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
+	}
+
+	k8sClient, err := k8s.NewApiForConfig(config, "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return initApi(k8sClient, config, resources...)
+}
+
+// InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
+func InitializeAPIForConfig(kubeConfig *rest.Config, resources ...APIResource) (*API, error) {
+	k8sClient, err := k8s.NewApiForConfig(kubeConfig, "", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return initApi(k8sClient, kubeConfig, resources...)
+}
+
 
 // NewAPI takes a Kubernetes client and returns an initialized API.
 func NewAPI(
@@ -203,6 +229,9 @@ func NewAPI(
 		case Node:
 			api.node = sharedInformers.Core().V1().Nodes()
 			api.syncChecks = append(api.syncChecks, api.node.Informer().HasSynced)
+		case SC:
+			api.sc = sharedInformers.Core().V1().Secrets()
+			api.syncChecks = append(api.syncChecks, api.sc.Informer().HasSynced)
 		}
 	}
 
@@ -350,6 +379,14 @@ func (api *API) Node() coreinformers.NodeInformer {
 		panic("Node informer not configured")
 	}
 	return api.node
+}
+
+// Secret provides access to a shared informer and lister for Secrets.
+func (api *API) Secret() coreinformers.SecretInformer {
+	if api.sc == nil {
+		panic("Secret informer not configured")
+	}
+	return api.sc
 }
 
 // GetObjects returns a list of Kubernetes objects, given a namespace, type, and name.

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -39,6 +39,11 @@ func NewAPI(configPath, kubeContext string, impersonate string, timeout time.Dur
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
 	}
+	return NewApiForConfig(config, impersonate, timeout)
+}
+
+
+func NewApiForConfig(config *rest.Config, impersonate string, timeout time.Duration)  (*KubernetesAPI, error) {
 
 	// k8s' client-go doesn't support injecting context
 	// https://github.com/kubernetes/kubernetes/issues/46503


### PR DESCRIPTION
This is really broad strokes but it shows in principle how service mirroring might actually work. This is based on #3734 that @grampelberg put together. At the moment this does not handle a lot of the details such as namespaces, fine grained permissions, etc and is adapted to work only on mac with kind a handful of hacks (but all this can be easily fixed). So to set this all up you can follow these steps: 


### Setting the remote cluster

- Create a config patch for kind names conf_patch.yaml: 
```yaml
kind: Cluster
apiVersion: kind.sigs.k8s.io/v1alpha3
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 30080
    hostPort: 30080
kubeadmConfigPatches:
- |
  apiVersion: kubeadm.k8s.io/v1beta2
  kind: ClusterConfiguration
  metadata:
    name: config
  kubernetesVersion: v1.15.3
  clusterName: "remote"
  controlPlaneEndpoint: "172.17.0.2:6443"
  apiServer:
    certSANs: [localhost, "127.0.0.1", "docker.for.mac.localhost"]
```
- Create the remote cluster `kind create cluster --name=remote --config=./conf_patch.yaml`
- Set kubectl to work with the remote cluster `export KUBECONFIG="$(kind get kubeconfig-path --name="remote")"`
- Initialize helm: 
```sh
kubectl -n kube-system create serviceaccount tiller
kubectl create clusterrolebinding tiller \
  --clusterrole=cluster-admin \
  --serviceaccount=kube-system:tiller
helm init --service-account tiller
```
- Install nginx ingress: 
```sh
helm install  stable/nginx-ingress --set controller.service.type=NodePort --set controller.service.nodePorts.http=30080  --set controller.service.nodePorts.https=30443
```
- Deploy ingress controller + two services: 
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: backend-one
spec:
  replicas: 1
  selector:
    matchLabels:
      app: backend-one
  template:
    metadata:
      labels:
        app: backend-one
    spec:
      containers:
      - name: backend-one
        image: buoyantio/bb:v0.0.5
        args:
        - terminus
        - "--h1-server-port=80"
        - "--response-text=backend-one"
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: backend-one-svc
spec:
  selector:
    app: backend-one
  ports:
  - name: http
    port: 80
    targetPort: 80
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: ingress-backend-one-svc
  annotations:
    # use the shared ingress-nginx
    kubernetes.io/ingress.class: "nginx"
spec:
  rules:
  - host: backend-one-svc.default.svc.cluster.local
    http:
      paths:
      - path: /
        backend:
          serviceName: backend-one-svc
          servicePort: 80
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: backend-two
spec:
  replicas: 1
  selector:
    matchLabels:
      app: backend-two
  template:
    metadata:
      labels:
        app: backend-two
    spec:
      containers:
      - name: backend-two
        image: buoyantio/bb:v0.0.5
        args:
        - terminus
        - "--h1-server-port=80"
        - "--response-text=backend-two"
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: backend-two-svc
spec:
  selector:
    app: backend-two
  ports:
  - name: http
    port: 80
    targetPort: 80
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: ingress-backend-two-svc
  annotations:
    # use the shared ingress-nginx
    kubernetes.io/ingress.class: "nginx"
spec:
  rules:
  - host: backend-two-svc.default.svc.cluster.local
    http:
      paths:
      - path: /
        backend:
          serviceName: backend-two-svc
          servicePort: 80
---
```
- Get the kubeconfig file of the remote cluster: 
`cat $(kind get kubeconfig-path --name="remote")` 
- Replace the `server: https://127.0.0.1:some-port` with `server:  https://docker.for.mac.localhost:some-port`
- Save the file as as remote_conf.yaml
- Base64 encode the contents of the file: `cat ./remote_conf.yaml | base64`
- Create a new file `remote-secret.yaml`: 
```
apiVersion: v1
data:
  config: <the base64 encoded remote server config>
kind: Secret
metadata:
  name: remote-secret
  namespace: srv-mirror
type: mirror.linkerd.io/kubeconfig
```

### Local cluster

- Checkout this branch  and build the cli + the controller image
- Create a local cluster with: `kind create cluster --name=local`
- Upload the controller image to the local cluster
- Set `kubectl` to work with the local cluster: `export KUBECONFIG="$(kind get kubeconfig-path --name="local")"`
- Install the service mirror component with: `bin/linkerd install-service-mirror | kubectl apply -f -`
- Create the secret that contains the configuration for the remote cluster with: `kubectl apply -f remote-secret.yaml`
- The service mirror component will create mirror services.
- Execute `kubectl describe service  backend-two-svc`
- You chould see something like: 
```
Name:              backend-two-svc
Namespace:         default
Labels:            linkerd.io/mirror-service=true
Annotations:       <none>
Selector:          <none>
Type:              ClusterIP
IP:                10.96.189.49
Port:              <unset>  80/TCP
TargetPort:        30080/TCP
Endpoints:         192.168.65.2:30080
Session Affinity:  None
Even
```
- Now install a container to try out hitting the remote service: 
```sh
cat <<EOF | kubectl apply -f -
apiVersion: apps/v1beta1
kind: Deployment
metadata:
  name: blue
  namespace: default
spec:
  replicas: 1
  template:
    metadata:
      labels:
        name: blue
    spec:
      containers:
      - name: blue-website
        image: scrapinghub/httpbin:latest
        command:
        - sleep
        - "3600"
        resources:
          requests:
            cpu: 0.1
            memory: 200
EOF
```
- Get a shell to the container and execute: 
`curl http://backend-two-svc.default.svc.cluster.local`
- You should see something like: 
```json
{
  "requestUID": "in:http-sid:terminus-grpc:-1-h1:80-84655700",
  "payload": "backend-two"
}
```

Signed-off-by: zaharidichev <zaharidichev@gmail.com>