### PR TITLE
Build linkerd2-cni Helm chart in `bin/helm-build`

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -9,6 +9,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
 "$bindir"/helm lint "$rootdir"/charts/partials
+"$bindir"/helm lint "$rootdir"/charts/linkerd2-cni
 "$bindir"/helm init --client-only
 "$bindir"/helm dep up "$rootdir"/charts/linkerd2
 "$bindir"/helm dep up "$rootdir"/charts/patch
@@ -28,6 +29,7 @@ if [ "$1" = package ]; then
     repo=${BASH_REMATCH[1]}
     version=${BASH_REMATCH[2]}
     "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
+    "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-$version.yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-$version.yaml "$rootdir"/target/helm
 fi


### PR DESCRIPTION
Fixes #3801

This will package and build the `linkerd2-cni` chart from the
`charts/linkerd2-cni` directory and update our Helm Hub's `index.yaml`
file to index it.

This will only be run in the `chart_deploy` job of our Github Actions
when an edge/stable tag is pushed.

Once that happens, users will be able to install the chart with a
command like:

```
helm install linkerd-edge/linkerd2-cni
```

Docs update will follow.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
