### PR TITLE
Utilize Common Name or Subject Alternate Name for access checks (#3459)

### DIFF
--- a/controller/tap/apiserver.go
+++ b/controller/tap/apiserver.go
@@ -87,8 +87,7 @@ func NewAPIServer(
 // ServeHTTP handles all routes for the APIServer.
 func (a *apiServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	a.log.Debugf("ServeHTTP(): %+v", req)
-	err := a.validate(req)
-	if err != nil {
+	if err := a.validate(req); err != nil {
 		a.log.Debug(err)
 		renderJSONError(w, err, http.StatusBadRequest)
 	} else {


### PR DESCRIPTION
**Subject**
Utilize Common Name or Subject Alternate Name for access checks (#3459)

**Problem**
When access restrictions to API server have been enabled with the `requestheader-allowed-names` configuration, only the _Common Name_ of the requestor certificate is being checked.  This check should include the use of _Subject Alternate Name_ attributes.

**Solution**
API server will now check the SAN attributes (DNS Names, Email Addresses, IP Addresses, and URIs) when determining accessibility for allowed names.

Fixes issue #3459 
