### PR TITLE
Improve cni resources labels

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -14,6 +14,12 @@ if [ -z "${namespaces_helm=$(kubectl --context=$k8s_context get ns -oname -l lin
   echo 'no helm namespaces found' >&2
 fi
 
+echo "cleaning up CNI namespaces in k8s-context [${k8s_context}]"
+
+if [ -z "${namespaces_cni=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/cni-resource)}" ]; then
+  echo 'no CNI namespaces found' >&2
+fi
+
 echo "cleaning up data-plane namespaces in k8s-context [${k8s_context}]"
 
 if [ -z "${namespaces_dataplane=$(kubectl --context=$k8s_context get ns -oname -l linkerd.io/is-test-data-plane)}" ]; then
@@ -52,8 +58,8 @@ if [ -z "${apiservices=$(kubectl --context=$k8s_context get apiservices -l linke
   echo 'no apiservices found' >&2
 fi
 
-if [[ $namespaces_controlplane || $namespaces_helm || $namespaces_dataplane || $clusterrolebindings || $clusterrolebindings_helm || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions || $apiservices ]]; then
-  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_helm $namespaces_dataplane $clusterrolebindings $clusterrolebindings_helm $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions $apiservices
+if [[ $namespaces_controlplane || $namespaces_cni || $namespaces_helm || $namespaces_dataplane || $clusterrolebindings || $clusterrolebindings_helm || $clusterroles || $webhookconfigs || $validatingconfigs || $podsecuritypolicies || $customresourcedefinitions || $apiservices ]]; then
+  kubectl --context=$k8s_context delete $namespaces_controlplane $namespaces_cni $namespaces_helm $namespaces_dataplane $clusterrolebindings $clusterrolebindings_helm $clusterroles $webhookconfigs $validatingconfigs $podsecuritypolicies $customresourcedefinitions $apiservices
 fi
 
 echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -25,7 +25,7 @@ metadata:
   annotations:
     {{.Values.proxyInjectAnnotation}}: {{.Values.proxyInjectDisabled}}
   labels:
-    {{.Values.linkerdNamespaceLabel}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
     config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1
@@ -33,7 +33,7 @@ kind: PodSecurityPolicy
 metadata:
   name: linkerd-{{.Values.namespace}}-cni
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
@@ -55,7 +55,7 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -63,7 +63,7 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
@@ -77,7 +77,7 @@ metadata:
   name: linkerd-cni
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -92,7 +92,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "namespaces"]
@@ -103,7 +103,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -119,7 +119,7 @@ metadata:
   name: linkerd-cni-config
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
 data:
   dest_cni_net_dir: "{{.Values.destCNINetDir}}"
   dest_cni_bin_dir: "{{.Values.destCNIBinDir}}"
@@ -161,7 +161,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     k8s-app: linkerd-cni
-    {{.Values.cniResourceAnnotation}}: "true"
+    {{.Values.cniResourceLabel}}: "true"
   annotations:
     {{.Values.createdByAnnotation}}: {{.Values.cliVersion}}
 spec:

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -1,5 +1,5 @@
 namespace: linkerd-cni
-cniResourceAnnotation: linkerd.io/cni-resource
+cniResourceLabel: linkerd.io/cni-resource
 inboundProxyPort: 4143
 outboundProxyPort: 4140
 ignoreInboundPorts: ""
@@ -17,4 +17,3 @@ useWaitFlag:      false
 # namespace annotation and labels - do not edit
 proxyInjectAnnotation: linkerd.io/inject
 proxyInjectDisabled: disabled
-linkerdNamespaceLabel: linkerd.io/is-control-plane

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -34,8 +34,7 @@ func testRenderCniHelm(t *testing.T, chart *pb.Chart, goldenFileName string) {
 	overrideJSON :=
 		`{
 			"namespace": "linkerd-test",
-  			"controllerNamespaceLabel": "linkerd.io/control-plane-ns-test",
-  			"cniResourceAnnotation": "linkerd.io/cni-resource-test",
+  			"cniResourceLabel": "linkerd.io/cni-resource-test",
   			"inboundProxyPort": 1234,
   			"outboundProxyPort": 5678,
 			"createdByAnnotation": "linkerd.io/created-by-test",

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -5,7 +5,7 @@ metadata:
   annotations:
     linkerd.io/inject: disabled
   labels:
-    linkerd.io/is-control-plane: "true"
+    linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -5,7 +5,7 @@ metadata:
   annotations:
     linkerd.io/inject: disabled
   labels:
-    linkerd.io/is-control-plane: "true"
+    linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -5,7 +5,7 @@ metadata:
   annotations:
     linkerd.io/inject: disabled
   labels:
-    linkerd.io/is-control-plane: "true"
+    linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1

--- a/cli/cmd/testdata/install_cni_helm_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_output.golden
@@ -7,7 +7,7 @@ metadata:
   annotations:
     linkerd.io/inject: disabled
   labels:
-    linkerd.io/is-control-plane: "true"
+    linkerd.io/cni-resource-test: "true"
     config.linkerd.io/admission-webhooks: disabled
 ---
 apiVersion: policy/v1beta1

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -16,7 +16,7 @@ const (
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
 	Namespace             string `json:"namespace"`
-	CNIResourceAnnotation string `json:"cniResourceAnnotation"`
+	CNIResourceLabel      string `json:"cniResourceLabel"`
 	InboundProxyPort      uint   `json:"inboundProxyPort"`
 	OutboundProxyPort     uint   `json:"outboundProxyPort"`
 	IgnoreInboundPorts    string `json:"ignoreInboundPorts"`
@@ -33,7 +33,6 @@ type Values struct {
 	UseWaitFlag           bool   `json:"useWaitFlag"`
 	ProxyInjectAnnotation string `json:"proxyInjectAnnotation"`
 	ProxyInjectDisabled   string `json:"proxyInjectDisabled"`
-	LinkerdNamespaceLabel string `json:"linkerdNamespaceLabel"`
 }
 
 // NewValues returns a new instance of the Values type.


### PR DESCRIPTION
Now that the CNI is in a different namespace, I it makes sense to use different kind of labels to identify the resources created by the chart/cli.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>