### PR TITLE
Use `kind export kubeconfig` instead of `scp`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -319,7 +319,6 @@ jobs:
           bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
             bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
         fi
-        scp $KUBECONFIG linkerd-docker:/tmp
 
   kind_integration:
     strategy:
@@ -393,7 +392,7 @@ jobs:
         # Restore kubeconfig from remote docker host.
         mkdir -p $HOME/.kube
         export KUBECONFIG=$HOME/.kube/kind-config-$KIND_CLUSTER
-        scp linkerd-docker:/tmp/kind-config-$KIND_CLUSTER $KUBECONFIG
+        bin/kind export kubeconfig --name=$KIND_CLUSTER $KUBECONFIG
         # Start ssh tunnel to allow kubectl to connect via localhost.
         export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='kind-$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
         echo "KIND_PORT: $KIND_PORT"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -416,7 +416,7 @@ jobs:
   docker_deploy:
     name: Docker deploy
     runs-on: ubuntu-18.04
-    needs: [validate_go_deps, go_unit_tests, go_lint, js_unit_tests, kind_integration]
+    needs: [validate_go_deps, go_unit_tests, go_lint, js_unit_tests, kind_integration, kind_cleanup]
     steps:
     - name: Download .git artifact
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -405,7 +405,56 @@ jobs:
           ${{ matrix.integration_test }}_integration_tests
         )
 
-
+  kind_cleanup:
+    if: always()
+    strategy:
+      fail-fast: false # always attempt to cleanup all clusters
+      matrix:
+        integration_test: [deep, upgrade, helm, custom_domain, external_issuer]
+    needs: [kind_integration]
+    name: Cluster cleanup (${{ matrix.integration_test }})
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Download .git artifact
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      uses: actions/download-artifact@v1
+      with:
+        name: linkerd2-src-${{ github.sha }}
+        path: ${{ runner.temp }}
+    - name: Clone source
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      run: |
+        tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
+        git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
+    # for debugging
+    - name: Dump env
+      run: |
+        env | sort
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Docker SSH setup
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      run: |
+        mkdir -p ~/.ssh/
+        touch ~/.ssh/id && chmod 600 ~/.ssh/id
+        echo "${{ secrets.DOCKER_SSH_CONFIG }}"  > ~/.ssh/config
+        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" > ~/.ssh/id
+        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+        ssh linkerd-docker docker version
+    - name: Kind cluster cleanup
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      env:
+        DOCKER_HOST: ssh://linkerd-docker
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
+        bin/kind delete cluster --name=$KIND_CLUSTER
 
   #
   # Docker deploy and cloud integration tests run for:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -313,11 +313,11 @@ jobs:
         # retry cluster creation once in case of port conflict or kubeadm failure
         if [ "${{ matrix.integration_test }}" == "custom_domain" ]
         then
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug --config=$CUSTOM_DOMAIN_CONFIG
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --verbosity 3 --config=$CUSTOM_DOMAIN_CONFIG ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --verbosity 3 --config=$CUSTOM_DOMAIN_CONFIG
         else
-          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug ||
-            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --loglevel debug
+          bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --verbosity 3 ||
+            bin/kind create cluster --name=$KIND_CLUSTER --wait=2m --verbosity 3
         fi
 
   kind_integration:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -392,7 +392,7 @@ jobs:
         # Restore kubeconfig from remote docker host.
         mkdir -p $HOME/.kube
         export KUBECONFIG=$HOME/.kube/kind-config-$KIND_CLUSTER
-        bin/kind export kubeconfig --name=$KIND_CLUSTER $KUBECONFIG
+        bin/kind export kubeconfig --name=$KIND_CLUSTER --kubeconfig $KUBECONFIG
         # Start ssh tunnel to allow kubectl to connect via localhost.
         export KIND_PORT=$(bin/kubectl config view -o jsonpath="{.clusters[?(@.name=='kind-$KIND_CLUSTER')].cluster.server}" | cut -d':' -f3)
         echo "KIND_PORT: $KIND_PORT"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -416,7 +416,7 @@ jobs:
   docker_deploy:
     name: Docker deploy
     runs-on: ubuntu-18.04
-    needs: [validate_go_deps, go_unit_tests, go_lint, js_unit_tests, kind_integration, kind_cleanup]
+    needs: [validate_go_deps, go_unit_tests, go_lint, js_unit_tests, kind_integration]
     steps:
     - name: Download .git artifact
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -405,56 +405,7 @@ jobs:
           ${{ matrix.integration_test }}_integration_tests
         )
 
-  kind_cleanup:
-    if: always()
-    strategy:
-      fail-fast: false # always attempt to cleanup all clusters
-      matrix:
-        integration_test: [deep, upgrade, helm, custom_domain, external_issuer]
-    needs: [kind_integration]
-    name: Cluster cleanup (${{ matrix.integration_test }})
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Download .git artifact
-      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-      uses: actions/download-artifact@v1
-      with:
-        name: linkerd2-src-${{ github.sha }}
-        path: ${{ runner.temp }}
-    - name: Clone source
-      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-      run: |
-        tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
-        git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
-    # for debugging
-    - name: Dump env
-      run: |
-        env | sort
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Dump job context
-      env:
-        JOB_CONTEXT: ${{ toJson(job) }}
-      run: echo "$JOB_CONTEXT"
-    - name: Docker SSH setup
-      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-      run: |
-        mkdir -p ~/.ssh/
-        touch ~/.ssh/id && chmod 600 ~/.ssh/id
-        echo "${{ secrets.DOCKER_SSH_CONFIG }}"  > ~/.ssh/config
-        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" > ~/.ssh/id
-        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-        ssh linkerd-docker docker version
-    - name: Kind cluster cleanup
-      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-      env:
-        DOCKER_HOST: ssh://linkerd-docker
-      run: |
-        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
-        export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
-        bin/kind delete cluster --name=$KIND_CLUSTER
+
 
   #
   # Docker deploy and cloud integration tests run for:

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -130,7 +130,7 @@ run_test(){
     shift
 
     printf 'Test script: [%s] Params: [%s]\n' "$(basename $filename 2>/dev/null || echo $filename )" "$*"
-    GO111MODULE=on go test --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
+    GO111MODULE=on go test -v --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
 }
 
 # Install the latest stable release.

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -130,7 +130,7 @@ run_test(){
     shift
 
     printf 'Test script: [%s] Params: [%s]\n' "$(basename $filename 2>/dev/null || echo $filename )" "$*"
-    GO111MODULE=on go test -v --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
+    GO111MODULE=on go test --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
 }
 
 # Install the latest stable release.


### PR DESCRIPTION
Followup to #3864 [comment](https://github.com/linkerd/linkerd2/pull/3864#discussion_r360976473)

Stop moving the kubeconfig file between the Github Action env and the
build server with `scp` and use instead `kind export kubeconfig`.