### PR TITLE
Allow custom host set from helm values 

### DIFF
--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -65,9 +65,13 @@ spec:
         - -grafana-addr=linkerd-grafana.{{.Values.global.namespace}}.svc.{{.Values.global.clusterDomain}}:3000
         - -controller-namespace={{.Values.global.namespace}}
         - -log-level={{.Values.controllerLogLevel}}
+        {{- if .Values.enforcedHostRegexp }}
+        - -enforced-host={{.Values.enforcedHostRegexp}}
+        {{- else -}}
         {{- $hostFull := replace "." "\\." (printf "linkerd-web.%s.svc.%s" .Values.global.namespace .Values.global.clusterDomain) }}
         {{- $hostAbbrev := replace "." "\\." (printf "linkerd-web.%s.svc" .Values.global.namespace) }}
         - -enforced-host=^(localhost|127\.0\.0\.1|{{ $hostFull }}|{{ $hostAbbrev }}|\[::1\])(:\d+)?$
+        {{- end}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
         image: {{.Values.webImage}}:{{default .Values.global.linkerdVersion .Values.controllerImageVersion}}
         imagePullPolicy: {{.Values.global.imagePullPolicy}}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -6,7 +6,6 @@
 global:
   clusterDomain: &cluster_domain cluster.local
   imagePullPolicy: &image_pull_policy IfNotPresent
-  
   # Control Plane Trace Configuration
   controlPlaneTracing: false
 
@@ -75,6 +74,8 @@ global:
   controllerNamespaceLabel: linkerd.io/control-plane-ns
   linkerdNamespaceLabel: linkerd.io/is-control-plane
 
+# Enforced Host Validation Regular Expression
+enforcedHostRegexp: ""
 
 enableH2Upgrade: true
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -6,7 +6,8 @@
 global:
   clusterDomain: &cluster_domain cluster.local
   imagePullPolicy: &image_pull_policy IfNotPresent
-  # Control Plane Trace Configuration
+
+ # control plane trace configuration
   controlPlaneTracing: false
 
   # control plane version. See Proxy section for proxy version
@@ -74,7 +75,7 @@ global:
   controllerNamespaceLabel: linkerd.io/control-plane-ns
   linkerdNamespaceLabel: linkerd.io/is-control-plane
 
-# Enforced Host Validation Regular Expression
+# enforced host validation regular expression
 enforcedHostRegexp: ""
 
 enableH2Upgrade: true


### PR DESCRIPTION
Allow custom host set from helm values #3961

Users should be able to set their hosts or use deafult host if not specified in helm

Fixes #3961

Signed-off-by: Sanni Michael Tomiwa <sannimichaelse@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
