### PR TITLE
CHANGES for edge-19.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,30 @@
+## edge-19.12.2
+
+* CLI
+  * Added support for injecting CronJobs and ReplicaSets, and the ability to use
+    them as targets in the CLI subcomands
+  * Added ability to update the trust anchor and issuer certificates during
+    `linkerd upgrade` with the new flags `--identity-issuer-certificate-file`,
+    `--identity-issuer-key-file` and `identity-trust-anchors-file`
+
+* Controller
+  * Fixed bug causing pods having security context capabilities to fail to be
+    injected
+  * Upgraded Prometheus to v1.2.1 (thanks @daxmc99!)
+
+* Web UI
+  * Added support for CronJobs and ReplicaSets, including new Grafana dashboards
+    for them
+
+* Proxy
+  * Increased destination controller client's connection receive window to avoid
+    it becoming exhausted, by single stalled streams
+  * Eagerly read profiles off the wire
+
+* Internal
+  * Moved CNI template into a Helm chart, soon to be published
+  * Reenabled certificates rotation integration tests
+
 ## edge-19.12.1
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
   * Added support for CronJobs and ReplicaSets, including new Grafana dashboards
     for them
 * Proxy
-  * Fixes a bug where the proxy could stop receiving service discovery updates,
+  * Fixed a bug where the proxy could stop receiving service discovery updates,
     resulting in 503 errors
 * Internal
   * Moved CNI template into a Helm chart to prepare for future publication

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,28 +1,22 @@
 ## edge-19.12.2
 
 * CLI
-  * Added support for injecting CronJobs and ReplicaSets, and the ability to use
-    them as targets in the CLI subcomands
-  * Added ability to update the trust anchor and issuer certificates during
-    `linkerd upgrade` with the new flags `--identity-issuer-certificate-file`,
-    `--identity-issuer-key-file` and `identity-trust-anchors-file`
-
+  * Added support for injecting CronJobs and ReplicaSets, as well as the ability
+    to use them as targets in the CLI subcommands
+  * Introduced the new flags `--identity-issuer-certificate-file`,
+    `--identity-issuer-key-file` and `identity-trust-anchors-file` to `linkerd
+    upgrade` to support trust anchor and issuer certificate rotation
 * Controller
-  * Fixed bug causing pods having security context capabilities to fail to be
-    injected
-  * Upgraded Prometheus to v1.2.1 (thanks @daxmc99!)
-
+  * Fixed inject failures for pods with security context capabilities
 * Web UI
   * Added support for CronJobs and ReplicaSets, including new Grafana dashboards
     for them
-
 * Proxy
-  * Increased destination controller client's connection receive window to avoid
-    it becoming exhausted, by single stalled streams
-  * Eagerly read profiles off the wire
-
+  * Fixes a bug where the proxy could stop receiving service discovery updates,
+    resulting in 503 errors
 * Internal
-  * Moved CNI template into a Helm chart, soon to be published
+  * Moved CNI template into a Helm chart to prepare for future publication
+  * Upgraded the Prometheus Go client library to v1.2.1 (thanks @daxmc99!)
   * Reenabled certificates rotation integration tests
 
 ## edge-19.12.1

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version edge-19.12.1
+LinkerdVersion: &linkerd_version edge-19.12.2
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
## edge-19.12.2

* CLI
  * Added support for injecting CronJobs and ReplicaSets, and the ability to use
    them as targets in the CLI subcomands
  * Added ability to update the trust anchor and issuer certificates during
    `linkerd upgrade` with the new flags `--identity-issuer-certificate-file`,
    `--identity-issuer-key-file` and `identity-trust-anchors-file`

* Controller
  * Fixed bug causing pods having security context capabilities to fail to be
    injected
  * Upgraded Prometheus to v1.2.1 (thanks @daxmc99!)

* Web UI
  * Added support for CronJobs and ReplicaSets, including new Grafana dashboards
    for them

* Proxy
  * Increased destination controller client's connection receive window to avoid
    it becoming exhausted, by single stalled streams
  * Eagerly read profiles off the wire

* Internal
  * Moved CNI template into a Helm chart, soon to be published
  * Reenabled certificates rotation integration tests