### PR TITLE
Fix issue with Community iframe height

### DIFF
--- a/web/app/js/components/Community.jsx
+++ b/web/app/js/components/Community.jsx
@@ -1,22 +1,38 @@
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
+import _has from 'lodash/has';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = () => ({
   iframe: {
     border: "0px",
-    height: "100vh",
     width: "100%",
     overflow: "hidden",
   },
 });
 
 const Community = ({classes}) => {
+  const [iframeHeight, setIframeHeight] = useState(0);
+  useEffect(() => {
+    // We add 5px to avoid cutting box shadow
+    const setFromIframeEvent = e => {
+      if (!_has(e.data, "dashboardHeight")) {
+        return;
+      }
+      setIframeHeight(e.data.dashboardHeight + 5);
+    };
+    window.addEventListener("message", setFromIframeEvent);
+    return () => {
+      window.removeEventListener("message", setFromIframeEvent);
+    };
+  }, []);
+
   return (
     <iframe
       title="Community"
       src="https://linkerd.io/dashboard/"
       scrolling="no"
+      style={{ height: iframeHeight > 0 ? iframeHeight : "100vh" }}
       className={classes.iframe} />
   );
 };


### PR DESCRIPTION
#### Problem
Browser cuts off the bottom of the posts if browser height is shorter than the height of the iframe.

Open Community page on a small height browser window looks like this:
￼
![Community](https://user-images.githubusercontent.com/1440981/70932479-22aa4e80-203a-11ea-8324-55ea96ea9405.png)

#### Solution
Post a message with the body `offsetHeight` from iframe itself to its parent. `Community` page, thanks to `useEffect` hook, is prepared to read the height and to update the `iframeHeight` state, which is used to modify the iframe height.  This PR depends on this [one](https://github.com/linkerd/website/pull/605) from [repo](https://github.com/linkerd/website), but it’s possible to merge it before that one due to it’s prepared to work like now without getting the iframe height.

Tested on Safari, Chrome, Firefox, Opera and Edge.

Related to #3764

Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
