### PR TITLE
Linkerd CLI Chocolatey Package

### DIFF
--- a/windowspkg/linkerd2-cli/linkerd2-cli.nuspec
+++ b/windowspkg/linkerd2-cli/linkerd2-cli.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>linkerd2-cli</id>
+    <version>2.6.1</version>
+    
+    <title>linkerd2-cli (Install)</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
+    <tags>linkerd2-cli SPACE_SEPARATED</tags>
+    <summary>__REPLACE__</summary>
+    <description>__REPLACE__MarkDown_Okay </description>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.1.0" />
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="tools\**" target="tools" />
+    </files>
+</package>

--- a/windowspkg/linkerd2-cli/tools/LICENSE.txt
+++ b/windowspkg/linkerd2-cli/tools/LICENSE.txt
@@ -1,0 +1,11 @@
+﻿
+Note: Include this file if including binaries you have the right to distribute. 
+Otherwise delete. this file.
+
+===DELETE ABOVE THIS LINE AND THIS LINE===
+
+From: <insert applicable license url here>
+
+LICENSE
+
+<Insert License Here>

--- a/windowspkg/linkerd2-cli/tools/VERIFICATION.txt
+++ b/windowspkg/linkerd2-cli/tools/VERIFICATION.txt
@@ -1,0 +1,13 @@
+﻿
+Note: Include this file if including binaries you have the right to distribute. 
+Otherwise delete. this file. If you are the software author, you can change this
+mention you are the author of the software.
+
+===DELETE ABOVE THIS LINE AND THIS LINE===
+
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+ 
+<Include details of how to verify checksum contents>
+<If software vendor, explain that here - checksum verification instructions are optional>

--- a/windowspkg/linkerd2-cli/tools/chocolateyinstall.ps1
+++ b/windowspkg/linkerd2-cli/tools/chocolateyinstall.ps1
@@ -1,0 +1,14 @@
+﻿$ErrorActionPreference = 'Stop';
+$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$packageArgs = @{
+
+  packageName    = 'linkerd'
+  fileFullPath   = "$toolsPath\linkerd.exe"
+  url            = 'https://github.com/linkerd/linkerd2/releases/download/stable-2.6.1/linkerd2-cli-stable-2.6.1-windows.exe'
+  checksum       = '4ed915b10c2a76070d40bf3223f09e742777105914acaeadfc83d99ef6cf1798'
+  checksumType   = 'sha256'
+}
+
+Get-ChocolateyWebFile @packageArgs
+Install-ChocolateyPath $packageArgs.fileFullPath 'Machine'

--- a/windowspkg/linkerd2-cli/update.ps1
+++ b/windowspkg/linkerd2-cli/update.ps1
@@ -1,0 +1,43 @@
+[CmdletBinding()]
+param([switch] $Force)
+Import-Module AU
+
+$domain = "https://github.com"
+$releases = "$domain/linkerd/linkerd2/releases"
+
+function global:au_BeforeUpdate {
+
+  Get-RemoteFiles -Purge -NoSuffix -FileNameBase "linkerd2-cli"
+  $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url
+
+}
+
+function global:au_SearchReplace {
+
+  @{
+      ".\tools\chocolateyInstall.ps1" = @{
+
+	        "(?i)(^\s*packageName\s*=\s*)('.*')" = "`$1'$($Latest.PackageName)'"
+	        "(?i)(^\s*url\s*=\s*)" = "`$1'$($Latest.URL)'"
+	        "(?i)(^\s*checksum\s*=\s*)" = "`$1'$($Latest.Checksum64)'"
+        
+        }  
+   }
+}
+
+function global:au_GetLatest {
+
+  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+  $url = $download_page.links | ? href -match '/linkerd2-cli-stable-(.+)-windows\.exe$' | % href | select -First 1
+  $url = $domain+$url
+  $version = $Matches[1]
+  return @{
+    
+    Version     = $version
+    URL       = $url
+    ReleaseURL  = "$domain/linkerd/linkerd2/releases/tag/v${version}"
+  
+  }
+
+}
+update -ChecksumFor none -Force:$Force


### PR DESCRIPTION
This draft PR aims to fix #3063 by building a chocolatey package for linkerd2's Windows CLI
The package currently exists in the folder `windowspkg`

To build (on windows system):
- Install chocolatey
- cd into `windowspkg/linkerd2-cli`
- Run `choco pack`
- Run `choco install linkerd2-cli -s . ` , make sure cmd is running as administrator
- Run `refreshenv` to add linkerd2-cli path to system
- To unistall run `choco uninstall linkerd2-cli`

The following is further work to be done:
- Fill `linkerd2-cli.nuspec` appropriately
- Fill `LICENSE.txt` and `VERIFICATION.txt` appropriately

Future work:
- After approval future commits will add auto update feature for the package

Signed-off-by: Animesh Narayan Dangwal <animesh.leo@gmail.com>