### PR TITLE
Fix issue with grid for Tap/Top form

### DIFF
--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -60,16 +60,12 @@ const styles = theme => ({
   formControlWrapper: {
     minWidth: 200,
   },
-  formControlWithAutoWidth: {
+  formControl: {
     padding: theme.spacing.unit,
     paddingLeft: 0,
     minWidth: 'inherit',
     maxWidth: '100%',
     width: 'auto',
-  },
-  formControl: {
-    margin: theme.spacing.unit,
-    minWidth: 200,
   },
   selectEmpty: {
     'margin-top': '32px'
@@ -329,12 +325,12 @@ class TapQueryForm extends React.Component {
       <Grid container>
 
         <Grid container spacing={24}>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             <FormControl className={classes.formControl}>
               {this.renderNamespaceSelect("To Namespace", "toNamespace", "toResource")}
             </FormControl>
           </Grid>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             <FormControl className={classes.formControl} disabled={_isEmpty(this.state.query.toNamespace)}>
               {this.renderResourceSelect("toResource", "toNamespace")}
             </FormControl>
@@ -342,7 +338,7 @@ class TapQueryForm extends React.Component {
         </Grid>
 
         <Grid container spacing={24}>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             <FormControl className={classes.formControl}>
               <InputLabel htmlFor="authority">Authority</InputLabel>
               <Select
@@ -359,19 +355,19 @@ class TapQueryForm extends React.Component {
               <FormHelperText>Display requests with this :authority</FormHelperText>
             </FormControl>
           </Grid>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             { this.renderTextInput("Path", "path", "Display requests with paths that start with this prefix") }
           </Grid>
         </Grid>
 
         <Grid container spacing={24}>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             { this.renderTextInput("Scheme", "scheme", "Display requests with this scheme") }
           </Grid>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             { this.renderTextInput("Max RPS", "maxRps", `Maximum requests per second to tap. Default ${defaultMaxRps}`) }
           </Grid>
-          <Grid item xs={6} md={3}>
+          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
             <FormControl className={classes.formControl}>
               <InputLabel htmlFor="method">HTTP method</InputLabel>
               <Select
@@ -417,14 +413,14 @@ class TapQueryForm extends React.Component {
       <Card className={classes.card}>
         <CardContent>
           <Grid container spacing={24}>
-            <Grid item xs={6} md="auto" spacing={1} classes={{ item: classes.formControlWrapper }}>
-              <FormControl className={classes.formControlWithAutoWidth} fullWidth>
+            <Grid item xs={6} md="auto" classes={{ item: classes.formControlWrapper }}>
+              <FormControl className={classes.formControl} fullWidth>
                 {this.renderNamespaceSelect("Namespace", "namespace", "resource")}
               </FormControl>
             </Grid>
 
-            <Grid item xs={6} md="auto" spacing={1} classes={{ item: classes.formControlWrapper }}>
-              <FormControl className={classes.formControlWithAutoWidth} disabled={_isEmpty(this.state.query.namespace)} fullWidth>
+            <Grid item xs={6} md="auto" classes={{ item: classes.formControlWrapper }}>
+              <FormControl className={classes.formControl} disabled={_isEmpty(this.state.query.namespace)} fullWidth>
                 {this.renderResourceSelect("resource", "namespace")}
               </FormControl>
             </Grid>

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -63,6 +63,7 @@ const styles = theme => ({
   formControl: {
     padding: theme.spacing.unit,
     paddingLeft: 0,
+    margin: 0,
     minWidth: 'inherit',
     maxWidth: '100%',
     width: 'auto',
@@ -325,12 +326,12 @@ class TapQueryForm extends React.Component {
       <Grid container>
 
         <Grid container spacing={24}>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             <FormControl className={classes.formControl}>
               {this.renderNamespaceSelect("To Namespace", "toNamespace", "toResource")}
             </FormControl>
           </Grid>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             <FormControl className={classes.formControl} disabled={_isEmpty(this.state.query.toNamespace)}>
               {this.renderResourceSelect("toResource", "toNamespace")}
             </FormControl>
@@ -355,19 +356,19 @@ class TapQueryForm extends React.Component {
               <FormHelperText>Display requests with this :authority</FormHelperText>
             </FormControl>
           </Grid>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             { this.renderTextInput("Path", "path", "Display requests with paths that start with this prefix") }
           </Grid>
         </Grid>
 
         <Grid container spacing={24}>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             { this.renderTextInput("Scheme", "scheme", "Display requests with this scheme") }
           </Grid>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             { this.renderTextInput("Max RPS", "maxRps", `Maximum requests per second to tap. Default ${defaultMaxRps}`) }
           </Grid>
-          <Grid item xs={6} md={3} classes={{ item: classes.formControlWrapper }}>
+          <Grid item xs={6} md={3} className={classes.formControlWrapper}>
             <FormControl className={classes.formControl}>
               <InputLabel htmlFor="method">HTTP method</InputLabel>
               <Select
@@ -413,13 +414,13 @@ class TapQueryForm extends React.Component {
       <Card className={classes.card}>
         <CardContent>
           <Grid container spacing={24}>
-            <Grid item xs={6} md="auto" classes={{ item: classes.formControlWrapper }}>
+            <Grid item xs={6} md="auto" className={classes.formControlWrapper}>
               <FormControl className={classes.formControl} fullWidth>
                 {this.renderNamespaceSelect("Namespace", "namespace", "resource")}
               </FormControl>
             </Grid>
 
-            <Grid item xs={6} md="auto" classes={{ item: classes.formControlWrapper }}>
+            <Grid item xs={6} md="auto" className={classes.formControlWrapper}>
               <FormControl className={classes.formControl} disabled={_isEmpty(this.state.query.namespace)} fullWidth>
                 {this.renderResourceSelect("resource", "namespace")}
               </FormControl>
@@ -427,7 +428,7 @@ class TapQueryForm extends React.Component {
 
             <Grid item>
               { this.renderTapButton(this.props.tapRequestInProgress, this.props.tapIsClosing) }
-              <Button onClick={this.resetTapForm} disabled={this.props.tapRequestInProgress} classes={{ root: classes.resetButton }}>Reset</Button>
+              <Button onClick={this.resetTapForm} disabled={this.props.tapRequestInProgress} className={classes.resetButton}>Reset</Button>
             </Grid>
           </Grid>
         </CardContent>

--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -57,6 +57,16 @@ const styles = theme => ({
     display: 'flex',
     flexWrap: 'wrap',
   },
+  formControlWrapper: {
+    minWidth: 200,
+  },
+  formControlWithAutoWidth: {
+    padding: theme.spacing.unit,
+    paddingLeft: 0,
+    minWidth: 'inherit',
+    maxWidth: '100%',
+    width: 'auto',
+  },
   formControl: {
     margin: theme.spacing.unit,
     minWidth: 200,
@@ -83,6 +93,9 @@ const styles = theme => ({
   },
   expandOpen: {
     transform: 'rotate(180deg)',
+  },
+  resetButton: {
+    marginLeft: theme.spacing.unit,
   }
 });
 
@@ -404,24 +417,21 @@ class TapQueryForm extends React.Component {
       <Card className={classes.card}>
         <CardContent>
           <Grid container spacing={24}>
-            <Grid item xs={6} md={3}>
-              <FormControl className={classes.formControl}>
+            <Grid item xs={6} md="auto" spacing={1} classes={{ item: classes.formControlWrapper }}>
+              <FormControl className={classes.formControlWithAutoWidth} fullWidth>
                 {this.renderNamespaceSelect("Namespace", "namespace", "resource")}
               </FormControl>
             </Grid>
 
-            <Grid item xs={6} md={3}>
-              <FormControl className={classes.formControl} disabled={_isEmpty(this.state.query.namespace)}>
+            <Grid item xs={6} md="auto" spacing={1} classes={{ item: classes.formControlWrapper }}>
+              <FormControl className={classes.formControlWithAutoWidth} disabled={_isEmpty(this.state.query.namespace)} fullWidth>
                 {this.renderResourceSelect("resource", "namespace")}
               </FormControl>
             </Grid>
 
-            <Grid item xs={4} md={1}>
+            <Grid item>
               { this.renderTapButton(this.props.tapRequestInProgress, this.props.tapIsClosing) }
-            </Grid>
-
-            <Grid item xs={4} md={1}>
-              <Button onClick={this.resetTapForm} disabled={this.props.tapRequestInProgress}>Reset</Button>
+              <Button onClick={this.resetTapForm} disabled={this.props.tapRequestInProgress} classes={{ root: classes.resetButton }}>Reset</Button>
             </Grid>
           </Grid>
         </CardContent>


### PR DESCRIPTION
#### Problem

Depending on the length of the resource name, the `Start` and `Reset` buttons in `Tap` and `Top` are incorrectly rendered, covering part of the input form. 

#### Solution

This PR fixes these problems related with the described problem:

- Remove units from buttons `Grid` - this was causing overlapping issues when the grid width was shorter than the buttons 
- Remove `200` value from `minWidth` from `FormControl` - this was causing the same problem described above
- Remove units from `md` prop for FormControl’s Grid - this was forcing to not render the full resource name (if we want to add a maxWidth for this input, please let me know)
- Add buttons into the same `Grid` to be sure that they are together when input is too long and some has to be rendered in a different line.

Closes #3778

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>

<img width="1436" alt="tapTop" src="https://user-images.githubusercontent.com/1440981/70098459-47f78f80-162c-11ea-8eff-53d97b170717.png">

<img width="1436" alt="tapTop_01" src="https://user-images.githubusercontent.com/1440981/70098464-4ded7080-162c-11ea-829d-67df1365f6ce.png">

<img width="777" alt="tapTop_02" src="https://user-images.githubusercontent.com/1440981/70098467-52b22480-162c-11ea-96f5-b41b6506f3d7.png">


