### PR TITLE
Refactored logic in inject.go's tranform()

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -20,7 +20,7 @@ type testCase struct {
 	inputFileName          string
 	goldenFileName         string
 	reportFileName         string
-	inject                 injectProxy
+	injectProxy            injectionMode
 	testInjectConfig       *config.All
 	overrideAnnotations    map[string]string
 	enableDebugSidecarFlag bool
@@ -44,7 +44,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	output := new(bytes.Buffer)
 	report := new(bytes.Buffer)
 	transformer := &resourceTransformerInject{
-		inject:              tc.inject,
+		injectProxy:         tc.injectProxy,
 		configs:             tc.testInjectConfig,
 		overrideAnnotations: tc.overrideAnnotations,
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
@@ -107,28 +107,28 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_version_config.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: emptyVersionConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_proxy_version_config.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: emptyProxyVersionConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_overridden_noinject.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyAnnotation,
+			injectProxy:      injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.ProxyAdminPortAnnotation: "1234",
@@ -138,7 +138,7 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_overridden.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.ProxyAdminPortAnnotation: "1234",
@@ -148,119 +148,119 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_list.input.yml",
 			goldenFileName:   "inject_emojivoto_list.golden.yml",
 			reportFileName:   "inject_emojivoto_list.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_false.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_false.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_false.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_true.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_injectDisabled.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_injectDisabled.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_injectDisabled.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_controller_name.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_controller_name.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_controller_name.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_statefulset.input.yml",
 			goldenFileName:   "inject_emojivoto_statefulset.golden.yml",
 			reportFileName:   "inject_emojivoto_statefulset.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod.input.yml",
 			goldenFileName:   "inject_emojivoto_pod.golden.yml",
 			reportFileName:   "inject_emojivoto_pod.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod_with_requests.input.yml",
 			goldenFileName:   "inject_emojivoto_pod_with_requests.golden.yml",
 			reportFileName:   "inject_emojivoto_pod_with_requests.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: proxyResourceConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_udp.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_udp.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_udp.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_already_injected.input.yml",
 			goldenFileName:   "inject_emojivoto_already_injected.golden.yml",
 			reportFileName:   "inject_emojivoto_already_injected.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_istio.input.yml",
 			goldenFileName:   "inject_emojivoto_istio.input.yml",
 			reportFileName:   "inject_emojivoto_istio.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_contour.input.yml",
 			goldenFileName:   "inject_contour.input.yml",
 			reportFileName:   "inject_contour.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_empty_resources.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_list_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_list_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_list_empty_resources.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_no_init_container.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: noInitContainerConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_config_overrides.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_config_overrides.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			inject:           injectProxyDirectly,
+			injectProxy:      injectProxyDirectly,
 			testInjectConfig: overrideConfig,
 		},
 		{
 			inputFileName:          "inject_emojivoto_deployment.input.yml",
 			goldenFileName:         "inject_emojivoto_deployment_debug.golden.yml",
 			reportFileName:         "inject_emojivoto_deployment.report",
-			inject:                 injectProxyDirectly,
+			injectProxy:            injectProxyDirectly,
 			testInjectConfig:       defaultConfig,
 			enableDebugSidecarFlag: true,
 		},
@@ -268,14 +268,14 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_namespace_good.input.yml",
 			goldenFileName:   "inject_emojivoto_namespace_good.golden.yml",
 			reportFileName:   "inject_emojivoto_namespace_good.golden.report",
-			inject:           injectProxyAnnotation,
+			injectProxy:      injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_namespace_good.input.yml",
 			goldenFileName:   "inject_emojivoto_namespace_overidden_good.golden.yml",
 			reportFileName:   "inject_emojivoto_namespace_good.golden.report",
-			inject:           injectProxyAnnotation,
+			injectProxy:      injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.IdentityModeAnnotation: "default",
@@ -302,7 +302,7 @@ type injectCmd struct {
 	stdErrGoldenFileName string
 	stdOutGoldenFileName string
 	exitCode             int
-	inject               injectProxy
+	injectProxy          injectionMode
 }
 
 func testInjectCmd(t *testing.T, tc injectCmd) {
@@ -318,8 +318,8 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 	}
 
 	transformer := &resourceTransformerInject{
-		inject:  tc.inject,
-		configs: testConfig,
+		injectProxy: tc.injectProxy,
+		configs:     testConfig,
 	}
 	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, transformer)
 	if exitCode != tc.exitCode {
@@ -341,20 +341,20 @@ func TestRunInjectCmd(t *testing.T) {
 			inputFileName:        "inject_gettest_deployment.bad.input.yml",
 			stdErrGoldenFileName: "inject_gettest_deployment.bad.golden",
 			exitCode:             1,
-			inject:               injectProxyDirectly,
+			injectProxy:          injectProxyDirectly,
 		},
 		{
 			inputFileName:        "inject_tap_deployment.bad.input.yml",
 			stdErrGoldenFileName: "inject_tap_deployment.bad.golden",
 			exitCode:             1,
-			inject:               injectProxyAnnotation,
+			injectProxy:          injectProxyAnnotation,
 		},
 		{
 			inputFileName:        "inject_gettest_deployment.good.input.yml",
 			stdOutGoldenFileName: "inject_gettest_deployment.good.golden.yml",
 			stdErrGoldenFileName: "inject_gettest_deployment.good.golden.stderr",
 			exitCode:             0,
-			inject:               injectProxyDirectly,
+			injectProxy:          injectProxyDirectly,
 		},
 	}
 
@@ -387,8 +387,8 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
 	transformer := &resourceTransformerInject{
-		inject:  injectProxyDirectly,
-		configs: testInstallConfig(),
+		injectProxy: injectProxyDirectly,
+		configs:     testInstallConfig(),
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
@@ -408,8 +408,8 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
 	transformer := &resourceTransformerInject{
-		inject:  injectProxyDirectly,
-		configs: testInstallConfig(),
+		injectProxy: injectProxyDirectly,
+		configs:     testInstallConfig(),
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -20,7 +20,7 @@ type testCase struct {
 	inputFileName          string
 	goldenFileName         string
 	reportFileName         string
-	injectProxy            bool
+	inject                 injectProxy
 	testInjectConfig       *config.All
 	overrideAnnotations    map[string]string
 	enableDebugSidecarFlag bool
@@ -44,7 +44,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 	output := new(bytes.Buffer)
 	report := new(bytes.Buffer)
 	transformer := &resourceTransformerInject{
-		injectProxy:         tc.injectProxy,
+		inject:              tc.inject,
 		configs:             tc.testInjectConfig,
 		overrideAnnotations: tc.overrideAnnotations,
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
@@ -107,28 +107,28 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_version_config.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: emptyVersionConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_proxy_version_config.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: emptyProxyVersionConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_overridden_noinject.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      false,
+			inject:           injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.ProxyAdminPortAnnotation: "1234",
@@ -138,7 +138,7 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_overridden.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.ProxyAdminPortAnnotation: "1234",
@@ -148,119 +148,119 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_list.input.yml",
 			goldenFileName:   "inject_emojivoto_list.golden.yml",
 			reportFileName:   "inject_emojivoto_list.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_false.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_false.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_false.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_hostNetwork_true.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_hostNetwork_true.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_injectDisabled.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_injectDisabled.input.yml",
 			reportFileName:   "inject_emojivoto_deployment_injectDisabled.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_controller_name.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_controller_name.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_controller_name.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_statefulset.input.yml",
 			goldenFileName:   "inject_emojivoto_statefulset.golden.yml",
 			reportFileName:   "inject_emojivoto_statefulset.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod.input.yml",
 			goldenFileName:   "inject_emojivoto_pod.golden.yml",
 			reportFileName:   "inject_emojivoto_pod.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_pod_with_requests.input.yml",
 			goldenFileName:   "inject_emojivoto_pod_with_requests.golden.yml",
 			reportFileName:   "inject_emojivoto_pod_with_requests.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: proxyResourceConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_udp.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_udp.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_udp.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_already_injected.input.yml",
 			goldenFileName:   "inject_emojivoto_already_injected.golden.yml",
 			reportFileName:   "inject_emojivoto_already_injected.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_istio.input.yml",
 			goldenFileName:   "inject_emojivoto_istio.input.yml",
 			reportFileName:   "inject_emojivoto_istio.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_contour.input.yml",
 			goldenFileName:   "inject_contour.input.yml",
 			reportFileName:   "inject_contour.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment_empty_resources.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_list_empty_resources.input.yml",
 			goldenFileName:   "inject_emojivoto_list_empty_resources.golden.yml",
 			reportFileName:   "inject_emojivoto_list_empty_resources.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_no_init_container.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: noInitContainerConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_deployment_config_overrides.input.yml",
 			goldenFileName:   "inject_emojivoto_deployment_config_overrides.golden.yml",
 			reportFileName:   "inject_emojivoto_deployment.report",
-			injectProxy:      true,
+			inject:           injectProxyDirectly,
 			testInjectConfig: overrideConfig,
 		},
 		{
 			inputFileName:          "inject_emojivoto_deployment.input.yml",
 			goldenFileName:         "inject_emojivoto_deployment_debug.golden.yml",
 			reportFileName:         "inject_emojivoto_deployment.report",
-			injectProxy:            true,
+			inject:                 injectProxyDirectly,
 			testInjectConfig:       defaultConfig,
 			enableDebugSidecarFlag: true,
 		},
@@ -268,14 +268,14 @@ func TestUninjectAndInject(t *testing.T) {
 			inputFileName:    "inject_emojivoto_namespace_good.input.yml",
 			goldenFileName:   "inject_emojivoto_namespace_good.golden.yml",
 			reportFileName:   "inject_emojivoto_namespace_good.golden.report",
-			injectProxy:      false,
+			inject:           injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 		},
 		{
 			inputFileName:    "inject_emojivoto_namespace_good.input.yml",
 			goldenFileName:   "inject_emojivoto_namespace_overidden_good.golden.yml",
 			reportFileName:   "inject_emojivoto_namespace_good.golden.report",
-			injectProxy:      false,
+			inject:           injectProxyAnnotation,
 			testInjectConfig: defaultConfig,
 			overrideAnnotations: map[string]string{
 				k8s.IdentityModeAnnotation: "default",
@@ -302,7 +302,7 @@ type injectCmd struct {
 	stdErrGoldenFileName string
 	stdOutGoldenFileName string
 	exitCode             int
-	injectProxy          bool
+	inject               injectProxy
 }
 
 func testInjectCmd(t *testing.T, tc injectCmd) {
@@ -318,8 +318,8 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 	}
 
 	transformer := &resourceTransformerInject{
-		injectProxy: tc.injectProxy,
-		configs:     testConfig,
+		inject:  tc.inject,
+		configs: testConfig,
 	}
 	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, transformer)
 	if exitCode != tc.exitCode {
@@ -341,20 +341,20 @@ func TestRunInjectCmd(t *testing.T) {
 			inputFileName:        "inject_gettest_deployment.bad.input.yml",
 			stdErrGoldenFileName: "inject_gettest_deployment.bad.golden",
 			exitCode:             1,
-			injectProxy:          true,
+			inject:               injectProxyDirectly,
 		},
 		{
 			inputFileName:        "inject_tap_deployment.bad.input.yml",
 			stdErrGoldenFileName: "inject_tap_deployment.bad.golden",
 			exitCode:             1,
-			injectProxy:          false,
+			inject:               injectProxyAnnotation,
 		},
 		{
 			inputFileName:        "inject_gettest_deployment.good.input.yml",
 			stdOutGoldenFileName: "inject_gettest_deployment.good.golden.yml",
 			stdErrGoldenFileName: "inject_gettest_deployment.good.golden.stderr",
 			exitCode:             0,
-			injectProxy:          true,
+			inject:               injectProxyDirectly,
 		},
 	}
 
@@ -387,8 +387,8 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
 	transformer := &resourceTransformerInject{
-		injectProxy: true,
-		configs:     testInstallConfig(),
+		inject:  injectProxyDirectly,
+		configs: testInstallConfig(),
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
@@ -408,8 +408,8 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 	errBuf := &bytes.Buffer{}
 	actual := &bytes.Buffer{}
 	transformer := &resourceTransformerInject{
-		injectProxy: true,
-		configs:     testInstallConfig(),
+		inject:  injectProxyDirectly,
+		configs: testInstallConfig(),
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -755,8 +755,8 @@ func render(w io.Writer, values *charts.Values, configs *pb.All) error {
 	}
 
 	return processYAML(&buf, w, ioutil.Discard, resourceTransformerInject{
-		injectProxy: true,
-		configs:     configs,
+		inject:  injectProxySkip,
+		configs: configs,
 	})
 }
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -755,8 +755,8 @@ func render(w io.Writer, values *charts.Values, configs *pb.All) error {
 	}
 
 	return processYAML(&buf, w, ioutil.Discard, resourceTransformerInject{
-		inject:  injectProxySkip,
-		configs: configs,
+		injectProxy: injectProxySkip,
+		configs:     configs,
 	})
 }
 

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: Namespace
   annotations:
     ProxyInjectAnnotation: ProxyInjectDisabled
-  creationTimestamp: null
   labels:
     LinkerdNamespaceLabel: "true"
     config.linkerd.io/admission-webhooks: disabled
-  name: Namespace
-spec: {}
-status: {}
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC


### PR DESCRIPTION
Refactored `resourceTransformerInject.inject` to an enum, so we can
clearly distinguish these cases:
- when we want to skip injection altogether (during install because the
helm templates do it for us)
- when we want to inject the proxy directly (using `--manual`)
- when we want to just add the inject annotation

That to be able to more clearly handle each case in the injection
`tranform` function, and fix an issue from #3687 where
`linkerd-heartbeat` was getting injected, after CronJob support was
added.

As a small nice side-effect, the namespace yamls in `cli/cmd/install_test.go` are no
longer needed to be parsed, which explains the yaml properties are no
longer redistributed as shown in the golden files diffs here.

I tested that we still can inject the debug sidecar into controller pods, but a
followup PR will have to add a unit (or integration) test for that.