### PR TITLE
Ensure browser cache does not store `index_bundle.js`

### DIFF
--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -252,7 +252,7 @@ func mkStaticHandler(staticDir string) httprouter.Handle {
 		filepath := p.ByName("filepath")
 		if filepath == "/index_bundle.js" {
 			// don't cache the bundle because it references a hashed js file
-			w.Header().Set("Cache-Control", "no-cache, private, max-age=0")
+			w.Header().Set("Cache-Control", "no-store, must-revalidate")
 		}
 
 		req.URL.Path = filepath


### PR DESCRIPTION
## Motivation

Full background: #2074

#2074 was recently reopened because a user reported an error that occurs when
refreshing an already opened dashboard after the dashboard build has changed.
This can occur when upgrading or downgrading.

#2074 explores a larger issue about a redirection that occurs when loading the
dashboard JS. However, the actual issue that users are experiencing happens
because `index_bundle.js` is being cached when it should not be.

Even if the hash of the JS bundle changes, users can see (on the current edge)
that browsers do in fact cache `index_bundle.js`.

The easiest way I reproduced this was:
1. Install `edge-19.12.3`
2. `linkerd dashboard` (and keep the tab open)
2. Uninstall `edge-19.12.3`
3. Install `stable-2.5.0`
4. `linkerd dashboard`
5. Refresh in all browsers: Users will observe the `edge-19.12.3` dashboard
   still renders (with all of it's new additions) even though `stable-2.5.0` is
   installed with it's older theme.

Below are screenshots of Safari and Firefox caching the file. Chrome was not as
easy to reproduce:

*Safari*
![Screen Shot 2020-01-07 at 5 39 00 PM](https://user-images.githubusercontent.com/4572153/71944121-9d691400-3177-11ea-9d36-e173e0b7138e.png)

*Firefox*
![Screen Shot 2020-01-07 at 5 39 21 PM](https://user-images.githubusercontent.com/4572153/71944161-c25d8700-3177-11ea-9cd4-796dd0a4900e.png)

## Solution

This change only changes the response header when requesting `index_bundle.js`
from the server to ensure caching does not take place; mainly `no-cache` is
changed to `no-store` and `must-revalidate` is now included.

`no-store` and `must-revalidate` are redundant on some browsers but both
required to cover all browsers (and versions).

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
