### PR TITLE
Temporarily fix flaky integration test

### DIFF
--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -1,10 +1,7 @@
 package egress
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/linkerd/linkerd2/testutil"
@@ -33,6 +30,15 @@ func TestMain(m *testing.M) {
 /// TEST EXECUTION ///
 //////////////////////
 
+// issue: https://github.com/linkerd/linkerd2/issues/2316
+//
+// The response from `http://httpbin.org/get` is non-deterministic--returning
+// either `http://..` or `https://..` for GET requests. As #2316 mentions,
+// this test should not have an external dependency on this endpoint. As a
+// workaround for edge-20.1.3, temporarily disable this test and renable with
+// one that has reliable behavior.
+
+/*
 func TestEgressHttp(t *testing.T) {
 	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
 	if err != nil {
@@ -101,3 +107,4 @@ func TestEgressHttp(t *testing.T) {
 	// Test egress for a domain with fewer than 3 segments.
 	testCase("egress-test-not-www-get", "httpbin.org", "https", "GET")
 }
+*/

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -92,8 +92,8 @@ func TestEgressHttp(t *testing.T) {
 			expectedResponseURL1 := fmt.Sprintf("http://%s/%s", dnsName, strings.ToLower(methodToUse))
 			expectedResponseURL2 := fmt.Sprintf("https://%s/%s", dnsName, strings.ToLower(methodToUse))
 			actualURL := messagePayload["url"]
-			if actualURL != expectedResponseURL1 || actualURL != expectedResponseURL2 {
-				t.Fatalf("Expecting response to say egress sent [%s] request to either URL [%s] or URL [%s], but got [%s]. Response:\n%s\n", methodToUse, expectedResponseURL1, expectedResponseURL2, actualURL, output)
+			if actualURL != expectedResponseURL1 && actualURL != expectedResponseURL2 {
+				t.Fatalf("Expecting response to say egress sent [%s] request to be either URL [%s] or URL [%s], but got [%s]. Response:\n%s\n", methodToUse, expectedResponseURL1, expectedResponseURL2, actualURL, output)
 			}
 		})
 	}

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -1,7 +1,10 @@
 package egress
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/linkerd/linkerd2/testutil"
@@ -13,7 +16,6 @@ import (
 
 var TestHelper *testutil.TestHelper
 
-/*
 var egressHTTPDeployments = []string{
 	"egress-test-https-post",
 	"egress-test-http-post",
@@ -21,7 +23,6 @@ var egressHTTPDeployments = []string{
 	"egress-test-http-get",
 	"egress-test-not-www-get",
 }
-*/
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
@@ -37,10 +38,9 @@ func TestMain(m *testing.M) {
 // The response from `http://httpbin.org/get` is non-deterministic--returning
 // either `http://..` or `https://..` for GET requests. As #2316 mentions,
 // this test should not have an external dependency on this endpoint. As a
-// workaround for edge-20.1.3, temporarily disable this test and renable with
-// one that has reliable behavior.
+// workaround for edge-20.1.3, temporarily expect either `http` or `https` so
+// that the test is not completely disabled.
 
-/*
 func TestEgressHttp(t *testing.T) {
 	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/proxy.yaml")
 	if err != nil {
@@ -89,10 +89,11 @@ func TestEgressHttp(t *testing.T) {
 			var messagePayload map[string]interface{}
 			json.Unmarshal([]byte(payloadText.(string)), &messagePayload)
 
-			expectedResponseURL := fmt.Sprintf("%s://%s/%s", protocolToUse, dnsName, strings.ToLower(methodToUse))
+			expectedResponseURL1 := fmt.Sprintf("http://%s/%s", dnsName, strings.ToLower(methodToUse))
+			expectedResponseURL2 := fmt.Sprintf("https://%s/%s", dnsName, strings.ToLower(methodToUse))
 			actualURL := messagePayload["url"]
-			if actualURL != expectedResponseURL {
-				t.Fatalf("Expecting response to say egress sent [%s] request to URL [%s] but got [%s]. Response:\n%s\n", methodToUse, expectedResponseURL, actualURL, output)
+			if actualURL != expectedResponseURL1 || actualURL != expectedResponseURL2 {
+				t.Fatalf("Expecting response to say egress sent [%s] request to either URL [%s] or URL [%s], but got [%s]. Response:\n%s\n", methodToUse, expectedResponseURL1, expectedResponseURL2, actualURL, output)
 			}
 		})
 	}
@@ -109,4 +110,3 @@ func TestEgressHttp(t *testing.T) {
 	// Test egress for a domain with fewer than 3 segments.
 	testCase("egress-test-not-www-get", "httpbin.org", "https", "GET")
 }
-*/

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -13,6 +13,7 @@ import (
 
 var TestHelper *testutil.TestHelper
 
+/*
 var egressHTTPDeployments = []string{
 	"egress-test-https-post",
 	"egress-test-http-post",
@@ -20,6 +21,7 @@ var egressHTTPDeployments = []string{
 	"egress-test-http-get",
 	"egress-test-not-www-get",
 }
+*/
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()


### PR DESCRIPTION
*From the comment disabling the test*:

#2316

The response from `http://httpbin.org/get` is non-deterministic--returning
either `http://..` or `https://..` for GET requests. As #2316 mentions, this
test should not have an external dependency on this endpoint. As a workaround
for edge-20.1.3, temporarily disable this test and renable with one that has
reliable behavior.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
