### PR TITLE
Updating usage of .Values to Helm-standard (#3744)

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -1,36 +1,36 @@
 {{- define "linkerd.configs.global" -}}
 {
-  "linkerdNamespace": "{{.Namespace}}",
+  "linkerdNamespace": "{{.Values.Namespace}}",
   "cniEnabled": false,
-  "version": "{{.LinkerdVersion}}",
+  "version": "{{.Values.LinkerdVersion}}",
   "identityContext":{
-    "trustDomain": "{{.Identity.TrustDomain}}",
-    "trustAnchorsPem": "{{required "Please provide the identity trust anchors" .Identity.TrustAnchorsPEM | trim | replace "\n" "\\n"}}",
-    "issuanceLifeTime": "{{.Identity.Issuer.IssuanceLifeTime}}",
-    "clockSkewAllowance": "{{.Identity.Issuer.ClockSkewAllowance}}",
-    "scheme": "{{.Identity.Issuer.Scheme}}"
+    "trustDomain": "{{.Values.Identity.TrustDomain}}",
+    "trustAnchorsPem": "{{required "Please provide the identity trust anchors" .Values.Identity.TrustAnchorsPEM | trim | replace "\n" "\\n"}}",
+    "issuanceLifeTime": "{{.Values.Identity.Issuer.IssuanceLifeTime}}",
+    "clockSkewAllowance": "{{.Values.Identity.Issuer.ClockSkewAllowance}}",
+    "scheme": "{{.Values.Identity.Issuer.Scheme}}"
   },
   "autoInjectContext": null,
-  "omitWebhookSideEffects": {{.OmitWebhookSideEffects}},
-  "clusterDomain": "{{.ClusterDomain}}"
+  "omitWebhookSideEffects": {{.Values.OmitWebhookSideEffects}},
+  "clusterDomain": "{{.Values.ClusterDomain}}"
 }
 {{- end -}}
 
 {{- define "linkerd.configs.proxy" -}}
 {
   "proxyImage":{
-    "imageName":"{{.Proxy.Image.Name}}",
-    "pullPolicy":"{{.Proxy.Image.PullPolicy}}"
+    "imageName":"{{.Values.Proxy.Image.Name}}",
+    "pullPolicy":"{{.Values.Proxy.Image.PullPolicy}}"
   },
   "proxyInitImage":{
-    "imageName":"{{.ProxyInit.Image.Name}}",
-    "pullPolicy":"{{.ProxyInit.Image.PullPolicy}}"
+    "imageName":"{{.Values.ProxyInit.Image.Name}}",
+    "pullPolicy":"{{.Values.ProxyInit.Image.PullPolicy}}"
   },
   "controlPort":{
-    "port": {{.Proxy.Ports.Control}}
+    "port": {{.Values.Proxy.Ports.Control}}
   },
   "ignoreInboundPorts":[
-    {{- $ports := splitList "," .ProxyInit.IgnoreInboundPorts -}}
+    {{- $ports := splitList "," .Values.ProxyInit.IgnoreInboundPorts -}}
     {{- if gt (len $ports) 1}}
     {{- $last := sub (len $ports) 1 -}}
     {{- range $i,$port := $ports -}}
@@ -39,7 +39,7 @@
     {{- end -}}
   ],
   "ignoreOutboundPorts":[
-    {{- $ports := splitList "," .ProxyInit.IgnoreOutboundPorts -}}
+    {{- $ports := splitList "," .Values.ProxyInit.IgnoreOutboundPorts -}}
     {{- if gt (len $ports) 1}}
     {{- $last := sub (len $ports) 1 -}}
     {{- range $i,$port := $ports -}}
@@ -48,33 +48,33 @@
     {{- end -}}
   ],
   "inboundPort":{
-    "port": {{.Proxy.Ports.Inbound}}
+    "port": {{.Values.Proxy.Ports.Inbound}}
   },
   "adminPort":{
-    "port": {{.Proxy.Ports.Admin}}
+    "port": {{.Values.Proxy.Ports.Admin}}
   },
   "outboundPort":{
-    "port": {{.Proxy.Ports.Outbound}}
+    "port": {{.Values.Proxy.Ports.Outbound}}
   },
   "resource":{
-    "requestCpu": "{{.Proxy.Resources.CPU.Request}}",
-    "limitCpu": "{{.Proxy.Resources.CPU.Limit}}",
-    "requestMemory": "{{.Proxy.Resources.Memory.Request}}",
-    "limitMemory": "{{.Proxy.Resources.Memory.Limit}}"
+    "requestCpu": "{{.Values.Proxy.Resources.CPU.Request}}",
+    "limitCpu": "{{.Values.Proxy.Resources.CPU.Limit}}",
+    "requestMemory": "{{.Values.Proxy.Resources.Memory.Request}}",
+    "limitMemory": "{{.Values.Proxy.Resources.Memory.Limit}}"
   },
-  "proxyUid": {{.Proxy.UID}},
+  "proxyUid": {{.Values.Proxy.UID}},
   "logLevel":{
-    "level": "{{.Proxy.LogLevel}}"
+    "level": "{{.Values.Proxy.LogLevel}}"
   },
-  "disableExternalProfiles": {{not .Proxy.EnableExternalProfiles}},
-  "proxyVersion": "{{.Proxy.Image.Version}}",
-  "proxyInitImageVersion": "{{.ProxyInit.Image.Version}}"
+  "disableExternalProfiles": {{not .Values.Proxy.EnableExternalProfiles}},
+  "proxyVersion": "{{.Values.Proxy.Image.Version}}",
+  "proxyInitImageVersion": "{{.Values.ProxyInit.Image.Version}}"
 }
 {{- end -}}
 
 {{- define "linkerd.configs.install" -}}
 {
-  "cliVersion":"{{ .LinkerdVersion }}",
+  "cliVersion":"{{ .Values.LinkerdVersion }}",
   "flags":[]
 }
 {{- end -}}

--- a/charts/linkerd2/templates/_nodeselector.tpl
+++ b/charts/linkerd2/templates/_nodeselector.tpl
@@ -1,4 +1,4 @@
 {{- define "linkerd.node-selector" -}}
 nodeSelector:
-{{- toYaml .NodeSelector | trim | nindent 2 }}
+{{- toYaml .Values.NodeSelector | trim | nindent 2 }}
 {{- end -}}

--- a/charts/linkerd2/templates/config.yaml
+++ b/charts/linkerd2/templates/config.yaml
@@ -1,38 +1,36 @@
-{{with .Values -}}
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 data:
   global: |
-  {{- if .Configs -}}
-  {{- if .Configs.Global -}}
-  {{.Configs.Global | nindent 4}}
+  {{- if .Values.Configs -}}
+  {{- if .Values.Configs.Global -}}
+  {{.Values.Configs.Global | nindent 4}}
   {{- end }}
   {{- else -}}
   {{- include "linkerd.configs.global" . | nindent 4}}
   {{- end }}
   proxy: |
-  {{- if .Configs -}}
-  {{- if .Configs.Proxy -}}
-  {{.Configs.Proxy | nindent 4}}
+  {{- if .Values.Configs -}}
+  {{- if .Values.Configs.Proxy -}}
+  {{.Values.Configs.Proxy | nindent 4}}
   {{- end }}
   {{- else -}}
   {{- include "linkerd.configs.proxy" . | nindent 4}}
   {{- end }}
   install: |
-  {{- if .Configs -}}
-  {{- if .Configs.Install -}}
-  {{.Configs.Install | nindent 4}}
+  {{- if .Values.Configs -}}
+  {{- if .Values.Configs.Install -}}
+  {{.Values.Configs.Install | nindent 4}}
   {{- end }}
   {{- else -}}
   {{- include "linkerd.configs.install" . | nindent 4}}
   {{- end }}
-{{- end }}

--- a/charts/linkerd2/templates/controller-rbac.yaml
+++ b/charts/linkerd2/templates/controller-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Controller RBAC
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-controller
+  name: linkerd-{{.Values.Namespace}}-controller
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -31,25 +30,24 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-controller
+  name: linkerd-{{.Values.Namespace}}-controller
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-controller
+  name: linkerd-{{.Values.Namespace}}-controller
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-controller
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{ end -}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Controller
@@ -8,66 +7,66 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-controller-api
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: controller
+    {{.Values.ControllerComponentLabel}}: controller
   ports:
   - name: http
     port: 8085
     targetPort: 8085
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-controller" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-controller" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: controller
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: controller
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-controller
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: controller
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: controller
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: controller
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: controller
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "controller" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "controller" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - public-api
-        - -prometheus-url=http://linkerd-prometheus.{{.Namespace}}.svc.{{.ClusterDomain}}:9090
-        - -destination-addr=linkerd-dst.{{.Namespace}}.svc.{{.ClusterDomain}}:8086
-        - -controller-namespace={{.Namespace}}
-        - -log-level={{.ControllerLogLevel}}
+        - -prometheus-url=http://linkerd-prometheus.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:9090
+        - -destination-addr=linkerd-dst.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:8086
+        - -controller-namespace={{.Values.Namespace}}
+        - -log-level={{.Values.ControllerLogLevel}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -84,16 +83,16 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        {{- if .PublicAPIResources -}}
-        {{- include "partials.resources" .PublicAPIResources | nindent 8 }}
+        {{- if .Values.PublicAPIResources -}}
+        {{- include "partials.resources" .Values.PublicAPIResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -103,4 +102,3 @@ spec:
           name: linkerd-config
         name: config
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{ end -}}

--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Destination Controller Service
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-destination
+  name: linkerd-{{.Values.Namespace}}-destination
   labels:
-    {{.ControllerComponentLabel}}: destination
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: destination
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
@@ -28,25 +27,24 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-destination
+  name: linkerd-{{.Values.Namespace}}-destination
   labels:
-    {{.ControllerComponentLabel}}: destination
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: destination
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-destination
+  name: linkerd-{{.Values.Namespace}}-destination
 subjects:
 - kind: ServiceAccount
   name: linkerd-destination
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: destination
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{ end -}}
+    {{.Values.ControllerComponentLabel}}: destination
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Destination Controller Service
@@ -8,66 +7,66 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: destination
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: destination
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: destination
+    {{.Values.ControllerComponentLabel}}: destination
   ports:
   - name: grpc
     port: 8086
     targetPort: 8086
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-destination" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-destination" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: destination
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: destination
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-destination
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: destination
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: destination
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: destination
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: destination
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "destination" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "destination" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - destination
         - -addr=:8086
-        - -controller-namespace={{.Namespace}}
-        - -enable-h2-upgrade={{.EnableH2Upgrade}}
-        - -log-level={{.ControllerLogLevel}}
+        - -controller-namespace={{.Values.Namespace}}
+        - -enable-h2-upgrade={{.Values.EnableH2Upgrade}}
+        - -log-level={{.Values.ControllerLogLevel}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -84,16 +83,16 @@ spec:
           httpGet:
             path: /ready
             port: 9996
-        {{- if .DestinationResources -}}
-        {{- include "partials.resources" .DestinationResources | nindent 8 }}
+        {{- if .Values.DestinationResources -}}
+        {{- include "partials.resources" .Values.DestinationResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -103,4 +102,3 @@ spec:
           name: linkerd-config
         name: config
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{ end -}}

--- a/charts/linkerd2/templates/grafana-rbac.yaml
+++ b/charts/linkerd2/templates/grafana-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Grafana RBAC
@@ -8,8 +7,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-grafana
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: grafana
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{- end }}
+    {{.Values.ControllerComponentLabel}}: grafana
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/grafana.yaml
+++ b/charts/linkerd2/templates/grafana.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Grafana
@@ -8,12 +7,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-grafana-config
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: grafana
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: grafana
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 data:
   grafana.ini: |-
     instance_name = linkerd-grafana
@@ -44,7 +43,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://linkerd-prometheus.{{.Namespace}}.svc.{{.ClusterDomain}}:9090
+      url: http://linkerd-prometheus.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -68,58 +67,58 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-grafana
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: grafana
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: grafana
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: grafana
+    {{.Values.ControllerComponentLabel}}: grafana
   ports:
   - name: http
     port: 3000
     targetPort: 3000
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-grafana" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-grafana" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: grafana
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: grafana
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-grafana
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: grafana
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: grafana
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: grafana
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: grafana
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
       - env:
         - name: GF_PATHS_DATA
           value: /data
-        image: {{.GrafanaImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.GrafanaImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /api/health
@@ -133,8 +132,8 @@ spec:
           httpGet:
             path: /api/health
             port: 3000
-        {{- if .GrafanaResources -}}
-        {{- include "partials.resources" .GrafanaResources | nindent 8 }}
+        {{- if .Values.GrafanaResources -}}
+        {{- include "partials.resources" .Values.GrafanaResources | nindent 8 }}
         {{- end }}
         securityContext:
           runAsUser: 472
@@ -145,7 +144,7 @@ spec:
           name: grafana-config
           readOnly: true
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -164,4 +163,3 @@ spec:
           name: linkerd-grafana-config
         name: grafana-config
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{end -}}

--- a/charts/linkerd2/templates/heartbeat-rbac.yaml
+++ b/charts/linkerd2/templates/heartbeat-rbac.yaml
@@ -1,5 +1,4 @@
-{{ with .Values -}}
-{{ if not .DisableHeartBeat -}}
+{{ if not .Values.DisableHeartBeat -}}
 ---
 ###
 ### Heartbeat RBAC
@@ -9,9 +8,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -22,9 +21,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   kind: Role
   name: linkerd-heartbeat
@@ -32,15 +31,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: heartbeat
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{- end }}
+    {{.Values.ControllerComponentLabel}}: heartbeat
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 {{- end }}

--- a/charts/linkerd2/templates/heartbeat.yaml
+++ b/charts/linkerd2/templates/heartbeat.yaml
@@ -1,5 +1,4 @@
-{{ with .Values -}}
-{{ if not .DisableHeartBeat -}}
+{{ if not .Values.DisableHeartBeat -}}
 ---
 ###
 ### Heartbeat
@@ -9,40 +8,39 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: heartbeat
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: heartbeat
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
-  schedule: "{{.HeartbeatSchedule}}"
+  schedule: "{{.Values.HeartbeatSchedule}}"
   successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
       template:
         metadata:
           labels:
-            {{.ControllerComponentLabel}}: heartbeat
+            {{.Values.ControllerComponentLabel}}: heartbeat
           annotations:
-            {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+            {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
         spec:
           {{- include "linkerd.node-selector" . | nindent 10 }}
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
           - name: heartbeat
-            image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-            imagePullPolicy: {{.ImagePullPolicy}}
+            image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+            imagePullPolicy: {{.Values.ImagePullPolicy}}
             args:
             - "heartbeat"
-            - "-prometheus-url=http://linkerd-prometheus.{{.Namespace}}.svc.{{.ClusterDomain}}:9090"
-            - "-controller-namespace={{.Namespace}}"
-            - "-log-level={{.ControllerLogLevel}}"
-            {{- if .HeartbeatResources -}}
-            {{- include "partials.resources" .HeartbeatResources | nindent 12 }}
+            - "-prometheus-url=http://linkerd-prometheus.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:9090"
+            - "-controller-namespace={{.Values.Namespace}}"
+            - "-log-level={{.Values.ControllerLogLevel}}"
+            {{- if .Values.HeartbeatResources -}}
+            {{- include "partials.resources" .Values.HeartbeatResources | nindent 12 }}
             {{- end }}
             securityContext:
-              runAsUser: {{.ControllerUID}}
-{{- end }}
+              runAsUser: {{.Values.ControllerUID}}
 {{- end }}

--- a/charts/linkerd2/templates/identity-rbac.yaml
+++ b/charts/linkerd2/templates/identity-rbac.yaml
@@ -1,5 +1,4 @@
-{{with .Values -}}
-{{if .Identity -}}
+{{if .Values.Identity -}}
 ---
 ###
 ### Identity Controller Service RBAC
@@ -8,10 +7,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-identity
+  name: linkerd-{{.Values.Namespace}}-identity
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -26,26 +25,25 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-identity
+  name: linkerd-{{.Values.Namespace}}-identity
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-identity
+  name: linkerd-{{.Values.Namespace}}-identity
 subjects:
 - kind: ServiceAccount
   name: linkerd-identity
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{ end -}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 {{ end -}}

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -1,90 +1,89 @@
-{{with .Values -}}
-{{if .Identity -}}
+{{if .Values.Identity -}}
 ---
 ###
 ### Identity Controller Service
 ###
-{{ if and (.Identity.Issuer) (eq .Identity.Issuer.Scheme "linkerd.io/tls") -}}
+{{ if and (.Values.Identity.Issuer) (eq .Values.Identity.Issuer.Scheme "linkerd.io/tls") -}}
 ---
 kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-    {{- if .Identity.Issuer.CrtExpiryAnnotation}}
-    {{.Identity.Issuer.CrtExpiryAnnotation}}: {{required "Please provide the identity issuer certificate expiry date" .Identity.Issuer.CrtExpiry}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+    {{- if .Values.Identity.Issuer.CrtExpiryAnnotation}}
+    {{.Values.Identity.Issuer.CrtExpiryAnnotation}}: {{required "Please provide the identity issuer certificate expiry date" .Values.Identity.Issuer.CrtExpiry}}
     {{- end}}
 data:
-  crt.pem: {{b64enc (required "Please provide the identity issuer certificate" .Identity.Issuer.TLS.CrtPEM | trim)}}
-  key.pem: {{b64enc (required "Please provide the identity issue private key" .Identity.Issuer.TLS.KeyPEM | trim)}}
+  crt.pem: {{b64enc (required "Please provide the identity issuer certificate" .Values.Identity.Issuer.TLS.CrtPEM | trim)}}
+  key.pem: {{b64enc (required "Please provide the identity issue private key" .Values.Identity.Issuer.TLS.KeyPEM | trim)}}
 {{- end}}
 ---
 kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: identity
+    {{.Values.ControllerComponentLabel}}: identity
   ports:
   - name: grpc
     port: 8080
     targetPort: 8080
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-identity" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-identity" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: identity
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: identity
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-identity
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: identity
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: identity
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: identity
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: identity
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "identity" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "identity" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - identity
-        - -log-level={{.ControllerLogLevel}}
+        - -log-level={{.Values.ControllerLogLevel}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -101,18 +100,18 @@ spec:
           httpGet:
             path: /ready
             port: 9990
-        {{- if .IdentityResources -}}
-        {{- include "partials.resources" .IdentityResources | nindent 8 }}
+        {{- if .Values.IdentityResources -}}
+        {{- include "partials.resources" .Values.IdentityResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -125,5 +124,4 @@ spec:
         secret:
           secretName: linkerd-identity-issuer
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{end -}}
 {{end -}}

--- a/charts/linkerd2/templates/namespace.yaml
+++ b/charts/linkerd2/templates/namespace.yaml
@@ -1,5 +1,4 @@
-{{with .Values -}}
-{{- if (.InstallNamespace) -}}
+{{- if (.Values.InstallNamespace) -}}
 ---
 ###
 ### Linkerd Namespace
@@ -8,11 +7,10 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{ .Namespace }}
+  name: {{ .Values.Namespace }}
   annotations:
-    {{.ProxyInjectAnnotation}}: {{.ProxyInjectDisabled}}
+    {{.Values.ProxyInjectAnnotation}}: {{.Values.ProxyInjectDisabled}}
   labels:
-    {{.LinkerdNamespaceLabel}}: "true"
+    {{.Values.LinkerdNamespaceLabel}}: "true"
     config.linkerd.io/admission-webhooks: disabled
 {{ end -}}
-{{- end -}}

--- a/charts/linkerd2/templates/prometheus-rbac.yaml
+++ b/charts/linkerd2/templates/prometheus-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Prometheus RBAC
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-prometheus
+  name: linkerd-{{.Values.Namespace}}-prometheus
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -19,25 +18,24 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-prometheus
+  name: linkerd-{{.Values.Namespace}}-prometheus
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-prometheus
+  name: linkerd-{{.Values.Namespace}}-prometheus
 subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{- end }}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/prometheus.yaml
+++ b/charts/linkerd2/templates/prometheus.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Prometheus
@@ -8,12 +7,12 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-prometheus-config
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 data:
   prometheus.yml: |-
     global:
@@ -33,7 +32,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['{{.Namespace}}']
+          names: ['{{.Values.Namespace}}']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -71,7 +70,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['{{.Namespace}}']
+          names: ['{{.Values.Namespace}}']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
@@ -91,7 +90,7 @@ data:
         - __meta_kubernetes_pod_container_port_name
         - __meta_kubernetes_pod_label_linkerd_io_control_plane_ns
         action: keep
-        regex: ^{{default .ProxyContainerName "linkerd-proxy" .ProxyContainerName}};linkerd-admin;{{.Namespace}}$
+        regex: ^{{default .Values.ProxyContainerName "linkerd-proxy" .Values.ProxyContainerName}};linkerd-admin;{{.Values.Namespace}}$
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: namespace
@@ -124,53 +123,53 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-prometheus
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerComponentLabel}}: prometheus
   ports:
   - name: admin-http
     port: 9090
     targetPort: 9090
 ---
-{{ if empty .Proxy.Image.Version -}}
-{{ $_ := set .Proxy.Image "Version" .LinkerdVersion -}}
+{{ if empty .Values.Proxy.Image.Version -}}
+{{ $_ := set .Values.Proxy.Image "Version" .Values.LinkerdVersion -}}
 {{ end -}}
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-prometheus" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-prometheus" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: prometheus
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: prometheus
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-prometheus
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: prometheus
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: prometheus
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: prometheus
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: prometheus
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
@@ -178,9 +177,9 @@ spec:
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
         - --config.file=/etc/prometheus/prometheus.yml
-        - --log.level={{lower .PrometheusLogLevel}}
-        image: {{.PrometheusImage}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        - --log.level={{lower .Values.PrometheusLogLevel}}
+        image: {{.Values.PrometheusImage}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -197,8 +196,8 @@ spec:
             port: 9090
           initialDelaySeconds: 30
           timeoutSeconds: 30
-        {{- if .PrometheusResources -}}
-        {{- include "partials.resources" .PrometheusResources | nindent 8 }}
+        {{- if .Values.PrometheusResources -}}
+        {{- include "partials.resources" .Values.PrometheusResources | nindent 8 }}
         {{- end }}
         securityContext:
           runAsUser: 65534
@@ -209,7 +208,7 @@ spec:
           name: prometheus-config
           readOnly: true
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -221,4 +220,3 @@ spec:
           name: linkerd-prometheus-config
         name: prometheus-config
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{- end }}

--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Proxy Injector RBAC
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-proxy-injector
+  name: linkerd-{{.Values.Namespace}}-proxy-injector
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -31,52 +30,52 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-proxy-injector
+  name: linkerd-{{.Values.Namespace}}-proxy-injector
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-proxy-injector
+  name: linkerd-{{.Values.Namespace}}-proxy-injector
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 ---
 kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector-tls
-  namespace: {{ .Namespace }}
+  namespace: {{ .Values.Namespace }}
   labels:
-    {{ .ControllerComponentLabel }}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 type: Opaque
 data:
-  {{ $ca := genCA (printf "linkerd-proxy-injector.%s.svc" .Namespace) 365 -}}
-  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .ProxyInjector.CrtPEM)) (empty .ProxyInjector.CrtPEM) }}
-  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .ProxyInjector.KeyPEM)) (empty .ProxyInjector.KeyPEM) }}
+  {{ $ca := genCA (printf "linkerd-proxy-injector.%s.svc" .Values.Namespace) 365 -}}
+  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.ProxyInjector.CrtPEM)) (empty .Values.ProxyInjector.CrtPEM) }}
+  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .Values.ProxyInjector.KeyPEM)) (empty .Values.ProxyInjector.KeyPEM) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-proxy-injector-webhook-config
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
@@ -88,16 +87,15 @@ webhooks:
   clientConfig:
     service:
       name: linkerd-proxy-injector
-      namespace: {{ .Namespace }}
+      namespace: {{ .Values.Namespace }}
       path: "/"
-    caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .ProxyInjector.CrtPEM)) (empty .ProxyInjector.CrtPEM) }}
-  failurePolicy: {{.WebhookFailurePolicy}}
+    caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.ProxyInjector.CrtPEM)) (empty .Values.ProxyInjector.CrtPEM) }}
+  failurePolicy: {{.Values.WebhookFailurePolicy}}
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]
-  {{- if not .OmitWebhookSideEffects }}
+  {{- if not .Values.OmitWebhookSideEffects }}
   sideEffects: None
   {{- end }}
-{{end -}}

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -1,51 +1,50 @@
-{{with .Values -}}
 ---
 ###
 ### Proxy Injector
 ###
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-proxy-injector" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-proxy-injector" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: proxy-injector
+      {{.Values.ControllerComponentLabel}}: proxy-injector
   template:
     metadata:
       annotations:
-        {{- if empty .CliVersion }}
+        {{- if empty .Values.CliVersion }}
         linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
         {{- end }}
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: proxy-injector
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: proxy-injector
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "proxy-injector" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "proxy-injector" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - proxy-injector
-        - -log-level={{.ControllerLogLevel}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        - -log-level={{.Values.ControllerLogLevel}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -62,11 +61,11 @@ spec:
           httpGet:
             path: /ready
             port: 9995
-        {{- if .ProxyInjectorResources -}}
-        {{- include "partials.resources" .ProxyInjectorResources | nindent 8 }}
+        {{- if .Values.ProxyInjectorResources -}}
+        {{- include "partials.resources" .Values.ProxyInjectorResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config
@@ -74,7 +73,7 @@ spec:
           name: tls
           readOnly: true
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -92,18 +91,17 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: proxy-injector
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: proxy-injector
+    {{.Values.ControllerComponentLabel}}: proxy-injector
   ports:
   - name: proxy-injector
     port: 443
     targetPort: proxy-injector
-{{ end -}}

--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Control Plane PSP
@@ -7,13 +6,13 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-{{.Namespace}}-control-plane
+  name: linkerd-{{.Values.Namespace}}-control-plane
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
-  {{- if empty .NoInitContainer }}
+  {{- if empty .Values.NoInitContainer }}
   allowedCapabilities:
   - NET_ADMIN
   - NET_RAW
@@ -26,7 +25,7 @@ spec:
   seLinux:
     rule: RunAsAny
   runAsUser:
-    {{- if .NoInitContainer }}
+    {{- if .Values.NoInitContainer }}
     rule: MustRunAsNonRoot
     {{- else }}
     rule: RunAsAny
@@ -34,7 +33,7 @@ spec:
   supplementalGroups:
     rule: MustRunAs
     ranges:
-    {{- if .NoInitContainer }}
+    {{- if .Values.NoInitContainer }}
     - min: 10001
       max: 65535
     {{- else }}
@@ -44,7 +43,7 @@ spec:
   fsGroup:
     rule: MustRunAs
     ranges:
-    {{- if .NoInitContainer }}
+    {{- if .Values.NoInitContainer }}
     - min: 10001
       max: 65535
     {{- else }}
@@ -63,23 +62,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-psp
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - linkerd-{{.Namespace}}-control-plane
+  - linkerd-{{.Values.Namespace}}-control-plane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-psp
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   kind: Role
   name: linkerd-psp
@@ -87,34 +86,33 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-controller
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-destination
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-grafana
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 {{ if not .DisableHeartBeat -}}
 - kind: ServiceAccount
   name: linkerd-heartbeat
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 {{ end -}}
 - kind: ServiceAccount
   name: linkerd-identity
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-prometheus
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-proxy-injector
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-sp-validator
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 - kind: ServiceAccount
   name: linkerd-web
-  namespace: {{.Namespace}}
-{{ end -}}
+  namespace: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/serviceprofile-crd.yaml
+++ b/charts/linkerd2/templates/serviceprofile-crd.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Service Profile CRD
@@ -9,9 +8,9 @@ kind: CustomResourceDefinition
 metadata:
   name: serviceprofiles.linkerd.io
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 spec:
   group: linkerd.io
   versions:
@@ -28,4 +27,3 @@ spec:
     kind: ServiceProfile
     shortNames:
     - sp
-{{ end -}}

--- a/charts/linkerd2/templates/sp-validator-rbac.yaml
+++ b/charts/linkerd2/templates/sp-validator-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Service Profile Validator RBAC
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-sp-validator
+  name: linkerd-{{.Values.Namespace}}-sp-validator
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -19,52 +18,52 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-sp-validator
+  name: linkerd-{{.Values.Namespace}}-sp-validator
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 subjects:
 - kind: ServiceAccount
   name: linkerd-sp-validator
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-sp-validator
+  name: linkerd-{{.Values.Namespace}}-sp-validator
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 ---
 kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator-tls
-  namespace: {{ .Namespace }}
+  namespace: {{ .Values.Namespace }}
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 type: Opaque
 data:
-  {{ $ca := genCA (printf "linkerd-sp-validator.%s.svc" .Namespace) 365 -}}
-  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .ProfileValidator.CrtPEM)) (empty .ProfileValidator.CrtPEM) }}
-  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .ProfileValidator.KeyPEM)) (empty .ProfileValidator.KeyPEM) }}
+  {{ $ca := genCA (printf "linkerd-sp-validator.%s.svc" .Values.Namespace) 365 -}}
+  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.ProfileValidator.CrtPEM)) (empty .Values.ProfileValidator.CrtPEM) }}
+  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .Values.ProfileValidator.KeyPEM)) (empty .Values.ProfileValidator.KeyPEM) }}
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: linkerd-sp-validator-webhook-config
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   namespaceSelector:
@@ -76,16 +75,15 @@ webhooks:
   clientConfig:
     service:
       name: linkerd-sp-validator
-      namespace: {{ .Namespace }}
+      namespace: {{ .Values.Namespace }}
       path: "/"
-    caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .ProfileValidator.CrtPEM)) (empty .ProfileValidator.CrtPEM) }}
-  failurePolicy: {{.WebhookFailurePolicy}}
+    caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.ProfileValidator.CrtPEM)) (empty .Values.ProfileValidator.CrtPEM) }}
+  failurePolicy: {{.Values.WebhookFailurePolicy}}
   rules:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
-  {{- if not .OmitWebhookSideEffects }}
+  {{- if not .Values.OmitWebhookSideEffects }}
   sideEffects: None
   {{- end }}
-{{end -}}

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Service Profile Validator
@@ -8,63 +7,63 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerComponentLabel}}: sp-validator
   ports:
   - name: sp-validator
     port: 443
     targetPort: sp-validator
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-sp-validator" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-sp-validator" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: sp-validator
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: sp-validator
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-sp-validator
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: sp-validator
+      {{.Values.ControllerComponentLabel}}: sp-validator
   template:
     metadata:
       annotations:
-        {{- if empty .CliVersion }}
+        {{- if empty .Values.CliVersion }}
         linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
         {{- end }}
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: sp-validator
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: sp-validator
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "sp-validator" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "sp-validator" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - sp-validator
-        - -log-level={{.ControllerLogLevel}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        - -log-level={{.Values.ControllerLogLevel}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -81,17 +80,17 @@ spec:
           httpGet:
             path: /ready
             port: 9997
-        {{- if .SPValidatorResources -}}
-        {{- include "partials.resources" .SPValidatorResources | nindent 8 }}
+        {{- if .Values.SPValidatorResources -}}
+        {{- include "partials.resources" .Values.SPValidatorResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -101,4 +100,3 @@ spec:
         secret:
           secretName: linkerd-sp-validator-tls
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{end -}}

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Tap RBAC
@@ -7,10 +6,10 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-tap
+  name: linkerd-{{.Values.Namespace}}-tap
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["pods", "services", "replicationcontrollers", "namespaces", "nodes"]
@@ -25,10 +24,10 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-tap-admin
+  name: linkerd-{{.Values.Namespace}}-tap-admin
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
@@ -37,26 +36,26 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-tap
+  name: linkerd-{{.Values.Namespace}}-tap
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-tap
+  name: linkerd-{{.Values.Namespace}}-tap
 subjects:
 - kind: ServiceAccount
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: linkerd-{{.Namespace}}-tap-auth-delegator
+  name: linkerd-{{.Values.Namespace}}-tap-auth-delegator
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -64,25 +63,25 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-{{.Namespace}}-tap-auth-reader
+  name: linkerd-{{.Values.Namespace}}-tap-auth-reader
   namespace: kube-system
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -90,31 +89,31 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-tap-tls
-  namespace: {{ .Namespace }}
+  namespace: {{ .Values.Namespace }}
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 type: Opaque
 data:
-  {{ $ca := genCA (printf "linkerd-tap.%s.svc" .Namespace) 365 -}}
-  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Tap.CrtPEM)) (empty .Tap.CrtPEM) }}
-  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .Tap.KeyPEM)) (empty .Tap.KeyPEM) }}
+  {{ $ca := genCA (printf "linkerd-tap.%s.svc" .Values.Namespace) 365 -}}
+  crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.Tap.CrtPEM)) (empty .Values.Tap.CrtPEM) }}
+  key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .Values.Tap.KeyPEM)) (empty .Values.Tap.KeyPEM) }}
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 spec:
   group: tap.linkerd.io
   version: v1alpha1
@@ -122,6 +121,5 @@ spec:
   versionPriority: 100
   service:
     name: linkerd-tap
-    namespace: {{.Namespace}}
-  caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Tap.CrtPEM)) (empty .Tap.CrtPEM) }}
-{{end -}}
+    namespace: {{.Values.Namespace}}
+  caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.Tap.CrtPEM)) (empty .Values.Tap.CrtPEM) }}

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Tap
@@ -8,16 +7,16 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: tap
+    {{.Values.ControllerComponentLabel}}: tap
   ports:
   - name: grpc
     port: 8088
@@ -26,52 +25,52 @@ spec:
     port: 443
     targetPort: apiserver
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-tap" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-tap" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: tap
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: tap
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-tap
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.ControllerReplicas}}
+  replicas: {{.Values.ControllerReplicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: tap
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: tap
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{- if empty .CliVersion }}
+        {{- if empty .Values.CliVersion }}
         linkerd.io/helm-release-version: {{ $.Release.Revision | quote}}
         {{- end }}
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: tap
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: tap
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .EnablePodAntiAffinity -}}
-      {{- $local := dict "Component" "tap" "Label" .ControllerComponentLabel -}}
+      {{- if .Values.EnablePodAntiAffinity -}}
+      {{- $local := dict "Component" "tap" "Label" .Values.ControllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:
       - args:
         - tap
-        - -controller-namespace={{.Namespace}}
-        - -log-level={{.ControllerLogLevel}}
+        - -controller-namespace={{.Values.Namespace}}
+        - -log-level={{.Values.ControllerLogLevel}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.ControllerImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.ControllerImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -90,11 +89,11 @@ spec:
           httpGet:
             path: /ready
             port: 9998
-        {{- if .TapResources -}}
-        {{- include "partials.resources" .TapResources | nindent 8 }}
+        {{- if .Values.TapResources -}}
+        {{- include "partials.resources" .Values.TapResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls
@@ -102,7 +101,7 @@ spec:
         - mountPath: /var/run/linkerd/config
           name: config
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -115,4 +114,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
-{{ end -}}

--- a/charts/linkerd2/templates/trafficsplit-crd.yaml
+++ b/charts/linkerd2/templates/trafficsplit-crd.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### TrafficSplit CRD
@@ -10,9 +9,9 @@ kind: CustomResourceDefinition
 metadata:
   name: trafficsplits.split.smi-spec.io
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 spec:
   group: split.smi-spec.io
   version: v1alpha1
@@ -28,4 +27,3 @@ spec:
     type: string
     description: The apex service of this split.
     JSONPath: .spec.service
-{{ end -}}

--- a/charts/linkerd2/templates/web-rbac.yaml
+++ b/charts/linkerd2/templates/web-rbac.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Web RBAC
@@ -8,16 +7,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get"]
   resourceNames: ["linkerd-config"]
-  {{- if not .RestrictDashboardPrivileges }}
+  {{- if not .Values.RestrictDashboardPrivileges }}
 - apiGroups: [""]
   resources: ["namespaces", "configmaps"]
   verbs: ["get"]
@@ -33,10 +32,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   kind: Role
   name: linkerd-web
@@ -44,16 +43,16 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
-{{- if not .RestrictDashboardPrivileges }}
+{{- if not .Values.RestrictDashboardPrivileges }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: linkerd-{{.Namespace}}-web-check
+  name: linkerd-{{.Values.Namespace}}-web-check
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles", "clusterrolebindings"]
@@ -74,42 +73,41 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: linkerd-{{.Namespace}}-web-check
+  name: linkerd-{{.Values.Namespace}}-web-check
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-web-check
+  name: linkerd-{{.Values.Namespace}}-web-check
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Namespace}}-web-admin
+  name: linkerd-{{.Values.Namespace}}-web-admin
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Namespace}}-tap-admin
+  name: linkerd-{{.Values.Namespace}}-tap-admin
 subjects:
 - kind: ServiceAccount
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 ---
 {{- end}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
-{{- end }}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}

--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -1,4 +1,3 @@
-{{with .Values -}}
 ---
 ###
 ### Web
@@ -8,16 +7,16 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.ControllerComponentLabel}}: web
+    {{.Values.ControllerComponentLabel}}: web
   ports:
   - name: http
     port: 8084
@@ -26,49 +25,49 @@ spec:
     port: 9994
     targetPort: 9994
 ---
-{{ $_ := set .Proxy "WorkloadKind" "deployment" -}}
-{{ $_ := set .Proxy "Component" "linkerd-web" -}}
-{{ include "linkerd.proxy.validation" .Proxy -}}
+{{ $_ := set .Values.Proxy "WorkloadKind" "deployment" -}}
+{{ $_ := set .Values.Proxy "Component" "linkerd-web" -}}
+{{ include "linkerd.proxy.validation" .Values.Proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
+    {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
   labels:
-    {{.ControllerComponentLabel}}: web
-    {{.ControllerNamespaceLabel}}: {{.Namespace}}
+    {{.Values.ControllerComponentLabel}}: web
+    {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
   name: linkerd-web
-  namespace: {{.Namespace}}
+  namespace: {{.Values.Namespace}}
 spec:
-  replicas: {{.Dashboard.Replicas}}
+  replicas: {{.Values.Dashboard.Replicas}}
   selector:
     matchLabels:
-      {{.ControllerComponentLabel}}: web
-      {{.ControllerNamespaceLabel}}: {{.Namespace}}
-      {{- include "partials.proxy.labels" .Proxy | nindent 6}}
+      {{.Values.ControllerComponentLabel}}: web
+      {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+      {{- include "partials.proxy.labels" .Values.Proxy | nindent 6}}
   template:
     metadata:
       annotations:
-        {{.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .LinkerdVersion) .CliVersion}}
-        {{- include "partials.proxy.annotations" .Proxy| nindent 8}}
+        {{.Values.CreatedByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.LinkerdVersion) .Values.CliVersion}}
+        {{- include "partials.proxy.annotations" .Values.Proxy| nindent 8}}
       labels:
-        {{.ControllerComponentLabel}}: web
-        {{.ControllerNamespaceLabel}}: {{.Namespace}}
-        {{- include "partials.proxy.labels" .Proxy | nindent 8}}
+        {{.Values.ControllerComponentLabel}}: web
+        {{.Values.ControllerNamespaceLabel}}: {{.Values.Namespace}}
+        {{- include "partials.proxy.labels" .Values.Proxy | nindent 8}}
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
       - args:
-        - -api-addr=linkerd-controller-api.{{.Namespace}}.svc.{{.ClusterDomain}}:8085
-        - -grafana-addr=linkerd-grafana.{{.Namespace}}.svc.{{.ClusterDomain}}:3000
-        - -controller-namespace={{.Namespace}}
-        - -log-level={{.ControllerLogLevel}}
-        {{- $hostFull := replace "." "\\." (printf "linkerd-web.%s.svc.%s" .Namespace .ClusterDomain) }}
-        {{- $hostAbbrev := replace "." "\\." (printf "linkerd-web.%s.svc" .Namespace) }}
+        - -api-addr=linkerd-controller-api.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:8085
+        - -grafana-addr=linkerd-grafana.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:3000
+        - -controller-namespace={{.Values.Namespace}}
+        - -log-level={{.Values.ControllerLogLevel}}
+        {{- $hostFull := replace "." "\\." (printf "linkerd-web.%s.svc.%s" .Values.Namespace .Values.ClusterDomain) }}
+        {{- $hostAbbrev := replace "." "\\." (printf "linkerd-web.%s.svc" .Values.Namespace) }}
         - -enforced-host=^(localhost|127\.0\.0\.1|{{ $hostFull }}|{{ $hostAbbrev }}|\[::1\])(:\d+)?$
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.WebImage}}:{{default .LinkerdVersion .ControllerImageVersion}}
-        imagePullPolicy: {{.ImagePullPolicy}}
+        image: {{.Values.WebImage}}:{{default .Values.LinkerdVersion .Values.ControllerImageVersion}}
+        imagePullPolicy: {{.Values.ImagePullPolicy}}
         livenessProbe:
           httpGet:
             path: /ping
@@ -85,16 +84,16 @@ spec:
           httpGet:
             path: /ready
             port: 9994
-        {{- if .WebResources -}}
-        {{- include "partials.resources" .WebResources | nindent 8 }}
+        {{- if .Values.WebResources -}}
+        {{- include "partials.resources" .Values.WebResources | nindent 8 }}
         {{- end }}
         securityContext:
-          runAsUser: {{.ControllerUID}}
+          runAsUser: {{.Values.ControllerUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .NoInitContainer -}}
+      {{ if not .Values.NoInitContainer -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -104,4 +103,3 @@ spec:
           name: linkerd-config
         name: config
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-{{end -}}

--- a/charts/partials/templates/_capabilities.tpl
+++ b/charts/partials/templates/_capabilities.tpl
@@ -1,16 +1,16 @@
 {{- define "partials.proxy.capabilities" -}}
 capabilities:
-  {{- if .Capabilities.Add }}
+  {{- if .Values.Capabilities.Add }}
   add:
-  {{- toYaml .Capabilities.Add | trim | nindent 4 }}
+  {{- toYaml .Values.Capabilities.Add | trim | nindent 4 }}
   {{- end }}
-  {{- if .Capabilities.Drop }}
+  {{- if .Values.Capabilities.Drop }}
   drop:
-  {{- toYaml .Capabilities.Drop | trim | nindent 4 }}
+  {{- toYaml .Values.Capabilities.Drop | trim | nindent 4 }}
   {{- end }}
 {{- end -}}
 
 {{- define "partials.proxy-init.capabilities.drop" -}}
 drop:
-{{ toYaml .Capabilities.Drop | trim }}
+{{ toYaml .Values.Capabilities.Drop | trim }}
 {{- end -}}

--- a/charts/partials/templates/_debug.tpl
+++ b/charts/partials/templates/_debug.tpl
@@ -1,6 +1,6 @@
 {{- define "partials.debug" -}}
-image: {{.Image.Name}}:{{.Image.Version}}
-imagePullPolicy: {{.Image.PullPolicy}}
+image: {{.Values.Image.Name}}:{{.Values.Image.Version}}
+imagePullPolicy: {{.Values.Image.PullPolicy}}
 name: linkerd-debug
 terminationMessagePolicy: FallbackToLogsOnError
 {{- end -}}

--- a/charts/partials/templates/_debug.tpl
+++ b/charts/partials/templates/_debug.tpl
@@ -1,6 +1,6 @@
 {{- define "partials.debug" -}}
-image: {{.Values.Image.Name}}:{{.Values.Image.Version}}
-imagePullPolicy: {{.Values.Image.PullPolicy}}
+image: {{.Image.Name}}:{{.Image.Version}}
+imagePullPolicy: {{.Image.PullPolicy}}
 name: linkerd-debug
 terminationMessagePolicy: FallbackToLogsOnError
 {{- end -}}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -1,36 +1,36 @@
 {{- define "partials.proxy-init" -}}
 args:
 - --incoming-proxy-port
-- {{.Proxy.Ports.Inbound | quote}}
+- {{.Values.Proxy.Ports.Inbound | quote}}
 - --outgoing-proxy-port
-- {{.Proxy.Ports.Outbound | quote}}
+- {{.Values.Proxy.Ports.Outbound | quote}}
 - --proxy-uid
-- {{.Proxy.UID | quote}}
+- {{.Values.Proxy.UID | quote}}
 - --inbound-ports-to-ignore
-- {{.Proxy.Ports.Control}},{{.Proxy.Ports.Admin}}{{ternary (printf ",%s" .ProxyInit.IgnoreInboundPorts) "" (not (empty .ProxyInit.IgnoreInboundPorts)) }}
-{{- if hasPrefix "linkerd-" .Proxy.Component }}
+- {{.Values.Proxy.Ports.Control}},{{.Values.Proxy.Ports.Admin}}{{ternary (printf ",%s" .Values.ProxyInit.IgnoreInboundPorts) "" (not (empty .Values.ProxyInit.IgnoreInboundPorts)) }}
+{{- if hasPrefix "linkerd-" .Values.Proxy.Component }}
 - --outbound-ports-to-ignore
-- {{ternary (printf "443,%s" .ProxyInit.IgnoreOutboundPorts) (quote "443") (not (empty .ProxyInit.IgnoreOutboundPorts)) }}
-{{- else if .ProxyInit.IgnoreOutboundPorts }}
+- {{ternary (printf "443,%s" .Values.ProxyInit.IgnoreOutboundPorts) (quote "443") (not (empty .Values.ProxyInit.IgnoreOutboundPorts)) }}
+{{- else if .Values.ProxyInit.IgnoreOutboundPorts }}
 - --outbound-ports-to-ignore
-- {{.ProxyInit.IgnoreOutboundPorts | quote}}
+- {{.Values.ProxyInit.IgnoreOutboundPorts | quote}}
 {{- end }}
-image: {{.ProxyInit.Image.Name}}:{{.ProxyInit.Image.Version}}
-imagePullPolicy: {{.ProxyInit.Image.PullPolicy}}
+image: {{.Values.ProxyInit.Image.Name}}:{{.Values.ProxyInit.Image.Version}}
+imagePullPolicy: {{.Values.ProxyInit.Image.PullPolicy}}
 name: linkerd-init
-{{ include "partials.resources" .ProxyInit.Resources }}
+{{ include "partials.resources" .Values.ProxyInit.Resources }}
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     add:
     - NET_ADMIN
     - NET_RAW
-    {{- if .ProxyInit.Capabilities -}}
-    {{- if .ProxyInit.Capabilities.Add }}
-    {{- toYaml .ProxyInit.Capabilities.Add | trim | nindent 4 }}
+    {{- if .Values.ProxyInit.Capabilities -}}
+    {{- if .Values.ProxyInit.Capabilities.Add }}
+    {{- toYaml .Values.ProxyInit.Capabilities.Add | trim | nindent 4 }}
     {{- end }}
-    {{- if .ProxyInit.Capabilities.Drop -}}
-    {{- include "partials.proxy-init.capabilities.drop" .ProxyInit | nindent 4 -}}
+    {{- if .Values.ProxyInit.Capabilities.Drop -}}
+    {{- include "partials.proxy-init.capabilities.drop" .Values.ProxyInit | nindent 4 -}}
     {{- end }}
     {{- end }}
   privileged: false
@@ -38,10 +38,10 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
 terminationMessagePolicy: FallbackToLogsOnError
-{{- if .ProxyInit.SAMountPath }}
+{{- if .Values.ProxyInit.SAMountPath }}
 volumeMounts:
-- mountPath: {{.ProxyInit.SAMountPath.MountPath}}
-  name: {{.ProxyInit.SAMountPath.Name}}
-  readOnly: {{.ProxyInit.SAMountPath.ReadOnly}}
+- mountPath: {{.Values.ProxyInit.SAMountPath.MountPath}}
+  name: {{.Values.ProxyInit.SAMountPath.Name}}
+  readOnly: {{.Values.ProxyInit.SAMountPath.ReadOnly}}
 {{- end -}}
 {{- end -}}

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -1,23 +1,23 @@
 {{ define "partials.proxy" -}}
 env:
 - name: LINKERD2_PROXY_LOG
-  value: {{.Proxy.LogLevel}}
+  value: {{.Values.Proxy.LogLevel}}
 - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
-  value: {{ternary "localhost.:8086" (printf "linkerd-dst.%s.svc.%s:8086" .Namespace .ClusterDomain) (eq .Proxy.Component "linkerd-destination")}}
+  value: {{ternary "localhost.:8086" (printf "linkerd-dst.%s.svc.%s:8086" .Values.Namespace .Values.ClusterDomain) (eq .Values.Proxy.Component "linkerd-destination")}}
 - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
-  value: 0.0.0.0:{{.Proxy.Ports.Control}}
+  value: 0.0.0.0:{{.Values.Proxy.Ports.Control}}
 - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
-  value: 0.0.0.0:{{.Proxy.Ports.Admin}}
+  value: 0.0.0.0:{{.Values.Proxy.Ports.Admin}}
 - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
-  value: 127.0.0.1:{{.Proxy.Ports.Outbound}}
+  value: 127.0.0.1:{{.Values.Proxy.Ports.Outbound}}
 - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
-  value: 0.0.0.0:{{.Proxy.Ports.Inbound}}
+  value: 0.0.0.0:{{.Values.Proxy.Ports.Inbound}}
 - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
-  {{- $internalProfileSuffix := printf "svc.%s." .ClusterDomain }}
-  value: {{ternary "." $internalProfileSuffix .Proxy.EnableExternalProfiles}}
+  {{- $internalProfileSuffix := printf "svc.%s." .Values.ClusterDomain }}
+  value: {{ternary "." $internalProfileSuffix .Values.Proxy.EnableExternalProfiles}}
 - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
-  {{- $internalProfileSuffix := printf "svc.%s." .ClusterDomain }}
-  value: {{ternary "." $internalProfileSuffix .Proxy.EnableExternalProfiles}}
+  {{- $internalProfileSuffix := printf "svc.%s." .Values.ClusterDomain }}
+  value: {{ternary "." $internalProfileSuffix .Values.Proxy.EnableExternalProfiles}}
 - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
   value: 10000ms
 - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
@@ -28,11 +28,11 @@ env:
       fieldPath: metadata.namespace
 - name: LINKERD2_PROXY_DESTINATION_CONTEXT
   value: ns:$(_pod_ns)
-{{ if eq .Proxy.Component "linkerd-prometheus" -}}
+{{ if eq .Values.Proxy.Component "linkerd-prometheus" -}}
 - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
   value: "10000"
 {{ end -}}
-{{ if .Proxy.DisableIdentity -}}
+{{ if .Values.Proxy.DisableIdentity -}}
 - name: LINKERD2_PROXY_IDENTITY_DISABLED
   value: disabled
 {{ else -}}
@@ -40,20 +40,20 @@ env:
   value: /var/run/linkerd/identity/end-entity
 - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
   value: |
-  {{- required "Please provide the identity trust anchors" .Identity.TrustAnchorsPEM | trim | nindent 4 }}
+  {{- required "Please provide the identity trust anchors" .Values.Identity.TrustAnchorsPEM | trim | nindent 4 }}
 - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
   value: /var/run/secrets/kubernetes.io/serviceaccount/token
 - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
-  {{- $identitySvcAddr := printf "linkerd-identity.%s.svc.%s:8080" .Namespace .ClusterDomain }}
-  value: {{ternary "localhost.:8080" $identitySvcAddr (eq .Proxy.Component "linkerd-identity")}}
+  {{- $identitySvcAddr := printf "linkerd-identity.%s.svc.%s:8080" .Values.Namespace .Values.ClusterDomain }}
+  value: {{ternary "localhost.:8080" $identitySvcAddr (eq .Values.Proxy.Component "linkerd-identity")}}
 - name: _pod_sa
   valueFrom:
     fieldRef:
       fieldPath: spec.serviceAccountName
 - name: _l5d_ns
-  value: {{.Namespace}}
+  value: {{.Values.Namespace}}
 - name: _l5d_trustdomain
-  value: {{.Identity.TrustDomain}}
+  value: {{.Values.Identity.TrustDomain}}
 - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
   value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
@@ -61,65 +61,65 @@ env:
 - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
   value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
-{{ if .Proxy.DisableTap -}}
+{{ if .Values.Proxy.DisableTap -}}
 - name: LINKERD2_PROXY_TAP_DISABLED
   value: "true"
-{{ else if not .Proxy.DisableIdentity -}}
+{{ else if not .Values.Proxy.DisableIdentity -}}
 - name: LINKERD2_PROXY_TAP_SVC_NAME
   value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
-{{ if .ControlPlaneTracing -}}
+{{ if .Values.ControlPlaneTracing -}}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
-  value: linkerd-collector.{{.Namespace}}.svc.{{.ClusterDomain}}:55678
+  value: linkerd-collector.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:55678
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME
-  value: linkerd-collector.{{.Namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-{{ else if .Proxy.Trace -}}
-{{ if .Proxy.Trace.CollectorSvcAddr -}}
+  value: linkerd-collector.{{.Values.Namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+{{ else if .Values.Proxy.Trace -}}
+{{ if .Values.Proxy.Trace.CollectorSvcAddr -}}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
-  value: {{ .Proxy.Trace.CollectorSvcAddr }}
+  value: {{ .Values.Proxy.Trace.CollectorSvcAddr }}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME
-  value: {{ .Proxy.Trace.CollectorSvcAccount }}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+  value: {{ .Values.Proxy.Trace.CollectorSvcAccount }}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
 {{ end -}}
-image: {{.Proxy.Image.Name}}:{{.Proxy.Image.Version}}
-imagePullPolicy: {{.Proxy.Image.PullPolicy}}
+image: {{.Values.Proxy.Image.Name}}:{{.Values.Proxy.Image.Version}}
+imagePullPolicy: {{.Values.Proxy.Image.PullPolicy}}
 livenessProbe:
   httpGet:
     path: /metrics
-    port: {{.Proxy.Ports.Admin}}
+    port: {{.Values.Proxy.Ports.Admin}}
   initialDelaySeconds: 10
 name: linkerd-proxy
 ports:
-- containerPort: {{.Proxy.Ports.Inbound}}
+- containerPort: {{.Values.Proxy.Ports.Inbound}}
   name: linkerd-proxy
-- containerPort: {{.Proxy.Ports.Admin}}
+- containerPort: {{.Values.Proxy.Ports.Admin}}
   name: linkerd-admin
 readinessProbe:
   httpGet:
     path: /ready
-    port: {{.Proxy.Ports.Admin}}
+    port: {{.Values.Proxy.Ports.Admin}}
   initialDelaySeconds: 2
-{{- if .Proxy.Resources }}
-{{ include "partials.resources" .Proxy.Resources }}
+{{- if .Values.Proxy.Resources }}
+{{ include "partials.resources" .Values.Proxy.Resources }}
 {{- end }}
 securityContext:
   allowPrivilegeEscalation: false
-  {{- if .Proxy.Capabilities -}}
-  {{- include "partials.proxy.capabilities" .Proxy | nindent 2 -}}
+  {{- if .Values.Proxy.Capabilities -}}
+  {{- include "partials.proxy.capabilities" .Values.Proxy | nindent 2 -}}
   {{- end }}
   readOnlyRootFilesystem: true
-  runAsUser: {{.Proxy.UID}}
+  runAsUser: {{.Values.Proxy.UID}}
 terminationMessagePolicy: FallbackToLogsOnError
-{{- if or (not .Proxy.DisableIdentity) (.Proxy.SAMountPath) }}
+{{- if or (not .Values.Proxy.DisableIdentity) (.Values.Proxy.SAMountPath) }}
 volumeMounts:
-{{- if not .Proxy.DisableIdentity }}
+{{- if not .Values.Proxy.DisableIdentity }}
 - mountPath: /var/run/linkerd/identity/end-entity
   name: linkerd-identity-end-entity
 {{- end -}}
-{{- if .Proxy.SAMountPath }}
-- mountPath: {{.Proxy.SAMountPath.MountPath}}
-  name: {{.Proxy.SAMountPath.Name}}
-  readOnly: {{.Proxy.SAMountPath.ReadOnly}}
+{{- if .Values.Proxy.SAMountPath }}
+- mountPath: {{.Values.Proxy.SAMountPath.MountPath}}
+  name: {{.Values.Proxy.SAMountPath.Name}}
+  readOnly: {{.Values.Proxy.SAMountPath.ReadOnly}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -1,5 +1,5 @@
 {{ define "partials.linkerd.trace" -}}
 {{ if .ControlPlaneTracing -}}
-- -trace-collector=linkerd-collector.{{.Namespace}}.svc.{{.ClusterDomain}}:55678
+- -trace-collector=linkerd-collector.{{.Values.Namespace}}.svc.{{.Values.ClusterDomain}}:55678
 {{ end -}}
 {{- end }}

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -1,36 +1,35 @@
-{{ with .Values -}}
-{{ $prefix := .PathPrefix -}}
-[    
-  {{- if .AddRootAnnotations }}
+{{ $prefix := .Values.PathPrefix -}}
+[
+  {{- if .Values.AddRootAnnotations }}
   {
     "op": "add",
     "path": "{{$prefix}}/metadata/annotations",
     "value": {}
   },
   {{- end }}
-  {{- range $label, $value := .Annotations }}
+  {{- range $label, $value := .Values.Annotations }}
   {
     "op": "add",
     "path": "{{$prefix}}/metadata/annotations/{{$label | replace "/" "~1"}}",
     "value": "{{$value}}"
   },
   {{- end }}
-  {{- if .AddRootLabels }}
+  {{- if .Values.AddRootLabels }}
   {
     "op": "add",
     "path": "{{$prefix}}/metadata/labels",
     "value": {}
   },
   {{- end }}
-  {{- range $label, $value := .Labels }}
+  {{- range $label, $value := .Values.Labels }}
   {
     "op": "add",
     "path": "{{$prefix}}/metadata/labels/{{$label | replace "/" "~1"}}",
     "value": "{{$value}}"
   },
   {{- end }}
-  {{- if .ProxyInit }}
-  {{- if .AddRootInitContainers }}
+  {{- if .Values.ProxyInit }}
+  {{- if .Values.AddRootInitContainers }}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/initContainers",
@@ -44,7 +43,7 @@
       {{- include "partials.proxy-init" . | fromYaml | toPrettyJson | nindent 6 }}
   },
   {{- end }}
-  {{- with .DebugContainer }}
+  {{- with .Values.DebugContainer }}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/containers/-",
@@ -52,15 +51,15 @@
       {{- include "partials.debug" . | fromYaml | toPrettyJson | nindent 6 }}
   },
   {{- end }}
-  {{- if .Proxy }}
-  {{- if .AddRootVolumes }}
+  {{- if .Values.Proxy }}
+  {{- if .Values.AddRootVolumes }}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/volumes",
     "value": []
   },
   {{- end }}
-  {{- if not .Proxy.DisableIdentity -}}
+  {{- if not .Values.Proxy.DisableIdentity -}}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/volumes/-",
@@ -80,4 +79,3 @@
   },
   {{- end }}
 ]
-{{- end -}}


### PR DESCRIPTION
**Problem**
Use of the `{{with .Values -}}` "shortcut" is discouraged based upon _Helm_ best practices.  The recommended approach is to fully qualify variable references within _Helm_ templates.

**Solution**
All uses of the shortened variable qualifier have been removed and all variable references now utilize the fully qualified "path."

**Validation**
Utilized the `cli/cmd/install_helm_test.go` unit test successfully to assure chart output matches the `install_helm_output.golden` and `install_helm_output_ha.golden` test files.  During the development process, ensured tests did fail prior to completion, then succeeded once all changes were made.

Successfully deployed the locally created _Helm chart_ into a local _docker-desktop_ environment.  Ran the _Kubernetes_ dashboard to ensure all resources were successfully running and ran `linkerd dashboard` to confirm operation as well.

Fixes #3744 

Signed-off-by: Paul Balogh <javaducky@gmail.com>
