### PR TITLE
edge-20.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,10 @@ where the proxy could consume inappropriate amounts of memory.
 
 * Proxy
   * Fixed a bug in the proxy's logging subsystem that could cause the proxy to
-    consume memory until the process is OOMKilled, especially when the proxy was
+    consume memory until the process is OOM killed, especially when the proxy was
     configured to log diagnostic information
   * Fixed properly emitting `grpc-status` headers when signaling proxy errors to
     gRPC clients
-* Internal
-  * Updated to Rust 1.40
   * Updated certain proxy dependencies to address RUSTSEC-2019-0033,
     RUSTSEC-2019-0034, and RUSTSEC-2020-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,19 @@
+## edge-20.2.1
+
+This edge release is a release candidate for `stable-2.7` and fixes an issue
+where the proxy could consume inappropriate amounts of memory.
+
+* Proxy
+  * Fixed a bug in the proxy's logging subsystem that could cause the proxy to
+    consume memory until the process is OOMKilled, especially when the proxy was
+    configured to log diagnostic information
+  * Fixed properly emitting `grpc-status` headers when signaling proxy errors to
+    gRPC clients
+* Internal
+  * Updated to Rust 1.40
+  * Updated certain proxy dependencies to address RUSTSEC-2019-0033,
+    RUSTSEC-2019-0034, and RUSTSEC-2020-02
+
 ## edge-20.1.4
 
 This edge release is a release candidate for `stable-2.7`.

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -6,7 +6,7 @@ ignoreInboundPorts: ""
 ignoreOutboundPorts: ""
 createdByAnnotation: linkerd.io/created-by
 cniPluginImage:   "gcr.io/linkerd-io/cni-plugin"
-cniPluginVersion: edge-20.1.4
+cniPluginVersion: edge-20.2.1
 logLevel:         info
 portsToRedirect:  ""
 proxyUID:         2102

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -8,7 +8,7 @@ global:
   imagePullPolicy: &image_pull_policy IfNotPresent
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version edge-20.1.4
+  linkerdVersion: &linkerd_version edge-20.2.1
 
   namespace: linkerd
 


### PR DESCRIPTION
This edge release is a release candidate for `stable-2.7` and fixes an issue
where the proxy could consume inappropriate amounts of memory.

* Proxy
  * Fixed a bug in the proxy's logging subsystem that could cause the proxy to
    consume memory until the process is OOMKilled, especially when the proxy was
    configured to log diagnostic information
  * Fixed properly emitting `grpc-status` headers when signaling proxy errors to
    gRPC clients
* Internal
  * Updated to Rust 1.40
  * Updated certain proxy dependencies to address RUSTSEC-2019-0033,
    RUSTSEC-2019-0034, and RUSTSEC-2020-02

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
