### PR TITLE
Avoid fetching data not needed in dashboard (II)

### DIFF
--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -154,7 +154,7 @@ export class ResourceDetailBase extends React.Component {
 
     let apiRequests =
       [
-        // inbound stats for this resource
+      // inbound stats for this resource
         this.api.fetchMetrics(
           `${this.api.urlsForResource(resource.type, resource.namespace, true)}&resource_name=${resource.name}`
         ),
@@ -168,6 +168,7 @@ export class ResourceDetailBase extends React.Component {
         )
       ];
 
+    // Fetch pods in a resource and their metrics (except when resource type is pod)
     if (resource.type !== "pod") {
       // list of all pods in this namespace (hack since we can't currently query for all pods in a resource)
       apiRequests.push(this.api.fetchPods(resource.namespace));

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -154,15 +154,9 @@ export class ResourceDetailBase extends React.Component {
 
     let apiRequests =
       [
-      // inbound stats for this resource
+        // inbound stats for this resource
         this.api.fetchMetrics(
           `${this.api.urlsForResource(resource.type, resource.namespace, true)}&resource_name=${resource.name}`
-        ),
-        // list of all pods in this namespace (hack since we can't currently query for all pods in a resource)
-        this.api.fetchPods(resource.namespace),
-        // metrics for all pods in this namespace (hack, continued)
-        this.api.fetchMetrics(
-          `${this.api.urlsForResource("pod", resource.namespace, true)}`
         ),
         // upstream resources of this resource (meshed traffic only)
         this.api.fetchMetrics(
@@ -173,6 +167,13 @@ export class ResourceDetailBase extends React.Component {
           `${this.api.urlsForResource("all")}&from_name=${resource.name}&from_type=${resource.type}&from_namespace=${resource.namespace}`
         )
       ];
+
+    if (resource.type !== "pod") {
+      // list of all pods in this namespace (hack since we can't currently query for all pods in a resource)
+      apiRequests.push(this.api.fetchPods(resource.namespace));
+      // metrics for all pods in this namespace (hack, continued)
+      apiRequests.push(this.api.fetchMetrics(`${this.api.urlsForResource("pod", resource.namespace, true)}`));
+    }
 
     if (this.state.queryForDefinition) {
       // definition for this resource
@@ -188,10 +189,18 @@ export class ResourceDetailBase extends React.Component {
     this.api.setCurrentRequests(apiRequests);
 
     Promise.all(this.api.getCurrentPromises())
-      .then(results => {
-        const [resourceRsp, podListRsp, podMetricsRsp, upstreamRsp, downstreamRsp, ...rsp] = [...results];
+      .then(apiResponses => {
+        let podMetrics;
+        let resourceRsp, upstreamRsp, downstreamRsp, podListRsp, podMetricsRsp, rsp;
+
+        if (resource.type === "pod") {
+          [resourceRsp, upstreamRsp, downstreamRsp, ...rsp] = [...apiResponses];
+        } else {
+          [resourceRsp, upstreamRsp, downstreamRsp, podListRsp, podMetricsRsp, ...rsp] = [...apiResponses];
+          podMetrics = processSingleResourceRollup(podMetricsRsp, resource.type);
+        }
+
         let resourceMetrics = processSingleResourceRollup(resourceRsp, resource.type);
-        let podMetrics = processSingleResourceRollup(podMetricsRsp, resource.type);
         let upstreamMetrics = processMultiResourceRollup(upstreamRsp, resource.type);
         let downstreamMetrics = processMultiResourceRollup(downstreamRsp, resource.type);
         let resourceDefinition = this.state.queryForDefinition ? rsp[0] : this.state.resourceDefinition;
@@ -210,9 +219,7 @@ export class ResourceDetailBase extends React.Component {
         let podMetricsForResource;
 
         if (resource.type === "pod") {
-          // get only info for the pod whose ResourceDetail is being shown
-          // pod.name in podMetrics is of the form `pod-name`
-          podMetricsForResource = _filter(podMetrics, pod => pod.name === resource.name);
+          podMetricsForResource = resourceMetrics;
         } else {
           let podBelongsToResource = _reduce(podListRsp.pods, (mem, pod) => {
             if (_get(pod, resourceTypeToCamelCase(resource.type)) === resourceName) {


### PR DESCRIPTION
#### Problem

Currently when viewing a pod details in the dashboard, we list all pods in the namespace and we fetch metrics for all of them every 2s. We do this to get all the pods belonging to the requested resource and display them. But in the case of a pod, that doesn't apply. So in that view, that data is not really needed. We need the requested pod metrics though, but we already fetch them in a separate query. This can lead to expensive Prometheus queries, specially in big clusters.

#### Solution

With this change we avoid listing all the pods in the namespace and fetching all their metrics when displaying a pod detail view.

More details about this issue and the impact of the solution [here](https://github.com/linkerd/linkerd2/issues/3618#issuecomment-557586629).

Related to #3618

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>