### PR TITLE
Remove experimental from CNI (part 2)

### DIFF
--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -76,8 +76,8 @@ func newCmdInstallCNIPlugin() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "install-cni [flags]",
-		Short: "Output Kubernetes configs to install Linkerd CNI (experimental)",
-		Long: `Output Kubernetes configs to install Linkerd CNI (experimental).
+		Short: "Output Kubernetes configs to install Linkerd CNI",
+		Long: `Output Kubernetes configs to install Linkerd CNI.
 
 This command installs a DaemonSet into the Linkerd control plane. The DaemonSet
 copies the necessary linkerd-cni plugin binaries and configs onto the host. It

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -499,7 +499,7 @@ func (options *installOptions) allStageFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("all-stage", pflag.ExitOnError)
 
 	flags.BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled,
-		"Experimental: Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed",
+		"Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed",
 	)
 
 	flags.BoolVar(


### PR DESCRIPTION
Now that https://github.com/linkerd/website/pull/656 is merged, we can do the same for the linkerd repo. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>