### PR TITLE
Add checks for CNI plugin

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the Linkerd2-cni chart 
 
 | Parameter                            | Description                                                           | Default                       |
 |--------------------------------------|-----------------------------------------------------------------------|-------------------------------|
-`cniPluginImage`                      | Docker image for the CNI plugin                                       |`gcr.io/linkerd-io/cni-plugin`|
+|`cniPluginImage`                      | Docker image for the CNI plugin                                       |`gcr.io/linkerd-io/cni-plugin`|
 |`cniPluginVersion`                    | Tag for the CNI container Docker image                                |latest version|
 |`cniResourceAnnotation`               | CNI resource annotation. Do not edit                                  |`linkerd.io/cni-resource`
 |`controllerNamespaceLabel`            | Control plane label. Do not edit                                      |`linkerd.io/control-plane-ns`|
@@ -24,7 +24,7 @@ The following table lists the configurable parameters of the Linkerd2-cni chart 
 |`ignoreOutboundPorts`                 | Outbound ports the proxy should ignore                                ||
 |`inboundProxyPort`                    | Inbound port for the proxy container                                  |`4143`|
 |`logLevel`                            | Log level for the CNI plugin                                          |`info`|
-|`namespace`                           | Control plane namespace                                               | `linkerd`|
+|`namespace`                           | CNI plugin plane namespace                                            |`linkerd-cni`|
 |`outboundProxyPort`                   | Outbound port for the proxy container                                 |`4140`|
 |`portsToRedirect`                     | Ports to redirect to proxy                                            ||
 |`proxyUID`                            | User id under which the proxy shall be ran                            |`2102`|

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -33,7 +33,6 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-{{.Values.namespace}}-cni
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -56,7 +55,6 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -65,7 +63,6 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
@@ -80,7 +77,6 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -96,7 +92,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 rules:
 - apiGroups: [""]
@@ -108,7 +103,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -125,7 +119,6 @@ metadata:
   name: linkerd-cni-config
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
 data:
   dest_cni_net_dir: "{{.Values.destCNINetDir}}"
@@ -164,7 +157,6 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     k8s-app: linkerd-cni
-    {{.Values.controllerNamespaceLabel}}: {{.Values.namespace}}
     {{.Values.cniResourceAnnotation}}: "true"
   annotations:
     {{.Values.createdByAnnotation}}: {{.Values.cliVersion}}

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -1,5 +1,4 @@
-namespace: linkerd
-controllerNamespaceLabel: linkerd.io/control-plane-ns
+namespace: linkerd-cni
 cniResourceAnnotation: linkerd.io/cni-resource
 inboundProxyPort: 4143
 outboundProxyPort: 4140

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -180,6 +180,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
+		CNINamespace:          cniNamespace,
 		DataPlaneNamespace:    options.namespace,
 		KubeConfig:            kubeconfigPath,
 		KubeContext:           kubeContext,

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -149,6 +149,8 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
+		} else {
+			checks = append(checks, healthcheck.LinkerdCniPluginChecks)
 		}
 		installManifest, err = renderInstallManifest()
 		if err != nil {
@@ -168,7 +170,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			} else {
 				checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
 			}
-
+			checks = append(checks, healthcheck.LinkerdCniPluginChecks)
 			checks = append(checks, healthcheck.LinkerdHAChecks)
 		}
 	}

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -150,10 +150,10 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 	var installManifest string
 	if options.preInstallOnly {
 		checks = append(checks, healthcheck.LinkerdPreInstallChecks)
-		if !options.cniEnabled {
-			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
-		} else {
+		if options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
+		} else {
+			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		}
 		installManifest, err = renderInstallManifest()
 		if err != nil {

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -65,6 +65,9 @@ func (options *checkOptions) validate() error {
 	if options.preInstallOnly && options.dataPlaneOnly {
 		return errors.New("--pre and --proxy flags are mutually exclusive")
 	}
+	if !options.preInstallOnly && options.cniEnabled {
+		return errors.New("--linkerd-cni-enabled can only be used with --pre")
+	}
 	if options.output != tableOutput && options.output != jsonOutput {
 		return fmt.Errorf("Invalid output type '%s'. Supported output types are: %s, %s", options.output, jsonOutput, tableOutput)
 	}
@@ -150,7 +153,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		if !options.cniEnabled {
 			checks = append(checks, healthcheck.LinkerdPreInstallCapabilityChecks)
 		} else {
-			checks = append(checks, healthcheck.LinkerdCniPluginChecks)
+			checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
 		}
 		installManifest, err = renderInstallManifest()
 		if err != nil {
@@ -170,7 +173,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			} else {
 				checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
 			}
-			checks = append(checks, healthcheck.LinkerdCniPluginChecks)
+			checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
 			checks = append(checks, healthcheck.LinkerdHAChecks)
 		}
 	}

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -164,7 +164,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.DestCNINetDir = options.destCNINetDir
 	installValues.DestCNIBinDir = options.destCNIBinDir
 	installValues.UseWaitFlag = options.useWaitFlag
-	installValues.Namespace = controlPlaneNamespace
+	installValues.Namespace = cniNamespace
 	return installValues, nil
 }
 

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRenderCNIPlugin(t *testing.T) {
-	defaultControlPlaneNamespace := controlPlaneNamespace
+	defaultCniNamespace := cniNamespace
 	defaultOptions, err := newCNIInstallOptionsWithDefaults()
 	if err != nil {
 		t.Fatalf("Unexpected error from newCNIInstallOptionsWithDefaults(): %v", err)
@@ -52,7 +52,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		namespace      string
 		goldenFileName string
 	}{
-		{defaultOptions, defaultControlPlaneNamespace, "install-cni-plugin_default.golden"},
+		{defaultOptions, defaultCniNamespace, "install-cni-plugin_default.golden"},
 		{fullyConfiguredOptions, otherNamespace, "install-cni-plugin_fully_configured.golden"},
 		{fullyConfiguredOptionsEqualDsts, otherNamespace, "install-cni-plugin_fully_configured_equal_dsts.golden"},
 	}
@@ -60,8 +60,8 @@ func TestRenderCNIPlugin(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc // pin
 		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
-			defer teardown(defaultControlPlaneNamespace)
-			controlPlaneNamespace = tc.namespace
+			defer teardown(defaultCniNamespace)
+			cniNamespace = tc.namespace
 
 			var buf bytes.Buffer
 			err := renderCNIPlugin(&buf, tc.cniPluginOptions)
@@ -72,9 +72,9 @@ func TestRenderCNIPlugin(t *testing.T) {
 		})
 	}
 
-	controlPlaneNamespace = defaultControlPlaneNamespace
+	cniNamespace = defaultCniNamespace
 }
 
 func teardown(originalNamespace string) {
-	controlPlaneNamespace = originalNamespace
+	cniNamespace = originalNamespace
 }

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -55,6 +55,7 @@ func diffTestdata(t *testing.T, path, actual string) {
 	if actual == expected {
 		return
 	}
+	println(actual)
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(expected, actual, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -55,7 +55,6 @@ func diffTestdata(t *testing.T, path, actual string) {
 	if actual == expected {
 		return
 	}
-	println(actual)
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(expected, actual, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultNamespace      = "linkerd"
+	defaultCNINamespace   = "linkerd-cni"
 	defaultClusterDomain  = "cluster.local"
 	defaultDockerRegistry = "gcr.io/linkerd-io"
 
@@ -37,6 +38,7 @@ var (
 	failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u00D7")    // ×
 
 	controlPlaneNamespace string
+	cniNamespace          string
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
 	kubeContext           string
@@ -90,6 +92,7 @@ var RootCmd = &cobra.Command{
 
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "linkerd-namespace", "l", defaultNamespace, "Namespace in which Linkerd is installed [$LINKERD_NAMESPACE]")
+	RootCmd.PersistentFlags().StringVarP(&cniNamespace, "cni-namespace", "", defaultCNINamespace, "Namespace in which the Linkerd CNI plugin is installed")
 	RootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 	RootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "Name of the kubeconfig context to use")
 	RootCmd.PersistentFlags().StringVar(&impersonate, "as", "", "Username to impersonate for Kubernetes operations")

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -1,7 +1,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: linkerd
+  name: linkerd-cni
   annotations:
     linkerd.io/inject: disabled
   labels:
@@ -11,9 +11,8 @@ metadata:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-linkerd-cni
+  name: linkerd-linkerd-cni-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -34,33 +33,30 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
   resourceNames:
-  - linkerd-linkerd-cni
+  - linkerd-linkerd-cni-cni
   verbs: ['use']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69,14 +65,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: [""]
@@ -88,7 +83,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -97,15 +91,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: linkerd
+  namespace: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 data:
   dest_cni_net_dir: "/etc/cni/net.d"
@@ -141,10 +134,9 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: linkerd-cni
   labels:
     k8s-app: linkerd-cni
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -13,7 +13,6 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-other-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -36,7 +35,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -45,7 +43,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
@@ -60,7 +57,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -76,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: [""]
@@ -88,7 +83,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -105,7 +99,6 @@ metadata:
   name: linkerd-cni-config
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 data:
   dest_cni_net_dir: "/etc/kubernetes/cni/net.d"
@@ -144,7 +137,6 @@ metadata:
   namespace: other
   labels:
     k8s-app: linkerd-cni
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -13,7 +13,6 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-other-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -36,7 +35,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -45,7 +43,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
@@ -60,7 +57,6 @@ metadata:
   name: linkerd-cni
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -76,7 +72,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: [""]
@@ -88,7 +83,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -105,7 +99,6 @@ metadata:
   name: linkerd-cni-config
   namespace: other
   labels:
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
 data:
   dest_cni_net_dir: "/etc/kubernetes/cni/net.d"
@@ -144,7 +137,6 @@ metadata:
   namespace: other
   labels:
     k8s-app: linkerd-cni
-    linkerd.io/control-plane-ns: other
     linkerd.io/cni-resource: "true"
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined

--- a/cli/cmd/testdata/install_cni_helm_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_output.golden
@@ -15,7 +15,6 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-linkerd-test-cni
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -38,7 +37,6 @@ metadata:
   name: linkerd-cni
   namespace: linkerd-test
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,7 +45,6 @@ metadata:
   name: linkerd-cni
   namespace: linkerd-test
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
@@ -62,7 +59,6 @@ metadata:
   name: linkerd-cni
   namespace: linkerd-test
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -78,7 +74,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 rules:
 - apiGroups: [""]
@@ -90,7 +85,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -107,7 +101,6 @@ metadata:
   name: linkerd-cni-config
   namespace: linkerd-test
   labels:
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
 data:
   dest_cni_net_dir: "/etc/cni/net.d-test"
@@ -146,7 +139,6 @@ metadata:
   namespace: linkerd-test
   labels:
     k8s-app: linkerd-cni
-    linkerd.io/control-plane-ns-test: linkerd-test
     linkerd.io/cni-resource-test: "true"
   annotations:
     linkerd.io/created-by-test: test-version

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -15,26 +15,25 @@ const (
 
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
-	Namespace                string `json:"namespace"`
-	ControllerNamespaceLabel string `json:"controllerNamespaceLabel"`
-	CNIResourceAnnotation    string `json:"cniResourceAnnotation"`
-	InboundProxyPort         uint   `json:"inboundProxyPort"`
-	OutboundProxyPort        uint   `json:"outboundProxyPort"`
-	IgnoreInboundPorts       string `json:"ignoreInboundPorts"`
-	IgnoreOutboundPorts      string `json:"ignoreOutboundPorts"`
-	CreatedByAnnotation      string `json:"createdByAnnotation"`
-	CliVersion               string `json:"cliVersion"`
-	CNIPluginImage           string `json:"cniPluginImage"`
-	CNIPluginVersion         string `json:"cniPluginVersion"`
-	LogLevel                 string `json:"logLevel"`
-	PortsToRedirect          string `json:"portsToRedirect"`
-	ProxyUID                 int64  `json:"proxyUID"`
-	DestCNINetDir            string `json:"destCNINetDir"`
-	DestCNIBinDir            string `json:"destCNIBinDir"`
-	UseWaitFlag              bool   `json:"useWaitFlag"`
-	ProxyInjectAnnotation    string `json:"proxyInjectAnnotation"`
-	ProxyInjectDisabled      string `json:"proxyInjectDisabled"`
-	LinkerdNamespaceLabel    string `json:"linkerdNamespaceLabel"`
+	Namespace             string `json:"namespace"`
+	CNIResourceAnnotation string `json:"cniResourceAnnotation"`
+	InboundProxyPort      uint   `json:"inboundProxyPort"`
+	OutboundProxyPort     uint   `json:"outboundProxyPort"`
+	IgnoreInboundPorts    string `json:"ignoreInboundPorts"`
+	IgnoreOutboundPorts   string `json:"ignoreOutboundPorts"`
+	CreatedByAnnotation   string `json:"createdByAnnotation"`
+	CliVersion            string `json:"cliVersion"`
+	CNIPluginImage        string `json:"cniPluginImage"`
+	CNIPluginVersion      string `json:"cniPluginVersion"`
+	LogLevel              string `json:"logLevel"`
+	PortsToRedirect       string `json:"portsToRedirect"`
+	ProxyUID              int64  `json:"proxyUID"`
+	DestCNINetDir         string `json:"destCNINetDir"`
+	DestCNIBinDir         string `json:"destCNIBinDir"`
+	UseWaitFlag           bool   `json:"useWaitFlag"`
+	ProxyInjectAnnotation string `json:"proxyInjectAnnotation"`
+	ProxyInjectDisabled   string `json:"proxyInjectDisabled"`
+	LinkerdNamespaceLabel string `json:"linkerdNamespaceLabel"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -143,7 +143,6 @@ const (
 	LinkerdCNIResourceLabel = "linkerd.io/cni-resource"
 
 	linkerdCNIDisabledSkipReason = "skipping check because CNI is not enabled"
-	linkerdCNIEnabledSkipReason  = "skipping check because CNI is enabled"
 	linkerdCNIResourceName       = "linkerd-cni"
 	linkerdCNIConfigMapName      = "linkerd-cni-config"
 )
@@ -415,9 +414,6 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "control plane namespace does not already exist",
 					hintAnchor:  "pre-ns",
 					check: func(context.Context) error {
-						if hc.NoInitContainer {
-							return &SkipError{Reason: linkerdCNIEnabledSkipReason}
-						}
 						return hc.checkNamespace(hc.ControlPlaneNamespace, false)
 					},
 				},
@@ -1311,7 +1307,7 @@ func (hc *HealthChecker) runCheckRPC(categoryID CategoryID, c *checker, observer
 }
 
 func (hc *HealthChecker) controlPlaneComponentsSelector() string {
-	return fmt.Sprintf("%s in (%s),%s notin (true)", k8s.ControllerNSLabel, hc.ControlPlaneNamespace, LinkerdCNIResourceLabel)
+	return fmt.Sprintf("%s,!%s", k8s.ControllerNSLabel, LinkerdCNIResourceLabel)
 }
 
 // PublicAPIClient returns a fully configured public API client. This client is

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -132,18 +132,20 @@ const (
 	// is correct. These checks are no ops if linkerd is not in HA mode
 	LinkerdHAChecks CategoryID = "linkerd-ha-checks"
 
-	// LinkerdCniPluginChecks adds checks to validate that the CNI
+	// LinkerdCNIPluginChecks adds checks to validate that the CNI
 	/// plugin is installed and ready
-	LinkerdCniPluginChecks CategoryID = "linkerd-cni-plugin"
+	LinkerdCNIPluginChecks CategoryID = "linkerd-cni-plugin"
 
-	// linkerdCniResourceLabel is the label key that is used to identify
+	// LinkerdCNIResourceLabel is the label key that is used to identify
 	// whether a Kubernetes resource is related to the install-cni command
 	// The value is expected to be "true", "false" or "", where "false" and
 	// "" are equal, making "false" the default
-	linkerdCniResourceLabel = "linkerd.io/cni-resource"
+	LinkerdCNIResourceLabel = "linkerd.io/cni-resource"
 
-	cniDisabledSkipReason = "skipping check because CNI is not enabled"
-	cniEnabledSkipReason  = "skipping check because CNI is enabled"
+	linkerdCNIDisabledSkipReason = "skipping check because CNI is not enabled"
+	linkerdCNIEnabledSkipReason  = "skipping check because CNI is enabled"
+	linkerdCNIResourceName       = "linkerd-cni"
+	linkerdCNIConfigMapName      = "linkerd-cni-config"
 )
 
 // HintBaseURL is the base URL on the linkerd.io website that all check hints
@@ -173,12 +175,6 @@ var (
 		"linkerd-web",
 		"linkerd-tap",
 	}
-
-	expectedCniServiceAccountNames = []string{
-		"linkerd-cni",
-	}
-	expectedCniDsName = "linkerd-cni"
-	cniConfigMapName  = "linkerd-cni-config"
 )
 
 // Resource provides a way to describe a Kubernetes object, kind, and name.
@@ -419,7 +415,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "pre-ns",
 					check: func(context.Context) error {
 						if hc.NoInitContainer {
-							return &SkipError{Reason: cniEnabledSkipReason}
+							return &SkipError{Reason: linkerdCNIEnabledSkipReason}
 						}
 						return hc.checkNamespace(hc.ControlPlaneNamespace, false)
 					},
@@ -517,14 +513,14 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "no ClusterRoles exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						return hc.checkClusterRoles(false, hc.expectedRBACNames(), hc.NoInitContainer)
+						return hc.checkClusterRoles(false)
 					},
 				},
 				{
 					description: "no ClusterRoleBindings exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						return hc.checkClusterRoleBindings(false, hc.expectedRBACNames(), hc.NoInitContainer)
+						return hc.checkClusterRoleBindings(false)
 					},
 				},
 				{
@@ -552,76 +548,7 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "no PodSecurityPolicies exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						return hc.checkPodSecurityPolicies(false, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)}, hc.NoInitContainer)
-					},
-				},
-			},
-		},
-		{
-			id: LinkerdConfigChecks,
-			checkers: []checker{
-				{
-					description: "control plane Namespace exists",
-					hintAnchor:  "l5d-existence-ns",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkNamespace(hc.ControlPlaneNamespace, true)
-					},
-				},
-				{
-					description: "control plane ClusterRoles exist",
-					hintAnchor:  "l5d-existence-cr",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkClusterRoles(true, hc.expectedRBACNames(), hc.NoInitContainer)
-					},
-				},
-				{
-					description: "control plane ClusterRoleBindings exist",
-					hintAnchor:  "l5d-existence-crb",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkClusterRoleBindings(true, hc.expectedRBACNames(), hc.NoInitContainer)
-					},
-				},
-				{
-					description: "control plane ServiceAccounts exist",
-					hintAnchor:  "l5d-existence-sa",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkServiceAccounts(expectedServiceAccountNames)
-					},
-				},
-				{
-					description: "control plane CustomResourceDefinitions exist",
-					hintAnchor:  "l5d-existence-crd",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkCustomResourceDefinitions(true)
-					},
-				},
-				{
-					description: "control plane MutatingWebhookConfigurations exist",
-					hintAnchor:  "l5d-existence-mwc",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkMutatingWebhookConfigurations(true)
-					},
-				},
-				{
-					description: "control plane ValidatingWebhookConfigurations exist",
-					hintAnchor:  "l5d-existence-vwc",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkValidatingWebhookConfigurations(true)
-					},
-				},
-				{
-					description: "control plane PodSecurityPolicies exist",
-					hintAnchor:  "l5d-existence-psp",
-					fatal:       true,
-					check: func(context.Context) error {
-						return hc.checkPodSecurityPolicies(true, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)}, hc.NoInitContainer)
+						return hc.checkPodSecurityPolicies(false)
 					},
 				},
 			},
@@ -722,7 +649,76 @@ func (hc *HealthChecker) allCategories() []category {
 			},
 		},
 		{
-			id: LinkerdCniPluginChecks,
+			id: LinkerdConfigChecks,
+			checkers: []checker{
+				{
+					description: "control plane Namespace exists",
+					hintAnchor:  "l5d-existence-ns",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkNamespace(hc.ControlPlaneNamespace, true)
+					},
+				},
+				{
+					description: "control plane ClusterRoles exist",
+					hintAnchor:  "l5d-existence-cr",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkClusterRoles(true)
+					},
+				},
+				{
+					description: "control plane ClusterRoleBindings exist",
+					hintAnchor:  "l5d-existence-crb",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkClusterRoleBindings(true)
+					},
+				},
+				{
+					description: "control plane ServiceAccounts exist",
+					hintAnchor:  "l5d-existence-sa",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkServiceAccounts(expectedServiceAccountNames)
+					},
+				},
+				{
+					description: "control plane CustomResourceDefinitions exist",
+					hintAnchor:  "l5d-existence-crd",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkCustomResourceDefinitions(true)
+					},
+				},
+				{
+					description: "control plane MutatingWebhookConfigurations exist",
+					hintAnchor:  "l5d-existence-mwc",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkMutatingWebhookConfigurations(true)
+					},
+				},
+				{
+					description: "control plane ValidatingWebhookConfigurations exist",
+					hintAnchor:  "l5d-existence-vwc",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkValidatingWebhookConfigurations(true)
+					},
+				},
+				{
+					description: "control plane PodSecurityPolicies exist",
+					hintAnchor:  "l5d-existence-psp",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkPodSecurityPolicies(true)
+					},
+				},
+			},
+		},
+		{
+			id: LinkerdCNIPluginChecks,
 			checkers: []checker{
 				{
 					description: "cni plugin ConfigMap exists",
@@ -730,13 +726,10 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						_, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get(cniConfigMapName, metav1.GetOptions{})
-						if err != nil {
-							return err
-						}
-						return nil
+						_, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get(linkerdCNIConfigMapName, metav1.GetOptions{})
+						return err
 					},
 				},
 				{
@@ -745,9 +738,14 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkPodSecurityPolicies(true, []string{fmt.Sprintf("linkerd-%s-cni", hc.ControlPlaneNamespace)}, false)
+						pspName := fmt.Sprintf("linkerd-%s-cni", hc.ControlPlaneNamespace)
+						_, err := hc.kubeAPI.PolicyV1beta1().PodSecurityPolicies().Get(pspName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing PodSecurityPolicy: %s", pspName)
+						}
+						return err
 					},
 				},
 				{
@@ -756,9 +754,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkClusterRoles(true, hc.expectedCniRBACNames(), false)
+						_, err := hc.kubeAPI.RbacV1().ClusterRoles().Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing ClusterRole: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -767,9 +769,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkClusterRoleBindings(true, hc.expectedCniRBACNames(), false)
+						_, err := hc.kubeAPI.RbacV1().ClusterRoleBindings().Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing ClusterRoleBinding: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -778,9 +784,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkCniRoles()
+						_, err := hc.kubeAPI.RbacV1().Roles(hc.ControlPlaneNamespace).Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing Role: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -789,9 +799,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkCniRolesBindings()
+						_, err := hc.kubeAPI.RbacV1().RoleBindings(hc.ControlPlaneNamespace).Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing RoleBinding: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -800,9 +814,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						return hc.checkServiceAccounts(expectedCniServiceAccountNames)
+						_, err := hc.kubeAPI.CoreV1().ServiceAccounts(hc.ControlPlaneNamespace).Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing ServiceAccount: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -811,10 +829,13 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:       true,
 					check: func(context.Context) (err error) {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
-						hc.cniDaemonSet, err = hc.kubeAPI.Interface.AppsV1().DaemonSets(hc.ControlPlaneNamespace).Get(expectedCniDsName, metav1.GetOptions{})
-						return
+						hc.cniDaemonSet, err = hc.kubeAPI.Interface.AppsV1().DaemonSets(hc.ControlPlaneNamespace).Get(linkerdCNIResourceName, metav1.GetOptions{})
+						if kerrors.IsNotFound(err) {
+							return fmt.Errorf("missing DaemonSet: %s", linkerdCNIResourceName)
+						}
+						return err
 					},
 				},
 				{
@@ -825,7 +846,7 @@ func (hc *HealthChecker) allCategories() []category {
 					fatal:               true,
 					check: func(ctx context.Context) error {
 						if !hc.NoInitContainer {
-							return &SkipError{Reason: cniDisabledSkipReason}
+							return &SkipError{Reason: linkerdCNIDisabledSkipReason}
 						}
 						scheduled := hc.cniDaemonSet.Status.DesiredNumberScheduled
 						ready := hc.cniDaemonSet.Status.NumberReady
@@ -1288,6 +1309,10 @@ func (hc *HealthChecker) runCheckRPC(categoryID CategoryID, c *checker, observer
 	return true
 }
 
+func (hc *HealthChecker) controlPlaneComponentsSelector() string {
+	return fmt.Sprintf("%s in (%s),%s notin (true)", k8s.ControllerNSLabel, hc.ControlPlaneNamespace, LinkerdCNIResourceLabel)
+}
+
 // PublicAPIClient returns a fully configured public API client. This client is
 // only configured if the KubernetesAPIChecks and LinkerdAPIChecks are
 // configured and run first.
@@ -1393,15 +1418,9 @@ func (hc *HealthChecker) expectedRBACNames() []string {
 	}
 }
 
-func (hc *HealthChecker) expectedCniRBACNames() []string {
-	return []string{
-		"linkerd-cni",
-	}
-}
-
-func (hc *HealthChecker) checkClusterRoles(shouldExist bool, expectedRoles []string, skipCni bool) error {
+func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	crList, err := hc.kubeAPI.RbacV1().ClusterRoles().List(options)
 	if err != nil {
@@ -1411,40 +1430,17 @@ func (hc *HealthChecker) checkClusterRoles(shouldExist bool, expectedRoles []str
 	objects := []runtime.Object{}
 
 	for _, item := range crList.Items {
-
-		if skipCni && isCniResource(item.ObjectMeta.Labels) {
-			continue
-		}
+		println(item.Name)
 		item := item // pin
 		objects = append(objects, &item)
 	}
 
-	return checkResources("ClusterRoles", objects, expectedRoles, shouldExist)
+	return checkResources("ClusterRoles", objects, hc.expectedRBACNames(), shouldExist)
 }
 
-func (hc *HealthChecker) checkCniRoles() error {
+func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
-	}
-	crList, err := hc.kubeAPI.RbacV1().Roles(hc.ControlPlaneNamespace).List(options)
-	if err != nil {
-		return err
-	}
-
-	objects := []runtime.Object{}
-
-	for _, item := range crList.Items {
-
-		item := item // pin
-		objects = append(objects, &item)
-	}
-
-	return checkResources("Roles", objects, hc.expectedCniRBACNames(), true)
-}
-
-func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool, expectedBindings []string, skipCni bool) error {
-	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	crbList, err := hc.kubeAPI.RbacV1().ClusterRoleBindings().List(options)
 	if err != nil {
@@ -1454,34 +1450,11 @@ func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool, expectedBind
 	objects := []runtime.Object{}
 
 	for _, item := range crbList.Items {
-		if skipCni && isCniResource(item.ObjectMeta.Labels) {
-			continue
-		}
-
 		item := item // pin
 		objects = append(objects, &item)
 	}
 
-	return checkResources("ClusterRoleBindings", objects, expectedBindings, shouldExist)
-}
-
-func (hc *HealthChecker) checkCniRolesBindings() error {
-	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
-	}
-	crbList, err := hc.kubeAPI.RbacV1().RoleBindings(hc.ControlPlaneNamespace).List(options)
-	if err != nil {
-		return err
-	}
-
-	objects := []runtime.Object{}
-
-	for _, item := range crbList.Items {
-		item := item // pin
-		objects = append(objects, &item)
-	}
-
-	return checkResources("RoleBindings", objects, hc.expectedCniRBACNames(), true)
+	return checkResources("ClusterRoleBindings", objects, hc.expectedRBACNames(), shouldExist)
 }
 
 func (hc *HealthChecker) isHA() bool {
@@ -1504,7 +1477,7 @@ func (hc *HealthChecker) isHeartbeatDisabled() bool {
 
 func (hc *HealthChecker) checkServiceAccounts(saNames []string) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	saList, err := hc.kubeAPI.CoreV1().ServiceAccounts(hc.ControlPlaneNamespace).List(options)
 	if err != nil {
@@ -1512,6 +1485,7 @@ func (hc *HealthChecker) checkServiceAccounts(saNames []string) error {
 	}
 
 	objects := []runtime.Object{}
+
 	for _, item := range saList.Items {
 		item := item // pin
 		objects = append(objects, &item)
@@ -1522,7 +1496,7 @@ func (hc *HealthChecker) checkServiceAccounts(saNames []string) error {
 
 func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	crdList, err := hc.kubeAPI.Apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
 	if err != nil {
@@ -1540,7 +1514,7 @@ func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error 
 
 func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	mwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(options)
 	if err != nil {
@@ -1558,7 +1532,7 @@ func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) er
 
 func (hc *HealthChecker) checkValidatingWebhookConfigurations(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	vwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().List(options)
 	if err != nil {
@@ -1574,9 +1548,9 @@ func (hc *HealthChecker) checkValidatingWebhookConfigurations(shouldExist bool) 
 	return checkResources("ValidatingWebhookConfigurations", objects, []string{k8s.SPValidatorWebhookConfigName}, shouldExist)
 }
 
-func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool, pspNames []string, skipCni bool) error {
+func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool) error {
 	options := metav1.ListOptions{
-		LabelSelector: k8s.ControllerNSLabel,
+		LabelSelector: hc.controlPlaneComponentsSelector(),
 	}
 	psp, err := hc.kubeAPI.PolicyV1beta1().PodSecurityPolicies().List(options)
 	if err != nil {
@@ -1585,16 +1559,10 @@ func (hc *HealthChecker) checkPodSecurityPolicies(shouldExist bool, pspNames []s
 
 	objects := []runtime.Object{}
 	for _, item := range psp.Items {
-
-		if skipCni && isCniResource(item.ObjectMeta.Labels) {
-			continue
-		}
-
 		item := item // pin
 		objects = append(objects, &item)
 	}
-
-	return checkResources("PodSecurityPolicies", objects, pspNames, shouldExist)
+	return checkResources("PodSecurityPolicies", objects, []string{fmt.Sprintf("linkerd-%s-control-plane", hc.ControlPlaneNamespace)}, shouldExist)
 }
 
 // MeshedPodIdentityData contains meshed pod details + root anchors of the proxy
@@ -2069,13 +2037,4 @@ func checkControlPlaneReplicaSets(rst []appsv1.ReplicaSet) error {
 	}
 
 	return nil
-}
-
-func isCniResource(labelMap map[string]string) bool {
-	isCni, err := strconv.ParseBool(labelMap[linkerdCniResourceLabel])
-	if err != nil {
-		log.Errorf("Error parsing %v, %v",
-			linkerdCniResourceLabel, err)
-	}
-	return isCni
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2630,9 +2630,8 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: linkerd
+  namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 data:
   dest_cni_net_dir: "/etc/cni/net.d"
@@ -2645,9 +2644,8 @@ data:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-linkerd-cni
+  name: linkerd-test-ns-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 spec:
   allowPrivilegeEscalation: false
@@ -2674,7 +2672,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: [""]
@@ -2691,7 +2688,6 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2700,7 +2696,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
 ---
 `)
 	}
@@ -2711,15 +2707,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
   resourceNames:
-  - linkerd-linkerd-cni
+  - linkerd-test-ns-cni
   verbs: ['use']
 ---
 `)
@@ -2731,9 +2726,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -2742,7 +2736,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
 ---
 `)
 	}
@@ -2753,9 +2747,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
 ---
 `)
@@ -2767,10 +2760,9 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: linkerd
+  namespace: test-ns
   labels:
     k8s-app: linkerd-cni
-    linkerd.io/control-plane-ns: linkerd
     linkerd.io/cni-resource: "true"
   annotations:
     linkerd.io/created-by: linkerd/cli git-b4266c93
@@ -2857,7 +2849,7 @@ func TestCniChecks(t *testing.T) {
 			fakeCniResourcesOpts{hasConfigMap: true},
 			[]string{
 				"linkerd-cni-plugin cni plugin ConfigMap exists",
-				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists: missing PodSecurityPolicy: linkerd-linkerd-cni"},
+				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists: missing PodSecurityPolicy: linkerd-test-ns-cni"},
 		},
 		{
 			"fails then there is no ClusterRole",
@@ -2962,7 +2954,7 @@ func TestCniChecks(t *testing.T) {
 			hc := NewHealthChecker(
 				[]CategoryID{LinkerdCNIPluginChecks},
 				&Options{
-					ControlPlaneNamespace: "linkerd",
+					CNINamespace: "test-ns",
 				},
 			)
 

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2153,6 +2153,7 @@ metadata:
 
 		var err error
 		hc.kubeAPI, err = k8s.NewFakeAPI(resources...)
+		hc.ControlPlaneNamespace = "test-ns"
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -2856,7 +2857,7 @@ func TestCniChecks(t *testing.T) {
 			fakeCniResourcesOpts{hasConfigMap: true},
 			[]string{
 				"linkerd-cni-plugin cni plugin ConfigMap exists",
-				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists: missing PodSecurityPolicies: linkerd-linkerd-cni"},
+				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists: missing PodSecurityPolicy: linkerd-linkerd-cni"},
 		},
 		{
 			"fails then there is no ClusterRole",
@@ -2864,7 +2865,7 @@ func TestCniChecks(t *testing.T) {
 			[]string{
 				"linkerd-cni-plugin cni plugin ConfigMap exists",
 				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists",
-				"linkerd-cni-plugin cni plugin ClusterRole exists: missing ClusterRoles: linkerd-cni"},
+				"linkerd-cni-plugin cni plugin ClusterRole exists: missing ClusterRole: linkerd-cni"},
 		},
 		{
 			"fails then there is no ClusterRoleBinding",
@@ -2873,7 +2874,7 @@ func TestCniChecks(t *testing.T) {
 				"linkerd-cni-plugin cni plugin ConfigMap exists",
 				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists",
 				"linkerd-cni-plugin cni plugin ClusterRole exists",
-				"linkerd-cni-plugin cni plugin ClusterRoleBinding exists: missing ClusterRoleBindings: linkerd-cni"},
+				"linkerd-cni-plugin cni plugin ClusterRoleBinding exists: missing ClusterRoleBinding: linkerd-cni"},
 		},
 		{
 			"fails then there is no Role",
@@ -2883,7 +2884,7 @@ func TestCniChecks(t *testing.T) {
 				"linkerd-cni-plugin cni plugin PodSecurityPolicy exists",
 				"linkerd-cni-plugin cni plugin ClusterRole exists",
 				"linkerd-cni-plugin cni plugin ClusterRoleBinding exists",
-				"linkerd-cni-plugin cni plugin Role exists: missing Roles: linkerd-cni"},
+				"linkerd-cni-plugin cni plugin Role exists: missing Role: linkerd-cni"},
 		},
 		{
 			"fails then there is no RoleBinding",
@@ -2894,7 +2895,7 @@ func TestCniChecks(t *testing.T) {
 				"linkerd-cni-plugin cni plugin ClusterRole exists",
 				"linkerd-cni-plugin cni plugin ClusterRoleBinding exists",
 				"linkerd-cni-plugin cni plugin Role exists",
-				"linkerd-cni-plugin cni plugin RoleBinding exists: missing RoleBindings: linkerd-cni"},
+				"linkerd-cni-plugin cni plugin RoleBinding exists: missing RoleBinding: linkerd-cni"},
 		},
 		{
 			"fails then there is no ServiceAccount",
@@ -2906,7 +2907,7 @@ func TestCniChecks(t *testing.T) {
 				"linkerd-cni-plugin cni plugin ClusterRoleBinding exists",
 				"linkerd-cni-plugin cni plugin Role exists",
 				"linkerd-cni-plugin cni plugin RoleBinding exists",
-				"linkerd-cni-plugin cni plugin ServiceAccount exists: missing ServiceAccounts: linkerd-cni",
+				"linkerd-cni-plugin cni plugin ServiceAccount exists: missing ServiceAccount: linkerd-cni",
 			},
 		},
 		{
@@ -2920,7 +2921,7 @@ func TestCniChecks(t *testing.T) {
 				"linkerd-cni-plugin cni plugin Role exists",
 				"linkerd-cni-plugin cni plugin RoleBinding exists",
 				"linkerd-cni-plugin cni plugin ServiceAccount exists",
-				"linkerd-cni-plugin cni plugin DaemonSet exists: daemonsets.apps \"linkerd-cni\" not found",
+				"linkerd-cni-plugin cni plugin DaemonSet exists: missing DaemonSet: linkerd-cni",
 			},
 		},
 		{
@@ -2959,7 +2960,7 @@ func TestCniChecks(t *testing.T) {
 		tc := tc // pin
 		t.Run(tc.description, func(t *testing.T) {
 			hc := NewHealthChecker(
-				[]CategoryID{LinkerdCniPluginChecks},
+				[]CategoryID{LinkerdCNIPluginChecks},
 				&Options{
 					ControlPlaneNamespace: "linkerd",
 				},

--- a/test/testdata/check.golden
+++ b/test/testdata/check.golden
@@ -8,6 +8,16 @@ kubernetes-version
 √ is running the minimum Kubernetes API version
 √ is running the minimum kubectl version
 
+linkerd-existence
+-----------------
+√ 'linkerd-config' config map exists
+√ heartbeat ServiceAccount exist
+√ control plane replica sets are ready
+√ no unschedulable pods
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
+
 linkerd-config
 --------------
 √ control plane Namespace exists
@@ -18,16 +28,6 @@ linkerd-config
 √ control plane MutatingWebhookConfigurations exist
 √ control plane ValidatingWebhookConfigurations exist
 √ control plane PodSecurityPolicies exist
-
-linkerd-existence
------------------
-√ 'linkerd-config' config map exists
-√ heartbeat ServiceAccount exist
-√ control plane replica sets are ready
-√ no unschedulable pods
-√ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-identity
 ----------------

--- a/test/testdata/check.proxy.golden
+++ b/test/testdata/check.proxy.golden
@@ -8,6 +8,16 @@ kubernetes-version
 √ is running the minimum Kubernetes API version
 √ is running the minimum kubectl version
 
+linkerd-existence
+-----------------
+√ 'linkerd-config' config map exists
+√ heartbeat ServiceAccount exist
+√ control plane replica sets are ready
+√ no unschedulable pods
+√ controller pod is running
+√ can initialize the client
+√ can query the control plane API
+
 linkerd-config
 --------------
 √ control plane Namespace exists
@@ -18,16 +28,6 @@ linkerd-config
 √ control plane MutatingWebhookConfigurations exist
 √ control plane ValidatingWebhookConfigurations exist
 √ control plane PodSecurityPolicies exist
-
-linkerd-existence
------------------
-√ 'linkerd-config' config map exists
-√ heartbeat ServiceAccount exist
-√ control plane replica sets are ready
-√ no unschedulable pods
-√ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-identity
 ----------------


### PR DESCRIPTION
As part of the effort to remove the "experimental" label from the CNI plugin, this PR introduces a `linkerd check --cni`.

Fixes #3804

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
