### PR TITLE
Add some unit tests for namespace select button

### DIFF
--- a/web/app/js/components/BaseTable.test.js
+++ b/web/app/js/components/BaseTable.test.js
@@ -102,6 +102,7 @@ describe("Tests for <BaseTable>", () => {
     });
 
     const component = mount(<BaseTable {...extraProps} />);
+    expect(component.find("TableBody").find("TableRow")).toHaveLength(2);
     const enableFilter = component.prop("enableFilter");
     const filterIcon = component.find("FilterListIcon");
     expect(enableFilter).toEqual(true);
@@ -113,6 +114,7 @@ describe("Tests for <BaseTable>", () => {
       input.simulate("change", {target: {value: "authors"}});
       expect(table.html()).not.toContain('books');
       expect(table.html()).toContain('authors');
+      expect(component.find("TableBody").find("TableRow")).toHaveLength(1);
     }, 100);
   });
 });

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -15,6 +15,11 @@ const loc = {
   search: '',
 };
 
+const namespaces = [
+  {key: "-namespace-default", name: "default", namespace: "", type: "namespace"},
+  {key: "-namespace-emojivoto", name: "emojivoto", namespace: "", type: "namespace"},
+  {key: "-namespace-linkerd", name: "linkerd", namespace: "", type: "namespace"},
+];
 
 describe('Navigation', () => {
   let curVer = "edge-1.2.3";
@@ -122,5 +127,122 @@ describe('Navigation', () => {
       expect(component.find("NavigationBase").state("error")).toBeDefined();
       expect(component.find("NavigationBase").state("error").statusText).toBe("Fake error");
     });
+  });
+});
+
+describe('Namespace Select Button', () => {
+  it('renders All Namespaces text', () => {
+    const component = mount(
+      <BrowserRouter>
+        <Navigation
+          ChildComponent={() => null}
+          classes={{}}
+          theme={{}}
+          location={loc}
+          api={ApiHelpers("")}
+          releaseVersion="edge-1.2.3"
+          selectedNamespace="_all"
+          pathPrefix=""
+          uuid="fakeuuid" />
+      </BrowserRouter>
+    );
+
+    const button = component.find("Button");
+    expect(button).toIncludeText("All Namespaces");
+  });
+
+  it('renders emojivoto text', () => {
+    const component = mount(
+      <BrowserRouter>
+        <Navigation
+          ChildComponent={() => null}
+          classes={{}}
+          theme={{}}
+          location={loc}
+          api={ApiHelpers("")}
+          releaseVersion="edge-1.2.3"
+          selectedNamespace="emojivoto"
+          pathPrefix=""
+          uuid="fakeuuid" />
+      </BrowserRouter>
+    );
+
+    const button = component.find("Button");
+    expect(button).toIncludeText("emojivoto");
+  });
+
+  it('renders emojivoto text', () => {
+    const component = mount(
+      <BrowserRouter>
+        <Navigation
+          ChildComponent={() => null}
+          classes={{}}
+          theme={{}}
+          location={loc}
+          api={ApiHelpers("")}
+          releaseVersion="edge-1.2.3"
+          selectedNamespace="emojivoto"
+          pathPrefix=""
+          uuid="fakeuuid" />
+      </BrowserRouter>
+    );
+
+    const button = component.find("Button");
+    expect(button).toIncludeText("emojivoto");
+  });
+
+  it('checks if button opens Menu', () => {
+    const component = mount(
+      <BrowserRouter>
+        <Navigation
+          ChildComponent={() => null}
+          classes={{}}
+          theme={{}}
+          location={loc}
+          api={ApiHelpers("")}
+          releaseVersion="edge-1.2.3"
+          selectedNamespace="emojivoto"
+          pathPrefix=""
+          uuid="fakeuuid" />
+      </BrowserRouter>
+    );
+
+    expect(component.find("Menu").props().open).toBeFalsy();
+
+    const button = component.find("Button");
+    button.simulate("click");
+
+    expect(component.find("Menu").props().open).toBeTruthy();
+  });
+
+  it('renders Menu with correct MenuItem number', () => {
+    const component = mount(
+      <BrowserRouter>
+        <Navigation
+          ChildComponent={() => null}
+          classes={{}}
+          theme={{}}
+          location={loc}
+          api={ApiHelpers("")}
+          releaseVersion="edge-1.2.3"
+          selectedNamespace="emojivoto"
+          pathPrefix=""
+          uuid="fakeuuid" />
+      </BrowserRouter>
+    );
+
+    expect(component.find("Menu").find("MenuItem")).toHaveLength(2);
+
+    component.find("NavigationBase").instance().setState({
+      namespaces: namespaces,
+    });
+    component.update();
+    expect(component.find("Menu").find("MenuItem")).toHaveLength(5);
+
+    component.find("NavigationBase").instance().setState({
+      formattedNamespaceFilter: "de",
+    });
+    component.update();
+    expect(component.find("Menu").find("MenuItem")).toHaveLength(3);
   });
 });

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -131,7 +131,7 @@ describe('Navigation', () => {
 });
 
 describe('Namespace Select Button', () => {
-  it('renders All Namespaces text', () => {
+  it('displays All Namespaces as button text if the selected namespace is _all', () => {
     const component = mount(
       <BrowserRouter>
         <Navigation
@@ -171,27 +171,7 @@ describe('Namespace Select Button', () => {
     expect(button).toIncludeText("emojivoto");
   });
 
-  it('renders emojivoto text', () => {
-    const component = mount(
-      <BrowserRouter>
-        <Navigation
-          ChildComponent={() => null}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={ApiHelpers("")}
-          releaseVersion="edge-1.2.3"
-          selectedNamespace="emojivoto"
-          pathPrefix=""
-          uuid="fakeuuid" />
-      </BrowserRouter>
-    );
-
-    const button = component.find("Button");
-    expect(button).toIncludeText("emojivoto");
-  });
-
-  it('checks if button opens Menu', () => {
+  it('opens the Namespace Selection menu if button is clicked', () => {
     const component = mount(
       <BrowserRouter>
         <Navigation
@@ -215,34 +195,58 @@ describe('Namespace Select Button', () => {
     expect(component.find("Menu").props().open).toBeTruthy();
   });
 
-  it('renders Menu with correct MenuItem number', () => {
-    const component = mount(
-      <BrowserRouter>
-        <Navigation
-          ChildComponent={() => null}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={ApiHelpers("")}
-          releaseVersion="edge-1.2.3"
-          selectedNamespace="emojivoto"
-          pathPrefix=""
-          uuid="fakeuuid" />
-      </BrowserRouter>
-    );
+  describe('renders namespace selection menu with correct number of options', () => {
+    it('5 options', () => {
+      const component = mount(
+        <BrowserRouter>
+          <Navigation
+            ChildComponent={() => null}
+            classes={{}}
+            theme={{}}
+            location={loc}
+            api={ApiHelpers("")}
+            releaseVersion="edge-1.2.3"
+            selectedNamespace="emojivoto"
+            pathPrefix=""
+            uuid="fakeuuid" />
+        </BrowserRouter>
+      );
 
-    expect(component.find("Menu").find("MenuItem")).toHaveLength(2);
+      expect(component.find("Menu").find("MenuItem")).toHaveLength(2);
 
-    component.find("NavigationBase").instance().setState({
-      namespaces: namespaces,
+      component.find("NavigationBase").instance().setState({
+        namespaces: namespaces,
+      });
+      component.update();
+      // 5 items = Input - "Select Namespace..." + "All Namespaces" item + 3 added namespaces
+      expect(component.find("Menu").find("MenuItem")).toHaveLength(5);
     });
-    component.update();
-    expect(component.find("Menu").find("MenuItem")).toHaveLength(5);
 
-    component.find("NavigationBase").instance().setState({
-      formattedNamespaceFilter: "de",
+    it('3 options', () => {
+      const component = mount(
+        <BrowserRouter>
+          <Navigation
+            ChildComponent={() => null}
+            classes={{}}
+            theme={{}}
+            location={loc}
+            api={ApiHelpers("")}
+            releaseVersion="edge-1.2.3"
+            selectedNamespace="emojivoto"
+            pathPrefix=""
+            uuid="fakeuuid" />
+        </BrowserRouter>
+      );
+
+      expect(component.find("Menu").find("MenuItem")).toHaveLength(2);
+
+      component.find("NavigationBase").instance().setState({
+        namespaces: namespaces,
+        formattedNamespaceFilter: "de",
+      });
+      component.update();
+      // 3 items = "Input - Select Namespace..." + "All Namespaces" item + 1 namespace which matches "de" string
+      expect(component.find("Menu").find("MenuItem")).toHaveLength(3);
     });
-    component.update();
-    expect(component.find("Menu").find("MenuItem")).toHaveLength(3);
   });
 });

--- a/web/app/js/components/util/Utils.test.js
+++ b/web/app/js/components/util/Utils.test.js
@@ -127,7 +127,7 @@ describe('Utils', () => {
   });
 
   describe('regexFilterString', () => {
-    it('converts string to a valid regex for namespaces', () => {
+    it('converts input string to a valid regex for filtering', () => {
       expect(regexFilterString('emojivoto')).toEqual(new RegExp(/emojivoto/));
       expect(regexFilterString('emojivoto123')).toEqual(new RegExp(/emojivoto123/));
       expect(regexFilterString('emojivoto*')).toEqual(new RegExp(/emojivoto.+/));
@@ -137,6 +137,9 @@ describe('Utils', () => {
       expect(regexFilterString('emojivoto_.')).toEqual(new RegExp(/emojivoto_./));
       expect(regexFilterString('emojivoto_.{')).toEqual(new RegExp(/emojivoto_./));
       expect(regexFilterString('emojivoto//')).toEqual(new RegExp(/emojivoto\/\//));
+      expect(regexFilterString('emojivoto//')).toEqual(new RegExp(/emojivoto\/\//));
+      expect(regexFilterString('emojivoto-prod-1')).toEqual(new RegExp(/emojivoto-prod-1/));
+      expect(regexFilterString('emoji??Voto-pr##od-1')).toEqual(new RegExp(/emojivoto-prod-1/));
     })
   });
 });

--- a/web/app/js/components/util/Utils.test.js
+++ b/web/app/js/components/util/Utils.test.js
@@ -1,6 +1,7 @@
 import {
   formatLatencySec,
   metricToFormatter,
+  regexFilterString,
   styleNum,
   toClassName
 } from './Utils.js';
@@ -123,5 +124,19 @@ describe('Utils', () => {
       expect(toClassName('potato123yam0squash')).toEqual('potato_123_yam_0_squash');
       expect(toClassName('test/potato-e1af21-f3f3')).toEqual('test_potato_e_1_af_21_f_3_f_3');
     });
+  });
+
+  describe('regexFilterString', () => {
+    it('converts string to a valid regex for namespaces', () => {
+      expect(regexFilterString('emojivoto')).toEqual(new RegExp(/emojivoto/));
+      expect(regexFilterString('emojivoto123')).toEqual(new RegExp(/emojivoto123/));
+      expect(regexFilterString('emojivoto*')).toEqual(new RegExp(/emojivoto.+/));
+      expect(regexFilterString('emojivoto**')).toEqual(new RegExp(/emojivoto.+.+/));
+      expect(regexFilterString('Emojivoto')).toEqual(new RegExp(/emojivoto/));
+      expect(regexFilterString('emojivoto{}')).toEqual(new RegExp(/emojivoto/));
+      expect(regexFilterString('emojivoto_.')).toEqual(new RegExp(/emojivoto_./));
+      expect(regexFilterString('emojivoto_.{')).toEqual(new RegExp(/emojivoto_./));
+      expect(regexFilterString('emojivoto//')).toEqual(new RegExp(/emojivoto\/\//));
+    })
   });
 });


### PR DESCRIPTION
This PR adds some unit tests for the namespace select button, and for filter functionality in both namespace selection and filter-able Table.

Tests have been added to components: `Utils`, `BaseTable` and `Navigation`.

Related to #3678

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
