### PR TITLE
Add `as-group` CLI flag

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -185,6 +185,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		KubeConfig:            kubeconfigPath,
 		KubeContext:           kubeContext,
 		Impersonate:           impersonate,
+		ImpersonateGroup:      impersonateGroup,
 		APIAddr:               apiAddr,
 		VersionOverride:       options.versionOverride,
 		RetryDeadline:         time.Now().Add(options.wait),

--- a/cli/cmd/dashboard.go
+++ b/cli/cmd/dashboard.go
@@ -71,7 +71,7 @@ func newCmdDashboard() *cobra.Command {
 			// ensure we can connect to the public API before starting the proxy
 			checkPublicAPIClientOrRetryOrExit(time.Now().Add(options.wait), true)
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/install-sp.go
+++ b/cli/cmd/install-sp.go
@@ -22,7 +22,7 @@ This command installs Service Profiles into the Linkerd control plane. A
 cluster-wide Linkerd control-plane is a prerequisite. To confirm Service Profile
 support, verify "kubectl api-versions" outputs "linkerd.io/v1alpha2".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -853,6 +853,7 @@ func errAfterRunningChecks(options *installOptions) error {
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
 		Impersonate:           impersonate,
+		ImpersonateGroup:      impersonateGroup,
 		KubeContext:           kubeContext,
 		APIAddr:               apiAddr,
 		NoInitContainer:       options.noInitContainer,
@@ -894,7 +895,7 @@ func errAfterRunningChecks(options *installOptions) error {
 }
 
 func errIfLinkerdConfigConfigMapExists() error {
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return err
 	}
@@ -1022,7 +1023,7 @@ func (idopts *installIdentityOptions) genValues() (*identityWithAnchorsAndTrustD
 
 func (idopts *installIdentityOptions) readExternallyManaged() (*identityWithAnchorsAndTrustDomain, error) {
 
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching external issuer config: %s", err)
 	}

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -144,8 +144,8 @@ func getControlPlaneComponentsAndContainers(pods *corev1.PodList) ([]string, []s
 	return controlPlaneComponents, containers
 }
 
-func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext, impersonate string) (*logCmdConfig, error) {
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+func newLogCmdConfig(options *logsOptions, kubeconfigPath, kubeContext, impersonate string, impersonateGroup []string) (*logCmdConfig, error) {
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func newCmdLogs() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			color.NoColor = options.noColor
 
-			opts, err := newLogCmdConfig(options, kubeconfigPath, kubeContext, impersonate)
+			opts, err := newLogCmdConfig(options, kubeconfigPath, kubeContext, impersonate, impersonateGroup)
 
 			if err != nil {
 				return err

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -93,7 +93,7 @@ func newCmdMetrics() *cobra.Command {
   )`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -100,7 +100,7 @@ func newCmdProfile() *cobra.Command {
 				return err
 			}
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -21,7 +21,7 @@ func rawPublicAPIClient() (pb.ApiClient, error) {
 		return public.NewInternalClient(controlPlaneNamespace, apiAddr)
 	}
 
-	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +62,7 @@ func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time) 
 		KubeConfig:            kubeconfigPath,
 		KubeContext:           kubeContext,
 		Impersonate:           impersonate,
+		ImpersonateGroup:      impersonateGroup,
 		APIAddr:               apiAddr,
 		RetryDeadline:         retryDeadline,
 	})

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -43,6 +43,7 @@ var (
 	kubeconfigPath        string
 	kubeContext           string
 	impersonate           string
+	impersonateGroup      []string
 	verbose               bool
 
 	// These regexs are not as strict as they could be, but are a quick and dirty
@@ -96,6 +97,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 	RootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "Name of the kubeconfig context to use")
 	RootCmd.PersistentFlags().StringVar(&impersonate, "as", "", "Username to impersonate for Kubernetes operations")
+	RootCmd.PersistentFlags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "Group to impersonate for Kubernetes operations")
 	RootCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -191,7 +191,7 @@ func newCmdTap() *cobra.Command {
 				return err
 			}
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -346,7 +346,7 @@ func newCmdTop() *cobra.Command {
 				return err
 			}
 
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -175,7 +175,7 @@ func upgradeRunE(options *upgradeOptions, stage string, flags *pflag.FlagSet) er
 			upgradeErrorf("Failed to parse Kubernetes objects from manifest %s: %s", options.manifests, err)
 		}
 	} else {
-		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 		if err != nil {
 			upgradeErrorf("Failed to create a kubernetes client: %s", err)
 		}

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -160,7 +160,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 
 	if namespace != "" && podName != "" {
-		client, err := k8s.NewAPI(conf.Kubernetes.Kubeconfig, "linkerd-cni-context", "", 0)
+		client, err := k8s.NewAPI(conf.Kubernetes.Kubeconfig, "linkerd-cni-context", "", []string{}, 0)
 		if err != nil {
 			return err
 		}

--- a/controller/cmd/heartbeat/main.go
+++ b/controller/cmd/heartbeat/main.go
@@ -38,7 +38,7 @@ func Main(args []string) {
 	v.Set("version", version.Version)
 	v.Set("source", "heartbeat")
 
-	kubeAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", 0)
+	kubeAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", []string{}, 0)
 	if err != nil {
 		log.Errorf("Failed to initialize k8s API: %s", err)
 	} else {

--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -127,7 +127,7 @@ func Main(args []string) {
 	//
 	// Create k8s API
 	//
-	k8sAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", 0)
+	k8sAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", []string{}, 0)
 	if err != nil {
 		log.Fatalf("Failed to load kubeconfig: %s: %s", *kubeConfigPath, err)
 	}

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -89,7 +89,7 @@ type API struct {
 
 // InitializeAPI creates Kubernetes clients and returns an initialized API wrapper.
 func InitializeAPI(kubeConfig string, resources ...APIResource) (*API, error) {
-	k8sClient, err := k8s.NewAPI(kubeConfig, "", "", 0)
+	k8sClient, err := k8s.NewAPI(kubeConfig, "", "", []string{}, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -304,6 +304,7 @@ type Options struct {
 	KubeConfig            string
 	KubeContext           string
 	Impersonate           string
+	ImpersonateGroup      []string
 	APIAddr               string
 	VersionOverride       string
 	RetryDeadline         time.Time
@@ -373,7 +374,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "k8s-api",
 					fatal:       true,
 					check: func(context.Context) (err error) {
-						hc.kubeAPI, err = k8s.NewAPI(hc.KubeConfig, hc.KubeContext, hc.Impersonate, requestTimeout)
+						hc.kubeAPI, err = k8s.NewAPI(hc.KubeConfig, hc.KubeContext, hc.Impersonate, hc.ImpersonateGroup, requestTimeout)
 						return
 					},
 				},

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -38,7 +38,7 @@ type KubernetesAPI struct {
 
 // NewAPI validates a Kubernetes config and returns a client for accessing the
 // configured cluster.
-func NewAPI(configPath, kubeContext string, impersonate string, timeout time.Duration) (*KubernetesAPI, error) {
+func NewAPI(configPath, kubeContext string, impersonate string, impersonateGroup []string, timeout time.Duration) (*KubernetesAPI, error) {
 	config, err := GetConfig(configPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %v", err)
@@ -54,6 +54,7 @@ func NewAPI(configPath, kubeContext string, impersonate string, timeout time.Dur
 	if impersonate != "" {
 		config.Impersonate = rest.ImpersonationConfig{
 			UserName: impersonate,
+			Groups:   impersonateGroup,
 		}
 	}
 

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -278,7 +278,7 @@ func (h *KubernetesHelper) ParseNamespacedResource(resource string) (string, str
 // tests can use for access to the given deployment. Note that the port-forward
 // remains running for the duration of the test.
 func (h *KubernetesHelper) URLFor(namespace, deployName string, remotePort int) (string, error) {
-	k8sAPI, err := k8s.NewAPI("", h.k8sContext, "", 0)
+	k8sAPI, err := k8s.NewAPI("", h.k8sContext, "", []string{}, 0)
 	if err != nil {
 		return "", err
 	}

--- a/web/main.go
+++ b/web/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.Warnf("failed to load cluster domain from global config: [%s] (falling back to %s)", err, clusterDomain)
 	}
 
-	k8sAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", 0)
+	k8sAPI, err := k8s.NewAPI(*kubeConfigPath, "", "", []string{}, 0)
 	if err != nil {
 		log.Fatalf("failed to construct Kubernetes API client: [%s]", err)
 	}


### PR DESCRIPTION
This PR addresses https://github.com/linkerd/linkerd2/issues/3914

- Add CLI flag `--as-group` that can impersonate group for k8s
operations

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
