### PR TITLE
When running `kind load` in the build host, don't ignore `ssh`'s stderr

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -354,7 +354,7 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
-        ssh -T linkerd-docker &> /dev/null << EOF
+        ssh -T linkerd-docker > /dev/null << EOF
           # TODO: This is using the kind binary on the remote host.
           kind load docker-image gcr.io/linkerd-io/proxy-init:v1.2.0 --name=$KIND_CLUSTER
           kind load docker-image prom/prometheus:v2.11.1 --name=$KIND_CLUSTER

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -270,7 +270,6 @@ jobs:
         DOCKER_HOST: ssh://linkerd-docker
       run: |
         export PATH="`pwd`/bin:$PATH"
-        bin/docker image prune -f
         DOCKER_TRACE=1 bin/docker-build
 
   kind_setup:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -270,8 +270,9 @@ jobs:
         DOCKER_HOST: ssh://linkerd-docker
       run: |
         export PATH="`pwd`/bin:$PATH"
-        DOCKER_TRACE=1 bin/docker-build
         bin/docker image prune -f
+        DOCKER_TRACE=1 bin/docker-build
+
   kind_setup:
     strategy:
       max-parallel: 3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -271,7 +271,7 @@ jobs:
       run: |
         export PATH="`pwd`/bin:$PATH"
         DOCKER_TRACE=1 bin/docker-build
-
+        bin/docker image prune -f
   kind_setup:
     strategy:
       max-parallel: 3


### PR DESCRIPTION
Trying to debug current CI failures...

Edit: More context:
Last week we were having lots of CI failures in different tests, where the the process was simply dying with no error message. The problem ended up being lack of disk space. The current change attempted having more output on the `kind_integration` step. It finally didn't help debugging the issue but I think it's a good change, that avoids swallowing the output of the `kind load` commands. 