### PR TITLE
[PoC] Get cluster credentials

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+type clusterOptions struct {
+	namespace      string
+	serviceAccount string
+	clusterName    string
+}
+
+func newCmdCluster() *cobra.Command {
+
+	options := clusterOptions{}
+
+	clusterCmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Set up cross-cluster access",
+		Args:  cobra.NoArgs,
+	}
+
+	getCredentialsCmd := &cobra.Command{
+		Use:   "get-credentials",
+		Short: "Get cluster credentials as a secret",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			rules := clientcmd.NewDefaultClientConfigLoadingRules()
+			rules.ExplicitPath = kubeconfigPath
+			overrides := &clientcmd.ConfigOverrides{CurrentContext: kubeContext}
+			loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+
+			config, err := loader.RawConfig()
+			if err != nil {
+				return err
+			}
+
+			k, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, 0)
+			if err != nil {
+				return err
+			}
+
+			sa, err := k.CoreV1().ServiceAccounts(options.namespace).Get(options.serviceAccount, metav1.GetOptions{})
+			if err != nil {
+				return nil
+			}
+
+			var secretName string
+			for _, s := range sa.Secrets {
+				if strings.HasPrefix(s.Name, fmt.Sprintf("%s-token", sa.Name)) {
+					secretName = s.Name
+					break
+				}
+			}
+			if secretName == "" {
+				return fmt.Errorf("Could not find service account token secret for %s", sa.Name)
+			}
+
+			secret, err := k.CoreV1().Secrets(options.namespace).Get(secretName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			token := secret.Data["token"]
+
+			context := config.Contexts[config.CurrentContext]
+			context.AuthInfo = options.serviceAccount
+			config.Contexts = map[string]*api.Context{
+				config.CurrentContext: context,
+			}
+			config.AuthInfos = map[string]*api.AuthInfo{
+				options.serviceAccount: &api.AuthInfo{
+					Token: string(token),
+				},
+			}
+			cluster := config.Clusters[context.Cluster]
+			config.Clusters = map[string]*api.Cluster{
+				context.Cluster: cluster,
+			}
+
+			kubeconfig, err := clientcmd.Write(config)
+			if err != nil {
+				return err
+			}
+
+			creds := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("cluster-credentials-%s", options.clusterName),
+					Namespace: controlPlaneNamespace,
+				},
+				Data: map[string][]byte{
+					"kubeconfig": kubeconfig,
+				},
+			}
+
+			out, err := yaml.Marshal(creds)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+
+			return nil
+		},
+	}
+
+	getCredentialsCmd.Flags().StringVar(&options.serviceAccount, "service-account", "linkerd-mirror", "service account")
+	getCredentialsCmd.Flags().StringVarP(&options.namespace, "namespace", "n", "linkerd", "service account namespace")
+	getCredentialsCmd.Flags().StringVar(&options.clusterName, "cluster-name", "remote", "cluster name")
+
+	clusterCmd.AddCommand(getCredentialsCmd)
+
+	return clusterCmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 
 	RootCmd.AddCommand(newCmdCheck())
+	RootCmd.AddCommand(newCmdCluster())
 	RootCmd.AddCommand(newCmdCompletion())
 	RootCmd.AddCommand(newCmdDashboard())
 	RootCmd.AddCommand(newCmdDoc())


### PR DESCRIPTION
This is a proof of concept to demonstrate how it's possible to get credentials for a service account from a Kubernetes cluster in the form of a Kubeconfig secret.  This secret could then be created in a different Kubernetes cluster to allow cross-cluster API requests.

Steps:

1. Create a service account called `linkerd-mirror` with RBAC to list services:

```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: linkerd
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: linkerd-mirror
rules:
- apiGroups:
  - ""
  resources:
  - services
  verbs:
  - list
---
kind: ServiceAccount
apiVersion: v1
metadata:
  name: linkerd-mirror
  namespace: linkerd
  labels:
    linkerd.io/control-plane-component: mirror
    linkerd.io/control-plane-ns: linkerd
---
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:
    linkerd.io/control-plane-component: mirror
    linkerd.io/control-plane-ns: linkerd
  name: linkerd-mirror
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: linkerd-mirror
subjects:
- kind: ServiceAccount
  name: linkerd-mirror
  namespace: linkerd
```

2. Run `linkerd cluster get-credentials`.  This outputs a secret containing the Kubeconfig.

3. Verify the Kubeconfig has the desired RBAC:

```
linkerd cluster get-credentials | grep kubeconfig | cut -c '15-' | base64 -D - > mirror.kubeconfig
env KUBECONFIG=mirror.kubeconfig kubectl get po # should fail
env KUBECONFIG=mirror.kubeconfig kubectl get svc # should succeed
```

4. Install the secret into another cluster

```
linkerd cluster get-credentials | kubectl --context=my-other-cluster apply -f -
```

5. Mount the secret and use the kubeconfig to make cross-cluster API calls

(left as an exercise to the reader)

Signed-off-by: Alex Leong <alex@buoyant.io>

