### PR TITLE
Fix helm list of ports not rendering correctly

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -30,22 +30,10 @@
     "port": {{.Values.global.proxy.ports.control}}
   },
   "ignoreInboundPorts":[
-    {{- $ports := splitList "," .Values.global.proxyInit.ignoreInboundPorts -}}
-    {{- if (and (gt (len $ports) 0) (ne (first $ports) "")) }}
-    {{- $last := sub (len $ports) 1 -}}
-    {{- range $i,$port := $ports -}}
-    {"port":{{$port}}}{{ternary "," "" (ne $i $last)}}
-    {{- end -}}
-    {{- end -}}
+    {{- include "partials.splitStringListToPorts" .Values.global.proxyInit.ignoreInboundPorts -}}
   ],
   "ignoreOutboundPorts":[
-    {{- $ports := splitList "," .Values.global.proxyInit.ignoreOutboundPorts -}}
-    {{- if (and (gt (len $ports) 0) (ne (first $ports) "")) }}
-    {{- $last := sub (len $ports) 1 -}}
-    {{- range $i,$port := $ports -}}
-    {"port":{{$port}}}{{ternary "," "" (ne $i $last)}}
-    {{- end -}}
-    {{- end -}}
+    {{- include "partials.splitStringListToPorts" .Values.global.proxyInit.ignoreOutboundPorts -}}
   ],
   "inboundPort":{
     "port": {{.Values.global.proxy.ports.inbound}}

--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -31,7 +31,7 @@
   },
   "ignoreInboundPorts":[
     {{- $ports := splitList "," .Values.global.proxyInit.ignoreInboundPorts -}}
-    {{- if gt (len $ports) 1}}
+    {{- if (and (gt (len $ports) 0) (ne (first $ports) "")) }}
     {{- $last := sub (len $ports) 1 -}}
     {{- range $i,$port := $ports -}}
     {"port":{{$port}}}{{ternary "," "" (ne $i $last)}}
@@ -40,7 +40,7 @@
   ],
   "ignoreOutboundPorts":[
     {{- $ports := splitList "," .Values.global.proxyInit.ignoreOutboundPorts -}}
-    {{- if gt (len $ports) 1}}
+    {{- if (and (gt (len $ports) 0) (ne (first $ports) "")) }}
     {{- $last := sub (len $ports) 1 -}}
     {{- range $i,$port := $ports -}}
     {"port":{{$port}}}{{ternary "," "" (ne $i $last)}}

--- a/charts/partials/templates/_helpers.tpl
+++ b/charts/partials/templates/_helpers.tpl
@@ -44,3 +44,18 @@ For example "11,22,55,44" will become "11","22","55","44"
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Splits a coma separated list into a list of port objects.
+For example "11,22,55" will become{"port":11},{"port":22},
+{"port":55}
+*/}}
+{{- define "partials.splitStringListToPorts" -}}
+{{- if gt (len .) 0 -}}
+{{- $ports := splitList "," . -}}
+{{- $last := sub (len $ports) 1 -}}
+{{- range $i,$port := $ports -}}
+{"port":{{$port}}}{{ternary "," "" (ne $i $last)}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -23,13 +23,13 @@ func TestRenderHelm(t *testing.T) {
 
 	t.Run("Non-HA mode", func(t *testing.T) {
 		ha := false
-		chartControlPlane := chartControlPlane(t, ha)
+		chartControlPlane := chartControlPlane(t, ha, "111", "222")
 		testRenderHelm(t, chartControlPlane, "install_helm_output.golden")
 	})
 
 	t.Run("HA mode", func(t *testing.T) {
 		ha := true
-		chartControlPlane := chartControlPlane(t, ha)
+		chartControlPlane := chartControlPlane(t, ha, "111", "222")
 		testRenderHelm(t, chartControlPlane, "install_helm_output_ha.golden")
 	})
 }
@@ -120,8 +120,8 @@ func testRenderHelm(t *testing.T, chart *pb.Chart, goldenFileName string) {
 	diffTestdata(t, goldenFileName, buf.String())
 }
 
-func chartControlPlane(t *testing.T, ha bool) *pb.Chart {
-	values, err := readTestValues(t, ha)
+func chartControlPlane(t *testing.T, ha bool, ignoreOutboundPorts string, ignoreInboundPorts string) *pb.Chart {
+	values, err := readTestValues(t, ha, ignoreOutboundPorts, ignoreInboundPorts)
 	if err != nil {
 		t.Fatal("Unexpected error", err)
 	}
@@ -194,11 +194,13 @@ func chartPartials(t *testing.T, paths []string) *pb.Chart {
 	return chart
 }
 
-func readTestValues(t *testing.T, ha bool) ([]byte, error) {
+func readTestValues(t *testing.T, ha bool, ignoreOutboundPorts string, ignoreInboundPorts string) ([]byte, error) {
 	values, err := l5dcharts.NewValues(ha)
 	if err != nil {
 		t.Fatal("Unexpected error", err)
 	}
+	values.Global.ProxyInit.IgnoreOutboundPorts = ignoreOutboundPorts
+	values.Global.ProxyInit.IgnoreInboundPorts = ignoreInboundPorts
 
 	return yaml.Marshal(values)
 }

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -907,8 +907,8 @@ data:
       "controlPort":{
         "port": 4190
       },
-      "ignoreInboundPorts":[],
-      "ignoreOutboundPorts":[],
+      "ignoreInboundPorts":[{"port":222}],
+      "ignoreOutboundPorts":[{"port":111}],
       "inboundPort":{
         "port": 4143
       },
@@ -1133,9 +1133,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1345,9 +1345,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1554,9 +1554,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1813,9 +1813,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2156,9 +2156,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2424,9 +2424,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2622,9 +2622,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2850,9 +2850,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -3066,9 +3066,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -907,8 +907,8 @@ data:
       "controlPort":{
         "port": 4190
       },
-      "ignoreInboundPorts":[],
-      "ignoreOutboundPorts":[],
+      "ignoreInboundPorts":[{"port":222}],
+      "ignoreOutboundPorts":[{"port":111}],
       "inboundPort":{
         "port": 4143
       },
@@ -1166,9 +1166,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1411,9 +1411,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1653,9 +1653,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -1932,9 +1932,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2288,9 +2288,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2569,9 +2569,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -2800,9 +2800,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -3061,9 +3061,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init
@@ -3310,9 +3310,9 @@ spec:
         - --proxy-uid
         - "2102"
         - --inbound-ports-to-ignore
-        - 4190,4191
+        - 4190,4191,222
         - --outbound-ports-to-ignore
-        - "443"
+        - 443,111
         image: gcr.io/linkerd-io/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init


### PR DESCRIPTION
There was a problem that caused helm install to not reflect the proper list of ignored inbound and outbound ports. Namely if you supply just one port, that would not get reflected.

To reproduce do a: 

```
 helm install \
       --name=linkerd2 \
       --set-file global.identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set identity.issuer.crtExpiry=2021-01-14T14:21:43Z \
       --set-string global.proxyInit.ignoreInboundPorts="6666" \
       linkerd-edge/linkerd2
```


Check your config: 

```bash
 $ kubectl get configmap -n linkerd -oyaml | grep ignoreInboundPort
 "ignoreInboundPorts":[],
```
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
