### PR TITLE
Cache StatSummary responses in dashboard web server

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:0279da99 as golang
+FROM gcr.io/linkerd-io/go-deps:2273074d as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:0279da99 as golang
+FROM gcr.io/linkerd-io/go-deps:2273074d as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:0279da99 as golang
+FROM gcr.io/linkerd-io/go-deps:2273074d as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller service
-FROM gcr.io/linkerd-io/go-deps:0279da99 as golang
+FROM gcr.io/linkerd-io/go-deps:2273074d as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/mattn/go-isatty v0.0.9
 	github.com/mattn/go-runewidth v0.0.2
 	github.com/nsf/termbox-go v0.0.0-20180613055208-5c94acc5e6eb
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/browser v0.0.0-20170505125900-c90ca0c84f15
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c h1:eSfnfIuwhxZyULg1NNu
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3 h1:EooPXg51Tn+xmWPXJUGCnJhJSpeuMlBmfJVcqIRmmv8=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:0279da99 as golang
+FROM gcr.io/linkerd-io/go-deps:2273074d as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	profiles "github.com/linkerd/linkerd2/pkg/profiles"
+	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,6 +29,7 @@ type (
 		clusterDomain       string
 		grafanaProxy        *grafanaProxy
 		hc                  healthChecker
+		statCache           *cache.Cache
 	}
 )
 


### PR DESCRIPTION
#### Problem

If the dashboard is opened multiple times (by the same or different users), depending on the view opened, it’s possible that the same API stats requests are processed multiple times within the same second. Some of these requests trigger expensive queries in Prometheus, specially on big clusters.

#### Solution

This changes adds a simple caching layer to the stats API handler using the raw query as the key. Json marshalled responses are cached for up to 1.5 seconds, and they are cleaned up automatically in 5 minutes.

More details about this issue and the impact of the solution [here](https://github.com/linkerd/linkerd2/issues/3618#issuecomment-556195957).

Related to #3618

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
