### PR TITLE
Fix dashboard unit test warning

### DIFF
--- a/web/app/js/components/util/ApiHelpers.test.jsx
+++ b/web/app/js/components/util/ApiHelpers.test.jsx
@@ -16,7 +16,8 @@ describe('ApiHelpers', () => {
     fetchStub = sinon.stub(window, 'fetch');
     fetchStub.resolves({
       ok: true,
-      json: () => Promise.resolve({})
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve({})
     });
     api = ApiHelpers('');
   });


### PR DESCRIPTION
### Problem

On #3666, I added an unit test that is causing the following warning when running:

```
(node:38272) UnhandledPromiseRejectionWarning: TypeError: r.text is not a function
(node:38272) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 5)
(node:38272) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

### Solution

Add missing `text` function for resolving the promise:

```javascript
   beforeEach(() => {
    fetchStub = sinon.stub(window, 'fetch');
    fetchStub.resolves({
      ok: true,
      json: () => Promise.resolve({}),
      text: () => Promise.resolve({})
    });
    api = ApiHelpers('');
  }); 
```


Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
