### PR TITLE
No need for `processYAML()` in `install`

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -754,10 +754,8 @@ func render(w io.Writer, values *charts.Values, configs *pb.All) error {
 		return err
 	}
 
-	return processYAML(&buf, w, ioutil.Discard, resourceTransformerInject{
-		injectProxy: true,
-		configs:     configs,
-	})
+	_, err = w.Write(buf.Bytes())
+	return err
 }
 
 func (options *installOptions) configs(identity *pb.IdentityContext) *pb.All {

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -380,12 +380,12 @@ control plane.`,
 }
 
 func installRunE(options *installOptions, stage string, flags *pflag.FlagSet) error {
-	values, configs, err := options.validateAndBuild(stage, flags)
+	values, _, err := options.validateAndBuild(stage, flags)
 	if err != nil {
 		return err
 	}
 
-	return render(os.Stdout, values, configs)
+	return render(os.Stdout, values)
 }
 
 func (options *installOptions) validateAndBuild(stage string, flags *pflag.FlagSet) (*charts.Values, *pb.All, error) {
@@ -714,8 +714,7 @@ func toPromLogLevel(level string) string {
 	}
 }
 
-// TODO: are `installValues.Configs` and `configs` redundant?
-func render(w io.Writer, values *charts.Values, configs *pb.All) error {
+func render(w io.Writer, values *charts.Values) error {
 	// Render raw values and create chart config
 	rawValues, err := yaml.Marshal(values)
 	if err != nil {

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -836,4 +833,3 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
----

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -2189,4 +2189,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3027,4 +3024,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3271,4 +3268,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3271,4 +3268,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -2727,4 +2724,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: Namespace
   annotations:
     ProxyInjectAnnotation: ProxyInjectDisabled
-  creationTimestamp: null
   labels:
     LinkerdNamespaceLabel: "true"
     config.linkerd.io/admission-webhooks: disabled
-  name: Namespace
-spec: {}
-status: {}
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3018,4 +3015,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3036,4 +3033,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3022,4 +3019,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3280,4 +3277,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -836,4 +833,3 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
----

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -170,7 +170,7 @@ func upgradeRunE(options *upgradeOptions, stage string, flags *pflag.FlagSet) er
 		}
 	}
 
-	values, configs, err := options.validateAndBuild(stage, k, flags)
+	values, _, err := options.validateAndBuild(stage, k, flags)
 	if err != nil {
 		upgradeErrorf("Failed to build upgrade configuration: %s", err)
 	}
@@ -178,7 +178,7 @@ func upgradeRunE(options *upgradeOptions, stage string, flags *pflag.FlagSet) er
 	// rendering to a buffer and printing full contents of buffer after
 	// render is complete, to ensure that okStatus prints separately
 	var buf bytes.Buffer
-	if err = render(&buf, values, configs); err != nil {
+	if err = render(&buf, values); err != nil {
 		upgradeErrorf("Could not render upgrade configuration: %s", err)
 	}
 

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -480,7 +480,7 @@ type: Opaque`,
 				}
 
 				var buf bytes.Buffer
-				if err = render(&buf, values, configs); err != nil {
+				if err = render(&buf, values); err != nil {
 					t.Fatalf("could not render upgrade configuration: %s", err)
 				}
 				diffTestdata(t, tc.outputfile, buf.String())


### PR DESCRIPTION
Since `install` uses helm to do its proxy injection, there's no need to
call `processYAML`. This also fixes an issue discovered in #3687 where
we started supporting injection of cronjobs, and even though `linkerd`'s
namespace is flagged to skip automatic injection it was being injected.

This replaces #3774 as it's a much simpler approach.