### PR TITLE
Upgrade `kind` to v0.6.1

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -357,8 +357,8 @@ jobs:
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
         ssh -T linkerd-docker > /dev/null << EOF
           # TODO: This is using the kind binary on the remote host.
-          # TODO: `kind` still points to v0.5.1. When there are no more old CI branches depending on that
-          # we can replace it with v0.6.1. In the meantime we explicitly use `kind-0.6.1`
+          # TODO: 'kind' still points to v0.5.1. When there are no more old CI branches depending on that
+          # we can replace it with v0.6.1. In the meantime we explicitly use 'kind-0.6.1'
           kind-0.6.1 load docker-image gcr.io/linkerd-io/proxy-init:v1.3.0 --name=$KIND_CLUSTER
           kind-0.6.1 load docker-image prom/prometheus:v2.11.1 --name=$KIND_CLUSTER
           for IMG in controller grafana proxy web ; do

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -319,7 +319,7 @@ jobs:
           bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6 ||
             bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6
         fi
-        scp /tmp/kind-config-$KIND_CLUSTER linkerd-docker:/tmp
+        scp $KUBECONFIG linkerd-docker:/tmp
 
   kind_integration:
     strategy:
@@ -392,8 +392,8 @@ jobs:
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
         # Restore kubeconfig from remote docker host.
         mkdir -p $HOME/.kube
-        scp linkerd-docker:/tmp/kind-config-$KIND_CLUSTER $HOME/.kube
         export KUBECONFIG=$HOME/.kube/kind-config-$KIND_CLUSTER
+        scp linkerd-docker:/tmp/kind-config-$KIND_CLUSTER $KUBECONFIG
         # Start ssh tunnel to allow kubectl to connect via localhost.
         export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='kind-$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
         echo "KIND_PORT: $KIND_PORT"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -313,11 +313,11 @@ jobs:
         # retry cluster creation once in case of port conflict or kubeadm failure
         if [ "${{ matrix.integration_test }}" == "custom_domain" ]
         then
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG --image kindest/node:v1.15.6 ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG --image kindest/node:v1.15.6
         else
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6 ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6
         fi
         scp /tmp/kind-config-$KIND_CLUSTER linkerd-docker:/tmp
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -395,7 +395,8 @@ jobs:
         scp linkerd-docker:/tmp/kind-config-$KIND_CLUSTER $HOME/.kube
         export KUBECONFIG=$HOME/.kube/kind-config-$KIND_CLUSTER
         # Start ssh tunnel to allow kubectl to connect via localhost.
-        export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
+        export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='kind-$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
+        echo "KIND_PORT: $KIND_PORT"
         ssh -4 -N -L $KIND_PORT:localhost:$KIND_PORT linkerd-docker &
         sleep 2 # Wait for ssh tunnel to come up.
         bin/kubectl version --short # Test connection to kind cluster.

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -313,11 +313,11 @@ jobs:
         # retry cluster creation once in case of port conflict or kubeadm failure
         if [ "${{ matrix.integration_test }}" == "custom_domain" ]
         then
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG --image kindest/node:v1.15.6 ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG --image kindest/node:v1.15.6
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG
         else
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6 ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --image kindest/node:v1.15.6
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
         fi
         scp $KUBECONFIG linkerd-docker:/tmp
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -308,6 +308,7 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        export KUBECONFIG=/tmp/kind-config-$KIND_CLUSTER 
         export CUSTOM_DOMAIN_CONFIG="test/testdata/custom_cluster_domain_config.yaml"
         # retry cluster creation once in case of port conflict or kubeadm failure
         if [ "${{ matrix.integration_test }}" == "custom_domain" ]
@@ -318,7 +319,7 @@ jobs:
           bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
             bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
         fi
-        scp $(bin/kind get kubeconfig-path --name=$KIND_CLUSTER) linkerd-docker:/tmp
+        scp /tmp/kind-config-$KIND_CLUSTER linkerd-docker:/tmp
 
   kind_integration:
     strategy:
@@ -356,10 +357,12 @@ jobs:
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
         ssh -T linkerd-docker > /dev/null << EOF
           # TODO: This is using the kind binary on the remote host.
-          kind load docker-image gcr.io/linkerd-io/proxy-init:v1.3.0 --name=$KIND_CLUSTER
-          kind load docker-image prom/prometheus:v2.11.1 --name=$KIND_CLUSTER
+          # TODO: `kind` still points to v0.5.1. When there are no more old CI branches depending on that
+          # we can replace it with v0.6.1. In the meantime we explicitly use `kind-0.6.1`
+          kind-0.6.1 load docker-image gcr.io/linkerd-io/proxy-init:v1.3.0 --name=$KIND_CLUSTER
+          kind-0.6.1 load docker-image prom/prometheus:v2.11.1 --name=$KIND_CLUSTER
           for IMG in controller grafana proxy web ; do
-            kind load docker-image gcr.io/linkerd-io/\$IMG:$TAG --name=$KIND_CLUSTER
+            kind-0.6.1 load docker-image gcr.io/linkerd-io/\$IMG:$TAG --name=$KIND_CLUSTER
           done
         EOF
     - name: Install linkerd CLI
@@ -390,7 +393,7 @@ jobs:
         # Restore kubeconfig from remote docker host.
         mkdir -p $HOME/.kube
         scp linkerd-docker:/tmp/kind-config-$KIND_CLUSTER $HOME/.kube
-        export KUBECONFIG=$(bin/kind get kubeconfig-path --name=$KIND_CLUSTER)
+        export KUBECONFIG=$HOME/.kube/kind-config-$KIND_CLUSTER
         # Start ssh tunnel to allow kubectl to connect via localhost.
         export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
         ssh -4 -N -L $KIND_PORT:localhost:$KIND_PORT linkerd-docker &

--- a/bin/kind
+++ b/bin/kind
@@ -2,7 +2,7 @@
 
 set -eu
 
-kindversion=v0.5.1
+kindversion=v0.6.1
 
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin


### PR DESCRIPTION
Fixes #3852

Upgraded `/bin/kind` to pull v0.6.1.
Also have `workflow.yml` use `KUBECONFIG` explicitly for setting the
location of the config file, now that `kind get kubeconfig-path` has
been deprecated (check
https://github.com/kubernetes-sigs/kind/releases/tag/v0.6.0 for detailed
info).
Note that in the build server the kind binary for this version is
`kind-0.6.1`, leaving the `kind` binary still pointing to v0.5.1 while
this gets merged and all the PR branches get this.