### PR TITLE
Exclude changes on markup files to trigger CI runs in master

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -1,6 +1,9 @@
 name: Cloud integration
 on:
   push:
+    paths-ignore:
+    - '*.md'
+    - '**/*.md'
     branches:
     - master
     tags:

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -2,6 +2,9 @@ name: KinD integration
 on:
   pull_request: {}
   push:
+    paths-ignore:
+    - '*.md'
+    - '**/*.md'
     branches:
     - master
     tags:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,6 +2,9 @@ name: Static checks
 on:
   pull_request: {}
   push:
+    paths-ignore:
+    - '*.md'
+    - '**/*.md'
     branches:
     - master
     tags:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,9 @@ name: Unit tests
 on:
   pull_request: {}
   push:
+    paths-ignore:
+    - '*.md'
+    - '**/*.md'
     branches:
     - master
     tags:


### PR DESCRIPTION
Fixes #4082

This tested fine in a fork, under various scenarios combining:
- Modify markup file in root dir
- Modify markup file in subdir
- Modify non-markup file
- In master
- In a PR
