### PR TITLE
Reuse bin/helm-build in Helm integration tests

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -190,8 +190,8 @@ setup_helm() {
         kubectl --context=$k8s_context label ns $tiller_namespace linkerd.io/is-test-helm=true
         kubectl --context=$k8s_context create clusterrolebinding ${tiller_namespace}:tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=${tiller_namespace}:default
         kubectl --context=$k8s_context label clusterrolebinding ${tiller_namespace}:tiller-cluster-admin linkerd.io/is-test-helm=true
+        "$bindir"/helm-build
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace init --wait
-        "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace dependency update "$helm_chart"
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace repo add linkerd https://helm.linkerd.io/stable
     )
     exit_on_err 'error setting up Helm'

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -25,6 +25,7 @@ rootdir=$( cd "$bindir"/.. && pwd )
 "$bindir"/helm dep up "$rootdir"/charts/linkerd2
 "$bindir"/helm dep up "$rootdir"/charts/patch
 "$bindir"/helm lint --set global.identityTrustAnchorsPEM="fake-trust" --set identity.issuer.tls.crtPEM="fake-cert" --set identity.issuer.tls.keyPEM="fake-key" --set identity.issuer.crtExpiry="fake-expiry-date" "$rootdir"/charts/linkerd2
+"$bindir"/helm lint "$rootdir"/charts/linkerd2-cni
 
 # `bin/helm-build package` assumes the presence of "$rootdir"/target/helm/index-pre.yaml which is downloaded in the chart_deploy CI job
 if [ "$1" = package ]; then


### PR DESCRIPTION
Have the preliminary setup for the Helm integration tests use
`bin/helm-build` instead of directly calling `helm dependency update`.
This allows testing `bin/helm-build` itself, and also lints the linkerd2
and linkerd2-cni charts (the latter lint call is being added as well in this
PR).
