### PR TITLE
Updating the namespace change button with the Autocomplete MUI component

### DIFF
--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -112,11 +112,33 @@ const styles = theme => {
       width: `${navLogoWidth}px`,
     },
     namespaceChangeButton: {
+      borderRadius: "5px",
       backgroundColor: grey[400],
       marginLeft: `${drawerWidth * .075}px`,
       marginRight: `${drawerWidth * .075}px`,
       marginTop: "11px",
       width: `${drawerWidth * .85}px`,
+    },
+    namespaceChangeButtonInputRoot: {
+      backgroundColor: grey[300],
+      boxShadow: "rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px",
+      padding: "4px 12px !important",
+      border: 0,
+      "&:hover": {
+        borderColor: "transparent",
+      },
+    },
+    namespaceChangeButtonInput: {
+      textAlign: "center",
+    },
+    namespaceChangeButtonInputFocused: {
+      textAlign: "center",
+    },
+    namespaceChangeButtonPopupIndicator: {
+      backgroundColor: "transparent",
+      "&:hover": {
+        backgroundColor: "transparent",
+      }
     },
     navMenuItem: {
       paddingLeft: `${contentPadding}px`,
@@ -436,7 +458,13 @@ class NavigationBase extends React.Component {
           autoSelect={true}
           getOptionLabel={option => { if (option.name !== "_all") {return option.name;} else {return "All Namespaces";}}}
           onChange={this.handleNamespaceChange}
-          style={{ borderRadius:"5px" }}
+          size="small"
+          classes={{
+            root: classes.namespaceChangeButton,
+            inputRoot: classes.namespaceChangeButtonInputRoot,
+            input: classes.namespaceChangeButtonInput,
+            popupIndicator: classes.namespaceChangeButtonPopupIndicator,
+          }}
           className={classes.namespaceChangeButton}
           renderInput={params => (
             <TextField

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -163,8 +163,8 @@ describe('Namespace Select Button', () => {
       </BrowserRouter>
     );
 
-    const button = component.find("button");
-    expect(button).toIncludeText("All Namespaces");
+    const input = component.find("input");
+    expect(input.instance().value).toEqual("ALL NAMESPACES")
   });
 
   it('renders emojivoto text', () => {
@@ -183,96 +183,7 @@ describe('Namespace Select Button', () => {
       </BrowserRouter>
     );
 
-    const button = component.find("button");
-    expect(button).toIncludeText("emojivoto");
-  });
-
-  it('opens the Namespace Selection menu if button is clicked', () => {
-    // Material-UI v4 requires that the popover needs a valid anchorEl
-    // if NODE_ENV is not "test"
-    delete process.env.NODE_ENV;
-    process.env.NODE_ENV = "test";
-
-    const component = mount(
-      <BrowserRouter>
-        <Navigation
-          ChildComponent={() => null}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={ApiHelpers("")}
-          releaseVersion="edge-1.2.3"
-          selectedNamespace="emojivoto"
-          pathPrefix=""
-          uuid="fakeuuid" />
-      </BrowserRouter>
-    );
-
-    expect(component.find(Menu).props().open).toBeFalsy();
-
-    const button = component.find("button");
-    button.simulate("click");
-
-    expect(component.find(Menu).props().open).toBeTruthy();
-  });
-
-  describe('renders namespace selection menu with correct number of options', () => {
-    beforeEach(() => {
-      // https://material-ui.com/components/use-media-query/#testing
-      window.matchMedia = createMatchMedia(window.innerWidth);
-    });
-
-    it('5 options', () => {
-      const component = mount(
-        <BrowserRouter>
-          <Navigation
-            ChildComponent={() => null}
-            classes={{}}
-            theme={{}}
-            location={loc}
-            api={ApiHelpers("")}
-            releaseVersion="edge-1.2.3"
-            selectedNamespace="emojivoto"
-            pathPrefix=""
-            uuid="fakeuuid" />
-        </BrowserRouter>
-      );
-
-      expect(component.find(Menu).find(MenuItem)).toHaveLength(2);
-
-      component.find("NavigationBase").instance().setState({
-        namespaces: namespaces,
-      });
-      component.update();
-      // 5 items = Input - "Select Namespace..." + "All Namespaces" item + 3 added namespaces
-      expect(component.find(Menu).find(MenuItem)).toHaveLength(5);
-    });
-
-    it('3 options', () => {
-      const component = mount(
-        <BrowserRouter>
-          <Navigation
-            ChildComponent={() => null}
-            classes={{}}
-            theme={{}}
-            location={loc}
-            api={ApiHelpers("")}
-            releaseVersion="edge-1.2.3"
-            selectedNamespace="emojivoto"
-            pathPrefix=""
-            uuid="fakeuuid" />
-        </BrowserRouter>
-      );
-
-      expect(component.find(Menu).find(MenuItem)).toHaveLength(2);
-
-      component.find("NavigationBase").instance().setState({
-        namespaces: namespaces,
-        formattedNamespaceFilter: "de",
-      });
-      component.update();
-      // 3 items = "Input - Select Namespace..." + "All Namespaces" item + 1 namespace which matches "de" string
-      expect(component.find(Menu).find(MenuItem)).toHaveLength(3);
-    });
+    const input = component.find("input");
+    expect(input.instance().value).toEqual("EMOJIVOTO")
   });
 });

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/react-fontawesome": "0.1.4",
     "@material-ui/core": "4.7.1",
     "@material-ui/icons": "4.5.1",
+    "@material-ui/lab": "^4.0.0-alpha.36",
     "classnames": "2.2.6",
     "css-mediaquery": "^0.1.2",
     "d3-drag": "1.2.3",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -1035,6 +1035,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.36":
+  version "4.0.0-alpha.36"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.36.tgz#85420c59c88a9620bd65fed530c288c04afee26a"
+  integrity sha512-T5dMW4RYmjH/VWjXui5uBPcqfMsKv5Ig/uX77UwTQts2CS6YeNF7619WtEm6yl9kV2O5CVpRsPw1ulrt2T2Hrg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.7.1"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
 "@material-ui/styles@^4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.7.1.tgz#48fa70f06441c35e301a9c4b6c825526a97b7a29"
@@ -2674,7 +2685,7 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
-clsx@^1.0.2:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==


### PR DESCRIPTION
The upgrade to Material-UI 4 in #3710 introduced a change into the namespace select button resulting in broken functionality. 

The namespace select button had a text input option to allow users to filter a long list of namespaces. With the upgrade, inputting text only resulted in highlighting the namespaces that began with the first letter (see below screenshot). The `onChange` event when typing into the text input did not fire consistently. I'm still investigating where exactly this event handling changed within the new MUI.

This PR updates the text input to be the new Material-UI `Autocomplete` component, which slightly alters the UI but maintains the original functionality of clicking onto the input, selecting the desired namespace and/or typing into the input, in desktop and mobile views. 

The `Autocomplete` component has some different default styling including left-justified content and a border on focus. This can be modified with some more work.

I updated the `Navigation` tests as well but the test coverage has been reduced, will file a follow-up PR for that. 

Original:
<img width="264" alt="Screen Shot 2019-12-19 at 12 14 30 AM" src="https://user-images.githubusercontent.com/2289389/71156408-d2c3b700-21f4-11ea-8173-b91372d073ce.png">

After Material UI upgrade:
<img width="262" alt="Screen Shot 2019-12-19 at 12 16 03 AM" src="https://user-images.githubusercontent.com/2289389/71156387-ca6b7c00-21f4-11ea-92d0-236c4bf9ca29.png">

Current branch:
<img width="272" alt="Screen Shot 2019-12-19 at 12 19 27 AM" src="https://user-images.githubusercontent.com/2289389/71156662-482f8780-21f5-11ea-8c9e-cb78269843b9.png">

<img width="287" alt="Screen Shot 2019-12-19 at 12 15 12 AM" src="https://user-images.githubusercontent.com/2289389/71156396-cdff0300-21f4-11ea-9c7b-47e26f9b4d5b.png"> 
