### PR TITLE
Add event regex to ignore in integration test

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -84,7 +84,8 @@ var (
 	}, "|"))
 
 	knownEventWarningsRegex = regexp.MustCompile(strings.Join([]string{
-		`MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition`,
+		`MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition`, // pre k8s 1.16
+		`MountVolume.SetUp failed for volume .* : failed to sync .* cache: timed out waiting for the condition`,         // post k8s 1.16
 		`(Liveness|Readiness) probe failed: HTTP probe failed with statuscode: 50(2|3)`,
 		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,


### PR DESCRIPTION
We were ignoring events like
```
MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition
```

but as k8s 1.16 those got replaced by more precise messages, like
```
MountVolume.SetUp failed for volume "linkerd-identity-token-cm4fn" :failed to sync secret cache: timed out waiting for the condition
MountVolume.SetUp failed for volume "prometheus-config" : failed to sync configmap cache: timed out waiting for the condition
```

This was causing sporadic CI test failures like [here](https://github.com/linkerd/linkerd2/runs/368424822#step:7:562)

So I'm including another regex for that.

Re: https://github.com/kubernetes/kubernetes/commit/96c41f8a1e1f3bee819b3e01a3fa1a89f3f55f66