### PR TITLE
Support for configuring service profile timeouts (x-linkerd-timeout) via openapi spec

### DIFF
--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	xLinkerdRetryable = "x-linkerd-retryable"
+	xLinkerdTimeout   = "x-linkerd-timeout"
 )
 
 var pathParamRegex = regexp.MustCompile(`\\{[^\}]*\\}`)
@@ -110,9 +111,11 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 
 func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operation) *sp.RouteSpec {
 	retryable := false
+	timeout := ""
 	var responses *spec.Responses
 	if operation != nil {
 		retryable, _ = operation.VendorExtensible.Extensions.GetBool(xLinkerdRetryable)
+		timeout, _ = operation.VendorExtensible.Extensions.GetString(xLinkerdTimeout)
 		responses = operation.Responses
 	}
 	return &sp.RouteSpec{
@@ -120,6 +123,7 @@ func mkRouteSpec(path, pathRegex string, method string, operation *spec.Operatio
 		Condition:       toReqMatch(pathRegex, method),
 		ResponseClasses: toRspClasses(responses),
 		IsRetryable:     retryable,
+		Timeout:         timeout,
 	}
 }
 

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -30,7 +30,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 									},
 								},
 								VendorExtensible: spec.VendorExtensible{
-									Extensions: spec.Extensions{xLinkerdRetryable: true},
+									Extensions: spec.Extensions{xLinkerdRetryable: true, xLinkerdTimeout: "60s"},
 								},
 							},
 						},
@@ -66,6 +66,7 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 						},
 					},
 					IsRetryable: true,
+					Timeout:     "60s",
 				},
 			},
 		},


### PR DESCRIPTION
This change is in a similar vein to #4052 (and issue #2073 which provided support for
configuring service profile retries via a vendor extension of
`x-linkerd-retryable`, when generating from an openapi specification.

This change is very similar to the final version of that pull request,
and adds a timeout value based on `x-linkerd-timeout`.

At this point I believe that if the timeout is not specified then the
default provided by linkerd of 30s will apply anyway, but won't
explicitly be reflected in the service profile, which I'm somewhat okay
with as a current state, but I think there's a potential future
improvement that the default timeout is always shown when generating
from an open api spec, but that's more to make it clear and obvious that
that timeout exists.