### PR TITLE
Fixed shellcheck warnings on bin/helm-build

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -9,7 +9,7 @@ setValues() {
 
 showErr() {
   printf "Error on exit:\n  Exit code: %d\n  Failed command: \"%s\"\n" $? "$BASH_COMMAND"
-  setValues $fullVersion "{version}"
+  setValues "$fullVersion" "{version}"
 }
 
 # trap the last failed command
@@ -28,6 +28,7 @@ rootdir=$( cd "$bindir"/.. && pwd )
 
 # `bin/helm-build package` assumes the presence of "$rootdir"/target/helm/index-pre.yaml which is downloaded in the chart_deploy CI job
 if [ "$1" = package ]; then
+    # shellcheck source=bin/_tag.sh
     . "$bindir"/_tag.sh
     tag=$(named_tag)
     clean_head || { echo 'There are uncommitted changes'; exit 1; }
@@ -42,13 +43,13 @@ if [ "$1" = package ]; then
     version=${BASH_REMATCH[2]}
 
     # set version in Values files
-    setValues "{version}" $fullVersion
+    setValues "{version}" "$fullVersion"
 
-    "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
-    "$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
-    mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-$version.yaml
-    "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-$version.yaml "$rootdir"/target/helm
+    "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
+    "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
+    mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-"$version".yaml
+    "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm
 
     # restore version in Values files
-    setValues $fullVersion "{version}"
+    setValues "$fullVersion" "{version}"
 fi


### PR DESCRIPTION
Followup to #4058

```
$ shellcheck -x bin/helm-build; echo $?
0
```