### PR TITLE
Fix spacing unit to new MUI v4 format

### DIFF
--- a/web/app/js/components/TapQueryForm.jsx
+++ b/web/app/js/components/TapQueryForm.jsx
@@ -59,7 +59,7 @@ const styles = theme => ({
     minWidth: 200,
   },
   formControl: {
-    padding: theme.spacing.unit,
+    padding: theme.spacing(1),
     paddingLeft: 0,
     margin: 0,
     minWidth: 'inherit',
@@ -90,7 +90,7 @@ const styles = theme => ({
     transform: 'rotate(180deg)',
   },
   resetButton: {
-    marginLeft: theme.spacing.unit,
+    marginLeft: theme.spacing(1),
   }
 });
 


### PR DESCRIPTION
#### Problem
Browser is logging some errors about incorrect spacing API usage (Material UI v4):

￼![has been deprecated  vMaterial-UI theme spacing unit usage](https://user-images.githubusercontent.com/1440981/71040697-7e9ed100-2127-11ea-8ae4-ce19cc78e2ef.png)

#### Solution
Replace in `TapQueryForm.jsx` file `theme.spacing.unit`, which is deprecated, for `theme.spacing(1)`.


Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
