### PR TITLE
Respect registry override during inject

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -368,17 +368,19 @@ func (options *proxyConfigOptions) overrideConfigs(configs *cfg.All, overrideAnn
 
 	if options.proxyImage != "" {
 		configs.Proxy.ProxyImage.ImageName = options.proxyImage
-		if options.dockerRegistry != "" {
-			configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
-		}
 		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
 	}
 
 	if options.initImage != "" {
 		configs.Proxy.ProxyInitImage.ImageName = options.initImage
-		if options.dockerRegistry != "" {
-			configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
-		}
+
+		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
+	}
+
+	if options.dockerRegistry != "" {
+		configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
+		configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
+		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
 		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -366,6 +366,13 @@ func (options *proxyConfigOptions) overrideConfigs(configs *cfg.All, overrideAnn
 		overrideAnnotations[k8s.ProxyOutboundPortAnnotation] = parsePort(configs.Proxy.OutboundPort)
 	}
 
+	if options.dockerRegistry != "" {
+		configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
+		configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
+		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
+		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
+	}
+
 	if options.proxyImage != "" {
 		configs.Proxy.ProxyImage.ImageName = options.proxyImage
 		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
@@ -374,13 +381,6 @@ func (options *proxyConfigOptions) overrideConfigs(configs *cfg.All, overrideAnn
 	if options.initImage != "" {
 		configs.Proxy.ProxyInitImage.ImageName = options.initImage
 
-		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
-	}
-
-	if options.dockerRegistry != "" {
-		configs.Proxy.ProxyImage.ImageName = registryOverride(configs.Proxy.ProxyImage.ImageName, options.dockerRegistry)
-		configs.Proxy.ProxyInitImage.ImageName = registryOverride(configs.Proxy.ProxyInitImage.ImageName, options.dockerRegistry)
-		overrideAnnotations[k8s.ProxyImageAnnotation] = configs.Proxy.ProxyImage.ImageName
 		overrideAnnotations[k8s.ProxyInitImageAnnotation] = configs.Proxy.ProxyInitImage.ImageName
 	}
 


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/3878

If the `--registry` flag is provided to Linkerd without the `--proxy-image` or `--init-image` flags, the `--registry` flag is ignored and not applied to the existing values for the proxy or init images pulled from the configmap.

We now override the registry with the value from the `--registry` flag regardless of which other flags are provided.

Signed-off-by: Alex Leong <alex@buoyant.io>


