### PR TITLE
edge-20.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,25 +30,26 @@ might be stability issues.
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
   * More improvements to Helm best practices (thanks to @Pothulapati!)
+
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups, 
-improves performance of the dashboard, and makes `linkerd check --pre` perform 
+This edge release adds support for pod IP and service cluster IP lookups,
+improves performance of the dashboard, and makes `linkerd check --pre` perform
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in 
+to `preStop hooks`. The details of this change are in
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and 
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
+classification and
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of 
+certain to read the details of
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -56,15 +57,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -72,7 +73,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-  
+
 ## edge-19.12.2
 
 * CLI
@@ -112,11 +113,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-    
+
 ## edge-19.11.2
 
 * CLI
@@ -297,7 +298,7 @@ instructions](https://linkerd.io/2/tasks/upgrade/#upgrade-notice-stable-2-6-0).
 
 ## edge-19.10.2
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Controller
   * Added the destination container back to the controller; it had previously
@@ -307,7 +308,7 @@ This edge release is a release candidate for `stable-2.6`.
 
 ## edge-19.10.1
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Proxy
   * Improved error logging when the proxy fails to emit trace spans
@@ -318,7 +319,7 @@ This edge release is a release candidate for `stable-2.6`.
 
 ## edge-19.9.5
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Helm
   * Added node selector constraints, so users can control which nodes the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## edge-20.1.8
+## edge-20.1.1
 
 This edge release includes experimental improvements to the Linkerd proxy's
 request buffering and backpressure infrastructure.
@@ -34,23 +34,23 @@ might be stability issues.
 
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups, 
-improves performance of the dashboard, and makes `linkerd check --pre` perform 
+This edge release adds support for pod IP and service cluster IP lookups,
+improves performance of the dashboard, and makes `linkerd check --pre` perform
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in 
+to `preStop hooks`. The details of this change are in
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and 
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
+classification and
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of 
+certain to read the details of
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -58,15 +58,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -74,7 +74,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-  
+
 ## edge-19.12.2
 
 * CLI
@@ -114,7 +114,7 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,39 @@
+## edge-20.1.8
+
+This edge release includes experimental improvements to the Linkerd proxy's
+request buffering and backpressure infrastructure.
+
+Additionally, we've fixed several bugs when installing Linkerd with Helm,
+updated the CLI to allow using both port numbers _and_ port ranges with the
+`--skip-inbound-ports` and `--skip-outbound-ports`  flags, and fixed a dashboard
+error that can occur if the dashboard is open in a browser while updating Linkerd.
+
+**Note**: The `linkerd-proxy` version included with this release is more
+experimental than usual. We'd love your help testing, but be aware that there
+might be stability issues.
+
+* CLI
+  * Added the ability to pass both port numbers and port ranges to
+    `--skip-inbound-ports` and `--skip-outbound-ports` (thanks to @javaducky!)
+* Controller
+  * Fixed a race condition in the `linkerd-web` service
+  * Updated Prometheus to 2.15.5 (thanks @Pothulapati)
+* Web UI
+  * Fixed an error when refreshing an already open dashboard when the Linkerd
+    version has changed
+* Proxy
+  * Internal changes to the proxy's request buffering and backpressure
+    infrastructure
+* Helm
+  * Fixed the `linkerd-cni` Helm chart not setting proper namespace annotations
+    and labels
+  * Fixed Helm install enabling init containers with the `--set
+    noInitContainers=true` flag
+  * Fixed certificate issuance lifetime not being set when installing through
+    Helm
+* Internal
+  * More improvements to Helm best practices (thanks to @Pothulapati!)
+
 ## edge-19.12.3
 
 This edge release adds support for pod IP and service cluster IP lookups, 
@@ -84,7 +120,7 @@ certain to read the details of
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-    
+
 ## edge-19.11.2
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,6 @@ might be stability issues.
     and labels
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
-* Internal
   * More improvements to Helm best practices (thanks to @Pothulapati!)
 
 ## edge-19.12.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,22 +1,58 @@
+## edge-20.1.8
+
+This edge release includes experimental improvements to the Linkerd proxy's
+request buffering and backpressure infrastructure.
+
+Additionally, we've fixed several bugs when installing Linkerd with Helm,
+updated the CLI to allow using both port numbers _and_ port ranges with the
+`--skip-inbound-ports` and `--skip-outbound-ports`  flags, and fixed a dashboard
+error that can occur if the dashboard is open in a browser while updating Linkerd.
+
+**Note**: The `linkerd-proxy` version included with this release is more
+experimental than usual. We'd love your help testing, but be aware that there
+might be stability issues.
+
+* CLI
+  * Added the ability to pass both port numbers and port ranges to
+    `--skip-inbound-ports` and `--skip-outbound-ports` (thanks to @javaducky!)
+* Controller
+  * Fixed a race condition in the `linkerd-web` service
+  * Updated Prometheus to 2.15.5 (thanks @Pothulapati)
+* Web UI
+  * Fixed an error when refreshing an already open dashboard when the Linkerd
+    version has changed
+* Proxy
+  * Internal changes to the proxy's request buffering and backpressure
+    infrastructure
+* Helm
+  * Fixed the `linkerd-cni` Helm chart not setting proper namespace annotations
+    and labels
+  * Fixed Helm install enabling init containers with the `--set
+    noInitContainers=true` flag
+  * Fixed certificate issuance lifetime not being set when installing through
+    Helm
+* Internal
+  * More improvements to Helm best practices (thanks to @Pothulapati!)
+
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups, 
-improves performance of the dashboard, and makes `linkerd check --pre` perform 
+This edge release adds support for pod IP and service cluster IP lookups,
+improves performance of the dashboard, and makes `linkerd check --pre` perform
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in 
+to `preStop hooks`. The details of this change are in
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and 
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
+classification and
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of 
+certain to read the details of
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -24,15 +60,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -40,7 +76,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-  
+
 ## edge-19.12.2
 
 * CLI
@@ -80,11 +116,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-    
+
 ## edge-19.11.2
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## edge-20.1.8
+## edge-20.1.1
 
 This edge release includes experimental improvements to the Linkerd proxy's
 request buffering and backpressure infrastructure.
@@ -36,23 +36,23 @@ might be stability issues.
 
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups, 
-improves performance of the dashboard, and makes `linkerd check --pre` perform 
+This edge release adds support for pod IP and service cluster IP lookups,
+improves performance of the dashboard, and makes `linkerd check --pre` perform
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in 
+to `preStop hooks`. The details of this change are in
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and 
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
+classification and
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of 
+certain to read the details of
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -60,15 +60,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -76,7 +76,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-  
+
 ## edge-19.12.2
 
 * CLI
@@ -116,7 +116,7 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ might be stability issues.
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
   * More improvements to Helm best practices (thanks to @Pothulapati!)
+
 ## edge-19.12.3
 
 This edge release adds support for pod IP and service cluster IP lookups, 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,26 +30,25 @@ might be stability issues.
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
   * More improvements to Helm best practices (thanks to @Pothulapati!)
-
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups,
-improves performance of the dashboard, and makes `linkerd check --pre` perform
+This edge release adds support for pod IP and service cluster IP lookups, 
+improves performance of the dashboard, and makes `linkerd check --pre` perform 
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in
+to `preStop hooks`. The details of this change are in 
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
+classification and 
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of
+certain to read the details of 
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -57,15 +56,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination
+  * Added support for pod ip and service cluster ip lookups in the destination 
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
-    sidecar to delay the start of its shutdown process (a huge commit from
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
+    sidecar to delay the start of its shutdown process (a huge commit from 
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the
+  * Increased the speed of the dashboard by pausing network activity when the 
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -73,7 +72,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-
+  
 ## edge-19.12.2
 
 * CLI
@@ -113,11 +112,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-
+    
 ## edge-19.11.2
 
 * CLI
@@ -298,7 +297,7 @@ instructions](https://linkerd.io/2/tasks/upgrade/#upgrade-notice-stable-2-6-0).
 
 ## edge-19.10.2
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Controller
   * Added the destination container back to the controller; it had previously
@@ -308,7 +307,7 @@ This edge release is a release candidate for `stable-2.6`.
 
 ## edge-19.10.1
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Proxy
   * Improved error logging when the proxy fails to emit trace spans
@@ -319,7 +318,7 @@ This edge release is a release candidate for `stable-2.6`.
 
 ## edge-19.9.5
 
-This edge release is a release candidate for `stable-2.6`.
+This edge release is a release candidate for `stable-2.6`.
 
 * Helm
   * Added node selector constraints, so users can control which nodes the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ might be stability issues.
     `--skip-inbound-ports` and `--skip-outbound-ports` (thanks to @javaducky!)
 * Controller
   * Fixed a race condition in the `linkerd-web` service
-  * Updated Prometheus to 2.15.5 (thanks @Pothulapati)
+  * Updated Prometheus to 2.15.2 (thanks @Pothulapati)
 * Web UI
   * Fixed an error when refreshing an already open dashboard when the Linkerd
     version has changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,26 +30,25 @@ might be stability issues.
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
   * More improvements to Helm best practices (thanks to @Pothulapati!)
-
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups,
-improves performance of the dashboard, and makes `linkerd check --pre` perform
+This edge release adds support for pod IP and service cluster IP lookups, 
+improves performance of the dashboard, and makes `linkerd check --pre` perform 
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in
+to `preStop hooks`. The details of this change are in 
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
+classification and 
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of
+certain to read the details of 
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -57,15 +56,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination
+  * Added support for pod ip and service cluster ip lookups in the destination 
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
-    sidecar to delay the start of its shutdown process (a huge commit from
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
+    sidecar to delay the start of its shutdown process (a huge commit from 
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the
+  * Increased the speed of the dashboard by pausing network activity when the 
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -73,7 +72,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-
+  
 ## edge-19.12.2
 
 * CLI
@@ -113,11 +112,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-
+    
 ## edge-19.11.2
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## edge-20.1.1
+## edge-20.1.8
 
 This edge release includes experimental improvements to the Linkerd proxy's
 request buffering and backpressure infrastructure.
@@ -34,23 +34,23 @@ might be stability issues.
 
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups,
-improves performance of the dashboard, and makes `linkerd check --pre` perform
+This edge release adds support for pod IP and service cluster IP lookups, 
+improves performance of the dashboard, and makes `linkerd check --pre` perform 
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in
+to `preStop hooks`. The details of this change are in 
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
+classification and 
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of
+certain to read the details of 
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -58,15 +58,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination
+  * Added support for pod ip and service cluster ip lookups in the destination 
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
-    sidecar to delay the start of its shutdown process (a huge commit from
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
+    sidecar to delay the start of its shutdown process (a huge commit from 
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the
+  * Increased the speed of the dashboard by pausing network activity when the 
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -74,7 +74,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-
+  
 ## edge-19.12.2
 
 * CLI
@@ -114,7 +114,7 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,8 +27,6 @@ might be stability issues.
 * Helm
   * Fixed the `linkerd-cni` Helm chart not setting proper namespace annotations
     and labels
-  * Fixed Helm install enabling init containers with the `--set
-    noInitContainers=true` flag
   * Fixed certificate issuance lifetime not being set when installing through
     Helm
 * Internal

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,58 +1,22 @@
-## edge-20.1.8
-
-This edge release includes experimental improvements to the Linkerd proxy's
-request buffering and backpressure infrastructure.
-
-Additionally, we've fixed several bugs when installing Linkerd with Helm,
-updated the CLI to allow using both port numbers _and_ port ranges with the
-`--skip-inbound-ports` and `--skip-outbound-ports`  flags, and fixed a dashboard
-error that can occur if the dashboard is open in a browser while updating Linkerd.
-
-**Note**: The `linkerd-proxy` version included with this release is more
-experimental than usual. We'd love your help testing, but be aware that there
-might be stability issues.
-
-* CLI
-  * Added the ability to pass both port numbers and port ranges to
-    `--skip-inbound-ports` and `--skip-outbound-ports` (thanks to @javaducky!)
-* Controller
-  * Fixed a race condition in the `linkerd-web` service
-  * Updated Prometheus to 2.15.5 (thanks @Pothulapati)
-* Web UI
-  * Fixed an error when refreshing an already open dashboard when the Linkerd
-    version has changed
-* Proxy
-  * Internal changes to the proxy's request buffering and backpressure
-    infrastructure
-* Helm
-  * Fixed the `linkerd-cni` Helm chart not setting proper namespace annotations
-    and labels
-  * Fixed Helm install enabling init containers with the `--set
-    noInitContainers=true` flag
-  * Fixed certificate issuance lifetime not being set when installing through
-    Helm
-* Internal
-  * More improvements to Helm best practices (thanks to @Pothulapati!)
-
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups,
-improves performance of the dashboard, and makes `linkerd check --pre` perform
+This edge release adds support for pod IP and service cluster IP lookups, 
+improves performance of the dashboard, and makes `linkerd check --pre` perform 
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in
+to `preStop hooks`. The details of this change are in 
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
+classification and 
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of
+certain to read the details of 
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -60,15 +24,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination
+  * Added support for pod ip and service cluster ip lookups in the destination 
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
-    sidecar to delay the start of its shutdown process (a huge commit from
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
+    sidecar to delay the start of its shutdown process (a huge commit from 
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the
+  * Increased the speed of the dashboard by pausing network activity when the 
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -76,7 +40,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-
+  
 ## edge-19.12.2
 
 * CLI
@@ -116,11 +80,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-
+    
 ## edge-19.11.2
 
 * CLI

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -4,74 +4,73 @@
 
 # Values that are passed along to sub-charts
 global:
-  clusterDomain: &cluster_domain cluster.local
-  imagePullPolicy: &image_pull_policy IfNotPresent
+    clusterDomain: &cluster_domain cluster.local
+    imagePullPolicy: &image_pull_policy IfNotPresent
 
-  # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-19.12.3
+    # control plane version. See Proxy section for proxy version
+    linkerdVersion: &linkerd_version edge-20.1.8
 
-  namespace: linkerd
+    namespace: linkerd
 
-  identityTrustAnchorsPEM: |
+    identityTrustAnchorsPEM: |
 
-  identityTrustDomain: *cluster_domain
+    identityTrustDomain: *cluster_domain
 
-  # proxy configuration
-  proxy:
-    enableExternalProfiles: false
-    image:
-      name: gcr.io/linkerd-io/proxy
-      pullPolicy: *image_pull_policy
-      version: *linkerd_version
-    logLevel: warn,linkerd2_proxy=info
-    ports:
-      admin: 4191
-      control: 4190
-      inbound: 4143
-      outbound: 4140
-    resources:
-      cpu:
-        limit: ""
-        request: ""
-      memory:
-        limit: ""
-        request: ""
-    trace:
-      collectorSvcAddr: ""
-      collectorSvcAccount: default
-    uid: 2102
-    # If set, the proxy's pre-stop hook will postpone the Kubernetes's SIGTERM signal
-    # and wait for this duration before letting the proxy process the SIGTERM signal.
-    # See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
-    # for more info on container lifecycle hooks.
-    waitBeforeExitSeconds: 0
+    # proxy configuration
+    proxy:
+        enableExternalProfiles: false
+        image:
+            name: gcr.io/linkerd-io/proxy
+            pullPolicy: *image_pull_policy
+            version: *linkerd_version
+        logLevel: warn,linkerd2_proxy=info
+        ports:
+            admin: 4191
+            control: 4190
+            inbound: 4143
+            outbound: 4140
+        resources:
+            cpu:
+                limit: ""
+                request: ""
+            memory:
+                limit: ""
+                request: ""
+        trace:
+            collectorSvcAddr: ""
+            collectorSvcAccount: default
+        uid: 2102
+        # If set, the proxy's pre-stop hook will postpone the Kubernetes's SIGTERM signal
+        # and wait for this duration before letting the proxy process the SIGTERM signal.
+        # See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+        # for more info on container lifecycle hooks.
+        waitBeforeExitSeconds: 0
 
-  # proxy-init configuration
-  proxyInit:
-    ignoreInboundPorts: ""
-    ignoreOutboundPorts: ""
-    image:
-      name: gcr.io/linkerd-io/proxy-init
-      pullPolicy: *image_pull_policy
-      version: v1.1.0
-    resources:
-      cpu:
-        limit: 100m
-        request: 10m
-      memory:
-        limit: 50Mi
-        request: 10Mi
+    # proxy-init configuration
+    proxyInit:
+        ignoreInboundPorts: ""
+        ignoreOutboundPorts: ""
+        image:
+            name: gcr.io/linkerd-io/proxy-init
+            pullPolicy: *image_pull_policy
+            version: v1.1.0
+        resources:
+            cpu:
+                limit: 100m
+                request: 10m
+            memory:
+                limit: 50Mi
+                request: 10Mi
 
-  # control plane annotations - do not edit
-  createdByAnnotation: linkerd.io/created-by
-  proxyInjectAnnotation: linkerd.io/inject
-  proxyInjectDisabled: disabled
+    # control plane annotations - do not edit
+    createdByAnnotation: linkerd.io/created-by
+    proxyInjectAnnotation: linkerd.io/inject
+    proxyInjectDisabled: disabled
 
-  # control plane labels - do not edit
-  controllerComponentLabel: linkerd.io/control-plane-component
-  controllerNamespaceLabel: linkerd.io/control-plane-ns
-  linkerdNamespaceLabel: linkerd.io/is-control-plane
-
+    # control plane labels - do not edit
+    controllerComponentLabel: linkerd.io/control-plane-component
+    controllerNamespaceLabel: linkerd.io/control-plane-ns
+    linkerdNamespaceLabel: linkerd.io/is-control-plane
 
 enableH2Upgrade: true
 
@@ -86,29 +85,29 @@ controllerUID: 2103
 
 # web dashboard configuration
 dashboard:
-  replicas: 1
+    replicas: 1
 
 # identity configuration
 identity:
-  issuer:
-    scheme: linkerd.io/tls
+    issuer:
+        scheme: linkerd.io/tls
 
-    clockSkewAllowance: 20s
+        clockSkewAllowance: 20s
 
-    # must match the expiry date in crtPEM
-    crtExpiry:
+        # must match the expiry date in crtPEM
+        crtExpiry:
 
-    # control plane annotation - do not edit
-    crtExpiryAnnotation: linkerd.io/identity-issuer-expiry
+        # control plane annotation - do not edit
+        crtExpiryAnnotation: linkerd.io/identity-issuer-expiry
 
-    issuanceLifetime: 86400s
+        issuanceLifetime: 86400s
 
-    tls:
-      # PEM-encoded certificate
-      crtPEM: |
+        tls:
+            # PEM-encoded certificate
+            crtPEM: |
 
-      # PEM-encoded ECDSA private key
-      keyPEM: |
+            # PEM-encoded ECDSA private key
+            keyPEM: |
 
 # grafana configuration
 grafanaImage: gcr.io/linkerd-io/grafana
@@ -126,24 +125,24 @@ controlPlaneTracing: false
 
 # proxy injector configuration
 proxyInjector:
-  # if empty, Helm will auto-generate these fields
-  crtPEM: |
+    # if empty, Helm will auto-generate these fields
+    crtPEM: |
 
-  keyPEM: |
+    keyPEM: |
 
 # service profile validator configuration
 profileValidator:
-  # if empty, Helm will auto-generate these fields
-  crtPEM: |
+    # if empty, Helm will auto-generate these fields
+    crtPEM: |
 
-  keyPEM: |
+    keyPEM: |
 
 # tap configuration
 tap:
-  # if empty, Helm will auto-generate these fields
-  crtPEM: |
+    # if empty, Helm will auto-generate these fields
+    crtPEM: |
 
-  keyPEM: |
+    keyPEM: |
 
 # web configuration
 webImage: gcr.io/linkerd-io/web
@@ -158,4 +157,4 @@ installNamespace: true
 # Node selection constraints for control-plane components
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector.
 nodeSelector:
-  beta.kubernetes.io/os: linux
+    beta.kubernetes.io/os: linux

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-19.12.3
+  linkerdVersion: &linkerd_version edge-20.1.8
 
   namespace: linkerd
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-20.1.8
+  linkerdVersion: &linkerd_version edge-20.1.1
 
   namespace: linkerd
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-20.1.1
+  linkerdVersion: &linkerd_version edge-20.1.8
 
   namespace: linkerd
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -4,73 +4,74 @@
 
 # Values that are passed along to sub-charts
 global:
-    clusterDomain: &cluster_domain cluster.local
-    imagePullPolicy: &image_pull_policy IfNotPresent
+  clusterDomain: &cluster_domain cluster.local
+  imagePullPolicy: &image_pull_policy IfNotPresent
 
-    # control plane version. See Proxy section for proxy version
-    linkerdVersion: &linkerd_version edge-20.1.8
+  # control plane version. See Proxy section for proxy version
+  linkerdVersion: &linkerd_version edge-19.12.3
 
-    namespace: linkerd
+  namespace: linkerd
 
-    identityTrustAnchorsPEM: |
+  identityTrustAnchorsPEM: |
 
-    identityTrustDomain: *cluster_domain
+  identityTrustDomain: *cluster_domain
 
-    # proxy configuration
-    proxy:
-        enableExternalProfiles: false
-        image:
-            name: gcr.io/linkerd-io/proxy
-            pullPolicy: *image_pull_policy
-            version: *linkerd_version
-        logLevel: warn,linkerd2_proxy=info
-        ports:
-            admin: 4191
-            control: 4190
-            inbound: 4143
-            outbound: 4140
-        resources:
-            cpu:
-                limit: ""
-                request: ""
-            memory:
-                limit: ""
-                request: ""
-        trace:
-            collectorSvcAddr: ""
-            collectorSvcAccount: default
-        uid: 2102
-        # If set, the proxy's pre-stop hook will postpone the Kubernetes's SIGTERM signal
-        # and wait for this duration before letting the proxy process the SIGTERM signal.
-        # See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
-        # for more info on container lifecycle hooks.
-        waitBeforeExitSeconds: 0
+  # proxy configuration
+  proxy:
+    enableExternalProfiles: false
+    image:
+      name: gcr.io/linkerd-io/proxy
+      pullPolicy: *image_pull_policy
+      version: *linkerd_version
+    logLevel: warn,linkerd2_proxy=info
+    ports:
+      admin: 4191
+      control: 4190
+      inbound: 4143
+      outbound: 4140
+    resources:
+      cpu:
+        limit: ""
+        request: ""
+      memory:
+        limit: ""
+        request: ""
+    trace:
+      collectorSvcAddr: ""
+      collectorSvcAccount: default
+    uid: 2102
+    # If set, the proxy's pre-stop hook will postpone the Kubernetes's SIGTERM signal
+    # and wait for this duration before letting the proxy process the SIGTERM signal.
+    # See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+    # for more info on container lifecycle hooks.
+    waitBeforeExitSeconds: 0
 
-    # proxy-init configuration
-    proxyInit:
-        ignoreInboundPorts: ""
-        ignoreOutboundPorts: ""
-        image:
-            name: gcr.io/linkerd-io/proxy-init
-            pullPolicy: *image_pull_policy
-            version: v1.1.0
-        resources:
-            cpu:
-                limit: 100m
-                request: 10m
-            memory:
-                limit: 50Mi
-                request: 10Mi
+  # proxy-init configuration
+  proxyInit:
+    ignoreInboundPorts: ""
+    ignoreOutboundPorts: ""
+    image:
+      name: gcr.io/linkerd-io/proxy-init
+      pullPolicy: *image_pull_policy
+      version: v1.1.0
+    resources:
+      cpu:
+        limit: 100m
+        request: 10m
+      memory:
+        limit: 50Mi
+        request: 10Mi
 
-    # control plane annotations - do not edit
-    createdByAnnotation: linkerd.io/created-by
-    proxyInjectAnnotation: linkerd.io/inject
-    proxyInjectDisabled: disabled
+  # control plane annotations - do not edit
+  createdByAnnotation: linkerd.io/created-by
+  proxyInjectAnnotation: linkerd.io/inject
+  proxyInjectDisabled: disabled
 
-    # control plane labels - do not edit
-    controllerComponentLabel: linkerd.io/control-plane-component
-    controllerNamespaceLabel: linkerd.io/control-plane-ns
-    linkerdNamespaceLabel: linkerd.io/is-control-plane
+  # control plane labels - do not edit
+  controllerComponentLabel: linkerd.io/control-plane-component
+  controllerNamespaceLabel: linkerd.io/control-plane-ns
+  linkerdNamespaceLabel: linkerd.io/is-control-plane
+
 
 enableH2Upgrade: true
 
@@ -85,29 +86,29 @@ controllerUID: 2103
 
 # web dashboard configuration
 dashboard:
-    replicas: 1
+  replicas: 1
 
 # identity configuration
 identity:
-    issuer:
-        scheme: linkerd.io/tls
+  issuer:
+    scheme: linkerd.io/tls
 
-        clockSkewAllowance: 20s
+    clockSkewAllowance: 20s
 
-        # must match the expiry date in crtPEM
-        crtExpiry:
+    # must match the expiry date in crtPEM
+    crtExpiry:
 
-        # control plane annotation - do not edit
-        crtExpiryAnnotation: linkerd.io/identity-issuer-expiry
+    # control plane annotation - do not edit
+    crtExpiryAnnotation: linkerd.io/identity-issuer-expiry
 
-        issuanceLifetime: 86400s
+    issuanceLifetime: 86400s
 
-        tls:
-            # PEM-encoded certificate
-            crtPEM: |
+    tls:
+      # PEM-encoded certificate
+      crtPEM: |
 
-            # PEM-encoded ECDSA private key
-            keyPEM: |
+      # PEM-encoded ECDSA private key
+      keyPEM: |
 
 # grafana configuration
 grafanaImage: gcr.io/linkerd-io/grafana
@@ -125,24 +126,24 @@ controlPlaneTracing: false
 
 # proxy injector configuration
 proxyInjector:
-    # if empty, Helm will auto-generate these fields
-    crtPEM: |
+  # if empty, Helm will auto-generate these fields
+  crtPEM: |
 
-    keyPEM: |
+  keyPEM: |
 
 # service profile validator configuration
 profileValidator:
-    # if empty, Helm will auto-generate these fields
-    crtPEM: |
+  # if empty, Helm will auto-generate these fields
+  crtPEM: |
 
-    keyPEM: |
+  keyPEM: |
 
 # tap configuration
 tap:
-    # if empty, Helm will auto-generate these fields
-    crtPEM: |
+  # if empty, Helm will auto-generate these fields
+  crtPEM: |
 
-    keyPEM: |
+  keyPEM: |
 
 # web configuration
 webImage: gcr.io/linkerd-io/web
@@ -157,4 +158,4 @@ installNamespace: true
 # Node selection constraints for control-plane components
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector.
 nodeSelector:
-    beta.kubernetes.io/os: linux
+  beta.kubernetes.io/os: linux


### PR DESCRIPTION
Depends on #3897 

## edge-20.1.1

This edge release includes experimental improvements to the Linkerd proxy's
request buffering and backpressure infrastructure.

Additionally, we've fixed several bugs when installing Linkerd with Helm,
updated the CLI to allow using both port numbers _and_ port ranges with the
`--skip-inbound-ports` and `--skip-outbound-ports`  flags, and fixed a dashboard
error that can occur if the dashboard is open in a browser while updating Linkerd.

**Note**: The `linkerd-proxy` version included with this release is more
experimental than usual. We'd love your help testing, but be aware that there
might be stability issues.

* CLI
  * Added the ability to pass both port numbers and port ranges to
    `--skip-inbound-ports` and `--skip-outbound-ports` (thanks to @javaducky!)
* Controller
  * Fixed a race condition in the `linkerd-web` service
  * Updated Prometheus to 2.15.2 (thanks @Pothulapati)
* Web UI
  * Fixed an error when refreshing an already open dashboard when the Linkerd
    version has changed
* Proxy
  * Internal changes to the proxy's request buffering and backpressure
    infrastructure
* Helm
  * Fixed the `linkerd-cni` Helm chart not setting proper namespace annotations
    and labels
  * Fixed certificate issuance lifetime not being set when installing through
    Helm
  * More improvements to Helm best practices (thanks to @Pothulapati!)