### PR TITLE
cli: handle panic caused by `linkerd metrics` port-forward failure

### DIFF
--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -165,6 +165,7 @@ func getMetrics(
 	defer portforward.Stop()
 	if err = portforward.Init(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+		return nil, err
 	}
 
 	metricsURL := portforward.URLFor("/metrics")

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -179,14 +179,6 @@ func (pf *PortForward) Init() error {
 			failure <- err
 			return
 		}
-
-		select {
-		case <-pf.GetStop():
-			// stopCh was closed, do nothing
-		default:
-			// pf.run() returned for some other reason, close stopCh
-			pf.Stop()
-		}
 	}()
 
 	// The `select` statement below depends on one of two outcomes from `pf.run()`:

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -177,6 +177,7 @@ func (pf *PortForward) Init() error {
 	go func() {
 		if err := pf.run(); err != nil {
 			failure <- err
+			return
 		}
 
 		select {
@@ -203,6 +204,7 @@ func (pf *PortForward) Init() error {
 }
 
 // Stop terminates the port-forward connection.
+// It is the caller's responsibility to call Stop even in case of errors
 func (pf *PortForward) Stop() {
 	close(pf.stopCh)
 }


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/3978

- add func `recoverStop()` to recover from panic caused by `close()` in method `Stop()`

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
