### PR TITLE
Add spacing in CallToAction banner

### DIFF
--- a/web/app/js/components/CallToAction.jsx
+++ b/web/app/js/components/CallToAction.jsx
@@ -9,12 +9,6 @@ import { incompleteMeshMessage } from './util/CopyUtils.jsx';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
   instructions: {
     marginTop: theme.spacing(1),
     marginBottom: theme.spacing(1),

--- a/web/app/js/components/CallToAction.jsx
+++ b/web/app/js/components/CallToAction.jsx
@@ -29,7 +29,7 @@ function getSteps(numResources, resource) {
   ];
 }
 
-const CallToAction = ({ resource, numResources }) => {
+const CallToAction = ({ resource, numResources, classes }) => {
   const steps = getSteps(numResources, resource);
   const lastStep = steps.length - 1; // hardcode the last step as the active step
 
@@ -38,6 +38,7 @@ const CallToAction = ({ resource, numResources }) => {
       <Typography>The service mesh was successfully installed!</Typography>
       <Stepper
         activeStep={lastStep}
+        className={classes.instructions}
         orientation="vertical">
         {
           steps.map((step, i) => {


### PR DESCRIPTION
The call to action banner in the control plane page is missing some spacing.

The CSS is defined but not yet used. So the solution is to add the class name to the corresponding banner.

After its merged, the banner will have more space.

Before:
![image](https://user-images.githubusercontent.com/6806035/75182572-fea57080-5740-11ea-874b-d99d1982691a.png)

After:
![image](https://user-images.githubusercontent.com/6806035/75182626-111faa00-5741-11ea-8cb2-7625dd0ea6da.png)


Fixes #3690

Signed-off-by: Ali Ariff <ali.ariff12@gmail.com>
