### PR TITLE
Remove extraneous return

### DIFF
--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -177,7 +177,6 @@ func (pf *PortForward) Init() error {
 	go func() {
 		if err := pf.run(); err != nil {
 			failure <- err
-			return
 		}
 	}()
 


### PR DESCRIPTION
Remove extraneous `return` which was missed in https://github.com/linkerd/linkerd2/pull/4007

Signed-off-by: Alex Leong <alex@buoyant.io>
