### PR TITLE
proxy: v2.84.0

### DIFF
--- a/.proxy-version
+++ b/.proxy-version
@@ -1,1 +1,1 @@
-v2.83.0-experimental
+v2.84.0


### PR DESCRIPTION
This release fixes an issue that could cause the OpenCensus exporter to
stall.

This release does NOT include the experimental changes from
v2.83.0-experimental.

---

* http: Use the endpoint type to inform URI normalization (linkerd/linkerd2-proxy#404)
* Remove clone in opencensus exporter to ensure task is notified (linkerd/linkerd2-proxy#405)