### PR TITLE
Remove envoy, contour restrictions

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -242,7 +242,7 @@ func TestUninjectAndInject(t *testing.T) {
 		},
 		{
 			inputFileName:    "inject_contour.input.yml",
-			goldenFileName:   "inject_contour.input.yml",
+			goldenFileName:   "inject_contour.golden.yml",
 			reportFileName:   "inject_contour.report",
 			injectProxy:      true,
 			testInjectConfig: defaultConfig,

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: contour
+  name: contour
+  namespace: heptio-contour
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: contour
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+        prometheus.io/format: prometheus
+        prometheus.io/path: /stats
+        prometheus.io/port: "9001"
+        prometheus.io/scrape: "true"
+      labels:
+        app: contour
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: contour
+    spec:
+      containers:
+      - args:
+        - serve
+        - --incluster
+        command:
+        - contour
+        image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: contour
+      - args:
+        - --config-path /config/contour.yaml
+        - --service-cluster cluster0
+        - --service-node node0
+        - --log-level info
+        - --v2-config-only
+        command:
+        - envoy
+        image: docker.io/envoyproxy/envoy-alpine:v1.6.0
+        name: envoy
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        volumeMounts:
+        - mountPath: /config
+          name: contour-config
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-dst.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_TAP_SVC_NAME
+          value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - bootstrap
+        - /config/contour.yaml
+        command:
+        - contour
+        image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: envoy-initconfig
+        volumeMounts:
+        - mountPath: /config
+          name: contour-config
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:v1.3.1
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+---

--- a/cli/cmd/testdata/inject_contour.report
+++ b/cli/cmd/testdata/inject_contour.report
@@ -1,6 +1,3 @@
 
-‼ known 3rd party sidecar detected in deployment/contour
-‼ no supported objects found
-
-deployment "contour" skipped
+deployment "contour" injected
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -1,9 +1,9 @@
 
 √ pods do not use host networking
-‼ known 3rd party sidecar detected in deployment/contour
+√ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
-‼ no supported objects found
+√ at least one resource injected
 √ pod specs do not include UDP ports
 
-deployment "contour" skipped
+deployment "contour" injected
 

--- a/cli/cmd/testdata/inject_contour_uninject.report
+++ b/cli/cmd/testdata/inject_contour_uninject.report
@@ -1,3 +1,3 @@
 
-deployment "contour" skipped
+deployment "contour" uninjected
 

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -75,7 +75,7 @@ func TestUninjectYAML(t *testing.T) {
 			reportFileName: "inject_emojivoto_istio_uninject.report",
 		},
 		{
-			inputFileName:  "inject_contour.input.yml",
+			inputFileName:  "inject_contour.golden.yml",
 			goldenFileName: "inject_contour.input.yml",
 			reportFileName: "inject_contour_uninject.report",
 		},

--- a/pkg/healthcheck/sidecar.go
+++ b/pkg/healthcheck/sidecar.go
@@ -13,12 +13,8 @@ func HasExistingSidecars(podSpec *corev1.PodSpec) bool {
 	for _, container := range podSpec.Containers {
 		if strings.HasPrefix(container.Image, "gcr.io/linkerd-io/proxy:") ||
 			strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
-			strings.HasPrefix(container.Image, "gcr.io/heptio-images/contour:") ||
-			strings.HasPrefix(container.Image, "docker.io/envoyproxy/envoy-alpine:") ||
 			container.Name == k8s.ProxyContainerName ||
-			container.Name == "istio-proxy" ||
-			container.Name == "contour" ||
-			container.Name == "envoy" {
+			container.Name == "istio-proxy" {
 			return true
 		}
 	}
@@ -26,10 +22,8 @@ func HasExistingSidecars(podSpec *corev1.PodSpec) bool {
 	for _, ic := range podSpec.InitContainers {
 		if strings.HasPrefix(ic.Image, "gcr.io/linkerd-io/proxy-init:") ||
 			strings.HasPrefix(ic.Image, "gcr.io/istio-release/proxy_init:") ||
-			strings.HasPrefix(ic.Image, "gcr.io/heptio-images/contour:") ||
 			ic.Name == "linkerd-init" ||
-			ic.Name == "istio-init" ||
-			ic.Name == "envoy-initconfig" {
+			ic.Name == "istio-init" {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/3910

Currently linkerd rejects injecting proxies into envoy/contour.

The reasons were probably historical since contour didn't support header manipulation.

With https://github.com/projectcontour/contour/releases/tag/v1.1.0 you can explicitly add headers to your routes making it possible to set the required `l5d-dst-override` header for linkerd.

---

Unfortunately contour doesn't support variables when setting headers, other than those provided by [envoy's custom headers](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers). To make linkerd work with contour+envoy you need to explicitly set the upstream cluster (read k8s service address) for every route:
```yaml
apiVersion: projectcontour.io/v1
kind: HTTPProxy
metadata:
  name: test-httpproxy
  namespace: default
spec:
  routes:
  - conditions:
    - prefix: /testroute
    requestHeadersPolicy:
      set:
      - name: l5d-dst-override
        value: test-service.default.svc:8443
    services:
    - name: test-service
      port: 8443
      namespace: default
```

Making this easier to configure is a problem for contour though.

---

This PR removes the restriction of linkerd not injecting sidecar proxies when using contour and envoy.