### PR TITLE
[PoC] Create cluster credentials

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -4,9 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "k8s.io/api/rbac/v1"
+
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -14,20 +18,81 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-type clusterOptions struct {
+type getCredentialsOptions struct {
 	namespace      string
 	serviceAccount string
 	clusterName    string
 }
 
+type createOptions struct {
+	serviceAccount string
+}
+
 func newCmdCluster() *cobra.Command {
 
-	options := clusterOptions{}
+	getOpts := getCredentialsOptions{}
+	createOpts := createOptions{}
 
 	clusterCmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Set up cross-cluster access",
 		Args:  cobra.NoArgs,
+	}
+
+	createCredentalsCommand := &cobra.Command{
+		Use:   "create-credentials",
+		Short: "Create the necessary credentials for service mirroring",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			labels := map[string]string{
+				k8s.ControllerComponentLabel: "mirror",
+				k8s.ControllerNSLabel:        controlPlaneNamespace,
+			}
+
+			clusterRole := v1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: createOpts.serviceAccount, Namespace: controlPlaneNamespace, Labels: labels},
+				TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"services"},
+						Verbs:     []string{"list"},
+					},
+				},
+			}
+
+			svcAccount := corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: createOpts.serviceAccount, Namespace: controlPlaneNamespace, Labels: labels},
+				TypeMeta:   metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
+			}
+
+			clusterRoleBinding := v1.ClusterRoleBinding{
+				TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: createOpts.serviceAccount, Namespace: controlPlaneNamespace, Labels: labels},
+
+				Subjects: []v1.Subject{
+					v1.Subject{Kind: v1.ServiceAccountKind, Name: createOpts.serviceAccount, Namespace: controlPlaneNamespace},
+				},
+				RoleRef: rbacv1.RoleRef{Kind: "ClusterRole", APIGroup: "rbac.authorization.k8s.io", Name: createOpts.serviceAccount},
+			}
+
+			crOut, err := yaml.Marshal(clusterRole)
+			if err != nil {
+				return err
+			}
+
+			saOut, err := yaml.Marshal(svcAccount)
+			if err != nil {
+				return err
+			}
+			crbOut, err := yaml.Marshal(clusterRoleBinding)
+			if err != nil {
+				return err
+			}
+			fmt.Println(fmt.Sprintf("---\n%s---\n%s---\n%s", crOut, saOut, crbOut))
+			return nil
+		},
 	}
 
 	getCredentialsCmd := &cobra.Command{
@@ -51,7 +116,7 @@ func newCmdCluster() *cobra.Command {
 				return err
 			}
 
-			sa, err := k.CoreV1().ServiceAccounts(options.namespace).Get(options.serviceAccount, metav1.GetOptions{})
+			sa, err := k.CoreV1().ServiceAccounts(getOpts.namespace).Get(getOpts.serviceAccount, metav1.GetOptions{})
 			if err != nil {
 				return nil
 			}
@@ -67,7 +132,7 @@ func newCmdCluster() *cobra.Command {
 				return fmt.Errorf("Could not find service account token secret for %s", sa.Name)
 			}
 
-			secret, err := k.CoreV1().Secrets(options.namespace).Get(secretName, metav1.GetOptions{})
+			secret, err := k.CoreV1().Secrets(getOpts.namespace).Get(secretName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -75,12 +140,12 @@ func newCmdCluster() *cobra.Command {
 			token := secret.Data["token"]
 
 			context := config.Contexts[config.CurrentContext]
-			context.AuthInfo = options.serviceAccount
+			context.AuthInfo = getOpts.serviceAccount
 			config.Contexts = map[string]*api.Context{
 				config.CurrentContext: context,
 			}
 			config.AuthInfos = map[string]*api.AuthInfo{
-				options.serviceAccount: &api.AuthInfo{
+				getOpts.serviceAccount: {
 					Token: string(token),
 				},
 			}
@@ -95,8 +160,9 @@ func newCmdCluster() *cobra.Command {
 			}
 
 			creds := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("cluster-credentials-%s", options.clusterName),
+					Name:      fmt.Sprintf("cluster-credentials-%s", getOpts.clusterName),
 					Namespace: controlPlaneNamespace,
 				},
 				Data: map[string][]byte{
@@ -114,11 +180,14 @@ func newCmdCluster() *cobra.Command {
 		},
 	}
 
-	getCredentialsCmd.Flags().StringVar(&options.serviceAccount, "service-account", "linkerd-mirror", "service account")
-	getCredentialsCmd.Flags().StringVarP(&options.namespace, "namespace", "n", "linkerd", "service account namespace")
-	getCredentialsCmd.Flags().StringVar(&options.clusterName, "cluster-name", "remote", "cluster name")
+	getCredentialsCmd.Flags().StringVar(&getOpts.serviceAccount, "service-account", "linkerd-mirror", "service account")
+	getCredentialsCmd.Flags().StringVarP(&getOpts.namespace, "namespace", "n", "linkerd", "service account namespace")
+	getCredentialsCmd.Flags().StringVar(&getOpts.clusterName, "cluster-name", "remote", "cluster name")
+
+	createCredentalsCommand.Flags().StringVar(&createOpts.serviceAccount, "service-account", "linkerd-mirror", "service account")
 
 	clusterCmd.AddCommand(getCredentialsCmd)
+	clusterCmd.AddCommand(createCredentalsCommand)
 
 	return clusterCmd
 }


### PR DESCRIPTION
A bit of POC expansion on the work @adleong did. Now we can do the following: 

```bash
# Create cluster and namespace
kind create cluster --name cluster-a
kubectl create namespace linkerd

# Create credentials on cluster
$ bin/linkerd cluster create-credentials | kubectl apply -f -
clusterrole.rbac.authorization.k8s.io/linkerd-mirror created
serviceaccount/linkerd-mirror created
clusterrolebinding.rbac.authorization.k8s.io/linkerd-mirror created

# Test credentials work
linkerd cluster get-credentials | grep kubeconfig | cut -c '15-' | base64 -D - > mirror.kubeconfig
export  KUBECONFIG=mirror.kubeconfig

# Accessing pods does not work
$ kubectl get pods --all-namespaces
Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:linkerd:linkerd-mirror" cannot list resource "pods" in API group "" at the cluster scope

# Accessing services works
$ kubectl get svc --all-namespaces
NAMESPACE     NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)                  AGE
default       kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP                  78s
kube-system   kube-dns     ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   76s
```