### PR TITLE
Enable no-use-before-define eslint rule

### DIFF
--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -71,6 +71,7 @@
     "react/jsx-filename-extension": 0,
     "react/jsx-fragments": 0,
     "react/jsx-one-expression-per-line": 0,
+    "react/sort-comp": 0,
 
     // These rules are disabled to support specific features/conventions that we use
     "no-bitwise": 0,
@@ -84,10 +85,6 @@
     // These rules represent best practices that we're not adhering to, and should be enabled
     "jsx-a11y/click-events-have-key-events": 0,
     "no-param-reassign": 0,
-    "react/no-did-update-set-state": 0,
-
-    // These rules require reordering and should be enabled in a follow-up branch
-    "no-use-before-define": 0,
-    "react/sort-comp": 0
+    "react/no-did-update-set-state": 0
   }
 }

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -1,13 +1,13 @@
+import _merge from 'lodash/merge';
 import ApiHelpers from './util/ApiHelpers.jsx';
 import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
 import mediaQuery from 'css-mediaquery';
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
 import Navigation from './Navigation.jsx';
 import sinon from 'sinon';
 import sinonStubPromise from 'sinon-stub-promise';
 import { mount } from 'enzyme';
+import { createMemoryHistory } from 'history';
 
 function createMatchMedia(width) {
   return query => ({
@@ -26,20 +26,26 @@ const loc = {
   search: '',
 };
 
-const namespaces = [
-  {key: "-namespace-default", name: "default", namespace: "", type: "namespace"},
-  {key: "-namespace-emojivoto", name: "emojivoto", namespace: "", type: "namespace"},
-  {key: "-namespace-linkerd", name: "linkerd", namespace: "", type: "namespace"},
-];
+const curVer = "edge-1.2.3";
+const newVer = "edge-2.3.4";
+
+const defaultProps = {
+  api: ApiHelpers(''),
+  checkNamespaceMatch: () => {},
+  ChildComponent: () => null,
+  classes: {},
+  history: createMemoryHistory('/namespaces'),
+  location: loc,
+  pathPrefix: '',
+  releaseVersion: curVer,
+  selectedNamespace: 'emojivoto',
+  theme: {},
+  updateNamespaceInContext: () => {},
+  uuid: 'fakeuuid',
+};
 
 describe('Navigation', () => {
-  let curVer = "edge-1.2.3";
-  let newVer = "edge-2.3.4";
-  let selectedNamespace = "emojivoto"
-
   let component, fetchStub;
-  let apiHelpers = ApiHelpers("");
-  const childComponent = () => null;
 
   function withPromise(fn) {
     return component.find("NavigationBase").instance().versionPromise.then(fn);
@@ -62,16 +68,7 @@ describe('Navigation', () => {
 
     component = mount(
       <BrowserRouter>
-        <Navigation
-          ChildComponent={childComponent}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={apiHelpers}
-          releaseVersion={curVer}
-          selectedNamespace={selectedNamespace}
-          pathPrefix=""
-          uuid="fakeuuid" />
+        <Navigation {...defaultProps} />
       </BrowserRouter>
     );
 
@@ -89,16 +86,7 @@ describe('Navigation', () => {
 
     component = mount(
       <BrowserRouter>
-        <Navigation
-          ChildComponent={childComponent}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={apiHelpers}
-          releaseVersion={curVer}
-          selectedNamespace={selectedNamespace}
-          pathPrefix=""
-          uuid="fakeuuid" />
+        <Navigation {...defaultProps} />
       </BrowserRouter>
     );
 
@@ -121,16 +109,7 @@ describe('Navigation', () => {
 
     component = mount(
       <BrowserRouter>
-        <Navigation
-          ChildComponent={childComponent}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={apiHelpers}
-          releaseVersion={curVer}
-          selectedNamespace={selectedNamespace}
-          pathPrefix=""
-          uuid="fakeuuid" />
+        <Navigation {...defaultProps} />
       </BrowserRouter>
     );
 
@@ -148,42 +127,28 @@ describe('Namespace Select Button', () => {
   });
 
   it('displays All Namespaces as button text if the selected namespace is _all', () => {
+    const extraProps = _merge({}, defaultProps, {
+      selectedNamespace: '_all',
+    });
+
     const component = mount(
       <BrowserRouter>
-        <Navigation
-          ChildComponent={() => null}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={ApiHelpers("")}
-          releaseVersion="edge-1.2.3"
-          selectedNamespace="_all"
-          pathPrefix=""
-          uuid="fakeuuid" />
+        <Navigation {...extraProps} />
       </BrowserRouter>
     );
 
     const input = component.find("input");
-    expect(input.instance().value).toEqual("ALL NAMESPACES")
+    expect(input.instance().value).toEqual("ALL NAMESPACES");
   });
 
   it('renders emojivoto text', () => {
     const component = mount(
       <BrowserRouter>
-        <Navigation
-          ChildComponent={() => null}
-          classes={{}}
-          theme={{}}
-          location={loc}
-          api={ApiHelpers("")}
-          releaseVersion="edge-1.2.3"
-          selectedNamespace="emojivoto"
-          pathPrefix=""
-          uuid="fakeuuid" />
+        <Navigation {...defaultProps} />
       </BrowserRouter>
     );
 
     const input = component.find("input");
-    expect(input.instance().value).toEqual("EMOJIVOTO")
+    expect(input.instance().value).toEqual("EMOJIVOTO");
   });
 });

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -48,6 +48,10 @@ const spinnerStyles = theme => ({
 const SpinnerBase = () => <CircularProgress size={20} />;
 const Spinner = withStyles(spinnerStyles)(SpinnerBase);
 
+const formatTapLatency = str => {
+  return formatLatencySec(str.replace('s', ''));
+};
+
 const httpStatusCol = {
   title: 'HTTP status',
   key: 'http-status',
@@ -121,10 +125,6 @@ const tapColumns = (resourceType, ResourceLink) => {
   return topLevelColumns(resourceType, ResourceLink).concat(
     [methodCol, pathCol, responseInitLatencyCol, httpStatusCol, grpcStatusCol],
   );
-};
-
-const formatTapLatency = str => {
-  return formatLatencySec(str.replace('s', ''));
 };
 
 const itemDisplay = (title, value) => {

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -95,6 +95,14 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     return path;
   };
 
+  const getMetricsWindow = () => metricsWindow;
+  const getMetricsWindowDisplayText = () => validMetricsWindows[metricsWindow];
+
+  const setMetricsWindow = window => {
+    if (!validMetricsWindows[window]) { return; }
+    metricsWindow = window;
+  };
+
   const fetchMetrics = path => {
     if (path.indexOf('window') === -1) {
       if (path.indexOf('?') === -1) {
@@ -130,14 +138,6 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
 
   const fetchResourceDefinition = (namespace, resourceType, resourceName) => {
     return apiFetchYAML(`/api/resource-definition?namespace=${namespace}&resource_type=${resourceType}&resource_name=${resourceName}`);
-  };
-
-  const getMetricsWindow = () => metricsWindow;
-  const getMetricsWindowDisplayText = () => validMetricsWindows[metricsWindow];
-
-  const setMetricsWindow = window => {
-    if (!validMetricsWindows[window]) { return; }
-    metricsWindow = window;
   };
 
   const urlsForResource = (type, namespace, includeTcp) => {
@@ -184,6 +184,8 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     });
   };
 
+  const prefixLink = to => `${pathPrefix}${to}`;
+
   // prefix all links in the app with `pathPrefix`
   const PrefixedLink = ({ to, targetBlank, children }) => {
     const url = prefixLink(to);
@@ -206,8 +208,6 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   PrefixedLink.defaultProps = {
     targetBlank: false,
   };
-
-  const prefixLink = to => `${pathPrefix}${to}`;
 
   const generateResourceURL = r => {
     if (r.type === 'namespace') {

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -11,6 +11,13 @@ import _reduce from 'lodash/reduce';
 import _size from 'lodash/size';
 import _values from 'lodash/values';
 
+const srArcClassLabels = {
+  good: 'good',
+  warning: 'warning',
+  poor: 'poor',
+  default: 'default',
+};
+
 export const getSuccessRateClassification = (rate, successRateLabels = srArcClassLabels) => {
   if (_isNull(rate)) {
     return successRateLabels.default;
@@ -23,13 +30,6 @@ export const getSuccessRateClassification = (rate, successRateLabels = srArcClas
   } else {
     return successRateLabels.good;
   }
-};
-
-const srArcClassLabels = {
-  good: 'good',
-  warning: 'warning',
-  poor: 'poor',
-  default: 'default',
 };
 
 const getTotalRequests = row => {
@@ -154,17 +154,6 @@ export const processTopRoutesResults = rows => {
   ));
 };
 
-export const processSingleResourceRollup = (rawMetrics, resourceType) => {
-  const result = processMultiResourceRollup(rawMetrics, resourceType);
-  if (_size(result) > 1) {
-    console.error('Multi metric returned; expected single metric.');
-  }
-  if (_isEmpty(result)) {
-    return [];
-  }
-  return _values(result)[0];
-};
-
 export const processMultiResourceRollup = (rawMetrics, resourceType) => {
   if (_isEmpty(rawMetrics.ok) || _isEmpty(rawMetrics.ok.statTables)) {
     return {};
@@ -194,6 +183,17 @@ export const processMultiResourceRollup = (rawMetrics, resourceType) => {
     metricsByResource[resource] = processStatTable(table);
   });
   return metricsByResource;
+};
+
+export const processSingleResourceRollup = (rawMetrics, resourceType) => {
+  const result = processMultiResourceRollup(rawMetrics, resourceType);
+  if (_size(result) > 1) {
+    console.error('Multi metric returned; expected single metric.');
+  }
+  if (_isEmpty(result)) {
+    return [];
+  }
+  return _values(result)[0];
 };
 
 export const groupResourcesByNs = apiRsp => {

--- a/web/app/js/components/util/Utils.js
+++ b/web/app/js/components/util/Utils.js
@@ -25,14 +25,6 @@ export const formatWithComma = m => {
   }
 };
 
-export const formatLatencyMs = m => {
-  if (_isNil(m)) {
-    return '---';
-  } else {
-    return `${formatLatencySec(m / 1000)}`;
-  }
-};
-
 const niceLatency = l => commaFormatter(Math.round(l));
 
 export const formatLatencySec = latency => {
@@ -50,13 +42,12 @@ export const formatLatencySec = latency => {
   }
 };
 
-export const metricToFormatter = {
-  REQUEST_RATE: m => _isNil(m) ? '---' : styleNum(m, ' RPS', true),
-  SUCCESS_RATE: m => _isNil(m) ? '---' : successRateFormatter(m),
-  LATENCY: formatLatencyMs,
-  UNTRUNCATED: m => styleNum(m, '', false),
-  BYTES: m => _isNil(m) ? '---' : styleNum(m, 'B/s', true),
-  NO_UNIT: m => _isNil(m) ? '---' : styleNum(m, '', true),
+export const formatLatencyMs = m => {
+  if (_isNil(m)) {
+    return '---';
+  } else {
+    return `${formatLatencySec(m / 1000)}`;
+  }
 };
 
 /*
@@ -107,6 +98,15 @@ export const styleNum = (number, unit = '', truncate = true) => {
   }
 };
 
+export const metricToFormatter = {
+  REQUEST_RATE: m => _isNil(m) ? '---' : styleNum(m, ' RPS', true),
+  SUCCESS_RATE: m => _isNil(m) ? '---' : successRateFormatter(m),
+  LATENCY: formatLatencyMs,
+  UNTRUNCATED: m => styleNum(m, '', false),
+  BYTES: m => _isNil(m) ? '---' : styleNum(m, 'B/s', true),
+  NO_UNIT: m => _isNil(m) ? '---' : styleNum(m, '', true),
+};
+
 /*
 * Convert a string to a valid css class name
 */
@@ -123,6 +123,15 @@ export const regexFilterString = input => {
   input = input.replace(/[^A-Z0-9/.\-_*]/gi, '').toLowerCase();
   // replace "*" in input with wildcard
   return new RegExp(input.replace(/[*]/g, '.+'));
+};
+
+/*
+  Get a singular resource name from a plural resource
+*/
+export const singularResource = resource => {
+  if (resource === 'authorities') {
+    return 'authority';
+  } else { return resource.replace(/s$/, ''); }
 };
 
 /*
@@ -152,15 +161,6 @@ export const friendlyTitle = singularOrPluralResource => {
     titles.plural = `${titles.singular}s`;
   }
   return titles;
-};
-
-/*
-  Get a singular resource name from a plural resource
-*/
-export const singularResource = resource => {
-  if (resource === 'authorities') {
-    return 'authority';
-  } else { return resource.replace(/s$/, ''); }
 };
 
 /*


### PR DESCRIPTION
This is a follow-up to #3882, which adopted a bunch of new linting rules
in our Javascript codebase. The [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define) rule requires
moving some functions around, so I'm doing it in a separate branch.

Note that I was originally going to also enable the react/sort-comp rule
as part of this branch, but I decided that the sort ordering doesn't
work for our codebase.

Signed-off-by: Kevin Lingerfelt <kl@buoyant.io>