### PR TITLE
Refactoring to suppress eslint warnings jsx-a11y/click-events-have-key-events

### DIFF
--- a/web/app/.eslintrc
+++ b/web/app/.eslintrc
@@ -83,7 +83,6 @@
     "react/jsx-props-no-spreading": 0,
 
     // These rules represent best practices that we're not adhering to, and should be enabled
-    "jsx-a11y/click-events-have-key-events": 0,
     "no-param-reassign": ["error", { "props": false }]
   }
 }

--- a/web/app/js/components/Popover.jsx
+++ b/web/app/js/components/Popover.jsx
@@ -21,6 +21,13 @@ class ClickablePopover extends React.Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
+  handleKeyPress = event => {
+    if (event.key === 'Enter') {
+      this.setState({ anchorEl: event.currentTarget });
+    }
+  }
+
+
   handleClose = () => {
     this.setState({ anchorEl: null });
   };
@@ -36,6 +43,7 @@ class ClickablePopover extends React.Component {
           aria-owns={open ? 'clickable-popover' : null}
           aria-haspopup="true"
           onClick={this.handleClick}
+          onKeyPress={this.handleKeyPress}
           role="button"
           tabIndex={0}>
           {baseContent}


### PR DESCRIPTION
Please review and merge #3974 before this. 

Refactoring to suppress eslint warnings

Upon enabling jsx-a11y/click-events-have-key-events flag in .eslintrc , a couple of warnings are raised because it is recommended
to provide a onKeyPress, onKeyDown or onKeyUp event handler for every onClick event handler.

The code has been refactored to follow the eslint spec.

Fixes #3926

Signed-off-by: Christy Jacob <christyjacob4@gmail.com>