### PR TITLE
stable-2.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## stable-2.6.1
+
+This release improves proxy stability by fixing a bug where the proxy could stop
+receiving service discovery updates, resulting in 503 errors.
+
+To install this release, run: `curl https://run.linkerd.io/install | sh`
+
+**Full release notes**:
+
+* Proxy
+  * Fixed a bug where the proxy could stop receiving service discovery updates,
+    resulting in 503 errors
+  * Improved debug/error logging to include detailed contextual information
+
 ## stable-2.6.0
 
 This release introduces distributed tracing support, adds request and response

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -7,7 +7,7 @@ EnableH2Upgrade: true
 ImagePullPolicy: &image_pull_policy IfNotPresent
 
 # control plane version. See Proxy section for proxy version
-LinkerdVersion: &linkerd_version stable-2.6.0
+LinkerdVersion: &linkerd_version stable-2.6.1
 
 Namespace: linkerd
 OmitWebhookSideEffects: false


### PR DESCRIPTION
This release improves proxy stability by fixing a bug where the proxy could stop
receiving service discovery updates, resulting in 503 errors

To install this release, run: `curl https://run.linkerd.io/install | sh`

**Full release notes**:

* Proxy
  * Fixed a bug where the proxy could stop receiving service discovery updates,
    resulting in 503 errors
  * Improved debug/error logging to include detailed contextual information
