### PR TITLE
Use `t.Name()` instead of `t.Name` in tests

### DIFF
--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -102,7 +102,7 @@ func makeEndpointTranslator(t *testing.T) (*mockDestinationGetServer, *endpointT
 		false,
 		"service-name.service-ns",
 		mockGetServer,
-		logging.WithField("test", t.Name),
+		logging.WithField("test", t.Name()),
 	)
 	return mockGetServer, translator
 }

--- a/controller/api/destination/profile_translator_test.go
+++ b/controller/api/destination/profile_translator_test.go
@@ -433,7 +433,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(profile)
@@ -453,7 +453,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(multipleRequestMatches)
@@ -473,7 +473,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(notEnoughRequestMatches)
@@ -489,7 +489,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(multipleResponseMatches)
@@ -509,7 +509,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(notEnoughResponseMatches)
@@ -525,7 +525,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(invalidStatusRange)
@@ -541,7 +541,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(oneSidedStatusRange)
@@ -557,7 +557,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(nil)
@@ -577,7 +577,7 @@ func TestProfileTranslator(t *testing.T) {
 
 		translator := &profileTranslator{
 			stream: mockGetProfileServer,
-			log:    logging.WithField("test", t.Name),
+			log:    logging.WithField("test", t.Name()),
 		}
 
 		translator.Update(profileWithTimeout)

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -97,7 +97,7 @@ spec:
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
-	log := logging.WithField("test", t.Name)
+	log := logging.WithField("test", t.Name())
 
 	k8sAPI.Sync()
 

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -468,7 +468,7 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name))
+			watcher := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()))
 
 			k8sAPI.Sync()
 

--- a/controller/api/destination/watcher/ip_watcher_test.go
+++ b/controller/api/destination/watcher/ip_watcher_test.go
@@ -427,8 +427,8 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			endpoints := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name))
-			watcher := NewIPWatcher(k8sAPI, endpoints, logging.WithField("test", t.Name))
+			endpoints := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()))
+			watcher := NewIPWatcher(k8sAPI, endpoints, logging.WithField("test", t.Name()))
 
 			k8sAPI.Sync()
 

--- a/controller/api/destination/watcher/profile_watcher_test.go
+++ b/controller/api/destination/watcher/profile_watcher_test.go
@@ -72,7 +72,7 @@ spec:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher := NewProfileWatcher(k8sAPI, logging.WithField("test", t.Name))
+			watcher := NewProfileWatcher(k8sAPI, logging.WithField("test", t.Name()))
 
 			k8sAPI.Sync()
 

--- a/controller/api/destination/watcher/traffic_split_watcher_test.go
+++ b/controller/api/destination/watcher/traffic_split_watcher_test.go
@@ -85,7 +85,7 @@ spec:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher := NewTrafficSplitWatcher(k8sAPI, logging.WithField("test", t.Name))
+			watcher := NewTrafficSplitWatcher(k8sAPI, logging.WithField("test", t.Name()))
 
 			k8sAPI.Sync()
 

--- a/controller/tap/handlers_test.go
+++ b/controller/tap/handlers_test.go
@@ -54,7 +54,7 @@ func TestHandleTap(t *testing.T) {
 
 			h := &handler{
 				k8sAPI: k8sAPI,
-				log:    logrus.WithField("test", t.Name),
+				log:    logrus.WithField("test", t.Name()),
 			}
 			recorder := httptest.NewRecorder()
 			h.handleTap(recorder, exp.req, exp.params)


### PR DESCRIPTION
Use `t.Name()` instead of `t.Name` when retrieving the name of tests.
This was causing an error to be added in the log:
```
output: logrus_error="can not add field \"test\"
```

Followup to [comment](https://github.com/linkerd/linkerd2/pull/3965#discussion_r370387990)