### PR TITLE
Add helm upgrade integration test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        integration_test: [deep, upgrade, helm, custom_domain, external_issuer]
+        integration_test: [deep, upgrade, helm, helm_upgrade, custom_domain, external_issuer]
     name: Cluster setup (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04
     steps:
@@ -213,7 +213,7 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         export KIND_CLUSTER=github-$TAG-${{ matrix.integration_test }}
-        export KUBECONFIG=/tmp/kind-config-$KIND_CLUSTER 
+        export KUBECONFIG=/tmp/kind-config-$KIND_CLUSTER
         export CUSTOM_DOMAIN_CONFIG="test/testdata/custom_cluster_domain_config.yaml"
         # retry cluster creation once in case of port conflict or kubeadm failure
         if [ "${{ matrix.integration_test }}" == "custom_domain" ]
@@ -229,7 +229,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        integration_test: [deep, upgrade, helm, custom_domain, external_issuer]
+        integration_test: [deep, upgrade, helm, helm_upgrade, custom_domain, external_issuer]
     needs: [docker_pull, docker_build, kind_setup]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04
@@ -307,7 +307,7 @@ jobs:
     strategy:
       fail-fast: false # always attempt to cleanup all clusters
       matrix:
-        integration_test: [deep, upgrade, helm, custom_domain, external_issuer]
+        integration_test: [deep, upgrade, helm, helm_upgrade, custom_domain, external_issuer]
     needs: [kind_integration]
     name: Cluster cleanup (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -3,6 +3,11 @@
 # This file is a collection of helper functions for running integration tests.
 # It is used primarily by `bin/test-run` and ci.
 
+# Returns the latest stable verson
+latest_stable() {
+  curl -s https://versioncheck.linkerd.io/version.json | grep -o "stable-[0-9]*.[0-9]*.[0-9]*"
+}
+
 # init_test_run parses input params, initializes global vars, and checks for
 # linkerd and kubectl. Call this prior to calling any of the
 # *_integration_tests() functions.
@@ -172,7 +177,7 @@ install_stable() {
 # $1 - namespace to use for the stable release
 run_upgrade_test() {
     local stable_namespace=$1
-    local stable_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "stable-[0-9]*.[0-9]*.[0-9]*")
+    local stable_version=$(latest_stable)
 
     install_stable $stable_namespace
     run_test "$test_directory/install_test.go" --upgrade-from-version=$stable_version --linkerd-namespace=$stable_namespace
@@ -194,7 +199,7 @@ setup_helm() {
 
 run_helm_upgrade_test() {
     setup_helm
-    local stable_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "stable-[0-9]*.[0-9]*.[0-9]*")
+    local stable_version=$(latest_stable)
     run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-helm \
         --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart="linkerd/linkerd2" --helm-release=$helm_release_name --tiller-ns=$tiller_namespace --upgrade-helm-from-version="$stable_version"
 }

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -42,6 +42,20 @@ upgrade_integration_tests() {
     cleanup
 }
 
+helm_upgrade_integration_tests() {
+    helm_path=$bindir/helm
+    helm_chart="$( cd "$bindir"/.. && pwd )"/charts/linkerd2
+    helm_release_name=$linkerd_namespace-test
+    tiller_namespace=$linkerd_namespace-tiller
+
+    run_helm_upgrade_test
+    exit_on_err 'error testing Helm upgrade'
+    helm_cleanup
+    exit_on_err 'error cleaning up Helm upgrade'
+    # clean the data plane test resources
+    cleanup
+}
+
 helm_integration_tests() {
     helm_path=$bindir/helm
     helm_chart="$( cd "$bindir"/.. && pwd )"/charts/linkerd2
@@ -164,8 +178,8 @@ run_upgrade_test() {
     run_test "$test_directory/install_test.go" --upgrade-from-version=$stable_version --linkerd-namespace=$stable_namespace
 }
 
-run_helm_test() {
-    (
+setup_helm() {
+      (
         set -e
         kubectl --context=$k8s_context create ns $tiller_namespace
         kubectl --context=$k8s_context label ns $tiller_namespace linkerd.io/is-test-helm=true
@@ -173,8 +187,20 @@ run_helm_test() {
         kubectl --context=$k8s_context label clusterrolebinding ${tiller_namespace}:tiller-cluster-admin linkerd.io/is-test-helm=true
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace init --wait
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace dependency update "$helm_chart"
+        "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace repo add linkerd https://helm.linkerd.io/stable
     )
     exit_on_err 'error setting up Helm'
+}
+
+run_helm_upgrade_test() {
+    setup_helm
+    local stable_version=$(curl -s https://versioncheck.linkerd.io/version.json | grep -o "stable-[0-9]*.[0-9]*.[0-9]*")
+    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-helm \
+        --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart="linkerd/linkerd2" --helm-release=$helm_release_name --tiller-ns=$tiller_namespace --upgrade-helm-from-version="$stable_version"
+}
+
+run_helm_test() {
+    setup_helm
     run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-helm \
         --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-release=$helm_release_name --tiller-ns=$tiller_namespace
 }

--- a/bin/test-run
+++ b/bin/test-run
@@ -3,8 +3,9 @@
 # This script executes the full suite of integration tests, in series:
 # 1. upgrade_integration_tests
 # 2. helm_integration_tests
-# 3. deep_integration_tests
-# 4. external_issuer_integration_tests
+# 3. helm_upgrade_integration_tests
+# 4. deep_integration_tests
+# 5. external_issuer_integration_tests
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 

--- a/bin/test-run
+++ b/bin/test-run
@@ -17,6 +17,7 @@ printf 'Testing Linkerd version [%s] namespace [%s] k8s-context [%s]\n' "$linker
 
 upgrade_integration_tests
 helm_integration_tests
+helm_upgrade_integration_tests
 deep_integration_tests
 external_issuer_integration_tests
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/linkerd/linkerd2/pkg/version"
+
 	"github.com/briandowns/spinner"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/mattn/go-isatty"
@@ -17,24 +19,26 @@ import (
 )
 
 type checkOptions struct {
-	versionOverride string
-	preInstallOnly  bool
-	dataPlaneOnly   bool
-	wait            time.Duration
-	namespace       string
-	cniEnabled      bool
-	output          string
+	versionOverride    string
+	preInstallOnly     bool
+	dataPlaneOnly      bool
+	wait               time.Duration
+	namespace          string
+	cniEnabled         bool
+	output             string
+	cliVersionOverride string
 }
 
 func newCheckOptions() *checkOptions {
 	return &checkOptions{
-		versionOverride: "",
-		preInstallOnly:  false,
-		dataPlaneOnly:   false,
-		wait:            300 * time.Second,
-		namespace:       "",
-		cniEnabled:      false,
-		output:          tableOutput,
+		versionOverride:    "",
+		preInstallOnly:     false,
+		dataPlaneOnly:      false,
+		wait:               300 * time.Second,
+		namespace:          "",
+		cniEnabled:         false,
+		output:             tableOutput,
+		cliVersionOverride: "",
 	}
 }
 
@@ -55,6 +59,7 @@ func (options *checkOptions) checkFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("check", pflag.ExitOnError)
 
 	flags.StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
+	flags.StringVar(&options.cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (mostly for testing)")
 	flags.StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json")
 	flags.DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 
@@ -141,6 +146,11 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 	if err != nil {
 		return fmt.Errorf("Validation error when executing check command: %v", err)
 	}
+
+	if options.cliVersionOverride != "" {
+		version.Version = options.cliVersionOverride
+	}
+
 	checks := []healthcheck.CategoryID{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.KubernetesVersionChecks,

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/linkerd/linkerd2/pkg/version"
-
 	"github.com/spf13/pflag"
 
 	"github.com/fatih/color"
@@ -40,7 +38,6 @@ var (
 	failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u00D7")    // ×
 
 	controlPlaneNamespace string
-	cliVersionOverride    string
 	cniNamespace          string
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
@@ -74,11 +71,6 @@ var RootCmd = &cobra.Command{
 	Short: "linkerd manages the Linkerd service mesh",
 	Long:  `linkerd manages the Linkerd service mesh.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-
-		if cliVersionOverride != "" {
-			version.Version = cliVersionOverride
-		}
-
 		// enable / disable logging
 		if verbose {
 			log.SetLevel(log.DebugLevel)
@@ -108,8 +100,6 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "Group to impersonate for Kubernetes operations")
 	RootCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
-	RootCmd.PersistentFlags().StringVar(&cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (mostly for testing)")
-
 	RootCmd.AddCommand(newCmdCheck())
 	RootCmd.AddCommand(newCmdCompletion())
 	RootCmd.AddCommand(newCmdDashboard())

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/linkerd/linkerd2/pkg/version"
+
 	"github.com/spf13/pflag"
 
 	"github.com/fatih/color"
@@ -38,6 +40,7 @@ var (
 	failStatus = color.New(color.FgRed, color.Bold).SprintFunc()("\u00D7")    // ×
 
 	controlPlaneNamespace string
+	cliVersionOverride    string
 	cniNamespace          string
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
@@ -71,6 +74,11 @@ var RootCmd = &cobra.Command{
 	Short: "linkerd manages the Linkerd service mesh",
 	Long:  `linkerd manages the Linkerd service mesh.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+
+		if cliVersionOverride != "" {
+			version.Version = cliVersionOverride
+		}
+
 		// enable / disable logging
 		if verbose {
 			log.SetLevel(log.DebugLevel)
@@ -100,6 +108,7 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "Group to impersonate for Kubernetes operations")
 	RootCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 	RootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
+	RootCmd.PersistentFlags().StringVar(&cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (mostly for testing)")
 
 	RootCmd.AddCommand(newCmdCheck())
 	RootCmd.AddCommand(newCmdCompletion())

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -331,6 +331,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 }
 
+// These need to be updated (if there are changes) once a new stable is released
 func helmOverridesStable(root *tls.CA) []string {
 	return []string{
 		"--set", "Namespace=" + TestHelper.GetLinkerdNamespace(),
@@ -345,6 +346,7 @@ func helmOverridesStable(root *tls.CA) []string {
 	}
 }
 
+// These need to correspond to the flags in the current edge
 func helmOverridesEdge(root *tls.CA) []string {
 	return []string{
 		"--set", "controllerLogLevel=debug",

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -34,6 +34,8 @@ func TestMain(m *testing.M) {
 var (
 	configMapUID string
 
+	helmTLSCerts *tls.CA
+
 	linkerdSvcs = []string{
 		"linkerd-controller-api",
 		"linkerd-dst",
@@ -329,18 +331,22 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 }
 
-func TestInstallHelm(t *testing.T) {
-	if TestHelper.GetHelmReleaseName() == "" {
-		return
+func helmOverridesStable(root *tls.CA) []string {
+	return []string{
+		"--set", "Namespace=" + TestHelper.GetLinkerdNamespace(),
+		"--set", "ControllerLogLevel=debug",
+		"--set", "LinkerdVersion=" + TestHelper.UpgradeHelmFromVersion(),
+		"--set", "Proxy.Image.Version=" + TestHelper.UpgradeHelmFromVersion(),
+		"--set", "Identity.TrustDomain=cluster.local",
+		"--set", "Identity.TrustAnchorsPEM=" + root.Cred.Crt.EncodeCertificatePEM(),
+		"--set", "Identity.Issuer.TLS.CrtPEM=" + root.Cred.Crt.EncodeCertificatePEM(),
+		"--set", "Identity.Issuer.TLS.KeyPEM=" + root.Cred.EncodePrivateKeyPEM(),
+		"--set", "Identity.Issuer.CrtExpiry=" + root.Cred.Crt.Certificate.NotAfter.Format(time.RFC3339),
 	}
+}
 
-	cn := fmt.Sprintf("identity.%s.cluster.local", TestHelper.GetLinkerdNamespace())
-	root, err := tls.GenerateRootCAWithDefaults(cn)
-	if err != nil {
-		t.Fatalf("failed to generate root certificate for identity: %s", err)
-	}
-
-	args := []string{
+func helmOverridesEdge(root *tls.CA) []string {
+	return []string{
 		"--set", "controllerLogLevel=debug",
 		"--set", "global.linkerdVersion=" + TestHelper.GetVersion(),
 		"--set", "global.proxy.image.version=" + TestHelper.GetVersion(),
@@ -350,7 +356,32 @@ func TestInstallHelm(t *testing.T) {
 		"--set", "identity.issuer.tls.keyPEM=" + root.Cred.EncodePrivateKeyPEM(),
 		"--set", "identity.issuer.crtExpiry=" + root.Cred.Crt.Certificate.NotAfter.Format(time.RFC3339),
 	}
-	if stdout, stderr, err := TestHelper.HelmRun("install", args...); err != nil {
+}
+
+func TestInstallHelm(t *testing.T) {
+	if TestHelper.GetHelmReleaseName() == "" {
+		return
+	}
+
+	cn := fmt.Sprintf("identity.%s.cluster.local", TestHelper.GetLinkerdNamespace())
+	var err error
+	helmTLSCerts, err = tls.GenerateRootCAWithDefaults(cn)
+	if err != nil {
+		t.Fatalf("failed to generate root certificate for identity: %s", err)
+	}
+
+	var chartToInstall string
+	args := []string{"--name", TestHelper.GetHelmReleaseName()}
+
+	if TestHelper.UpgradeHelmFromVersion() != "" {
+		chartToInstall = TestHelper.GetHelmStableChart()
+		args = append(args, helmOverridesStable(helmTLSCerts)...)
+	} else {
+		chartToInstall = TestHelper.GetHelmChart()
+		args = append(args, helmOverridesEdge(helmTLSCerts)...)
+	}
+
+	if stdout, stderr, err := TestHelper.HelmInstall(chartToInstall, args...); err != nil {
 		t.Fatalf("helm install command failed\n%s\n%s", stdout, stderr)
 	}
 }
@@ -380,6 +411,29 @@ func TestResourcesPostInstall(t *testing.T) {
 	}
 }
 
+func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
+	if TestHelper.UpgradeHelmFromVersion() == "" {
+		t.Skip("Skipping as this is not a helm upgrade test")
+	}
+	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion())
+}
+
+func TestUpgradeHelm(t *testing.T) {
+	if TestHelper.UpgradeHelmFromVersion() == "" {
+		t.Skip("Skipping as this is not a helm upgrade test")
+	}
+
+	args := []string{
+		"--reset-values",
+		"--atomic",
+		"--wait",
+	}
+	args = append(args, helmOverridesEdge(helmTLSCerts)...)
+	if stdout, stderr, err := TestHelper.HelmUpgrade(TestHelper.GetHelmChart(), args...); err != nil {
+		t.Fatalf("helm upgrade command failed\n%s\n%s", stdout, stderr)
+	}
+}
+
 func TestRetrieveUidPostUpgrade(t *testing.T) {
 	if TestHelper.UpgradeFromVersion() != "" {
 		newConfigMapUID, err := TestHelper.KubernetesHelper.GetConfigUID(TestHelper.GetLinkerdNamespace())
@@ -402,12 +456,25 @@ func TestVersionPostInstall(t *testing.T) {
 	}
 }
 
-// TODO: run this after a `linkerd install config`
-func TestCheckConfigPostInstall(t *testing.T) {
-	cmd := []string{"check", "config", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
-	golden := "check.config.golden"
+func testCheckCommand(t *testing.T, stage string, expectedVersion string, namespace string, cliVersionOverride string) {
+	var cmd []string
+	var golden string
+	if stage == "proxy" {
+		cmd = []string{"check", "--proxy", "--expected-version", expectedVersion, "--namespace", namespace, "--wait=0"}
+		golden = "check.proxy.golden"
+	} else if stage == "config" {
+		cmd = []string{"check", "config", "--expected-version", expectedVersion, "--wait=0"}
+		golden = "check.config.golden"
+	} else {
+		cmd = []string{"check", "--expected-version", expectedVersion, "--wait=0"}
+		golden = "check.golden"
+	}
 
 	err := TestHelper.RetryFor(time.Minute, func() error {
+		if cliVersionOverride != "" {
+			cliVOverride := []string{"--cli-version-override", cliVersionOverride}
+			cmd = append(cmd, cliVOverride...)
+		}
 		out, stderr, err := TestHelper.LinkerdRun(cmd...)
 
 		if err != nil {
@@ -424,30 +491,17 @@ func TestCheckConfigPostInstall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+}
+
+// TODO: run this after a `linkerd install config`
+func TestCheckConfigPostInstall(t *testing.T) {
+	testCheckCommand(t, "config", TestHelper.GetVersion(), "", "")
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	cmd := []string{"check", "--expected-version", TestHelper.GetVersion(), "--wait=0"}
-	golden := "check.golden"
-
-	err := TestHelper.RetryFor(time.Minute, func() error {
-		out, stderr, err := TestHelper.LinkerdRun(cmd...)
-
-		if err != nil {
-			return fmt.Errorf("Check command failed\n%s\n%s", stderr, out)
-		}
-
-		err = TestHelper.ValidateOutput(out, golden)
-		if err != nil {
-			return fmt.Errorf("Received unexpected output\n%s", err.Error())
-		}
-
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err.Error())
-	}
+	testCheckCommand(t, "", TestHelper.GetVersion(), "", "")
 }
+
 func TestUpgradeTestAppWorksAfterUpgrade(t *testing.T) {
 	if TestHelper.UpgradeFromVersion() != "" {
 		testAppNamespace := TestHelper.GetTestNamespace("upgrade-test")
@@ -603,25 +657,7 @@ func TestCheckProxy(t *testing.T) {
 		tc := tc // pin
 		t.Run(tc.ns, func(t *testing.T) {
 			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
-			cmd := []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", prefixedNs, "--wait=0"}
-			golden := "check.proxy.golden"
-
-			err := TestHelper.RetryFor(time.Minute, func() error {
-				out, stderr, err := TestHelper.LinkerdRun(cmd...)
-				if err != nil {
-					return fmt.Errorf("Check command failed\n%s\n%s", out, stderr)
-				}
-
-				err = TestHelper.ValidateOutput(out, golden)
-				if err != nil {
-					return fmt.Errorf("Received unexpected output\n%s", err.Error())
-				}
-
-				return nil
-			})
-			if err != nil {
-				t.Fatal(err.Error())
-			}
+			testCheckCommand(t, "proxy", TestHelper.GetVersion(), prefixedNs, "")
 		})
 	}
 }


### PR DESCRIPTION
In light of the breaking changes we are introducing to the Helm chart and the convoluted upgrade process (see https://github.com/linkerd/website/pull/647) an integration test can be quite helpful. This simply installs latest stable through helm install and then upgrades to the current head of the branch. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>