### PR TITLE
bin/helm-build automatically updates version in values.yaml

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -394,6 +394,10 @@ chart consists of the Linkerd proxy specification, which is used by the proxy
 injector to inject the proxy container. Both charts depend on the partials
 subchart which can be found in the [`charts/partials`](charts/partials) folder.
 
+Note that the `charts/linkerd2/values.yaml` file contains a placeholder
+`{version}` that you need to replace with an appropriate string (like
+`edge-20.2.2`) before proceeding.
+
 During development, please use the [`bin/helm`](bin/helm) wrapper script to
 invoke the Helm commands. For example,
 

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -2,14 +2,14 @@
 
 set -e
 
-restoreValues() {
-    sed -i "s/$1/{version}/" charts/linkerd2/values.yaml
-    sed -i "s/$1/{version}/" charts/linkerd2-cni/values.yaml
+setValues() {
+    sed -i "s/$1/$2/" charts/linkerd2/values.yaml
+    sed -i "s/$1/$2/" charts/linkerd2-cni/values.yaml
 }
 
 showErr() {
   printf "Error on exit:\n  Exit code: %d\n  Failed command: \"%s\"\n" $? "$BASH_COMMAND"
-  restoreValues
+  setValues $fullVersion "{version}"
 }
 
 # trap the last failed command
@@ -42,12 +42,13 @@ if [ "$1" = package ]; then
     version=${BASH_REMATCH[2]}
 
     # set version in Values files
-    sed -i "s/{version}/$fullVersion/" charts/linkerd2/values.yaml
-    sed -i "s/{version}/$fullVersion/" charts/linkerd2-cni/values.yaml
+    setValues "{version}" $fullVersion
 
     "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
     "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-$version.yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-$version.yaml "$rootdir"/target/helm
-    restoreValues $fullVersion
+
+    # restore version in Values files
+    setValues $fullVersion "{version}"
 fi

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -2,8 +2,18 @@
 
 set -e
 
+restoreValues() {
+    sed -i "s/$1/{version}/" charts/linkerd2/values.yaml
+    sed -i "s/$1/{version}/" charts/linkerd2-cni/values.yaml
+}
+
+showErr() {
+  printf "Error on exit:\n  Exit code: %d\n  Failed command: \"%s\"\n" $? "$BASH_COMMAND"
+  restoreValues
+}
+
 # trap the last failed command
-trap 'printf "Error on exit:\n  Exit code: $?\n  Failed command: \"$BASH_COMMAND\"\n"' ERR
+trap 'showErr' ERR
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
@@ -27,10 +37,17 @@ if [ "$1" = package ]; then
         echo 'Version tag is malformed'
         exit 1
     fi
+    fullVersion=${BASH_REMATCH[0]}
     repo=${BASH_REMATCH[1]}
     version=${BASH_REMATCH[2]}
+
+    # set version in Values files
+    sed -i "s/{version}/$fullVersion/" charts/linkerd2/values.yaml
+    sed -i "s/{version}/$fullVersion/" charts/linkerd2-cni/values.yaml
+
     "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
     "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-$version.yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-$version.yaml "$rootdir"/target/helm
+    restoreValues $fullVersion
 fi

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -6,7 +6,7 @@ ignoreInboundPorts: ""
 ignoreOutboundPorts: ""
 createdByAnnotation: linkerd.io/created-by
 cniPluginImage:   "gcr.io/linkerd-io/cni-plugin"
-cniPluginVersion: stable-2.7.0
+cniPluginVersion: {version}
 logLevel:         info
 portsToRedirect:  ""
 proxyUID:         2102

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -11,7 +11,7 @@ global:
   controlPlaneTracing: false
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version stable-2.7.0
+  linkerdVersion: &linkerd_version {version}
 
   namespace: linkerd
 

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -3,13 +3,17 @@ package charts
 import (
 	"bytes"
 	"path"
+	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/charts/static"
+	"github.com/linkerd/linkerd2/pkg/version"
 	"k8s.io/helm/pkg/chartutil"
 	helmChart "k8s.io/helm/pkg/proto/hapi/chart"
 	"k8s.io/helm/pkg/renderutil"
 	"k8s.io/helm/pkg/timeconv"
 )
+
+const versionPlaceholder = "{version}"
 
 // Chart holds the necessary info to render a Helm chart
 type Chart struct {
@@ -121,4 +125,11 @@ func FilesReader(dir string, files []*chartutil.BufferedFile) error {
 		}
 	}
 	return nil
+}
+
+// InsertVersion returns the chart values file contents passed in
+// with the version placeholder replaced with the current version
+func InsertVersion(data []byte) []byte {
+	dataWithVersion := strings.Replace(string(data), versionPlaceholder, version.Version, 1)
+	return []byte(dataWithVersion)
 }

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -57,7 +57,7 @@ func readDefaults(chartDir string) (*Values, error) {
 		return nil, err
 	}
 	values := Values{}
-	if err := yaml.Unmarshal(file.Data, &values); err != nil {
+	if err := yaml.Unmarshal(charts.InsertVersion(file.Data), &values); err != nil {
 		return nil, err
 	}
 	return &values, nil

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -250,7 +250,7 @@ func readDefaults(chartDir string, ha bool) (*Values, error) {
 	values := Values{}
 	for _, valuesFile := range valuesFiles {
 		var v Values
-		if err := yaml.Unmarshal(valuesFile.Data, &v); err != nil {
+		if err := yaml.Unmarshal(charts.InsertVersion(valuesFile.Data), &v); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Have the Helm charts building script (`bin/helm-build`) update the
linkerd version in the `values.yaml` files according to the tagged
version, thus removing the need of doing this manually on every release.

This is akin to the update we do in `version.go` at CLI build time.

Note that `shellcheck` is issuing some warnings about this script, but
that's on code that was already there, so that will be handled in an
followup PR.