### PR TITLE
Add edge-19.12.1 changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,16 +3,12 @@
 * CLI
   * Added condition to the `linkerd stat` command that requires a window size
     of at least 15 seconds to work properly with Prometheus
-* Web UI
-  * Fixed a table wrap issue in the resource detail view that made sidebar 
-    font size inconsistent
 * Internal
   * Fixed whitespace path handling in non-docker build scripts (thanks
     @joakimr-axis!)
-  * Removed calico logutils dependency that was incompatible with go 1.13
+  * Removed Calico logutils dependency that was incompatible with Go 1.13
   * Updated Helm templates to use fully-qualified variable references based
     upon Helm best practices (thanks @javaducky!)
-  * Added new browser tests for URL routing in dashboard
 
 ## edge-19.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## edge-19.12.1
+
+* CLI
+  * Added condition to the `linkerd stat` command that requires a window size
+    of at least 15 seconds to work properly with Prometheus
+* Web UI
+  * Fixed a table wrap issue in the resource detail view that made sidebar 
+    font size inconsistent
+* Internal
+  * Fixed whitespace path handling in non-docker build scripts (thanks
+    @joakimr-axis!)
+  * Removed calico logutils dependency that was incompatible with go 1.13
+  * Updated Helm templates to use fully-qualified variable references based
+    upon Helm best practices (thanks @javaducky!)
+  * Added new browser tests for URL routing in dashboard
+
 ## edge-19.11.3
 
 * CLI

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.11.3
+LinkerdVersion: &linkerd_version edge-19.12.1
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.12.1

* CLI
  * Added condition to the `linkerd stat` command that requires a window size
    of at least 15 seconds to work properly with Prometheus
* Web UI
  * Fixed a table wrap issue in the resource detail view that made sidebar 
    font size inconsistent
* Internal
  * Fixed whitespace path handling in non-docker build scripts (thanks
    @joakimr-axis!)
  * Removed calico logutils dependency that was incompatible with go 1.13
  * Updated Helm templates to use fully-qualified variable references based
    upon Helm best practices (thanks @javaducky!)
  * Added new browser tests for URL routing in dashboard

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
