### PR TITLE
Upgrade yarn and add network-concurrency flag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -191,7 +191,7 @@ jobs:
         git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
     - name: Yarn setup
       run: |
-        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
     - name: JS unit tests
       run: |
         export PATH="$HOME/.yarn/bin:$PATH"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 ## bundle web assets
 FROM node:10 as webpack-bundle
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
 
 ENV PATH /root/.yarn/bin:$PATH
 ENV ROOT /linkerd-build


### PR DESCRIPTION
CI runs are [occasionally failing during the JS unit tests due to Yarn](https://github.com/linkerd/linkerd2/runs/346497367), with a “404 Not Found” for a specific package:

`error An unexpected error occurred: "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.0.tgz: Request failed \"404 Not Found\””.`

This seems to be a widespread Yarn problem with many different packages ([example](https://github.com/yarnpkg/yarn/issues/2738)). 

This PR attempts to fix this with two main changes:
* Upgrading yarn from `1.7.0` to `1.21.1` (current stable version) in the Dockerfile and Github Actions workflow
* Wrapping the yarn installation with the `--network-concurrency 1` flag, setting the maximum number of concurrent network requests to 1, which is suggested as a fix [here](https://github.com/yarnpkg/yarn/issues/2629) — thanks @admc 

**To test the PR**
Check out this branch and run 
```bash
bin/docker-build && bin/linkerd install --ignore-cluster | kubectl apply -f -
bin/linkerd dashboard
```

Note on this specific package: Ever since #3725 was merged in November, we are no longer using the subdependency `es-abstract 1.14.0` anywhere. You can confirm this by looking in the `yarn.lock` file for master (and the diff for #3725).