### PR TITLE
Generate correct path name in case package name is missing in proto file

### DIFF
--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -45,11 +45,18 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain 
 			pkg = typed.Name
 		case *proto.RPC:
 			if service, ok := typed.Parent.(*proto.Service); ok {
+				var path string
+				switch pkg {
+				case "":
+					path = fmt.Sprintf("/%s/%s", service.Name, typed.Name)
+				default:
+					path = fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)
+				}
 				route := &sp.RouteSpec{
 					Name: typed.Name,
 					Condition: &sp.RequestMatch{
 						Method:    http.MethodPost,
-						PathRegex: regexp.QuoteMeta(fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)),
+						PathRegex: regexp.QuoteMeta(path),
 					},
 				}
 				routes = append(routes, route)


### PR DESCRIPTION
**Problem**

Default path regex in linkerd profile goes like this:

`/Package\.Service/Method`

When package name is missing in proto files, linkerd profile generates path names like this:

`/\.Service/Method`

What it should generate:

`/Service/Method`

**Solution**

Check package name for being empty and change path regex accordingly.

**Validation**

Create proto files without package name and generate profile from them. 