### PR TITLE
The `linkerd-cni` chart should set proper annotations/labels for the namespace

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -22,6 +22,11 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
+  annotations:
+    {{.Values.proxyInjectAnnotation}}: {{.Values.proxyInjectDisabled}}
+  labels:
+    {{.Values.linkerdNamespaceLabel}}: "true"
+    config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -14,3 +14,8 @@ proxyUID:         2102
 destCNINetDir:    "/etc/cni/net.d"
 destCNIBinDir:    "/opt/cni/bin"
 useWaitFlag:      false
+
+# namespace annotation and labels - do not edit
+proxyInjectAnnotation: linkerd.io/inject
+proxyInjectDisabled: disabled
+linkerdNamespaceLabel: linkerd.io/is-control-plane

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -28,7 +28,7 @@
     "value": "{{$value}}"
   },
   {{- end }}
-  {{- if .Values.proxyInit }}
+  {{- if and .Values.proxyInit (not .Values.noInitContainer) }}
   {{- if .Values.addRootInitContainers }}
   {
     "op": "add",

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -28,7 +28,7 @@
     "value": "{{$value}}"
   },
   {{- end }}
-  {{- if and .Values.proxyInit (not .Values.noInitContainer) }}
+  {{- if .Values.proxyInit }}
   {{- if .Values.addRootInitContainers }}
   {
     "op": "add",

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -2,6 +2,11 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
+    config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -2,6 +2,11 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: other
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
+    config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -2,6 +2,11 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: other
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
+    config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/cli/cmd/testdata/install_cni_helm_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_output.golden
@@ -4,6 +4,11 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-test
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/is-control-plane: "true"
+    config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -32,6 +32,9 @@ type Values struct {
 	DestCNINetDir            string `json:"destCNINetDir"`
 	DestCNIBinDir            string `json:"destCNIBinDir"`
 	UseWaitFlag              bool   `json:"useWaitFlag"`
+	ProxyInjectAnnotation    string `json:"proxyInjectAnnotation"`
+	ProxyInjectDisabled      string `json:"proxyInjectDisabled"`
+	LinkerdNamespaceLabel    string `json:"linkerdNamespaceLabel"`
 }
 
 // NewValues returns a new instance of the Values type.


### PR DESCRIPTION
When installing through Helm, the `linkerd-cni` chart will (by default)
install itself under the same namespace ("linkerd") that the `linkerd` chart will be
installed aftewards. So it needs to set up the proper annotations and labels.