### PR TITLE
Update enzyme-adapter-react-16 library

### DIFF
--- a/web/app/js/components/BaseTable.test.js
+++ b/web/app/js/components/BaseTable.test.js
@@ -82,4 +82,37 @@ describe("Tests for <BaseTable>", () => {
     expect(emptyCard).toBeDefined();
     expect(emptyCard).toHaveLength(1);
   });
+
+  it("if enableFilter is true, user can filter rows by search term", () => {
+    let extraProps = _merge({}, defaultProps, {
+      tableRows: [{
+        deployment: "authors",
+        namespace: "default",
+        key: "default-deployment-authors",
+        pods: {totalPods: "1", meshedPods: "1"}
+      },
+      {
+        deployment: "books",
+        namespace: "default",
+        key: "default-deployment-books",
+        pods: {totalPods: "2", meshedPods: "1"}
+      }],
+      tableColumns: tableColumns,
+      enableFilter: true
+    });
+
+    const component = mount(<BaseTable {...extraProps} />);
+    const enableFilter = component.prop("enableFilter");
+    const filterIcon = component.find("FilterListIcon");
+    expect(enableFilter).toEqual(true);
+    expect(filterIcon).toHaveLength(1);
+
+    filterIcon.simulate("click");
+    setTimeout(() => {
+      const input = table.find("input");
+      input.simulate("change", {target: {value: "authors"}});
+      expect(table.html()).not.toContain('books');
+      expect(table.html()).toContain('authors');
+    }, 100);
+  });
 });

--- a/web/app/js/components/MetricsTable.test.js
+++ b/web/app/js/components/MetricsTable.test.js
@@ -46,24 +46,15 @@ describe('Tests for <MetricsTable>', () => {
       enableFilter: true
     });
     const component = mount(routerWrap(MetricsTable, extraProps));
-
     const table = component.find('BaseTable');
-
     const enableFilter = table.prop('enableFilter');
-
-    const filterIcon = table.find("FilterListIcon");
-
     expect(enableFilter).toEqual(true);
-    expect(filterIcon).toBeDefined();
     expect(table.html()).toContain('books');
     expect(table.html()).toContain('authors');
-    filterIcon.simulate("click");
-    setTimeout(() => {
-      const input = table.find("input");
-      input.simulate("change", {target: {value: "authors"}});
-      expect(table.html()).not.toContain('books');
-      expect(table.html()).toContain('authors');
-      }, 100);
+    table.instance().setState({ showFilter: true, filterBy: /authors/ });
+    component.update();
+    expect(table.html()).not.toContain('books');
+    expect(table.html()).toContain('authors');
   });
 
   it('omits the namespace column for the namespace resource', () => {

--- a/web/app/js/components/MetricsTable.test.js
+++ b/web/app/js/components/MetricsTable.test.js
@@ -46,8 +46,11 @@ describe('Tests for <MetricsTable>', () => {
       enableFilter: true
     });
     const component = mount(routerWrap(MetricsTable, extraProps));
+
     const table = component.find('BaseTable');
+
     const enableFilter = table.prop('enableFilter');
+
     expect(enableFilter).toEqual(true);
     expect(table.html()).toContain('books');
     expect(table.html()).toContain('authors');

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -60,7 +60,8 @@ describe('Navigation', () => {
     );
 
     return withPromise(() => {
-      expect(component).toIncludeText("Linkerd is up to date");
+      expect(component.find("NavigationBase").state("isLatest")).toBeTruthy();
+      expect(component.find("NavigationBase").state("latestVersion")).toBe(curVer);
     });
   });
 
@@ -86,7 +87,8 @@ describe('Navigation', () => {
     );
 
     return withPromise(() => {
-      expect(component).toIncludeText("A new version (2.3.4) is available.");
+      expect(component.find("NavigationBase").state("isLatest")).toBeFalsy();
+      expect(component.find("NavigationBase").state("latestVersion")).toBe(newVer);
     });
   });
 
@@ -117,8 +119,8 @@ describe('Navigation', () => {
     );
 
     return withPromise(() => {
-      expect(component).toIncludeText("Version check failed: Fake error.");
-      expect(component).toIncludeText(errMsg);
+      expect(component.find("NavigationBase").state("error")).toBeDefined();
+      expect(component.find("NavigationBase").state("error").statusText).toBe("Fake error");
     });
   });
 });

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -38,7 +38,7 @@ describe('Navigation', () => {
     window.fetch.restore();
   });
 
-  it('renders up to date message when versions match', () => {
+  it('checks state when versions match', () => {
     fetchStub.resolves({
       ok: true,
       json: () => Promise.resolve({ edge: curVer })
@@ -65,7 +65,7 @@ describe('Navigation', () => {
     });
   });
 
-  it('renders update message when versions do not match', () => {
+  it('checks state when versions do not match', () => {
     fetchStub.resolves({
       ok: true,
       json: () => Promise.resolve({ edge: newVer })
@@ -92,7 +92,7 @@ describe('Navigation', () => {
     });
   });
 
-  it('renders error when version check fails', () => {
+  it('checks state when version check fails', () => {
     let errMsg = "Fake error";
 
     fetchStub.rejects({

--- a/web/app/js/components/TopRoutesTable.test.js
+++ b/web/app/js/components/TopRoutesTable.test.js
@@ -53,8 +53,11 @@ describe("Tests for <TopRoutesTable>", () => {
       enableFilter: true
     });
     const component = mount(routerWrap(TopRoutesTable, extraProps));
+
     const table = component.find("BaseTable");
+
     const enableFilter = table.prop("enableFilter");
+
     expect(enableFilter).toEqual(true);
     expect(table.html()).toContain("authors:7001");
     expect(table.html()).toContain("localhost");

--- a/web/app/js/components/TopRoutesTable.test.js
+++ b/web/app/js/components/TopRoutesTable.test.js
@@ -53,23 +53,14 @@ describe("Tests for <TopRoutesTable>", () => {
       enableFilter: true
     });
     const component = mount(routerWrap(TopRoutesTable, extraProps));
-
     const table = component.find("BaseTable");
-
     const enableFilter = table.prop("enableFilter");
-
-    const filterIcon = table.find("FilterListIcon");
-
     expect(enableFilter).toEqual(true);
-    expect(filterIcon).toBeDefined();
     expect(table.html()).toContain("authors:7001");
     expect(table.html()).toContain("localhost");
-    filterIcon.simulate("click");
-    setTimeout(() => {
-      const input = table.find("input");
-      input.simulate("change", {target: {value: "localhost"}});
-      expect(table.html()).not.toContain("authors:7001");
-      expect(table.html()).toContain("localhost");
-    }, 100);
+    table.setState({ showFilter: true, filterBy: /localhost/ });
+    component.update();
+    expect(table.html()).not.toContain("authors:7001");
+    expect(table.html()).toContain("localhost");
   });
 });

--- a/web/app/js/components/Version.test.js
+++ b/web/app/js/components/Version.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Version from './Version.jsx';
+import { mount } from 'enzyme';
+
+describe('Version', () => {
+  let curVer = "edge-1.2.3";
+  let newVer = "edge-2.3.4";
+
+  it('renders up to date message when versions match', () => {
+    const component = mount(
+      <Version
+        classes={{}}
+        isLatest
+        latestVersion={curVer}
+        releaseVersion={curVer} />
+    );
+
+    expect(component).toIncludeText("Linkerd is up to date");
+  });
+
+  it('renders update message when versions do not match', () => {
+    const component = mount(
+      <Version
+        classes={{}}
+        isLatest={false}
+        latestVersion={newVer}
+        releaseVersion={curVer} />
+    );
+
+    expect(component).toIncludeText("A new version (2.3.4) is available.");
+  });
+
+  it('renders error when version check fails', () => {
+    let errMsg = "Fake error";
+
+    const component = mount(
+      <Version
+        classes={{}}
+        error={{
+          statusText: errMsg,
+        }}
+        isLatest={false}
+        releaseVersion={curVer} />
+    );
+
+    expect(component).toIncludeText("Version check failed: Fake error.");
+    expect(component).toIncludeText(errMsg);
+  });
+});

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -49,7 +49,7 @@
     "clean-webpack-plugin": "3.0.0",
     "css-loader": "2.1.1",
     "enzyme": "3.7.0",
-    "enzyme-adapter-react-16": "1.6.0",
+    "enzyme-adapter-react-16": "1.15.1",
     "eslint": "4.18.2",
     "eslint-config-airbnb": "16.1.0",
     "eslint-loader": "2.0.0",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -3542,20 +3542,22 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
-enzyme-adapter-react-16@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.6.0.tgz#3fca28d3c32f3ff427495380fe2dd51494689073"
-  integrity sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==
+enzyme-adapter-react-16@1.15.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.1.tgz#8ad55332be7091dc53a25d7d38b3485fc2ba50d5"
+  integrity sha512-yMPxrP3vjJP+4wL/qqfkT6JAIctcwKF+zXO6utlGPgUJT2l4tzrdjMDWGd/Pp1BjHBcljhN24OzNEGRteibJhA==
   dependencies:
-    enzyme-adapter-utils "^1.8.0"
-    function.prototype.name "^1.1.0"
+    enzyme-adapter-utils "^1.12.1"
+    enzyme-shallow-equal "^1.0.0"
+    has "^1.0.3"
     object.assign "^4.1.0"
-    object.values "^1.0.4"
-    prop-types "^15.6.2"
-    react-is "^16.5.2"
+    object.values "^1.1.0"
+    prop-types "^15.7.2"
+    react-is "^16.10.2"
     react-test-renderer "^16.0.0-0"
+    semver "^5.7.0"
 
-enzyme-adapter-utils@^1.8.0:
+enzyme-adapter-utils@^1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.1.tgz#e828e0d038e2b1efa4b9619ce896226f85c9dd88"
   integrity sha512-KWiHzSjZaLEoDCOxY8Z1RAbUResbqKN5bZvenPbfKtWorJFVETUw754ebkuCQ3JKm0adx1kF8JaiR+PHPiP47g==
@@ -3574,6 +3576,14 @@ enzyme-matchers@^7.0.2:
   dependencies:
     circular-json-es6 "^2.0.1"
     deep-equal-ident "^1.1.1"
+
+enzyme-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.0.tgz#d8e4603495e6ea279038eef05a4bf4887b55dc69"
+  integrity sha512-VUf+q5o1EIv2ZaloNQQtWCJM9gpeux6vudGVH6vLmfPXFLRuxl5+Aq3U260wof9nn0b0i+P5OEUXm1vnxkRpXQ==
+  dependencies:
+    has "^1.0.3"
+    object-is "^1.0.1"
 
 enzyme-to-json@^3.3.0:
   version "3.4.3"
@@ -3637,7 +3647,24 @@ es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.15.0, es-abstract@^1.5.
     string.prototype.trimleft "^2.1.0"
     string.prototype.trimright "^2.1.0"
 
-es-to-primitive@^1.2.0:
+es-abstract@^1.17.0-next.1:
+  version "1.17.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.0-next.1.tgz#94acc93e20b05a6e96dacb5ab2f1cb3a81fc2172"
+  integrity sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.0"
+    string.prototype.trimright "^2.1.0"
+
+es-to-primitive@^1.2.0, es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
@@ -4652,6 +4679,11 @@ has-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
   integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
+
+has-symbols@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -7045,7 +7077,7 @@ object-hash@^1.1.4:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
-object-inspect@^1.6.0:
+object-inspect@^1.6.0, object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
@@ -7119,6 +7151,16 @@ object.values@^1.0.4:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
+object.values@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
+  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
 
@@ -7920,6 +7962,11 @@ react-event-listener@^0.6.2:
     "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     warning "^4.0.1"
+
+react-is@^16.10.2:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react-is@^16.5.2, react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.11.0"


### PR DESCRIPTION
#### Problem

Material UI 4 requires to update `enzyme-adapter-react-16` library.

#### Solution

This PR updates `enzyme-adapter-react-16` in preparation for Material UI upgrading (#3710).

The following solutions have been applied in the tests to address the issue with Material UI `Hidden` component (more details [here](https://github.com/airbnb/enzyme/issues/2179)):

* Add tests in children components where the Hidden wrap doesn’t apply, reducing the need to inspect the children rendered markup from the parent.
* Use shallow instead of mount to render the components hierarchy. When using shallow, the problem described above with the wrapped Hidden component is not occurring as all components are being rendered.
* To not remove some other existing tests, only the state and props of some children components is tested, instead of testing their events and methods. The first point in this list should take care of testing those remaining bits though.

**Note**: Before merging #3710, we’ll need to change a little bit the new test added to `BaseTable` component to find the `FilterListIcon` component and simulate the click event.


Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>