### PR TITLE
New CI job to automatically generate the Github release

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Set environment variables from scripts
-      run: |
-        . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
     - name: Setup SSH config for Packet
       run: |
         mkdir -p ~/.ssh/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,10 +212,36 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  gh_release:
+    name: Create GH release
+    runs-on: ubuntu-18.04
+    needs: [kind_integration_tests, cloud_integration_tests]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Pull CLI binaries
+      env:
+        TAG: ${{ github.ref }}
+      run : bin/docker-pull-binaries $TAG
+    - name: Create release
+      id: create_release
+      uses: softprops/action-gh-release@91409e7
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        draft: false
+        prelease: false
+        files: |
+          ./target/release/linkerd2-cli-${{ github.ref }}-darwin
+          ./target/release/linkerd2-cli-${{ github.ref }}-darwin.sha256
+          ./target/release/linkerd2-cli-${{ github.ref }}-linux
+          ./target/release/linkerd2-cli-${{ github.ref }}-linux.sha256
+          ./target/release/linkerd2-cli-${{ github.ref }}-windows.exe
+          ./target/release/linkerd2-cli-${{ github.ref }}-windows.exe.sha256
   chart_deploy:
     name: Helm chart deploy
     runs-on: ubuntu-18.04
-    needs: [kind_integration_tests, cloud_integration_tests]
+    needs: [gh_release]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Set environment variables from scripts
-      run: |
-        . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
     - name: Setup SSH config for Packet
       run: |
         mkdir -p ~/.ssh/
@@ -214,14 +210,17 @@ jobs:
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
   gh_release:
     name: Create GH release
+    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
     needs: [kind_integration_tests, cloud_integration_tests]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Set environment variables from scripts
+      run: |
+        . bin/_tag.sh
+        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
     - name: Pull CLI binaries
-      env:
-        TAG: ${{ github.ref }}
       run : bin/docker-pull-binaries $TAG
     - name: Create release
       id: create_release
@@ -232,12 +231,12 @@ jobs:
         draft: false
         prelease: false
         files: |
-          ./target/release/linkerd2-cli-${{ github.ref }}-darwin
-          ./target/release/linkerd2-cli-${{ github.ref }}-darwin.sha256
-          ./target/release/linkerd2-cli-${{ github.ref }}-linux
-          ./target/release/linkerd2-cli-${{ github.ref }}-linux.sha256
-          ./target/release/linkerd2-cli-${{ github.ref }}-windows.exe
-          ./target/release/linkerd2-cli-${{ github.ref }}-windows.exe.sha256
+          ./target/release/linkerd2-cli-*-darwin
+          ./target/release/linkerd2-cli-*-darwin.sha256
+          ./target/release/linkerd2-cli-*-linux
+          ./target/release/linkerd2-cli-*-linux.sha256
+          ./target/release/linkerd2-cli-*-windows.exe
+          ./target/release/linkerd2-cli-*-windows.exe.sha256
   chart_deploy:
     name: Helm chart deploy
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Fixes #4083

New `gh_release` job in the `release.yml` for creating the release in
Github and uploading the CLI binaries for each platform, along with
their checksum files.

This job only gets triggered upon successful docker images building and
pushing, and kind and cloud integration tests passing.

The Helm chart deploying job gets now triggered upon the success of this
new job.