### PR TITLE
Ensure proxy cert has proper lifetime

### DIFF
--- a/pkg/tls/ca_test.go
+++ b/pkg/tls/ca_test.go
@@ -1,0 +1,67 @@
+package tls
+
+import (
+	"testing"
+	"time"
+)
+
+func getCa(validFrom time.Time, issuerCertLifetime time.Duration, endCertLifetime time.Duration) (*CA, error) {
+	key, err := GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	ca, err := CreateRootCA("fake-name", key, Validity{ValidFrom: &validFrom, Lifetime: issuerCertLifetime})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCA(ca.Cred, Validity{ValidFrom: &validFrom, Lifetime: endCertLifetime}), nil
+}
+
+func TestCaIssuesCertsWithCorrectExpiration(t *testing.T) {
+
+	validFrom := time.Now().UTC().Round(time.Second)
+
+	testCases := []struct {
+		desc                   string
+		validFrom              time.Time
+		issuerLifeTime         time.Duration
+		endCertLifeime         time.Duration
+		expectedCertExpiration time.Time
+	}{
+		{
+			desc:                   "issuer cert expires after end cert",
+			validFrom:              validFrom,
+			issuerLifeTime:         time.Hour * 48,
+			endCertLifeime:         time.Hour * 24,
+			expectedCertExpiration: validFrom.Add(time.Hour * 24).Add(DefaultClockSkewAllowance),
+		},
+		{
+			desc:                   "issuer cert expires before end cert",
+			validFrom:              validFrom,
+			issuerLifeTime:         time.Hour * 10,
+			endCertLifeime:         time.Hour * 24,
+			expectedCertExpiration: validFrom.Add(time.Hour * 10).Add(DefaultClockSkewAllowance),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+
+			ca, err := getCa(tc.validFrom, tc.issuerLifeTime, tc.endCertLifeime)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			crt, err := ca.GenerateEndEntityCred("fake-name")
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if crt.Certificate.NotAfter != tc.expectedCertExpiration {
+				t.Fatalf("Expected cert expiration %v but got %v", tc.expectedCertExpiration, crt.Certificate.NotAfter)
+			}
+		})
+	}
+
+}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -253,7 +253,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		crt2, err := root.GenerateCA(identity, root.Validity, -1)
+		crt2, err := root.GenerateCA(identity, -1)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR fixes a problem where the identitiy serice can issue a certificate that has a lifetime larger than the issuer certificate. This eas causing the proxies to end up using an invalid TLS certificate. This fix ensures that the lifetime of the issued certificate is not greater than the smallest lifetime of the certs in the issuer cert trust chain.

Fixes #3880

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>