### PR TITLE
cli: Update 'check' command to validate HA configuration

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -166,6 +166,15 @@ const HintBaseURL = "https://linkerd.io/checks/#"
 // TODO: Make this default value overridiable, e.g. by CLI flag
 const AllowedClockSkew = time.Minute + tls.DefaultClockSkewAllowance
 
+var linkerdHAControlPlaneComponents = []string{
+	"linkerd-controller",
+	"linkerd-destination",
+	"linkerd-identity",
+	"linkerd-proxy-injector",
+	"linkerd-sp-validator",
+	"linkerd-tap",
+}
+
 var (
 	retryWindow    = 5 * time.Second
 	requestTimeout = 30 * time.Second
@@ -1167,9 +1176,34 @@ func (hc *HealthChecker) allCategories() []category {
 						return &SkipError{Reason: "not run for non HA installs"}
 					},
 				},
+				{
+					description: "multiple replicas of control plane pods",
+					hintAnchor:  "l5d-control-plane-replicas",
+					warning:     true,
+					check: func(ctx context.Context) error {
+						if hc.isHA() {
+							return hc.controlPlaneComponentsAreHA()
+						}
+						return &SkipError{Reason: "not run for non HA installs"}
+					},
+				},
 			},
 		},
 	}
+}
+
+func (hc *HealthChecker) controlPlaneComponentsAreHA() error {
+	for _, component := range linkerdHAControlPlaneComponents {
+		conf, err := hc.kubeAPI.AppsV1().Deployments(hc.ControlPlaneNamespace).Get(component, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if conf.Status.AvailableReplicas <= 1 {
+			return fmt.Errorf("not enough replicas available for %s", component)
+		}
+	}
+	return nil
 }
 
 func (hc *HealthChecker) issuerIdentity() string {


### PR DESCRIPTION
This PR addresses https://github.com/linkerd/linkerd2/issues/3505

Checks are added to validate the following properties of HA:
- [x] The control plane components (except, for web, grafana and prometheus) should have more than one replicas.
- [x] ~~The replicated pods should be scheduled on different hosts.~~ (Not required anymore)
- [x] ~~The MWC and VWC's FailurePolicy should be set to Fail to prevent uninjected workloads from entering the service mesh.~~ (Not required anymore)
- [x] ~~The control plane components are assigned CPU and memory resource requirements.~~ (Not required anymore)

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
