### PR TITLE
Fix inject integration tests failing due to wrong golden files

### DIFF
--- a/test/inject/testdata/injected_default.golden
+++ b/test/inject/testdata/injected_default.golden
@@ -1,13 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: inject-test-terminus
 spec:
   selector:
     matchLabels:
       app: inject-test-terminus
-  strategy: {}
   template:
     metadata:
       annotations:
@@ -18,7 +16,6 @@ spec:
         linkerd.io/created-by: fake # this gets removed during testing
         linkerd.io/identity-mode: disabled
         linkerd.io/proxy-version: fake # this gets removed during testing
-      creationTimestamp: null
       labels:
         app: inject-test-terminus
         linkerd.io/control-plane-ns: fake-ns
@@ -35,7 +32,6 @@ spec:
         name: bb-terminus
         ports:
         - containerPort: 9090
-        resources: {}
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn,linkerd=info
@@ -83,7 +79,6 @@ spec:
             path: /ready
             port: 4191
           initialDelaySeconds: 2
-        resources: {}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -120,5 +115,4 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
-status: {}
 ---

--- a/test/inject/testdata/injected_params.golden
+++ b/test/inject/testdata/injected_params.golden
@@ -1,13 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: inject-test-terminus
 spec:
   selector:
     matchLabels:
       app: inject-test-terminus
-  strategy: {}
   template:
     metadata:
       annotations:
@@ -33,7 +31,6 @@ spec:
         linkerd.io/created-by: fake # this gets removed during testing
         linkerd.io/identity-mode: disabled
         linkerd.io/proxy-version: fake # this gets removed during testing
-      creationTimestamp: null
       labels:
         app: inject-test-terminus
         linkerd.io/control-plane-ns: fake-ns
@@ -50,7 +47,6 @@ spec:
         name: bb-terminus
         ports:
         - containerPort: 9090
-        resources: {}
       - env:
         - name: LINKERD2_PROXY_LOG
           value: warn
@@ -145,5 +141,4 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
-status: {}
 ---


### PR DESCRIPTION
The golden files for inject IT tests were not updated as part of #3886 which was causing a build failure on master. This PR fixes that.