### PR TITLE
Pluralize dashboard breadcrumbs if appropriate

### DIFF
--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -78,6 +78,11 @@ class BreadcrumbHeader extends React.Component {
 
     if (isMeshResource) {
       if (numCrumbs === 1 || index !== 0) {
+        // If the segment is a K8s resource type, it should be pluralized if
+        // the complete breadcrumb group describes a single-word list of
+        // resources ("Namespaces") OR if the breadcrumb group describes a list
+        // of resources within a specific namespace ("Namespace > linkerd >
+        // Deployments")
         return this.segmentToFriendlyTitle(segment, true);
       }
       return friendlyTitle(segment).singular;

--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -73,14 +73,14 @@ class BreadcrumbHeader extends React.Component {
     }
   }
 
-  renderBreadcrumbSegment(segment, shouldPluralizeFirstSegment) {
+  renderBreadcrumbSegment(segment, numCrumbs, index) {
     let isMeshResource = isResource(segment);
 
     if (isMeshResource) {
-      if (!shouldPluralizeFirstSegment) {
-        return friendlyTitle(segment).singular;
+      if (numCrumbs === 1 || index !== 0) {
+        return this.segmentToFriendlyTitle(segment, true);
       }
-      return this.segmentToFriendlyTitle(segment, true);
+      return friendlyTitle(segment).singular;
     }
     return this.segmentToFriendlyTitle(segment, false);
   }
@@ -88,12 +88,11 @@ class BreadcrumbHeader extends React.Component {
   render() {
     let prefix = this.props.pathPrefix;
     let breadcrumbs = this.convertURLToBreadcrumbs(this.props.location.pathname.replace(prefix, ""));
-    let shouldPluralizeFirstSegment = breadcrumbs.length === 1;
 
     return breadcrumbs.map((pathSegment, index) => {
       return (
         <span key={pathSegment.segment}>
-          {this.renderBreadcrumbSegment(pathSegment.segment, shouldPluralizeFirstSegment && index === 0)}
+          {this.renderBreadcrumbSegment(pathSegment.segment, breadcrumbs.length, index)}
           { index < breadcrumbs.length - 1 ? " > " : null }
         </span>
       );

--- a/web/app/js/components/BreadcrumbHeader.test.jsx
+++ b/web/app/js/components/BreadcrumbHeader.test.jsx
@@ -27,7 +27,45 @@ describe('Tests for <BreadcrumbHeader>', () => {
     expect(crumbs).toHaveLength(3);
   });
 
-  it("renders correct breadcrumb text for resource list page", () => {
+  it("renders correct breadcrumb text for top-level pages [Namespaces]", () => {
+    loc.pathname = "/namespaces";
+    const component = mount(
+      <BrowserRouter>
+        <BreadcrumbHeader
+          location={loc}
+          pathPrefix="" />
+      </BrowserRouter>
+    );
+    const crumbs = component.find("span");
+    expect(crumbs).toHaveLength(1);
+    const crumbText = crumbs.reduce((acc, crumb) => {
+      acc+= crumb.text();
+      return acc;
+    }, "")
+    expect(crumbText).toEqual("Namespaces");
+  });
+
+  it("renders correct breadcrumb text for top-level pages [Control Plane]",
+    () => {
+    loc.pathname = "/controlplane";
+    const component = mount(
+      <BrowserRouter>
+        <BreadcrumbHeader
+          location={loc}
+          pathPrefix="" />
+      </BrowserRouter>
+    );
+    const crumbs = component.find("span");
+    expect(crumbs).toHaveLength(1);
+    const crumbText = crumbs.reduce((acc, crumb) => {
+      acc+= crumb.text();
+      return acc;
+    }, "")
+    expect(crumbText).toEqual("Control Plane");
+  });
+
+  it(`renders correct breadcrumb text for resource list page
+    [Namespace > emojivoto > Deployments`, () => {
 
     loc.pathname = "/namespaces/emojivoto/deployments";
     const component = mount(
@@ -47,7 +85,8 @@ describe('Tests for <BreadcrumbHeader>', () => {
     expect(crumbText).toEqual("Namespace > emojivoto > Deployments")
   });
 
-  it("renders correct breadcrumb text for resource detail page", () => {
+  it(`renders correct breadcrumb text for resource detail page
+    [Namespace > emojivoto > deployment/web`, () => {
 
     loc.pathname = "/namespaces/emojivoto/deployments/web";
     const component = mount(

--- a/web/app/js/components/BreadcrumbHeader.test.jsx
+++ b/web/app/js/components/BreadcrumbHeader.test.jsx
@@ -26,4 +26,45 @@ describe('Tests for <BreadcrumbHeader>', () => {
     const crumbs = component.find("span");
     expect(crumbs).toHaveLength(3);
   });
+
+  it("renders correct breadcrumb text for resource list page", () => {
+
+    loc.pathname = "/namespaces/emojivoto/deployments";
+    const component = mount(
+      <BrowserRouter>
+        <BreadcrumbHeader
+          location={loc}
+          pathPrefix="" />
+      </BrowserRouter>
+    );
+
+    const crumbs = component.find("span");
+    expect(crumbs).toHaveLength(3);
+    const crumbText = crumbs.reduce((acc, crumb) => {
+      acc+= crumb.text();
+      return acc;
+    }, "")
+    expect(crumbText).toEqual("Namespace > emojivoto > Deployments")
+  });
+
+  it("renders correct breadcrumb text for resource detail page", () => {
+
+    loc.pathname = "/namespaces/emojivoto/deployments/web";
+    const component = mount(
+      <BrowserRouter>
+        <BreadcrumbHeader
+          location={loc}
+          pathPrefix="" />
+      </BrowserRouter>
+    );
+
+    const crumbs = component.find("span");
+    expect(crumbs).toHaveLength(3);
+    const crumbText = crumbs.reduce((acc, crumb) => {
+      acc+= crumb.text();
+      return acc;
+    }, "")
+    expect(crumbText).toEqual("Namespace > emojivoto > deployment/web")
+
+  });
 });


### PR DESCRIPTION
Closes #3483.

This PR refactors and simplifies breadcrumb text pluralization. The redesigned dashboard added a view that shows the user a list of all pods, deployments, etc. in a namespace. The breadcrumb navigation text needs to be tweaked to correctly pluralize the resource type selected. 

Currently the breadcrumbs for /namespaces/linkerd/deployments/ are:
`Namespace > linkerd > Deployment`
They should be:
`Namespace > linkerd > Deployments`

Before (incorrect):
<img width="1439" alt="Screen Shot 2019-12-15 at 5 28 00 PM" src="https://user-images.githubusercontent.com/2289389/70873176-5796a280-1f61-11ea-9994-77023ce3ff0c.png">

After:
<img width="1440" alt="Screen Shot 2019-12-15 at 5 28 50 PM" src="https://user-images.githubusercontent.com/2289389/70873178-5bc2c000-1f61-11ea-9e38-9f0624a5168f.png">
