### PR TITLE
Prevent upgrade from breaking proxies when issuer cert is overwritten

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/issuercerts"
@@ -34,6 +35,7 @@ const (
 
 type upgradeOptions struct {
 	manifests string
+	force     bool
 	*installOptions
 
 	verifyTLS func(tls *charts.TLS, service string) error
@@ -61,6 +63,10 @@ func (options *upgradeOptions) upgradeOnlyFlagSet() *pflag.FlagSet {
 	flags.StringVar(
 		&options.manifests, "from-manifests", options.manifests,
 		"Read config from a Linkerd install YAML rather than from Kubernetes",
+	)
+	flags.BoolVar(
+		&options.force, "force", options.force,
+		"Force upgrade operation despite validation errors",
 	)
 
 	return flags
@@ -379,6 +385,32 @@ func fetchTLSSecret(k kubernetes.Interface, webhook string, options *upgradeOpti
 	return value, nil
 }
 
+func ensureIssuerCertWorksWithAllProxies(k kubernetes.Interface, cred *tls.Cred) error {
+	meshedPods, err := healthcheck.GetMeshedPodsIdentitiyData(k, "")
+	var problematicPods []string
+	if err != nil {
+		return err
+	}
+	for _, pod := range meshedPods {
+		roots, err := tls.DecodePEMCertPool(pod.Anchors)
+
+		if roots != nil {
+			err = cred.Verify(roots, "")
+		}
+
+		if err != nil {
+			problematicPods = append(problematicPods, fmt.Sprintf("* %s", pod.Name))
+		}
+	}
+
+	if len(problematicPods) > 0 {
+		errorMessageHeader := "You are attempting to use an issuer certificate which does not validate against the trust roots of the following pods:"
+		errorMessageFooter := "These pods do not have the current trust bundle and must be restarted.  Use the --force flag to proceed anyway (this will likely prevent those pods from sending or receiving traffic)."
+		return fmt.Errorf("%s\n\t%s\n%s", errorMessageHeader, strings.Join(problematicPods, "\n\t"), errorMessageFooter)
+	}
+	return nil
+}
+
 // fetchIdentityValue checks the kubernetes API to fetch an existing
 // linkerd identity configuration.
 //
@@ -410,13 +442,27 @@ func (options *upgradeOptions) fetchIdentityValues(k kubernetes.Interface, idctx
 		trustAnchorsPEM = idctx.GetTrustAnchorsPem()
 	}
 
-	if options.identityOptions.crtPEMFile != "" && options.identityOptions.keyPEMFile != "" {
+	updatingIssuerCert := options.identityOptions.crtPEMFile != "" && options.identityOptions.keyPEMFile != ""
+
+	if updatingIssuerCert {
 		issuerData, err = readIssuer(trustAnchorsPEM, options.identityOptions.crtPEMFile, options.identityOptions.keyPEMFile)
 	} else {
 		issuerData, err = fetchIssuer(k, trustAnchorsPEM, idctx.Scheme)
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	cred, err := issuerData.VerifyAndBuildCreds("")
+	if err != nil {
+		return nil, err
+	}
+	issuerData.Expiry = &cred.Crt.Certificate.NotAfter
+
+	if updatingIssuerCert && !options.force {
+		if err := ensureIssuerCertWorksWithAllProxies(k, cred); err != nil {
+			return nil, err
+		}
 	}
 
 	return &charts.Identity{
@@ -446,13 +492,6 @@ func readIssuer(trustPEM, issuerCrtPath, issuerKeyPath string) (*issuercerts.Iss
 		IssuerCrt:    crt,
 		IssuerKey:    key,
 	}
-
-	cred, err := issuerData.VerifyAndBuildCreds("")
-	if err != nil {
-		return nil, err
-	}
-
-	issuerData.Expiry = &cred.Crt.Certificate.NotAfter
 
 	return issuerData, nil
 }

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -399,7 +399,7 @@ func ensureIssuerCertWorksWithAllProxies(k kubernetes.Interface, cred *tls.Cred)
 		}
 
 		if err != nil {
-			problematicPods = append(problematicPods, fmt.Sprintf("* %s", pod.Name))
+			problematicPods = append(problematicPods, fmt.Sprintf("* %s/%s", pod.Namespace, pod.Name))
 		}
 	}
 
@@ -455,7 +455,7 @@ func (options *upgradeOptions) fetchIdentityValues(k kubernetes.Interface, idctx
 
 	cred, err := issuerData.VerifyAndBuildCreds("")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("issuer certificate does not work with the provided provided roots: %s\nFor more information: https://linkerd.io/2/tasks/rotating_identity_trust_root/", err)
 	}
 	issuerData.Expiry = &cred.Crt.Certificate.NotAfter
 

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -799,6 +799,226 @@ type: Opaque`,
 				options.identityOptions.trustPEMFile = filepath.Join("testdata", "valid-trust-anchors.pem")
 			},
 		},
+
+		{
+			"",
+			[]string{`
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-config
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: controller
+  annotations:
+    linkerd.io/created-by: linkerd/cli edge-19.4.1
+data:
+  global: |
+    {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"edge-19.4.1","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"-----BEGIN CERTIFICATE-----\nMIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy\nLmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE\nAxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0\nxtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364\n6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF\nBQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE\nAiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv\nOLO4Zsk1XrGZHGsmyiEyvYF9lpY=\n-----END CERTIFICATE-----\n","issuanceLifetime":"86400s","clockSkewAllowance":"20s","scheme":"linkerd.io/tls"}, "clusterDomain":"cluster.local"}
+  proxy: |
+    {"proxyImage":{"imageName":"gcr.io/linkerd-io/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"gcr.io/linkerd-io/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd2_proxy=info"},"disableExternalProfiles":true}
+  install: |
+    {"cliVersion":"edge-19.4.1","flags":[]}`,
+				`
+kind: Secret
+apiVersion: v1
+metadata:
+  name: linkerd-identity-issuer
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: identity
+  annotations:
+    linkerd.io/created-by: linkerd/cli edge-19.4.1
+    linkerd.io/identity-issuer-expiry: 2020-04-03T23:53:57Z
+data:
+  crt.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJnekNDQVNtZ0F3SUJBZ0lCQVRBS0JnZ3Foa2pPUFFRREFqQXBNU2N3SlFZRFZRUURFeDVwWkdWdWRHbDAKZVM1c2FXNXJaWEprTG1Oc2RYTjBaWEl1Ykc5allXd3dIaGNOTVRrd05EQTBNak0xTXpNM1doY05NakF3TkRBegpNak0xTXpVM1dqQXBNU2N3SlFZRFZRUURFeDVwWkdWdWRHbDBlUzVzYVc1clpYSmtMbU5zZFhOMFpYSXViRzlqCllXd3dXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CQndOQ0FBVCtTYjVYNHdpNFhQMFgzckp3TXAyM1ZCZGcKRU1NVThFVStLRzhVSTJMbUM1VmpnNVJXTE9XNkJKakJtalhWaUtNK2IrMS9vS0FlT2c2RnJKazhxeUZsbzBJdwpRREFPQmdOVkhROEJBZjhFQkFNQ0FRWXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0VHQ0NzR0FRVUZCd01DCk1BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFLVUZHM3NZT1MrK2Jha1cKWW1KWlU0NWlDZFRMdGFlbE1EU0ZpSG9DOWVCS0FpQkRXenpvKy9DWUxMbW4zM2JBRW44cFFub2dQNEZ4MDZhagorVTlLNFdsYnpBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  key.pem: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUhaaEFWTnNwSlRzMWZ4YmZ4VmptTTJvMTNTOFd4U2VVdTlrNFhZK0NPY3JvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFL2ttK1YrTUl1Rno5Rjk2eWNES2R0MVFYWUJEREZQQkZQaWh2RkNOaTVndVZZNE9VVml6bAp1Z1NZd1pvMTFZaWpQbS90ZjZDZ0hqb09oYXlaUEtzaFpRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=`,
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linkerd-proxy-injector-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: proxy-injector
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/helm git-54b2103b
+data:
+  crt.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKakNDQWc2Z0F3SUJBZ0lRVjFrSXJhRG1sdzNTVzY5UXNRWjNQREFOQmdrcWhraUc5dzBCQVFzRkFEQXQKTVNzd0tRWURWUVFERXlKc2FXNXJaWEprTFhCeWIzaDVMV2x1YW1WamRHOXlMbXhwYm10bGNtUXVjM1pqTUI0WApEVEU1TURnd056SXhNelkwTUZvWERUSXdNRGd3TmpJeE16WTBNRm93TFRFck1Da0dBMVVFQXhNaWJHbHVhMlZ5ClpDMXdjbTk0ZVMxcGJtcGxZM1J2Y2k1c2FXNXJaWEprTG5OMll6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQUQKZ2dFUEFEQ0NBUW9DZ2dFQkFOek5iMmd0VVU2SmsxVDV4Smx3dTNlSmViSml4T01Vc3QyMzVkSWJXU1F2OUlNagpXRTR1Z3dlbk1ZSDh5V1ppV1F5NCsya0h3c1JkdWNxM3lqZUIrMmFsUll6enBLcFUvdHVxVi9XT2U3VVpxcGRaCkNsNTUzNXlmUzMzNndadjFrWlRlU3g1dHc0d3YwaU9vVG9jVGlsSm1tOGVsWDJUN0toajJVam5oSDNWUXFxbjEKcERRUGIvalRMOVcySlZYL2luOXdvTEptc294aFNkR2MxTDRsVnlvWEFOSVdSWENwQVYzVlo5MXV6SHFqaWYyZgpyWnBaRTQ0QWtaM1hWRnVlaldtcTZURWxHL1M1YnBkaExDcy8zWE41T1lZUXVYbXlTdHEyb055ZzFUOEx6RmxECmJ6eXZBSldmSXV6d3hZa051NTljbkhaUjBRY2liUDF5NTQ0QlV2c0NBd0VBQWFOQ01FQXdEZ1lEVlIwUEFRSC8KQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZCUWNEQWpBUEJnTlZIUk1CQWY4RQpCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQjBNZERONWRuaUgxYS96UGI5QWFBT2JqaFBEUC9FCngreVlRU3VDYXpyeFZCUlpPeGdpUkUyN1JjZ05BRGZmOVRkRU9ER1BrUVY4aTRnVVVOdi9VanljODYxdW55SG0KR3FacEp0OFROZ0pWN2VHR00wUWlrNkFYZTdLT1N0aFdzVVZDSHlGMUFyam01U2dRUHRsREttVGk1bDBCZ1pyKwpBblVzOVllNHhUSFFFYSswSFN3NXNjdnFsVDhYS0ZCanoza2hJbHFVd3IvSy9seVZITDcwQTMyUi9UODh5Z1YzClQ4MitwS1R5T3lZU1IrZG1ZUWdxcW00ajVhVVp5aURPZVFHR1kycEZNQnJMY0tGZjFqcmJHWXlVQVNrdlh6NXoKaHZIOUtJWXFOckdhMDloTFBjb00rMW9CNHNnY2RKdFpCV2pCRWdiTHdwWEJJdUVFVXY5cno0dDAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  key.pem: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM00xdmFDMVJUb21UVlBuRW1YQzdkNGw1c21MRTR4U3kzYmZsMGh0WkpDLzBneU5ZClRpNkRCNmN4Z2Z6SlptSlpETGo3YVFmQ3hGMjV5cmZLTjRIN1pxVkZqUE9rcWxUKzI2cFg5WTU3dFJtcWwxa0sKWG5uZm5KOUxmZnJCbS9XUmxONUxIbTNEakMvU0k2aE9oeE9LVW1hYng2VmZaUHNxR1BaU09lRWZkVkNxcWZXawpOQTl2K05NdjFiWWxWZitLZjNDZ3NtYXlqR0ZKMFp6VXZpVlhLaGNBMGhaRmNLa0JYZFZuM1c3TWVxT0ovWit0Cm1sa1RqZ0NSbmRkVVc1Nk5hYXJwTVNVYjlMbHVsMkVzS3ovZGMzazVoaEM1ZWJKSzJyYWczS0RWUHd2TVdVTnYKUEs4QWxaOGk3UERGaVEyN24xeWNkbEhSQnlKcy9YTG5qZ0ZTK3dJREFRQUJBb0lCQVFDd1BGVEFyUE1wb1l0MApGc3VCd1VZUU9pMWxZWXBPeVpXZWZJcTJNZGZybDA4dFlJZTZGMHZFVHdHb0EvRm9nL1VadjRnRHBBc2tHcjhSCmU3S3VyVlBROFBkYmNwaXF6NTZBREMyYXRIZ3U2MmFLMktuN0VJR1hqRm1BR3ladmFna2g3bSs4d05XRXppS0gKRFc1b1NBTnVrN0doSDNETnM5ODgvMVpRRmt5Nm9BVThzWEhaTEpsNGJoV05UU3FSS0VnT3pIRDRwYWRITzUrMwp3cFVHamg1VklaS1BlMzRqYmMwTVZDOUwwNjhJY3Fibmp6d3g3NnYrQnh6MXFyRFNNMDR2TytGWUZUTVVmWEtyClBZRU5qMEN6UEhUanlwT2FBdFNwZFJTY2x1YzVGMTVmcXpKRnE5dVVLM2VpWFY3amNjTW1Sb0l0bkxMS3Z5VkgKVWJOZ1pnZmhBb0dCQVBpOU40MjRwK1ZxWnJRRTZ3K21kTTh2S2JIb0NPWUNlVDZrYXExMzhLVFJ2Z0MzZGJQNgpRcFpSNXlYNlhQeW1YMnNkZkxQTDk2NE1DeGJlS1ovWmw5UC9zRkxhRDVOc0RXMXZ2djJkYXBhQ1d0U0hwNHFFClJIN2tWWTZmcHZUYmZWN2FWL1JQZlhGbWVrbEJZd05pNTNkNFRYZEhJWC9ONHM0aFgwVzNtMk1yQW9HQkFPTS8KYzk0anJDbGtESUN4YWhUYlp4UHdST1hqVEZvdEpxaGRhandZOXcxdEVIelNnNUY1QVFSaWR4WGxFa0lENVdCRApYeG1JZWF2TDgyRkpUeWFXWlBzUnRkOXNJV3BIM084VDh2TnZLN1Z0SXY2RzZYSy9XUjhHMjhodTl6bVNlMk5HCjVUN2FkL0dMSlZ3Mm9GcTEzNGFIbHdvY00xMUFPa2YwYU9SWGJTZHhBb0dCQU0vT1JQdEJxZ01nUVcxa0xuMkUKczFIa05SRk1xU0tBTG9zSEVaaWErNUMzS2VXdlg4WmM3Z1JucUpVeDlUMmVRVmxiNlRMTTFMK3prQkFxeXR1aApEaGN2SmtBUnJiR2NOQnVab0JhQnpPcXhQUEVSNUFiMU9jUkpQckZJOEZMZ2pIMFNMU2tPdjk1ZG53eFVkRVAvCi9TRHlnTVdGeDViZWl2MXJKQTA2dDdiQkFvR0FVSkg2dnRQZkFuM2FnUFptS2lid0VQMnJMK2E2OTIzeXV0Y0UKQjNMQ2hSd2FNR2RqQm56a2cyMTEwMmw0WTdlRjUrOTdGRTV5OVJwR25FT2xzSVM2SU5wU3BYaHRFSVdTSzZIagpEYlJveHRaL0JjZEhsY3VLQ1pvZzZwdU5RL2hQanc5ZjBEMGRNYUtvQ0YzRjFPT084Tis2Q1hlZUxuM0xMQi9YCjRMMnVrY0VDZ1lCeWxEY2haSHR3YjlxYWFoeVhiQUI2WHAvMTdLUEtZOFltbDBqN0cydm1VMXJUZDdTREhHek4Kc1B5LzErY3FraWkrVVQxc2I0d1RQaW9wTXZxa3hsY05tdzM4L2NRL05ET3JENlEvN1NJN0I3TkNod1BLNFBhWgpCVEo1MW84RktSRTczcDhVYkdDUlNtdjVzYk5aTUMyWlRBaVNWa0MzUHU4QmxGN1VoM3RCeEE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+type: Opaque`,
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linkerd-sp-validator-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: sp-validator
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: linkerd/helm git-54b2103b
+data:
+  crt.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJakNDQWdxZ0F3SUJBZ0lRQkhsRWhOb3Y0Z1hHT0EzbGFOamErekFOQmdrcWhraUc5dzBCQVFzRkFEQXIKTVNrd0p3WURWUVFERXlCc2FXNXJaWEprTFhOd0xYWmhiR2xrWVhSdmNpNXNhVzVyWlhKa0xuTjJZekFlRncweApPVEE0TURjeU1UTTJOREJhRncweU1EQTRNRFl5TVRNMk5EQmFNQ3N4S1RBbkJnTlZCQU1USUd4cGJtdGxjbVF0CmMzQXRkbUZzYVdSaGRHOXlMbXhwYm10bGNtUXVjM1pqTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEEKTUlJQkNnS0NBUUVBdklFVW5YdlBkSDFra2lJM2JPc01wQ0Zpb3FoN0dCK1ZtSmE5Q2RoNEQ3bWhiMWhoMUNYdgpNblZtQVduUE9UYWRvUHRZNFNZZU9pUDBURVQ1enZ1MUlEUzVyZFhUcDlZaHZHWDRMM1NhVk5XdnlsbzNXT1FmCk5sSXZPWFU4bHZHaDAyeE9TK3RZeklSMVh0dmFhOUV6K1QyN0p4ei9meHhnK2tHRmRES3BBK0tQeitvZHRKL1YKYTYvc2N6UWhaczhtTWt3L0Y3MzJxS1JtWG83bm9pTjhYRjAxSFBiT1pVdFpGZjJ6L2hGMHhKaEVMNlRNWTNlNwpZNnZ4UFoyMGVobTR5cUk1Q2RqcWN1WFNwL0xhbFNJOTBsb0ZMMU5SZFRuREgzZ1BNUWM3VE9KenIzQUI0bmxjCmJIU0ZsNkFvN2J1U3EvOTJ4MmdwMjRRT2w0UURkdlVZaVFJREFRQUJvMEl3UURBT0JnTlZIUThCQWY4RUJBTUMKQXFRd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQThHQTFVZEV3RUIvd1FGTUFNQgpBZjh3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUtJQUc5T2E4SndtSzBUaGVtc2RxdjhvdkhZUk5XTHBWOVBhCkJNejJhQklFQVlvMURxQmFaQWFkdWZKa0k1bmFoTC81K2NaQXp3M2s4RmpYN2plT1ErYmlPaS9TNlU4K0FNZEUKZnZvdVR5N05Kb0xXM1NUclhCcjJnYzY3RUtLQ2JGQmsxYzM3b21KSUhhZU15aWNkRHY0SHRYTExDcUtrYk54aAo0NGQ2YUpzL3lNZm9kZGFhZFN0L1RwMGZtaHNPMTR5OUp3RDFWL2s1M3ppUmxDcXNYVUtBK05vejhqRC8wVkI5CnFyd0dpWGk4S1ZsZS9LYjFDZktOM1VhczdBRHlxbVVEUGNKY2tQMGM5QnBRQzlLYTJqZHhzb0hvWi8vSG5SVGYKalc2dExlcjN1UHZpek5qM2swcWt2SVAydVVJNDg0MkJjQmUrbVB1NlJoeVozdWt4elNVPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  key.pem: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdklFVW5YdlBkSDFra2lJM2JPc01wQ0Zpb3FoN0dCK1ZtSmE5Q2RoNEQ3bWhiMWhoCjFDWHZNblZtQVduUE9UYWRvUHRZNFNZZU9pUDBURVQ1enZ1MUlEUzVyZFhUcDlZaHZHWDRMM1NhVk5XdnlsbzMKV09RZk5sSXZPWFU4bHZHaDAyeE9TK3RZeklSMVh0dmFhOUV6K1QyN0p4ei9meHhnK2tHRmRES3BBK0tQeitvZAp0Si9WYTYvc2N6UWhaczhtTWt3L0Y3MzJxS1JtWG83bm9pTjhYRjAxSFBiT1pVdFpGZjJ6L2hGMHhKaEVMNlRNClkzZTdZNnZ4UFoyMGVobTR5cUk1Q2RqcWN1WFNwL0xhbFNJOTBsb0ZMMU5SZFRuREgzZ1BNUWM3VE9KenIzQUIKNG5sY2JIU0ZsNkFvN2J1U3EvOTJ4MmdwMjRRT2w0UURkdlVZaVFJREFRQUJBb0lCQVFDU1hGTHFXQWhpdFQyUwpMVmtGaTVjY0ZRUGxzWlVwek5RMVRzem1TUm9uYzRWQjA4alpsTDZkV2dQaWt3b2ZyU1ZFcWdOL2hUNHcvRnVoCm9HaXA2a3ZlL3JFd3BQYWF1U3NtZ2JIcS9za1psM1RQVTY3bnFQQUhHRmFzY1RlakoyZnpwWU5CZFRGVVVvQmoKTDZidTBkZGQ3UzFVR0RMVXVlOGVRQ05qYmpaRzJadnhiclhHQ1hTcjZtankvUTI2UkhrM0JSZXZ6UlFEMXIzbgpsSUxGdm9ueHNoTnVvU2xGVmJlTXNoN0JQQlBkbmR0MGNwZDRLcW5oQ0NCZVk0YUlsNmQ2eVJ1K1h4akhmRWRUCjlFTXhjYjJidEIzWHUrNTBtSWJsd1NEK2ZkVkFJUmFYeFRNMlc2dys4ZEZNSjFidXBRbTRLKy9KMC9UMko5b0sKRWpzdno5WVZBb0dCQU9td2t0NXpMVW5GVkNCR1p1aWJhTGRhcUFncy9pNldDcnJzL2xKd0VMb0grWDA4ZFkyWApIMS95ay8xVzZlbFFWVUEwOWg0dEZXSm1JM3BiT0c4d25iVU53MGVIZmlodkU2N0QvdlpXTi83b2FOUDZrdXdhCmNoTWRvaE5JNmhpSXd0cGo2L3JrVEIvTENtaXFWUHlEWXc2U0tiKzh5TktMZE1VdkFDZUpCRXVqQW9HQkFNNkEKS2NsUHNGeStrUzZDQzh4YkUvMER1eTZxc1BPQ3BBdDVDZWNGMHhHZHhBOXp4ZUdBWkxBTk5vZ0dPRjRrVTQxSwo0V20rRFoyNFFIV2FtWEp4dkhOZlZSdVVwSkR6UFJHcGdWSXJJNEMwMWprN0xxYy9VNEtpK2lYVGxWZDE0cWtJClVzalJTOUVrSU4yN3VIQzRnYnpoRW9PbXlOS0Q0U1JTQ2xyellrM2pBb0dBZUV0MHp4M3JDamFSLzZzOS9pOUIKMEdEU2JxTDZsWENYUlhJSjJOWG5SbHdraWRzOWlBMXJFVEVHRFR0WVhjb0VtSENxNFEzRUhFc0hxRXljMkYvbQpUdlV1dVB0K2JjSUFGODY4eUlISmdXYVJ6ODBGSkpUWWRBNmxCOWhZNlJnOWRiNUtFM1RCMnZ2aDk4NzJ3S1hCCnNCWjlkejN2QXJMWEFVb1lna0Y5L0pFQ2dZQmRObzhtTnhtR0UrT1hHYzdYbFRsRm1ieVJ5UzBORHFpY0lTdnUKSTd2dUZNZ2VyWVRpVU1HaWtxUk43SGpmVGdpRkhBcjZYM2JuL2ZiaTMwRnEzcHBSZmZQOStpLzYya0Z6eW83OApsMHAwVzZ6anNxcFJobzFjeDlLZzVveGdLVytDRzZhNnpYY3ExZU1jRkJPaWxqYkNHdHJ2b0liQU9CV1YvbzU4CkZhY0hQd0tCZ1FERS9nb2sxZ3VEaGVXUmJEaTdpNVVqd0ZqcnRJZ1hVbTA5N29yOW5Mb2dibFdIK0EyWmgvaG8KQ0hmekdLMUtnZytTd1I2YlRhZ29wRGVCMkRnNTk2ODFwTTQ4ZjVYbzV6NkJUejhFMVFPREpIRlkyNlNJNTlIRwpwZFlWMno5QmdxaDZKQWprZWhQWDlYMWFCcTRrVkpCQzg5MDBOUk1pbG1EdlBISjNhU1EyT0E9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+type: Opaque`,
+				`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linkerd-tap-tls
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: tap
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    linkerd.io/created-by: "linkerd/helm git-54b2103b"
+data:
+  crt.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFRENDQWZpZ0F3SUJBZ0lRRlNhSmJjd0ZrMHNvclpsUENLUmhuakFOQmdrcWhraUc5dzBCQVFzRkFEQWkKTVNBd0hnWURWUVFERXhkc2FXNXJaWEprTFhSaGNDNXNhVzVyWlhKa0xuTjJZekFlRncweE9UQTRNRGN5TVRNMgpOREJhRncweU1EQTRNRFl5TVRNMk5EQmFNQ0l4SURBZUJnTlZCQU1URjJ4cGJtdGxjbVF0ZEdGd0xteHBibXRsCmNtUXVjM1pqTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF1UTRhb3hLSWVnUncKZW5FWHY0QVBjWTc0SnNqNUJXSEhwMUJzY1d1Y24weEwrcEo5UnJDRXphOURXcklad2JTazhpNnlHYnpQWTZCaQpHdlIxK0NMRkZNR1VraERuS1lINk9hNzlvTXN3WGZEc1lmKzVFNU12WlZGay9XeW03ck5GWWhqWXNmengzdTY3CldWbFgyRTBGaHBrU1pMUGN6bHNCQzFzN0hxVzV4TnBYUmc2WDJqYlFWZ0xMdUNsL3FjZE05MzRsay81ODNtT3kKeVIwSkQvV3RMc3VxdVIrOWJZSjlVYXUrbGpqZUc3U1h0UVYrdkR5VDNscEZ2SFpraG5sSm53am9XN0RIN3dPNwplK0ZQc3FmOG9nQk8xUlBmUEhNakRZRERoVlJUTWRKVFpZK2VlcFc5VjVGbGJvRFZvOUtOMlhTSVRkbVJsWmF0CjJuRng3TU83YndJREFRQUJvMEl3UURBT0JnTlZIUThCQWY4RUJBTUNBcVF3SFFZRFZSMGxCQll3RkFZSUt3WUIKQlFVSEF3RUdDQ3NHQVFVRkJ3TUNNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVMQlFBRApnZ0VCQUZNd3hXVnV1NFMzMi9LSVhsdURsR3dpQjh0YzFCTEVRQzUyY3hhNERodnBGNFkwZmRSOXRwMDN3S1VYClRlRWp6OUMyYzBFTW1EcVpheDVsQmxaaDBtWUFpNFowSUZkbXg4Q0FLYWowUVV1MEdQL1Jmd0taYWFuTjhBbEUKbCtRQjRLWG1ZNjRnOFZUUXR0VXhNL2FZdjkrU0FrMlcvbkZiZTFjUXpHbGFCSVh2WW9Da1N3TDFiTEpDV0N2WQowaEtteFhYdGpHZmpqZXJGTk9CTUdRZkJmQ0czZUJTZE45aS8rOEs3NS9FM21EV01iTGMwVHU2OEFsdWRxVUJRCmZsbngrNXlUaUtlaExhaW9BY0psTldrOVRCSEcySSswLy9tNTM4VGhYbnZ2ZC9uTXdTWitJbEZiVUpvbEo3Rk4KNXVUNG91Vm8xUU9BTlh3Nk5LWU1PT0VURXo0PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  key.pem: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdVE0YW94S0llZ1J3ZW5FWHY0QVBjWTc0SnNqNUJXSEhwMUJzY1d1Y24weEwrcEo5ClJyQ0V6YTlEV3JJWndiU2s4aTZ5R2J6UFk2QmlHdlIxK0NMRkZNR1VraERuS1lINk9hNzlvTXN3WGZEc1lmKzUKRTVNdlpWRmsvV3ltN3JORlloallzZnp4M3U2N1dWbFgyRTBGaHBrU1pMUGN6bHNCQzFzN0hxVzV4TnBYUmc2WAoyamJRVmdMTHVDbC9xY2RNOTM0bGsvNTgzbU95eVIwSkQvV3RMc3VxdVIrOWJZSjlVYXUrbGpqZUc3U1h0UVYrCnZEeVQzbHBGdkhaa2hubEpud2pvVzdESDd3TzdlK0ZQc3FmOG9nQk8xUlBmUEhNakRZRERoVlJUTWRKVFpZK2UKZXBXOVY1Rmxib0RWbzlLTjJYU0lUZG1SbFphdDJuRng3TU83YndJREFRQUJBb0lCQVFDdUtVNzZjS1BQS2tSdApoK2hReTRZOVdzL0RPTnZjcTlUS2E4OVR3M0tKSGJaWUlld1RUbWYrYUZkY2tVZmFYVmZyc2ZUZWNpdEEyUjNiCnZuMFVSaXp6UnVpN3UzckRQdGV2MkRoTlQwMjY2OWFjdUo2SGhMdFRnSklxVEVxalZrY1Rkc3ppWG11SVkyZ2gKUkF0L3Y2VldzdE56d1M4cmFzeUYwcHZHVVRTUHhVK29Vcm9BYm54TmRnMzRzbzBrR1lDRDJUbGk3ZmRvTWRuQQpRZWovUVp5aFFDTkorUWxJUGEyN2VkN3R5TWNVN3NpdXQ2aGVBRUJqT3AzVXJLS1BwUnc4VHhZNTltZ05oamt2CjVnT3FhZmV2U0ZPZS96TzNnNFpheXVoU3c5N1ZXR3NwZ0NvbmZETy8vNlZabG44cVlkdmQrNWdTTVBtanBKVlIKZCtRcE9BVmhBb0dCQU9VZmUyVkxXR1JlQVlidXhwdWt5OUFtRlkxSGN2eWN3SXlVZmphWEVUNDQvc0hXODdtMwo0MkVaK3BiYUd2ZE5VOVZtNytCblJ2WFBLVzlCaVNDT0dSSVppSDFWTnQ0d0ZMaTI1ZGNIamlZYitxbVNyUGpkCmI3MThHMTN3SU90L1ZsSDFOQW4zUU9qcmdMZm5udFgrUjlLMEtqVzRYbU4yVmpxUGd3MUZBSWdmQW9HQkFNN0QKUmExR29JSnduaHhuTXd0T08zVCtLUnVKc0Y1aUlYTW40Q1JhWUFwanN1cTUwYmdHQjV5MmdCazR6Y2ZOajVVbgpVQ0hXb2JFNFphcFhveHgvWXFkYkJRdTJaK2gxbnpCdTJJQTVoUEFJRmo1dTJ0SXI5d3FMczFLR1pTUjJScUM0Ck9nL2NFbnFEUUtHcStmUEtBeSs1NWRlbm1BYm8xM2FNOXhQZWZxS3hBb0dBR2JJOExwSVNxYjc1UU43S20yNFMKQlpnZjFxWnF1UFlEaWtDbEh3NDJPdG85aUJQSlpjeS96WVlTV3BTL2JYallyQmhOVXNlQ1o5TUIvSjVHK01XMgovaGFxL2hOdWdlQzJrampBOGlyQXdIbG0xVm5EMkcxTk9OMFFYS3F2cG5temZxR1hZbjYrWXVEMm9LbHpZT0NSCndZbS9LaU14UXNwa3hWQ1BEQS92RFZVQ2dZQUtUQzlzTWRoTXBzODVHdXF2NVhXUW5oZnVCeTJCaGVHa21wZlAKTjdFUTAyWlZ5bXRuZnVWaUtMUzRqTnV5MThvTzQ2WmFDUmFFZlFxVE1Vb3VZU25JcS8vVVZZRlhVb1JiSlNvagpPTG9tT2tEaFd5UUswNlc2SUxzTm9TUG9iUHVYaFpWZXROYzJ3dEsxT282NFZaZFRDUzhwVG0rRDZKVFNrcks3CmlwbEVBUUtCZ0VWb2hsNkpMNWhxcDc3dGg1RVp1VFpqUFZDUkJrU3VUeHZuY1pPUGZHemJjQUp2d05pYVZnblAKbVpnMXdKZDVMczZtbkV3QVJLOXhIRmpFbVpkdEpwSkIwY1ZhVzFvZFY4bWFQamFwRGFiNHJwR3NrL2tuRFZ5TAphWTl3M2FlakFiNlZhaVJ3bUZDZDlzOVhPYmFnQkJ4UU05bVBoTXh2WWdiQzdrSUZJUXVaCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+type: Opaque`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/cli some-version
+    linkerd.io/identity-mode: default
+    linkerd.io/proxy-version: some-version
+  creationTimestamp: "2019-12-12T12:45:05Z"
+  generateName: backend-66f7544cb6-
+  labels:
+    app: backend
+    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/proxy-deployment: backend
+  name: backend-wrong-anchors
+  namespace: some-namespace
+  resourceVersion: "10456"
+  uid: 8018fa11-e2cc-48d6-8e2c-1c83f9a3675c
+spec:
+  containers:
+  - env:
+    - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIBsjCCAVmgAwIBAgIBATAKBggqhkjOPQQDAjBBMT8wPQYDVQQDEzZpZGVudGl0
+        eS5sNWQtaW50ZWdyYXRpb24tZXh0ZXJuYWwtaXNzdWVyLmNsdXN0ZXIubG9jYWww
+        HhcNMTkxMjEyMTIzMjMyWhcNMjAxMjExMTIzMjUyWjBBMT8wPQYDVQQDEzZpZGVu
+        dGl0eS5sNWQtaW50ZWdyYXRpb24tZXh0ZXJuYWwtaXNzdWVyLmNsdXN0ZXIubG9j
+        YWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASdpgf24q6YSKyK6EJr+bItGxsn
+        9wI2e+W0+zkiijgv7AdaVoMLGvvlwUhilkUqJbVOCa0o3f57feXsXan2kq4ko0Iw
+        QDAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC
+        MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDRwAwRAIgcU9CkA4+elkcBF4s
+        58HiWR7kmtMzypOKy34ymLQNAIUCIBRhzErsbaTFmA3f+NM+nX4GT6jSnEhGg19n
+        CG6G2Xq/
+        -----END CERTIFICATE-----
+    image: gcr.io/linkerd-io/proxy:some-version
+    imagePullPolicy: IfNotPresent
+    name: linkerd-proxy
+    ports:
+    - containerPort: 4143
+      name: linkerd-proxy
+      protocol: TCP
+    - containerPort: 4191
+      name: linkerd-admin
+      protocol: TCP
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/linkerd/identity/end-entity
+      name: linkerd-identity-end-entity
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-vgd8j
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: linkerd-identity-end-entity
+  - name: default-token-vgd8j
+    secret:
+      defaultMode: 420
+      secretName: default-token-vgd8j
+  phase: Running
+  podIP: 10.244.0.75
+  podIPs:
+  - ip: 10.244.0.75
+  qosClass: Burstable
+  startTime: "2019-12-12T12:45:05Z"`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/cli some-version
+    linkerd.io/identity-mode: default
+    linkerd.io/proxy-version: some-version
+  creationTimestamp: "2019-12-12T12:45:05Z"
+  generateName: backend-66f7544cb6-
+  labels:
+    app: backend
+    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/proxy-deployment: backend
+  name: backend-right-anchors
+  namespace: some-namespace
+  resourceVersion: "10456"
+  uid: 8018fa11-e2cc-48d6-8e2c-1c83f9a3675c
+spec:
+  containers:
+  - env:
+    - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+        LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+        AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+        xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+        6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+        BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+        AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+        OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+        -----END CERTIFICATE-----
+    image: gcr.io/linkerd-io/proxy:some-version
+    imagePullPolicy: IfNotPresent
+    name: linkerd-proxy
+    ports:
+    - containerPort: 4143
+      name: linkerd-proxy
+      protocol: TCP
+    - containerPort: 4191
+      name: linkerd-admin
+      protocol: TCP
+    resources: {}
+    volumeMounts:
+    - mountPath: /var/run/linkerd/identity/end-entity
+      name: linkerd-identity-end-entity
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-vgd8j
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: linkerd-identity-end-entity
+  - name: default-token-vgd8j
+    secret:
+      defaultMode: 420
+      secretName: default-token-vgd8j
+  phase: Running
+  podIP: 10.244.0.75
+  podIPs:
+  - ip: 10.244.0.75
+  qosClass: Burstable
+  startTime: "2019-12-12T12:45:05Z"`,
+			},
+			"upgrade_overwrite_issuer.golden",
+			// use Errorf here to stop the linter complaining that our error message is capitalized...
+			fmt.Errorf("%s", "You are attempting to use an issuer certificate which does not validate against the trust roots of the following pods:\n\t* backend-wrong-anchors\nThese pods do not have the current trust bundle and must be restarted.  Use the --force flag to proceed anyway (this will likely prevent those pods from sending or receiving traffic)."),
+			func(options *upgradeOptions) {
+				options.identityOptions.crtPEMFile = filepath.Join("testdata", "valid-crt.pem")
+				options.identityOptions.keyPEMFile = filepath.Join("testdata", "valid-key.pem")
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -1013,7 +1013,7 @@ spec:
 			},
 			"upgrade_overwrite_issuer.golden",
 			// use Errorf here to stop the linter complaining that our error message is capitalized...
-			fmt.Errorf("%s", "You are attempting to use an issuer certificate which does not validate against the trust roots of the following pods:\n\t* backend-wrong-anchors\nThese pods do not have the current trust bundle and must be restarted.  Use the --force flag to proceed anyway (this will likely prevent those pods from sending or receiving traffic)."),
+			fmt.Errorf("%s", "You are attempting to use an issuer certificate which does not validate against the trust roots of the following pods:\n\t* some-namespace/backend-wrong-anchors\nThese pods do not have the current trust bundle and must be restarted.  Use the --force flag to proceed anyway (this will likely prevent those pods from sending or receiving traffic)."),
 			func(options *upgradeOptions) {
 				options.identityOptions.crtPEMFile = filepath.Join("testdata", "valid-crt.pem")
 				options.identityOptions.keyPEMFile = filepath.Join("testdata", "valid-key.pem")

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1391,21 +1391,23 @@ func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool) error {
 	return checkResources("PodSecurityPolicies", objects, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)}, shouldExist)
 }
 
-func (hc *HealthChecker) checkDataPlaneProxiesCertificate() error {
-	podList, err := hc.kubeAPI.CoreV1().Pods(hc.DataPlaneNamespace).List(metav1.ListOptions{LabelSelector: k8s.ControllerNSLabel})
+// MeshedPodIdentitiyData contains meshed pod details + root anchors of the proxy
+type MeshedPodIdentitiyData struct {
+	Name      string
+	Namespace string
+	Anchors   string
+}
+
+// GetMeshedPodsIdentitiyData obtains the identity data (trust anchors) for all meshed pods
+func GetMeshedPodsIdentitiyData(api kubernetes.Interface, dataPlaneNamespace string) ([]MeshedPodIdentitiyData, error) {
+	podList, err := api.CoreV1().Pods(dataPlaneNamespace).List(metav1.ListOptions{LabelSelector: k8s.ControllerNSLabel})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	// Return early if no proxies are deployed on the cluster yet (or on the targeted namespace)
 	if len(podList.Items) == 0 {
-		return nil
+		return nil, nil
 	}
-	_, configPB, err := FetchLinkerdConfigMap(hc.kubeAPI, hc.ControlPlaneNamespace)
-	if err != nil {
-		return err
-	}
-	trustAnchorsPem := configPB.GetGlobal().GetIdentityContext().GetTrustAnchorsPem()
-	offendingPods := []string{}
+	pods := []MeshedPodIdentitiyData{}
 	for _, pod := range podList.Items {
 		for _, containerSpec := range pod.Spec.Containers {
 			if containerSpec.Name != k8s.ProxyContainerName {
@@ -1415,13 +1417,34 @@ func (hc *HealthChecker) checkDataPlaneProxiesCertificate() error {
 				if envVar.Name != identity.EnvTrustAnchors {
 					continue
 				}
-				if strings.TrimSpace(envVar.Value) != strings.TrimSpace(trustAnchorsPem) {
-					if hc.DataPlaneNamespace == "" {
-						offendingPods = append(offendingPods, fmt.Sprintf("* %s/%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name))
-					} else {
-						offendingPods = append(offendingPods, fmt.Sprintf("* %s", pod.ObjectMeta.Name))
-					}
-				}
+				pods = append(pods, MeshedPodIdentitiyData{
+					pod.Name, pod.Namespace, strings.TrimSpace(envVar.Value),
+				})
+			}
+		}
+	}
+	return pods, nil
+}
+
+func (hc *HealthChecker) checkDataPlaneProxiesCertificate() error {
+	meshedPods, err := GetMeshedPodsIdentitiyData(hc.kubeAPI.Interface, hc.DataPlaneNamespace)
+	if err != nil {
+		return err
+	}
+
+	_, configPB, err := FetchLinkerdConfigMap(hc.kubeAPI, hc.ControlPlaneNamespace)
+	if err != nil {
+		return err
+	}
+
+	trustAnchorsPem := configPB.GetGlobal().GetIdentityContext().GetTrustAnchorsPem()
+	offendingPods := []string{}
+	for _, pod := range meshedPods {
+		if strings.TrimSpace(pod.Anchors) != strings.TrimSpace(trustAnchorsPem) {
+			if hc.DataPlaneNamespace == "" {
+				offendingPods = append(offendingPods, fmt.Sprintf("* %s/%s", pod.Namespace, pod.Name))
+			} else {
+				offendingPods = append(offendingPods, fmt.Sprintf("* %s", pod.Name))
 			}
 		}
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1391,15 +1391,15 @@ func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool) error {
 	return checkResources("PodSecurityPolicies", objects, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)}, shouldExist)
 }
 
-// MeshedPodIdentitiyData contains meshed pod details + root anchors of the proxy
-type MeshedPodIdentitiyData struct {
+// MeshedPodIdentityData contains meshed pod details + root anchors of the proxy
+type MeshedPodIdentityData struct {
 	Name      string
 	Namespace string
 	Anchors   string
 }
 
-// GetMeshedPodsIdentitiyData obtains the identity data (trust anchors) for all meshed pods
-func GetMeshedPodsIdentitiyData(api kubernetes.Interface, dataPlaneNamespace string) ([]MeshedPodIdentitiyData, error) {
+// GetMeshedPodsIdentityData obtains the identity data (trust anchors) for all meshed pods
+func GetMeshedPodsIdentityData(api kubernetes.Interface, dataPlaneNamespace string) ([]MeshedPodIdentityData, error) {
 	podList, err := api.CoreV1().Pods(dataPlaneNamespace).List(metav1.ListOptions{LabelSelector: k8s.ControllerNSLabel})
 	if err != nil {
 		return nil, err
@@ -1407,7 +1407,7 @@ func GetMeshedPodsIdentitiyData(api kubernetes.Interface, dataPlaneNamespace str
 	if len(podList.Items) == 0 {
 		return nil, nil
 	}
-	pods := []MeshedPodIdentitiyData{}
+	pods := []MeshedPodIdentityData{}
 	for _, pod := range podList.Items {
 		for _, containerSpec := range pod.Spec.Containers {
 			if containerSpec.Name != k8s.ProxyContainerName {
@@ -1417,7 +1417,7 @@ func GetMeshedPodsIdentitiyData(api kubernetes.Interface, dataPlaneNamespace str
 				if envVar.Name != identity.EnvTrustAnchors {
 					continue
 				}
-				pods = append(pods, MeshedPodIdentitiyData{
+				pods = append(pods, MeshedPodIdentityData{
 					pod.Name, pod.Namespace, strings.TrimSpace(envVar.Value),
 				})
 			}
@@ -1427,7 +1427,7 @@ func GetMeshedPodsIdentitiyData(api kubernetes.Interface, dataPlaneNamespace str
 }
 
 func (hc *HealthChecker) checkDataPlaneProxiesCertificate() error {
-	meshedPods, err := GetMeshedPodsIdentitiyData(hc.kubeAPI.Interface, hc.DataPlaneNamespace)
+	meshedPods, err := GetMeshedPodsIdentityData(hc.kubeAPI.Interface, hc.DataPlaneNamespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2381,46 +2381,46 @@ func TestLinkerdIdentityCheck(t *testing.T) {
 			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid: key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true"},
 		},
 		{
-			checkerToTest:      "issuer cert can be verified with trust root",
+			checkerToTest:      "issuer cert is issued by the trust root",
 			checkDescription:   "fails when cert dns is wrong",
 			certificateDNSName: "wrong.linkerd.cluster.local",
-			expectedOutput:     []string{"linkerd-identity-test-cat issuer cert can be verified with trust root: x509: certificate is valid for wrong.linkerd.cluster.local, not identity.linkerd.cluster.local"},
+			expectedOutput:     []string{"linkerd-identity-test-cat issuer cert is issued by the trust root: x509: certificate is valid for wrong.linkerd.cluster.local, not identity.linkerd.cluster.local"},
 		},
 		{
-			checkerToTest:    "all control plane trust roots have valid lifetimes",
+			checkerToTest:    "trust roots are within their validity period",
 			checkDescription: "fails when the only root cert is not valid yet",
 			lifespan: &lifeSpan{
 				starts: time.Date(2100, 1, 1, 1, 1, 1, 1, time.UTC),
 				ends:   time.Date(2101, 1, 1, 1, 1, 1, 1, time.UTC),
 			},
-			expectedOutput: []string{"linkerd-identity-test-cat all control plane trust roots have valid lifetimes: Invalid roots:\n\t* 1 identity.linkerd.cluster.local not valid before: 2100-01-01T01:00:51Z"},
+			expectedOutput: []string{"linkerd-identity-test-cat trust roots are within their validity period: Invalid roots:\n\t* 1 identity.linkerd.cluster.local not valid before: 2100-01-01T01:00:51Z"},
 		},
 		{
-			checkerToTest:    "all control plane trust roots have valid lifetimes",
+			checkerToTest:    "trust roots are within their validity period",
 			checkDescription: "fails when the only root cert is expired",
 			lifespan: &lifeSpan{
 				starts: time.Date(1989, 1, 1, 1, 1, 1, 1, time.UTC),
 				ends:   time.Date(1990, 1, 1, 1, 1, 1, 1, time.UTC),
 			},
-			expectedOutput: []string{"linkerd-identity-test-cat all control plane trust roots have valid lifetimes: Invalid roots:\n\t* 1 identity.linkerd.cluster.local not valid anymore. Expired on 1990-01-01T01:01:11Z"},
+			expectedOutput: []string{"linkerd-identity-test-cat trust roots are within their validity period: Invalid roots:\n\t* 1 identity.linkerd.cluster.local not valid anymore. Expired on 1990-01-01T01:01:11Z"},
 		},
 		{
-			checkerToTest:    "issuer cert has valid lifetime",
+			checkerToTest:    "issuer cert is within its validity period",
 			checkDescription: "fails when the issuer cert is not valid yet",
 			lifespan: &lifeSpan{
 				starts: time.Date(2100, 1, 1, 1, 1, 1, 1, time.UTC),
 				ends:   time.Date(2101, 1, 1, 1, 1, 1, 1, time.UTC),
 			},
-			expectedOutput: []string{"linkerd-identity-test-cat issuer cert has valid lifetime: issuer certificate is not valid before: 2100-01-01T01:00:51Z"},
+			expectedOutput: []string{"linkerd-identity-test-cat issuer cert is within its validity period: issuer certificate is not valid before: 2100-01-01T01:00:51Z"},
 		},
 		{
-			checkerToTest:    "issuer cert has valid lifetime",
+			checkerToTest:    "issuer cert is within its validity period",
 			checkDescription: "fails when the issuer cert is expired",
 			lifespan: &lifeSpan{
 				starts: time.Date(1989, 1, 1, 1, 1, 1, 1, time.UTC),
 				ends:   time.Date(1990, 1, 1, 1, 1, 1, 1, time.UTC),
 			},
-			expectedOutput: []string{"linkerd-identity-test-cat issuer cert has valid lifetime: issuer certificate is not valid anymore. Expired on 1990-01-01T01:01:11Z"},
+			expectedOutput: []string{"linkerd-identity-test-cat issuer cert is within its validity period: issuer certificate is not valid anymore. Expired on 1990-01-01T01:01:11Z"},
 		},
 	}
 

--- a/pkg/issuercerts/issuercerts.go
+++ b/pkg/issuercerts/issuercerts.go
@@ -101,8 +101,8 @@ func LoadIssuerDataFromFiles(keyPEMFile, crtPEMFile, trustPEMFile string) (*Issu
 	return &IssuerCertData{string(anchors), crt, key, nil}, nil
 }
 
-// CheckCertTimeValidity ensures the certificate is valid time - wise
-func CheckCertTimeValidity(cert *x509.Certificate) error {
+// CheckCertValidityPeriod ensures the certificate is valid time - wise
+func CheckCertValidityPeriod(cert *x509.Certificate) error {
 	if cert.NotBefore.After(time.Now()) {
 		return fmt.Errorf("not valid before: %s", cert.NotBefore.Format(time.RFC3339))
 	}
@@ -151,7 +151,7 @@ func (ic *IssuerCertData) VerifyAndBuildCreds(dnsName string) (*tls.Cred, error)
 	}
 
 	// we check the time validity of the issuer cert
-	if err := CheckCertTimeValidity(creds.Certificate); err != nil {
+	if err := CheckCertValidityPeriod(creds.Certificate); err != nil {
 		return nil, err
 	}
 

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -32,13 +32,13 @@ linkerd-existence
 linkerd-identity
 ----------------
 √ certificate config is valid
-√ control plane is using supported trust roots
-√ identity is using supported issuer certificate
-√ all control plane trust roots have valid lifetimes
-√ no control plane trust roots are near expiry
-√ issuer cert has valid lifetime
-√ issuer cert is not near expiry
-√ issuer cert can be verified with trust root
+√ trust roots are using supported crypto algorithm
+√ trust roots are within their validity period
+√ trust roots are valid for at least 60 days
+√ issuer cert is using supported crypto algorithm
+√ issuer cert is within its validity period
+√ issuer cert is valid for at least 60 days
+√ issuer cert is issued by the trust root
 
 linkerd-api
 -----------

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -32,13 +32,13 @@ linkerd-existence
 linkerd-identity
 ----------------
 √ certificate config is valid
-√ control plane is using supported trust roots
-√ identity is using supported issuer certificate
-√ all control plane trust roots have valid lifetimes
-√ no control plane trust roots are near expiry
-√ issuer cert has valid lifetime
-√ issuer cert is not near expiry
-√ issuer cert can be verified with trust root
+√ trust roots are using supported crypto algorithm
+√ trust roots are within their validity period
+√ trust roots are valid for at least 60 days
+√ issuer cert is using supported crypto algorithm
+√ issuer cert is within its validity period
+√ issuer cert is valid for at least 60 days
+√ issuer cert is issued by the trust root
 
 linkerd-identity-data-plane
 ---------------------------


### PR DESCRIPTION
This PR adds functionality that alloes upgrade to check whether all proxies roots can be verified with the issuer cert we are upgrading to. This is done by fetching all the proxies trust anchors from the cluster and performing vrification against the credentials we are moving to. If any of the proxies anchors do not work, a report will be produced listing them. This check can be overwritten by supplying the --force flag to upgrade. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
