### PR TITLE
Refactoring to suppress eslint warnings react/no-did-update-set-state flag

### DIFF
--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -84,7 +84,6 @@
 
     // These rules represent best practices that we're not adhering to, and should be enabled
     "jsx-a11y/click-events-have-key-events": 0,
-    "no-param-reassign": 0,
-    "react/no-did-update-set-state": 1
+    "no-param-reassign": 0
   }
 }

--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -85,6 +85,6 @@
     // These rules represent best practices that we're not adhering to, and should be enabled
     "jsx-a11y/click-events-have-key-events": 0,
     "no-param-reassign": 0,
-    "react/no-did-update-set-state": 0
+    "react/no-did-update-set-state": 1
   }
 }

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -48,7 +48,9 @@ class Namespaces extends React.Component {
     if (!_isEqual(prevProps.match.params.namespace, params.namespace)) {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
-      this.setState(this.getInitialState(params));
+      this.onUpdate(function callback() {
+        this.setState(this.getInitialState(params));
+      });
     }
 
     handlePageVisibility({

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -48,9 +48,7 @@ class Namespaces extends React.Component {
     if (!_isEqual(prevProps.match.params.namespace, params.namespace)) {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
-      this.onUpdate(function callback() {
-        this.setState(this.getInitialState(params));
-      });
+      this.resetState(params);
     }
 
     handlePageVisibility({
@@ -59,6 +57,10 @@ class Namespaces extends React.Component {
       onVisible: () => this.startServerPolling(),
       onHidden: () => this.stopServerPolling(),
     });
+  }
+
+  resetState(params) {
+    this.setState(this.getInitialState(params));
   }
 
   componentWillUnmount() {

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -93,9 +93,7 @@ export class ResourceDetailBase extends React.Component {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
       this.unmeshedSources = {};
-      this.onUpdate(function callback() {
-        this.setState(this.getInitialState(match, pathPrefix));
-      });
+      this.resetState(match, pathPrefix);
     }
 
     handlePageVisibility({
@@ -104,6 +102,10 @@ export class ResourceDetailBase extends React.Component {
       onVisible: () => this.startServerPolling(),
       onHidden: () => this.stopServerPolling(),
     });
+  }
+
+  resetState(match, pathPrefix) {
+    this.setState(this.getInitialState(match, pathPrefix));
   }
 
   componentWillUnmount() {

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -93,7 +93,9 @@ export class ResourceDetailBase extends React.Component {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
       this.unmeshedSources = {};
-      this.setState(this.getInitialState(match, pathPrefix));
+      this.onUpdate(function callback() {
+        this.setState(this.getInitialState(match, pathPrefix));
+      });
     }
 
     handlePageVisibility({

--- a/web/app/js/components/util/withREST.jsx
+++ b/web/app/js/components/util/withREST.jsx
@@ -56,10 +56,12 @@ const withREST = (WrappedComponent, componentPromises, options = {}) => {
 
       // React won't unmount this component when switching resource pages so we need to clear state
       this.stopServerPolling();
-      this.onUpdate(function callback() {
-        this.setState(this.getInitialState());
-      });
+      this.resetState();
       this.startServerPolling(this.props);
+    }
+
+    resetState() {
+      this.setState(this.getInitialState());
     }
 
     componentWillUnmount() {

--- a/web/app/js/components/util/withREST.jsx
+++ b/web/app/js/components/util/withREST.jsx
@@ -56,7 +56,9 @@ const withREST = (WrappedComponent, componentPromises, options = {}) => {
 
       // React won't unmount this component when switching resource pages so we need to clear state
       this.stopServerPolling();
-      this.setState(this.getInitialState());
+      this.onUpdate(function callback() {
+        this.setState(this.getInitialState());
+      });
       this.startServerPolling(this.props);
     }
 


### PR DESCRIPTION
Upon enabling react/no-did-update-set-state flag in .eslintrc , a couple of warnings are raised because it is a
bad practice to use the setState() function within the componentDidUpdate() hook.

The code has been refactored to follow the eslint spec.

Fixes #3928

Signed-off-by: Christy Jacob <christyjacob4@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
