### PR TITLE
Show traffic split metrics from sources in all namespaces

### DIFF
--- a/controller/api/public/stat_summary.go
+++ b/controller/api/public/stat_summary.go
@@ -453,15 +453,13 @@ func buildRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labe
 }
 
 func buildTrafficSplitRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labelNames model.LabelNames) {
-	// trafficsplit labels are always direction="outbound" with an optional namespace="value" if the -A flag is not used.
-	// if the --from or --to flags were used, we merge an additional ToResource or FromResource label.
-	// trafficsplit metrics results are always grouped by dst_service.
+	// Trafficsplit labels are always direction="outbound". If the --from or --to flags were used,
+	// we merge an additional ToResource or FromResource label. Trafficsplit metrics results are
+	// always grouped by dst_service.
+	// N.b. requests to a traffic split may come from any namespace so we do not do any filtering
+	// by namespace.
 	labels = model.LabelSet{
 		"direction": model.LabelValue("outbound"),
-	}
-
-	if req.Selector.Resource.Namespace != "" {
-		labels["namespace"] = model.LabelValue(req.Selector.Resource.Namespace)
 	}
 
 	switch out := req.Outbound.(type) {


### PR DESCRIPTION
Fixes #3562 

When a pod in one namespace sends traffic to a service which is the apex of a traffic split in another namespace, that traffic is not displayed in the `linkerd stat trafficsplit` output.  This is because when we do a Prometheus query for traffic to the traffic split, we supply a Prometheus label selector to only select traffic sources in the namespace of the traffic split.

Since any pod in any namespace can send traffic to the apex service of a traffic split, we must look at all possible sources of traffic, not just the ones in the same namespace.

Before:

```
$ bin/linkerd stat ts
NAME           APEX     LEAF       WEIGHT   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
webapp-split   webapp   webapp       900m         -     -             -             -             -
webapp-split   webapp   webapp-2     100m         -     -             -             -             -
```

After:

```
$ bin/linkerd stat ts
NAME           APEX     LEAF       WEIGHT   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
webapp-split   webapp   webapp       900m    80.00%   1.4rps          31ms          99ms        2530ms
webapp-split   webapp   webapp-2     100m    60.00%   0.2rps          35ms          93ms          99ms
```

Signed-off-by: Alex Leong <alex@buoyant.io>