### PR TITLE
Add Allotrac to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,5 +1,6 @@
 # Linkerd 2.x adopters
 
+- [Allotrac](https://allotrac.com.au)
 - [AlphaSights](https://www.alphasights.com)
 - [Apester](https://apester.com)
 - [Attest](https://www.askattest.com)
@@ -18,7 +19,6 @@
 - [Paybase](https://paybase.io/)
 - [PlayStudios Asia](https://www.playstudios.asia)
 - [Studyo](https://studyo.co)
-- [Allotrac](https://allotrac.com.au)
 
 If you're using Linkerd 2.x and aren't on this list, please [submit a pull
 request](https://github.com/linkerd/linkerd2/pulls)!

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,6 +18,7 @@
 - [Paybase](https://paybase.io/)
 - [PlayStudios Asia](https://www.playstudios.asia)
 - [Studyo](https://studyo.co)
+- [Allotrac](https://allotrac.com.au)
 
 If you're using Linkerd 2.x and aren't on this list, please [submit a pull
 request](https://github.com/linkerd/linkerd2/pulls)!


### PR DESCRIPTION
Subject: Add Allotrac to ADOPTERS.md

Problem: Allotrac has moved their entire production workload over to Linkerd.

Solution Add it to the ADOPTERS.md!