### PR TITLE
Add script to create release tag

### DIFF
--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -40,4 +40,4 @@ tmp=$(mktemp -t release-commit-message.XXX.txt)
 awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' "$rootdir"/CHANGES.md > "$tmp"
 
 # Create an unsigned tag with the commit message.
-git tag -F "$tmp" "$new_linkerd_version"
+git tag -s -F "$tmp" "$new_linkerd_version"

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: ${0##*/} (edge|stable)-xx.xx.xx" >&2
+    exit 1
+fi
+
+new_linkerd_version="$1"
+
+# Verify the tag format
+tag_format="^(edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
+if [[ $new_linkerd_version =~ $tag_format ]]; then
+    # todo: Use these values to verify the tag version increment.
+    _release_channel="${BASH_REMATCH[1]}"
+    _release_major="${BASH_REMATCH[2]}"
+    _release_minor="${BASH_REMATCH[3]}"
+    _release_patch="${BASH_REMATCH[4]}"
+else
+    echo "tag format incorrect; expected: $tag_format"
+    echo "example: edge-20.12.2, stable-2.10.1"
+    exit 1
+fi
+
+# todo: Verify the tag version increment.
+
+rootdir=$( cd "${0%/*}"/.. && pwd )
+
+# Make temporary file to save the release commit message into.
+tmp=$(mktemp -t release-commit-message.XXX.txt)
+echo $tmp
+
+# Save commit message into temporary file.
+#
+# Match each occurence of the regex and increment `n` by 1. While n == 1
+# (which is true only for the first section) print that line of `CHANGES.md`.
+# This ends up being the first section of release changes.
+awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' $rootdir/CHANGES.md > $tmp
+
+# Create an unsigned tag with the commit message.
+git tag -F $tmp $new_linkerd_version

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -11,13 +11,14 @@ fi
 new_linkerd_version="$1"
 
 # Verify the tag format
-tag_format="^(edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
+tag_format="^(test|edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
 if [[ $new_linkerd_version =~ $tag_format ]]; then
     # todo: Use these values to verify the tag version increment.
-    _release_channel="${BASH_REMATCH[1]}"
-    _release_major="${BASH_REMATCH[2]}"
-    _release_minor="${BASH_REMATCH[3]}"
-    _release_patch="${BASH_REMATCH[4]}"
+    # release_channel="${BASH_REMATCH[1]}"
+    # release_major="${BASH_REMATCH[2]}"
+    # release_minor="${BASH_REMATCH[3]}"
+    # release_patch="${BASH_REMATCH[4]}"
+    :
 else
     echo "tag format incorrect; expected: $tag_format"
     echo "example: edge-20.12.2, stable-2.10.1"

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -11,7 +11,7 @@ fi
 new_linkerd_version="$1"
 
 # Verify the tag format
-tag_format="^(test|edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
+tag_format="^(edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
 if [[ $new_linkerd_version =~ $tag_format ]]; then
     # todo: Use these values to verify the tag version increment.
     # release_channel="${BASH_REMATCH[1]}"

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -31,14 +31,13 @@ rootdir=$( cd "${0%/*}"/.. && pwd )
 
 # Make temporary file to save the release commit message into.
 tmp=$(mktemp -t release-commit-message.XXX.txt)
-echo $tmp
 
 # Save commit message into temporary file.
 #
 # Match each occurence of the regex and increment `n` by 1. While n == 1
 # (which is true only for the first section) print that line of `CHANGES.md`.
 # This ends up being the first section of release changes.
-awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' $rootdir/CHANGES.md > $tmp
+awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' "$rootdir"/CHANGES.md > "$tmp"
 
 # Create an unsigned tag with the commit message.
-git tag -F $tmp $new_linkerd_version
+git tag -F "$tmp" "$new_linkerd_version"


### PR DESCRIPTION
## Motivation

Creating a release tag is a manual process that is prone to error by the
release responsible member.

Additionally, the automated release project will require that a message is
included that is a copy of the recent `CHANGES.md` changes.

These steps can be scripted so that the member will just need to run a release
script.

## Solution

A `bin/create-release-tag` script will:
- Take a `$TAG` argument (maybe can remove this in the future) to use as the
  tag name
- Pull out the top section of `CHANGES.md` to use as the commit message
- Create the a tag with `$TAG` name and release changes as the message

## Example

```
$ TAG="edge-20.2.3"
$ bin/create-release-tag $TAG
$ git push $TAG
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>