### PR TITLE
edge-20.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,13 @@
 ## edge-20.1.2
 
-**Note**: The `linkerd-proxy` version included with this release is more
-experimental than usual. We'd love your help testing, but be aware that there
-might be stability issues.
-
 * CLI
   * Added HA specific checks to `linkerd check` to ensure that the `kube-system`
     namespace has the `config.linkerd.io/admission-webhooks:disabled`
     label set
-  * Fixed a problem causing the presence of unnecessary fields in
+  * Fixed a problem causing the presence of unnecessary empty fields in
     generated resource definitions (thanks @mayankshah1607)
+* Proxy
+  * Fixed an issue that could cause the OpenCensus exporter to stall
 * Internal
   * Added validation to incoming sidecar injection requests that ensures
     the value of `linkerd.io/inject` is either `enabled` or `disabled`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+## edge-20.1.2
+
+**Note**: The `linkerd-proxy` version included with this release is more
+experimental than usual. We'd love your help testing, but be aware that there
+might be stability issues.
+
+* CLI
+  * Added HA specific checks to `linkerd check` to ensure that the `kube-system`
+    namespace has the `config.linkerd.io/admission-webhooks:disabled`
+    annotation set
+  * Fixed a problem causing the presence of unnecessary fields in
+    generated resource definitions (thanks @mayankshah1607)
+* Internal
+  * Added validation to incoming sidecar injection requests that ensures
+    the value of `linkerd.io/inject` is either `enabled` or `disabled`
+    (thanks @mayankshah1607)
+    
 ## edge-20.1.1
 
 This edge release includes experimental improvements to the Linkerd proxy's

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ might be stability issues.
 * CLI
   * Added HA specific checks to `linkerd check` to ensure that the `kube-system`
     namespace has the `config.linkerd.io/admission-webhooks:disabled`
-    annotation set
+    label set
   * Fixed a problem causing the presence of unnecessary fields in
     generated resource definitions (thanks @mayankshah1607)
 * Internal

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -7,7 +7,7 @@ ignoreInboundPorts: ""
 ignoreOutboundPorts: ""
 createdByAnnotation: linkerd.io/created-by
 cniPluginImage:   "gcr.io/linkerd-io/cni-plugin"
-cniPluginVersion: edge-20.1.1
+cniPluginVersion: edge-20.1.2
 logLevel:         info
 portsToRedirect:  ""
 proxyUID:         2102

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-20.1.1
+  linkerdVersion: &linkerd_version edge-20.1.2
 
   namespace: linkerd
 


### PR DESCRIPTION
## edge-20.1.2

* CLI
  * Added HA specific checks to `linkerd check` to ensure that the `kube-system`
    namespace has the `config.linkerd.io/admission-webhooks:disabled`
    label set
  * Fixed a problem causing the presence of unnecessary empty fields in
    generated resource definitions (thanks @mayankshah1607)
* Proxy
  * Fixed an issue that could cause the OpenCensus exporter to stall
* Internal
  * Added validation to incoming sidecar injection requests that ensures
    the value of `linkerd.io/inject` is either `enabled` or `disabled`
    (thanks @mayankshah1607)
    
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
