### PR TITLE
proxy: v2.83.0-experimental

### DIFF
--- a/.proxy-version
+++ b/.proxy-version
@@ -1,1 +1,1 @@
-v2.82.0
+v2.83.0-experimental

--- a/.proxy-version
+++ b/.proxy-version
@@ -1,1 +1,1 @@
-v2.83.1-experimental
+v2.83.0-experimental

--- a/.proxy-version
+++ b/.proxy-version
@@ -1,1 +1,1 @@
-v2.83.0-experimental
+v2.83.1-experimental

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -78,7 +78,7 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--proxy-log-level=warn,linkerd=trace", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s\n%s", out, stderr)
 	}
@@ -257,7 +257,7 @@ func validateExpected(events []*tapEvent, expectedEvent tapEvent) error {
 	}
 	for _, event := range events {
 		if *event != expectedEvent {
-			return fmt.Errorf("Unexpected tap event [%+v]", *event)
+			return fmt.Errorf("Unexpected tap event [%+v]; expected=[%+v]", *event, expectedEvent)
 		}
 	}
 	return nil

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -78,7 +78,7 @@ var (
 //////////////////////
 
 func TestCliTap(t *testing.T) {
-	out, stderr, err := TestHelper.LinkerdRun("inject", "--proxy-log-level=warn,linkerd=trace", "--manual", "testdata/tap_application.yaml")
+	out, stderr, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/tap_application.yaml")
 	if err != nil {
 		t.Fatalf("linkerd inject command failed\n%s\n%s", out, stderr)
 	}


### PR DESCRIPTION
This is an experimental release that includes large changes to the
proxy's request buffering and backpressure infrastructure.

Please exercise caution before deploying this proxy version into mission
critical environments.