### PR TITLE
Pause dashboard network activity when page is hidden

### DIFF
--- a/web/app/js/components/Top.jsx
+++ b/web/app/js/components/Top.jsx
@@ -1,3 +1,4 @@
+import { handlePageVisibility, withPageVisibility } from './util/PageVisibility.jsx';
 import ErrorBanner from './ErrorBanner.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -14,6 +15,7 @@ class Top extends React.Component {
     api: PropTypes.shape({
       PrefixedLink: PropTypes.func.isRequired,
     }).isRequired,
+    isPageVisible: PropTypes.bool.isRequired,
     pathPrefix: PropTypes.string.isRequired
   }
 
@@ -36,6 +38,15 @@ class Top extends React.Component {
 
   componentDidMount() {
     this.startServerPolling();
+  }
+
+  componentDidUpdate(prevProps) {
+    handlePageVisibility({
+      prevVisibilityState: prevProps.isPageVisible,
+      currentVisibilityState: this.props.isPageVisible,
+      onVisible: () => this.startServerPolling(),
+      onHidden: () => this.stopServerPolling(),
+    });
   }
 
   componentWillUnmount() {
@@ -82,6 +93,7 @@ class Top extends React.Component {
   stopServerPolling() {
     window.clearInterval(this.timerId);
     this.api.cancelCurrentRequests();
+    this.setState({ pendingRequests: false });
   }
 
   loadFromServer() {
@@ -179,4 +191,4 @@ class Top extends React.Component {
   }
 }
 
-export default withContext(Top);
+export default withPageVisibility(withContext(Top));

--- a/web/app/js/components/TopRoutes.jsx
+++ b/web/app/js/components/TopRoutes.jsx
@@ -1,4 +1,5 @@
 import { StringParam, withQueryParams } from 'use-query-params';
+import { handlePageVisibility, withPageVisibility } from './util/PageVisibility.jsx';
 
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
@@ -61,6 +62,7 @@ class TopRoutes extends React.Component {
       PrefixedLink: PropTypes.func.isRequired,
     }).isRequired,
     classes: PropTypes.shape({}).isRequired,
+    isPageVisible: PropTypes.bool.isRequired,
     query: topRoutesQueryPropType.isRequired,
     setQuery: PropTypes.func.isRequired,
   }
@@ -94,6 +96,15 @@ class TopRoutes extends React.Component {
   componentDidMount() {
     this._isMounted = true; // https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
     this.startServerPolling();
+  }
+
+  componentDidUpdate(prevProps) {
+    handlePageVisibility({
+      prevVisibilityState: prevProps.isPageVisible,
+      currentVisibilityState: this.props.isPageVisible,
+      onVisible: () => this.startServerPolling(),
+      onHidden: () => this.stopServerPolling(),
+    });
   }
 
   componentWillUnmount() {
@@ -149,6 +160,7 @@ class TopRoutes extends React.Component {
   stopServerPolling = () => {
     window.clearInterval(this.timerId);
     this.api.cancelCurrentRequests();
+    this.setState({ pendingRequests: false });
   }
 
   handleBtnClick = inProgress => () => {
@@ -336,4 +348,4 @@ class TopRoutes extends React.Component {
   }
 }
 
-export default withQueryParams(topRoutesQueryConfig, (withContext(withStyles(styles, { withTheme: true })(TopRoutes))));
+export default withPageVisibility(withQueryParams(topRoutesQueryConfig, (withContext(withStyles(styles, { withTheme: true })(TopRoutes)))));

--- a/web/app/js/components/util/PageVisibility.jsx
+++ b/web/app/js/components/util/PageVisibility.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import _isFunction from 'lodash/isFunction';
+import _isUndefined from 'lodash/isUndefined';
+import { usePageVisibility } from 'react-page-visibility';
+
+export function handlePageVisibility(params) {
+  const { prevVisibilityState, currentVisibilityState, onVisible, onHidden } = params;
+  if (_isUndefined(prevVisibilityState) || _isUndefined(currentVisibilityState)) {
+    return;
+  }
+
+  if (prevVisibilityState && !currentVisibilityState && _isFunction(onHidden)) {
+    onHidden();
+  }
+
+  if (!prevVisibilityState && currentVisibilityState && _isFunction(onVisible)) {
+    onVisible();
+  }
+}
+
+export const withPageVisibility = WrappedComponent => {
+  const Component = props => {
+    const isVisible = usePageVisibility();
+    return <WrappedComponent {...props} isPageVisible={isVisible} />;
+  };
+
+  return Component;
+};

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -23,6 +23,7 @@
     "react": "16.11.0",
     "react-dom": "16.11.0",
     "react-linkify": "1.0.0-alpha",
+    "react-page-visibility": "^5.1.0",
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
     "react-router-prop-types": "1.0.4",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -8000,6 +8000,13 @@ react-linkify@1.0.0-alpha:
     linkify-it "^2.0.3"
     tlds "^1.199.0"
 
+react-page-visibility@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-page-visibility/-/react-page-visibility-5.1.0.tgz#64f44961f57b12a48603f1bdfe7d082310e161bf"
+  integrity sha512-xzo063refxWUSVbBvLon3/hlkPZGtrypwKACIe48C2PLH9I2YT5tnaNOCnJCvN7p3UFovxf4jc2yXszWmzXPBA==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-router-dom@5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"


### PR DESCRIPTION
#### Problem

At the moment, if a user opens the dashboard and leaves it in a browser tab or a minimised window, it will keep polling the backend every 2 seconds. This may have an important impact on Prometheus, specially on big clusters and/or if multiple users do the same. Some browsers (Safari mostly) try to slow down intervals when this happens, but it's not as good as it could be and not consistent across browsers.

#### Solution

With this change we pause the network activity when the dashboard is not visible, resuming it as soon as the user goes back to it. To do that, we are using the [react-page-visibility](https://github.com/pgilad/react-page-visibility) library. This is an example of how we are using it:

```javascript
import { handlePageVisibility, withPageVisibility } from './PageVisibility.jsx';

class Component extends React.Component {
  static propTypes = {
    isPageVisible: PropTypes.bool.isRequired,
  }

  componentDidUpdate(prevProps) {
    handlePageVisibility({
      prevVisibilityState: prevProps.isPageVisible,
      currentVisibilityState: this.props.isPageVisible,
      onVisible: () => this.startServerPolling(),
      onHidden: () => this.stopServerPolling(),
    });
  }

  startServerPolling() {
    …
  }

  stopServerPolling() {
    …
  }

  render() {
    return <div>Hi!</div>;
  }
}

export default withPageVisibility(Component);
```

The change has been applied to 8 components, the ones in which network operations are taking place.

More details about this issue and the impact of the solution [here](https://github.com/linkerd/linkerd2/issues/3618#issuecomment-556167134)

Related to #3618

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>

This branch was created from the [react-update branch](https://github.com/linkerd/linkerd2/pull/3737) as it needs a more recent React version, so please check only the commit `Pause dashboard network activity when page is hidden`. This may cause the PR to look bigger than it actually is.