### PR TITLE
Fix dense mode for MUI v4 Table

### DIFF
--- a/web/app/js/components/Octopus.jsx
+++ b/web/app/js/components/Octopus.jsx
@@ -146,7 +146,7 @@ class Octopus extends React.Component {
 
               <Progress variant="determinate" value={resource.successRate * 100} />
 
-              <Table padding="dense">
+              <Table>
                 {showTcp ? this.renderTCPStats(resource) : this.renderHttpStats(resource)}
               </Table>
             </CardContent>


### PR DESCRIPTION
#### Problem

Browser is logging some errors about invalid prop `padding` (Material UI v4):

￼<img width="1055" alt="Screenshot 2019-12-18 at 19 07 01" src="https://user-images.githubusercontent.com/1440981/71112330-82842f00-21cb-11ea-94f3-2a6b326d823e.png">

#### Solution

Delete dense mode from `padding` prop in `Octopus.jsx` file. 


Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
