### PR TITLE
Don't hide stderr in integration tests

### DIFF
--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -34,9 +34,9 @@ func TestMain(m *testing.M) {
 //////////////////////
 
 func TestEgressHttp(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v\n%s", err, stderr)
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("egress-test")

--- a/test/externalissuer/external_issuer_test.go
+++ b/test/externalissuer/external_issuer_test.go
@@ -37,9 +37,9 @@ func TestExternalIssuer(t *testing.T) {
 }
 
 func verifyInstallApp(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/external_issuer_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/external_issuer_application.yaml")
 	if err != nil {
-		t.Fatalf("linkerd inject command failed\n%s", out)
+		t.Fatalf("linkerd inject command failed\n%s\n%s", out, stderr)
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace(TestAppNamespaceSuffix)

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -50,9 +50,9 @@ var (
 //////////////////////
 
 func TestCliGet(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "testdata/to_be_injected_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/to_be_injected_application.yaml")
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatalf("Unexpected error: %v\n%s", err, stderr)
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("get-test")
@@ -83,10 +83,9 @@ func TestCliGet(t *testing.T) {
 	}
 
 	t.Run("get pods from --all-namespaces", func(t *testing.T) {
-		out, _, err = TestHelper.LinkerdRun("get", "pods", "--all-namespaces")
-
+		out, stderr, err = TestHelper.LinkerdRun("get", "pods", "--all-namespaces")
 		if err != nil {
-			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+			t.Fatalf("Unexpected error: %v output:\n%s\n%s", err, out, stderr)
 		}
 
 		err := checkPodOutput(out, deployReplicas, "", prefixedNs)
@@ -96,10 +95,9 @@ func TestCliGet(t *testing.T) {
 	})
 
 	t.Run("get pods from the linkerd namespace", func(t *testing.T) {
-		out, _, err = TestHelper.LinkerdRun("get", "pods", "-n", TestHelper.GetLinkerdNamespace())
-
+		out, stderr, err = TestHelper.LinkerdRun("get", "pods", "-n", TestHelper.GetLinkerdNamespace())
 		if err != nil {
-			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+			t.Fatalf("Unexpected error: %v output:\n%s\n%s", err, out, stderr)
 		}
 
 		err := checkPodOutput(out, linkerdPods, "linkerd-heartbeat", TestHelper.GetLinkerdNamespace())

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -145,9 +145,9 @@ func TestCheckPreInstall(t *testing.T) {
 
 	cmd := []string{"check", "--pre", "--expected-version", TestHelper.GetVersion()}
 	golden := "check.pre.golden"
-	out, _, err := TestHelper.LinkerdRun(cmd...)
+	out, stderr, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
-		t.Fatalf("Check command failed\n%s", out)
+		t.Fatalf("Check command failed\n%s\n%s", out, stderr)
 	}
 
 	err = TestHelper.ValidateOutput(out, golden)
@@ -269,9 +269,9 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 		cmd = "upgrade"
 		// test 2-stage install during upgrade
-		out, _, err := TestHelper.LinkerdRun(cmd, "config")
+		out, stderr, err := TestHelper.LinkerdRun(cmd, "config")
 		if err != nil {
-			t.Fatalf("linkerd upgrade config command failed\n%s", out)
+			t.Fatalf("linkerd upgrade config command failed\n%s\n%s", out, stderr)
 		}
 
 		// apply stage 1
@@ -287,7 +287,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	exec := append([]string{cmd}, args...)
 	out, stderr, err := TestHelper.LinkerdRun(exec...)
 	if err != nil {
-		t.Fatalf("linkerd install command failed: \n%s\n%s\n%s", out, stderr, out)
+		t.Fatalf("linkerd install command failed: \n%s\n%s", out, stderr)
 	}
 
 	// test `linkerd upgrade --from-manifests`
@@ -309,9 +309,9 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		if out != upgradeFromManifests {
 			// retry in case it's just a discrepancy in the heartbeat cron schedule
 			exec := append([]string{cmd}, args...)
-			out, _, err := TestHelper.LinkerdRun(exec...)
+			out, stderr, err := TestHelper.LinkerdRun(exec...)
 			if err != nil {
-				t.Fatalf("command failed: %v\n%s", exec, out)
+				t.Fatalf("command failed: %v\n%s\n%s", exec, out, stderr)
 			}
 
 			if out != upgradeFromManifests {
@@ -460,9 +460,9 @@ func TestUpgradeTestAppWorksAfterUpgrade(t *testing.T) {
 func TestInstallSP(t *testing.T) {
 	cmd := []string{"install-sp"}
 
-	out, _, err := TestHelper.LinkerdRun(cmd...)
+	out, stderr, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
-		t.Fatalf("linkerd install-sp command failed\n%s", out)
+		t.Fatalf("linkerd install-sp command failed\n%s\n%s", out, stderr)
 	}
 
 	out, err = TestHelper.KubectlApply(out, TestHelper.GetLinkerdNamespace())
@@ -605,9 +605,9 @@ func TestCheckProxy(t *testing.T) {
 			golden := "check.proxy.golden"
 
 			err := TestHelper.RetryFor(time.Minute, func() error {
-				out, _, err := TestHelper.LinkerdRun(cmd...)
+				out, stderr, err := TestHelper.LinkerdRun(cmd...)
 				if err != nil {
-					return fmt.Errorf("Check command failed\n%s", out)
+					return fmt.Errorf("Check command failed\n%s\n%s", out, stderr)
 				}
 
 				err = TestHelper.ValidateOutput(out, golden)

--- a/test/routes/routes_test.go
+++ b/test/routes/routes_test.go
@@ -29,9 +29,9 @@ func TestMain(m *testing.M) {
 func TestRoutes(t *testing.T) {
 	// control-plane routes
 	cmd := []string{"routes", "--namespace", TestHelper.GetLinkerdNamespace(), "deploy"}
-	out, _, err := TestHelper.LinkerdRun(cmd...)
+	out, stderr, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
-		t.Fatalf("Routes command failed\n%s", out)
+		t.Fatalf("Routes command failed\n%s\n%s", out, stderr)
 	}
 
 	routeStrings := []struct {
@@ -69,9 +69,9 @@ func TestRoutes(t *testing.T) {
 	cmd = []string{"routes", "--namespace", prefixedNs, "deploy"}
 	golden := "routes.smoke.golden"
 
-	out, _, err = TestHelper.LinkerdRun(cmd...)
+	out, stderr, err = TestHelper.LinkerdRun(cmd...)
 	if err != nil {
-		t.Fatalf("Routes command failed\n%s", out)
+		t.Fatalf("Routes command failed\n%s\n%s", out, stderr)
 	}
 
 	err = TestHelper.ValidateOutput(out, golden)

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -78,9 +78,9 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
-		t.Fatalf("linkerd inject command failed\n%s", out)
+		t.Fatalf("linkerd inject command failed\n%s\n%s", out, stderr)
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("tap-test")

--- a/test/trafficsplit/trafficsplit_test.go
+++ b/test/trafficsplit/trafficsplit_test.go
@@ -147,9 +147,9 @@ func validateExpectedTsOutput(rows map[string]*statTsRow, expectedBackendSvc, ex
 }
 
 func TestTrafficSplitCli(t *testing.T) {
-	out, _, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/traffic_split_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/traffic_split_application.yaml")
 	if err != nil {
-		t.Fatalf("linkerd inject command failed\n%s", out)
+		t.Fatalf("linkerd inject command failed\n%s\n%s", out, stderr)
 	}
 
 	prefixedNs := TestHelper.GetTestNamespace("trafficsplit-test")

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -98,15 +98,15 @@ func NewTestHelper() *TestHelper {
 		externalIssuer: *externalIssuer,
 	}
 
-	version, _, err := testHelper.LinkerdRun("version", "--client", "--short")
+	version, stderr, err := testHelper.LinkerdRun("version", "--client", "--short")
 	if err != nil {
-		exit(1, "error getting linkerd version: "+err.Error())
+		exit(1, fmt.Sprintf("error getting linkerd version: %s\n%s", err.Error(), stderr))
 	}
 	testHelper.version = strings.TrimSpace(version)
 
 	kubernetesHelper, err := NewKubernetesHelper(*k8sContext, testHelper.RetryFor)
 	if err != nil {
-		exit(1, "error creating kubernetes helper: "+err.Error())
+		exit(1, fmt.Sprintf("error creating kubernetes helper: %s\n%s", err.Error(), stderr))
 	}
 	testHelper.KubernetesHelper = *kubernetesHelper
 


### PR DESCRIPTION
In various integration tests we're not showing stderr when a failure
happens, thus hiding some possibly useful debugging info.
E.g. in the latest CI failures, commands like `linkerd update` were
failing with no visible reason why.
