### PR TITLE
Fix Helm install when disabling init containers (the real deal)

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -1,7 +1,7 @@
 {{- define "linkerd.configs.global" -}}
 {
   "linkerdNamespace": "{{.Values.global.namespace}}",
-  "cniEnabled": false,
+  "cniEnabled": {{ default false .Values.noInitContainer }},
   "version": "{{.Values.global.linkerdVersion}}",
   "identityContext":{
     "trustDomain": "{{.Values.global.identityTrustDomain}}",


### PR DESCRIPTION
`cniEnabled` was hard-coded to `false` in the `_config.tpl` template, thus always adding the init container during injection regardless of having installed the control plane with `--set noInitContainer=true`.
This affects injection after having installed with Helm, not when having installed with the CLI.

Repro steps under the edge-19.12.3's tag:
```bash
$ helm install charts/linkerd2-cni
# wait for the linkerd-cni-xxx pod to come up

# refresh linkerd2's chart dependencies
$ bin/helm-build

# overrides.yaml should contain all the mandatory values for certs
$ helm install -f overrides.yaml --set noInitContainer=true --set installNamespace=false charts/linkerd2

# verify the global config `cniEnabled` is NOT being persisted appropriately
$ k -n linkerd get cm linkerd-config -oyaml | grep cni
      "cniEnabled": false,

# install and inject emojivoto
$ curl https://run.linkerd.io/emojivoto.yml|bin/go-run cli inject -|k apply -f -

# verify that the init container is being (unexpectedly) added
$ k -n emojivoto get po emoji-xxxxx-xxx -oyaml | grep initContainer
  initContainers:
    initContainerStatuses:
```

In this branch:
```bash
$ helm install charts/linkerd2-cni
# wait for the linkerd-cni-xxx pod to come up

# refresh linkerd2's chart dependencies
$ bin/helm-build

# overrides.yaml should contain all the mandatory values for certs
$ helm install -f overrides.yaml --set noInitContainer=true --set installNamespace=false charts/linkerd2

# verify the global config `cniEnabled` is being persisted appropriately
$ k -n linkerd get cm linkerd-config -oyaml | grep cni
      "cniEnabled": true,

# install and inject emojivoto
$ curl https://run.linkerd.io/emojivoto.yml|bin/go-run cli inject -|k apply -f -

# verify that the init container is NOT being added
$ k -n emojivoto get po emoji-xxxxx-xxx -oyaml | grep initContainer
# nothing returned
```

This replaces #3872