### PR TITLE
Trim space when comparing roots between the issuer secret and the config

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1360,7 +1360,7 @@ func (hc *HealthChecker) checkCertificatesConfig() (*tls.Cred, []*x509.Certifica
 	} else {
 		data, err = issuercerts.FetchExternalIssuerData(hc.kubeAPI, hc.ControlPlaneNamespace)
 		// ensure trust trustRoots in config matches whats in the secret
-		if data != nil && idctx.TrustAnchorsPem != data.TrustAnchors {
+		if data != nil && strings.TrimSpace(idctx.TrustAnchorsPem) != strings.TrimSpace(data.TrustAnchors) {
 			errFormat := "IdentityContext.TrustAnchorsPem does not match %s in %s"
 			err = fmt.Errorf(errFormat, k8s.IdentityIssuerTrustAnchorsNameExternal, k8s.IdentityIssuerSecretName)
 		}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2524,7 +2524,7 @@ func TestLinkerdIdentityCheck(t *testing.T) {
 		},
 		{
 			checkerToTest:    "certificate config is valid",
-			checkDescription: "does not get influenced by newline differences between trust anchors",
+			checkDescription: "does not get influenced by newline differences between trust anchors (missing newline)",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),
 			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
@@ -2534,12 +2534,12 @@ func TestLinkerdIdentityCheck(t *testing.T) {
 		},
 		{
 			checkerToTest:    "certificate config is valid",
-			checkDescription: "fails when roots in config and secret do not match",
+			checkDescription: "does not get influenced by newline differences between trust anchors (extra newline)",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid: IdentityContext.TrustAnchorsPem does not match ca.crt in linkerd-identity-issuer"},
+			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
 			configAnchorsModifier: func(anchors string) string {
-				return "nonsense"
+				return anchors + "\n"
 			},
 		},
 		{


### PR DESCRIPTION
This fix ensures that we ignore whitespace and newlines when checking that roots match between the Linkerd config map and the issuer secret (in the case of using external issue + Helm). 

Fixes: #3907
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
