### PR TITLE
Add minimal release workflow

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - "*"
 jobs:
   docker_build:
     name: Docker build
@@ -72,6 +70,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Try to load cached Go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Install linkerd CLI
       id: install_cli
       run: |
@@ -104,31 +109,3 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
-  chart_deploy:
-    name: Helm chart deploy
-    if: startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-18.04
-    needs: [cloud_integration_tests]
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Configure gsutils
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
-      with:
-        cloud_sdk_service_account_key: ${{ secrets.LINKERD_SITE_TOKEN }}
-        gcp_project: ${{ secrets.LINKERD_SITE_PROJECT }}
-        gcp_zone: ${{ secrets.LINKERD_SITE_ZONE }}
-    - name: Edge Helm chart creation and upload
-      if: startsWith(github.ref, 'refs/tags/edge')
-      run: |
-        mkdir -p target/helm
-        gsutil cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
-        bin/helm-build package
-        gsutil rsync target/helm gs://helm.linkerd.io/edge
-    - name: Stable Helm chart creation and upload
-      if: startsWith(github.ref, 'refs/tags/stable')
-      run: |
-        mkdir -p target/helm
-        gsutil cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
-        bin/helm-build package
-        gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -4,6 +4,7 @@ on:
     branches:
     - master
 jobs:
+  # todo: Keep in sync with `release.yml`
   docker_build:
     name: Docker build
     runs-on: ubuntu-18.04
@@ -29,6 +30,7 @@ jobs:
       run: |
         export PATH="`pwd`/bin:$PATH"
         bin/docker-build
+  # todo: Keep in sync with `release.yml`
   docker_push:
     name: Docker push
     runs-on: ubuntu-18.04
@@ -63,6 +65,7 @@ jobs:
         bin/docker-push $TAG
         bin/docker-retag-all $TAG master
         bin/docker-push master
+  # todo: Keep in sync with `release.yml`
   cloud_integration_tests:
     name: Cloud integration tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         name: image-archives
         path: /home/runner/archives
+  # todo: Keep in sync with `release.yml`
   kind_integration_tests:
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,18 @@
+#
+# This file is a mostly a concatenation of `kind_integration.yml` and
+# `cloud_integration.yml`, specifically for release. Once GitHub Actions
+# supports YAML anchors, we should be able to share most of the content
+# between these files:
+# https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/m-p/30336
+#
+
 name: Release
 on:
   push:
     tags:
     - "*"
 jobs:
+  # todo: Keep in sync with `cloud_integration.yml`
   docker_build:
     name: Docker build
     runs-on: ubuntu-18.04
@@ -29,6 +38,7 @@ jobs:
       run: |
         export PATH="`pwd`/bin:$PATH"
         bin/docker-build
+  # todo: Keep in sync with `cloud_integration.yml`
   docker_push:
     name: Docker push
     runs-on: ubuntu-18.04
@@ -63,6 +73,7 @@ jobs:
         bin/docker-push $TAG
         bin/docker-retag-all $TAG master
         bin/docker-push master
+  # todo: Keep in sync with `kind_integration.yml`
   kind_integration_tests:
     strategy:
       matrix:
@@ -154,6 +165,7 @@ jobs:
 
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
+  # todo: Keep in sync with `cloud_integration.yml`
   cloud_integration_tests:
     name: Cloud integration tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-name: KinD integration
+name: Release
 on:
-  pull_request: {}
   push:
-    branches:
-    - master
+    tags:
+    - "*"
 jobs:
   docker_build:
     name: Docker build
@@ -15,11 +14,7 @@ jobs:
       run: |
         . bin/_tag.sh
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
-
-        . bin/_docker.sh
-        echo ::set-env name=DOCKER_REGISTRY::$DOCKER_REGISTRY
     - name: Setup SSH config for Packet
-      if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       run: |
         mkdir -p ~/.ssh/
         touch ~/.ssh/id && chmod 600 ~/.ssh/id
@@ -27,38 +22,47 @@ jobs:
         echo "${{ secrets.DOCKER_PRIVATE_KEY }}" > ~/.ssh/id
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
         ssh linkerd-docker docker version
-        echo ::set-env name=DOCKER_HOST::ssh://linkerd-docker
     - name: Build docker images
       env:
+        DOCKER_HOST: ssh://linkerd-docker
         DOCKER_TRACE: 1
       run: |
         export PATH="`pwd`/bin:$PATH"
         bin/docker-build
-    - name: Create artifact with CLI and image archives (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      env:
-        ARCHIVES: /home/runner/archives
+  docker_push:
+    name: Docker push
+    runs-on: ubuntu-18.04
+    needs: [docker_build]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set environment variables from scripts
       run: |
-        mkdir -p $ARCHIVES
-
-        for image in proxy controller web cni-plugin debug cli-bin grafana; do
-          docker save "$DOCKER_REGISTRY/$image:$TAG" > $ARCHIVES/$image.tar || tee save_fail &
-        done
-
-        # Wait for `docker save` background processes to complete. Exit early
-        # if any job failed.
-        wait < <(jobs -p)
-        test -f save_fail && exit 1 || true
-    # `with.path` values do not support environment variables yet, so an
-    # absolute path is used here.
-    #
-    # https://github.com/actions/upload-artifact/issues/8
-    - name: Upload artifact (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      uses: actions/upload-artifact@v1
+        . bin/_tag.sh
+        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+    - name: Configure gcloud
+      uses: linkerd/linkerd2-action-gcloud@v1.0.1
       with:
-        name: image-archives
-        path: /home/runner/archives
+        cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+        gcp_project: ${{ secrets.GCP_PROJECT }}
+        gcp_zone: ${{ secrets.GCP_ZONE }}
+    - name: Docker SSH setup
+      run: |
+        mkdir -p ~/.ssh/
+        touch ~/.ssh/id && chmod 600 ~/.ssh/id
+        echo "${{ secrets.DOCKER_SSH_CONFIG }}"  > ~/.ssh/config
+        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" > ~/.ssh/id
+        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+        ssh linkerd-docker docker version
+    - name: Push docker images to registry
+      env:
+        DOCKER_HOST: ssh://linkerd-docker
+      run: |
+        export PATH="`pwd`/bin:$PATH"
+        bin/docker-push-deps
+        bin/docker-push $TAG
+        bin/docker-retag-all $TAG master
+        bin/docker-push master
   kind_integration_tests:
     strategy:
       matrix:
@@ -84,20 +88,13 @@ jobs:
         . bin/_docker.sh
         echo ::set-env name=DOCKER_REGISTRY::$DOCKER_REGISTRY
     - name: Setup SSH config for Packet
-      if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       run: |
         mkdir -p ~/.ssh/
         touch ~/.ssh/id && chmod 600 ~/.ssh/id
         echo "${{ secrets.DOCKER_SSH_CONFIG }}"  > ~/.ssh/config
         echo "${{ secrets.DOCKER_PRIVATE_KEY }}" > ~/.ssh/id
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-    - name: Download image archives (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      uses: actions/download-artifact@v1
-      with:
-        name: image-archives
     - name: Load cli-bin image into local docker images
-      if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       run: |
         # `docker load` only accepts input from STDIN, so pipe the image
         # archive into the command.
@@ -105,9 +102,6 @@ jobs:
         # In order to pipe the image archive, set `DOCKER_HOST` for a single
         # command and `docker save` the CLI image from the Packet host.
         DOCKER_HOST=ssh://linkerd-docker docker save "$DOCKER_REGISTRY/cli-bin:$TAG" | docker load
-    - name: Load cli-bin image into local docker images (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      run: docker load < image-archives/cli-bin.tar
     - name: Install CLI
       run: |
         # Copy the CLI out of the local cli-bin container.
@@ -128,7 +122,6 @@ jobs:
         config: test/testdata/custom_cluster_domain_config.yaml
         version: "v0.6.1"
     - name: Load image archives into the local KinD cluster
-      if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1
         PROMETHEUS_IMAGE_NAME: prom/prometheus:v2.15.2
@@ -153,17 +146,6 @@ jobs:
         # for the next run.
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROXY_INIT_IMAGE_NAME) 2>&1 || true
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROMETHEUS_IMAGE_NAME) 2>&1 || true
-    - name: Load image archives into the local KinD cluster (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      run: |
-        for image in proxy controller web cni-plugin debug grafana; do
-          kind load image-archive image-archives/$image.tar || tee load_fail &
-        done
-
-        # Wait for `kind load` background processes to complete. Exit early if
-        # any job failed.
-        wait < <(jobs -p)
-        test -f load_fail && exit 1 || true
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the
@@ -172,3 +154,76 @@ jobs:
 
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
+  cloud_integration_tests:
+    name: Cloud integration tests
+    runs-on: ubuntu-18.04
+    needs: [docker_push]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Try to load cached Go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install linkerd CLI
+      id: install_cli
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        image="gcr.io/linkerd-io/cli-bin:$TAG"
+        id=$(bin/docker create $image)
+        bin/docker cp "$id:/out/linkerd-linux" "$HOME/.linkerd"
+        $HOME/.linkerd version --client
+        # validate CLI version matches the repo
+        [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
+        echo "Installed Linkerd CLI version: $TAG"
+        echo "::set-output name=tag::$TAG"
+    - name: Create GKE cluster
+      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      with:
+        cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+        gcp_project: ${{ secrets.GCP_PROJECT }}
+        gcp_zone: ${{ secrets.GCP_ZONE }}
+        create: true
+        name: testing-${{ steps.install_cli.outputs.tag }}-${{ github.run_id }}
+    - name: Run integration tests
+      env:
+        GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+      run: |
+        export PATH="`pwd`/bin:$PATH"
+        echo "$GITCOOKIE_SH" | bash
+        version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
+        bin/test-run $HOME/.linkerd linkerd-$version
+    - name: CNI tests
+      run: |
+        export TAG="$($HOME/.linkerd version --client --short)"
+        go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  chart_deploy:
+    name: Helm chart deploy
+    runs-on: ubuntu-18.04
+    needs: [kind_integration_tests, cloud_integration_tests]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Configure gsutils
+      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      with:
+        cloud_sdk_service_account_key: ${{ secrets.LINKERD_SITE_TOKEN }}
+        gcp_project: ${{ secrets.LINKERD_SITE_PROJECT }}
+        gcp_zone: ${{ secrets.LINKERD_SITE_ZONE }}
+    - name: Edge Helm chart creation and upload
+      if: startsWith(github.ref, 'refs/tags/edge')
+      run: |
+        mkdir -p target/helm
+        gsutil cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
+        bin/helm-build package
+        gsutil rsync target/helm gs://helm.linkerd.io/edge
+    - name: Stable Helm chart creation and upload
+      if: startsWith(github.ref, 'refs/tags/stable')
+      run: |
+        mkdir -p target/helm
+        gsutil cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
+        bin/helm-build package
+        gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - "*"
 jobs:
   go_dependencies:
     name: Go dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - master
-    tags:
-    - "*"
 jobs:
   go_unit_tests:
     name: Go unit tests


### PR DESCRIPTION
## Motivation

A release workflow will be the only triggered workflow on `push.tags` events.

As a first step in automating the release process, it should assert that
integration tests pass once the docker images have been tagged.

Both KinD and cloud integration tests should run since they have different
sets of integration tests that they are responsible for running.

It then needs to run the `chart_deploy` job.

## Testing

This has been fully tested with a release tag push on my fork. The run can be
found [here](https://github.com/kleimkuhler/linkerd2/actions/runs/42664128)

It properly failed on `chart_deploy` because I did not want to push a test tag
helm chart.

## Solution

This workflow will:

- Build the docker images on the Packet Host
- Tag the docker images with the release tag
- Run KinD integration tests
- Run cloud integration tests
- Run `chart_deploy`

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
