### PR TITLE
Changelog for edge-20.1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## edge-20.1.4
+
+This edge release is a release candidate for `stable-2.7`.
+
+The `linkerd check` command has been updated to improve the control plane
+debugging experience.
+
+* CLI
+  * Updated the mTLS trust anchor checks to eliminate false positives caused by
+    extra trailing spaces
+  * Reduced the severity level of the Linkerd version checks, so that they
+    don't fail when the external version endpoint is unreachable
+    (thanks @mayankshah1607!)
+  * Added a new `tap` APIService check to aid with uncovering Kubernetes API
+    aggregatation layer issues (thanks @droidnoob!)
+
 ## edge-20.1.3
 
 This edge release is a release candidate for `stable-2.7`.

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -6,7 +6,7 @@ ignoreInboundPorts: ""
 ignoreOutboundPorts: ""
 createdByAnnotation: linkerd.io/created-by
 cniPluginImage:   "gcr.io/linkerd-io/cni-plugin"
-cniPluginVersion: edge-20.1.3
+cniPluginVersion: edge-20.1.4
 logLevel:         info
 portsToRedirect:  ""
 proxyUID:         2102

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-20.1.3
+  linkerdVersion: &linkerd_version edge-20.1.4
 
   namespace: linkerd
 


### PR DESCRIPTION
This edge release is a release candidate for `stable-2.7`.

The `linkerd check` command has been updated to improve the control plane
debugging experience.

* CLI
  * Updated the mTLS trust anchor checks to eliminate false positives caused by
    extra trailing spaces
  * Reduced the severity level of the Linkerd version checks, so that they
    don't fail when the external version endpoint is unreachable
    (thanks @mayankshah1607!)
  * Added a new `tap` APIService check to aid with uncovering Kubernetes API
    aggregatation layer issues (thanks @droidnoob!)

Signed-off-by: Ivan Sim <ivan@buoyant.io>