### PR TITLE
Fix upgrade unit tests golden files

### DIFF
--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3027,4 +3024,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -3,18 +3,15 @@
 ### Linkerd Namespace
 ###
 ---
-apiVersion: v1
 kind: Namespace
+apiVersion: v1
 metadata:
+  name: linkerd
   annotations:
     linkerd.io/inject: disabled
-  creationTimestamp: null
   labels:
-    config.linkerd.io/admission-webhooks: disabled
     linkerd.io/is-control-plane: "true"
-  name: linkerd
-spec: {}
-status: {}
+    config.linkerd.io/admission-webhooks: disabled
 ---
 ###
 ### Identity Controller Service RBAC
@@ -3027,4 +3024,3 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-tap-tls
----


### PR DESCRIPTION
Turns out #3784 introduced a change in the format of the namespace and was merged just before #3771 which resulted in the golden files added in #3771 not reflecting the change and causing the upgrade unit tests to fail. This pr fixes that. 


Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
