### PR TITLE
Support for configuring service profile retries(x-linkerd-retryable) via openapi spec

### DIFF
--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -73,7 +73,7 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 		path := path.Join(swagger.BasePath, relPath)
 		pathRegex := pathToRegex(path)
 		if item.Delete != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodGet, item.Delete.Responses, item.Delete)
+			spec := mkRouteSpec(path, pathRegex, http.MethodDelete, item.Delete.Responses, item.Delete)
 			routes = append(routes, spec)
 		}
 		if item.Get != nil {

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -110,7 +110,7 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 
 func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operation) *sp.RouteSpec {
 	retryable := false
-	var responses = (*spec.Responses)(nil)
+	var responses *spec.Responses
 	if operation != nil {
 		retryable, _ = operation.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
 		responses = operation.Responses

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -15,7 +15,9 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const xLinkerdRetryable = "x-linkerd-retryable"
+const (
+	xLinkerdRetryable = "x-linkerd-retryable"
+)
 
 var pathParamRegex = regexp.MustCompile(`\\{[^\}]*\\}`)
 
@@ -108,15 +110,15 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 
 func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operation) *sp.RouteSpec {
 	retryable := false
-	operationResponses := nil
+	var responses = (*spec.Responses)(nil)
 	if operation != nil {
 		retryable, _ = operation.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
-		operationResponses = operation.Responses
+		responses = operation.Responses
 	}
 	return &sp.RouteSpec{
 		Name:            fmt.Sprintf("%s %s", method, path),
 		Condition:       toReqMatch(pathRegex, method),
-		ResponseClasses: toRspClasses(operationResponses),
+		ResponseClasses: toRspClasses(responses),
 		IsRetryable:     retryable,
 	}
 }

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -73,31 +73,31 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 		path := path.Join(swagger.BasePath, relPath)
 		pathRegex := pathToRegex(path)
 		if item.Delete != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodDelete, item.Delete.Responses, item.Delete)
+			spec := mkRouteSpec(path, pathRegex, http.MethodDelete, item.Delete)
 			routes = append(routes, spec)
 		}
 		if item.Get != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodGet, item.Get.Responses, item.Get)
+			spec := mkRouteSpec(path, pathRegex, http.MethodGet, item.Get)
 			routes = append(routes, spec)
 		}
 		if item.Head != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodHead, item.Head.Responses, item.Head)
+			spec := mkRouteSpec(path, pathRegex, http.MethodHead, item.Head)
 			routes = append(routes, spec)
 		}
 		if item.Options != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodOptions, item.Options.Responses, item.Options)
+			spec := mkRouteSpec(path, pathRegex, http.MethodOptions, item.Options)
 			routes = append(routes, spec)
 		}
 		if item.Patch != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodPatch, item.Patch.Responses, item.Patch)
+			spec := mkRouteSpec(path, pathRegex, http.MethodPatch, item.Patch)
 			routes = append(routes, spec)
 		}
 		if item.Post != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodPost, item.Post.Responses, item.Post)
+			spec := mkRouteSpec(path, pathRegex, http.MethodPost, item.Post)
 			routes = append(routes, spec)
 		}
 		if item.Put != nil {
-			spec := mkRouteSpec(path, pathRegex, http.MethodPut, item.Put.Responses, item.Put)
+			spec := mkRouteSpec(path, pathRegex, http.MethodPut, item.Put)
 			routes = append(routes, spec)
 		}
 	}
@@ -106,7 +106,7 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 	return profile
 }
 
-func mkRouteSpec(path, pathRegex string, method string, responses *spec.Responses, exception *spec.Operation) *sp.RouteSpec {
+func mkRouteSpec(path, pathRegex string, method string,  exception *spec.Operation) *sp.RouteSpec {
 	retryable := false
 	if exception != nil {
 		retryable, _ = exception.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
@@ -114,7 +114,7 @@ func mkRouteSpec(path, pathRegex string, method string, responses *spec.Response
 	return &sp.RouteSpec{
 		Name:            fmt.Sprintf("%s %s", method, path),
 		Condition:       toReqMatch(pathRegex, method),
-		ResponseClasses: toRspClasses(responses),
+		ResponseClasses: toRspClasses(exception.Responses),
 		IsRetryable:     retryable,
 	}
 }

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -106,7 +106,7 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 	return profile
 }
 
-func mkRouteSpec(path, pathRegex string, method string,  exception *spec.Operation) *sp.RouteSpec {
+func mkRouteSpec(path, pathRegex string, method string, exception *spec.Operation) *sp.RouteSpec {
 	retryable := false
 	if exception != nil {
 		retryable, _ = exception.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -108,13 +108,15 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 
 func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operation) *sp.RouteSpec {
 	retryable := false
+	operationResponses := nil
 	if operation != nil {
 		retryable, _ = operation.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
+		operationResponses = operation.Responses
 	}
 	return &sp.RouteSpec{
 		Name:            fmt.Sprintf("%s %s", method, path),
 		Condition:       toReqMatch(pathRegex, method),
-		ResponseClasses: toRspClasses(operation.Responses),
+		ResponseClasses: toRspClasses(operationResponses),
 		IsRetryable:     retryable,
 	}
 }

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -106,15 +106,15 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 	return profile
 }
 
-func mkRouteSpec(path, pathRegex string, method string, exception *spec.Operation) *sp.RouteSpec {
+func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operation) *sp.RouteSpec {
 	retryable := false
-	if exception != nil {
-		retryable, _ = exception.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
+	if operation != nil {
+		retryable, _ = operation.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
 	}
 	return &sp.RouteSpec{
 		Name:            fmt.Sprintf("%s %s", method, path),
 		Condition:       toReqMatch(pathRegex, method),
-		ResponseClasses: toRspClasses(exception.Responses),
+		ResponseClasses: toRspClasses(operation.Responses),
 		IsRetryable:     retryable,
 	}
 }

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -107,12 +107,15 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 }
 
 func mkRouteSpec(path, pathRegex string, method string, responses *spec.Responses, exception *spec.Operation) *sp.RouteSpec {
-	xLinkerdRetryable, _ := exception.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
+	retryable := false
+	if exception != nil {
+		retryable, _ = exception.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
+	}
 	return &sp.RouteSpec{
 		Name:            fmt.Sprintf("%s %s", method, path),
 		Condition:       toReqMatch(pathRegex, method),
 		ResponseClasses: toRspClasses(responses),
-		IsRetryable:     xLinkerdRetryable,
+		IsRetryable:     retryable,
 	}
 }
 

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -12,6 +12,8 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
 	clusterDomain := "mycluster.local"
+	xLinkerdRetryable := make(spec.Extensions)
+	xLinkerdRetryable.Add("x-linkerd-retryable", true)
 
 	swagger := spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
@@ -28,6 +30,9 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 											},
 										},
 									},
+								},
+								VendorExtensible: spec.VendorExtensible{
+									Extensions: xLinkerdRetryable,
 								},
 							},
 						},
@@ -62,6 +67,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 							IsFailure: true,
 						},
 					},
+					IsRetryable: true,
 				},
 			},
 		},

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -12,9 +12,6 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
 	clusterDomain := "mycluster.local"
-	xLinkerdRetryable := make(spec.Extensions)
-	xLinkerdRetryable.Add("x-linkerd-retryable", true)
-
 	swagger := spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
 			Paths: &spec.Paths{
@@ -32,7 +29,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 									},
 								},
 								VendorExtensible: spec.VendorExtensible{
-									Extensions: xLinkerdRetryable,
+									Extensions: spec.Extensions{"x-linkerd-retryable": true},
 								},
 							},
 						},

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -8,6 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const xLinkerdRetryable = "x-linkerd-retryable"
+
 func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
@@ -30,7 +32,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 									},
 								},
 								VendorExtensible: spec.VendorExtensible{
-									Extensions: spec.Extensions{"x-linkerd-retryable": true},
+									Extensions: spec.Extensions{xLinkerdRetryable: true},
 								},
 							},
 						},

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -8,8 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const xLinkerdRetryable = "x-linkerd-retryable"
-
 func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -12,6 +12,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 	namespace := "myns"
 	name := "mysvc"
 	clusterDomain := "mycluster.local"
+
 	swagger := spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
 			Paths: &spec.Paths{

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -130,7 +130,7 @@ func getPathDataFromTap(event *pb.TapEvent) *sp.RouteSpec {
 			pathToRegex(path), // for now, no path consolidation
 			ev.RequestInit.GetMethod().GetRegistered().String(),
 			nil,
-			false)
+			nil)
 	default:
 		return nil
 	}

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -129,7 +129,6 @@ func getPathDataFromTap(event *pb.TapEvent) *sp.RouteSpec {
 			path,
 			pathToRegex(path), // for now, no path consolidation
 			ev.RequestInit.GetMethod().GetRegistered().String(),
-			nil,
 			nil)
 	default:
 		return nil

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -129,7 +129,8 @@ func getPathDataFromTap(event *pb.TapEvent) *sp.RouteSpec {
 			path,
 			pathToRegex(path), // for now, no path consolidation
 			ev.RequestInit.GetMethod().GetRegistered().String(),
-			nil)
+			nil,
+			false)
 	default:
 		return nil
 	}


### PR DESCRIPTION
 Retry policy is manually written in yaml file and patched it into the service profile

 Added support for configuring service profile retries(x-linkerd-retryable) via openapi spec

 Fixes #2073
    
 Signed-off-by: Kohsheen Tiku <kohsheen.t@gmail.com>