### PR TITLE
Generate correct path regex for proto files without package name

### DIFF
--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -45,11 +45,18 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain 
 			pkg = typed.Name
 		case *proto.RPC:
 			if service, ok := typed.Parent.(*proto.Service); ok {
+				var path string
+				switch pkg {
+				case "":
+					path = fmt.Sprintf("/%s/%s", service.Name, typed.Name)
+				default:
+					path = fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)
+				}
 				route := &sp.RouteSpec{
 					Name: typed.Name,
 					Condition: &sp.RequestMatch{
 						Method:    http.MethodPost,
-						PathRegex: regexp.QuoteMeta(fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)),
+						PathRegex: regexp.QuoteMeta(path),
 					},
 				}
 				routes = append(routes, route)


### PR DESCRIPTION
**Problem**

When generating linkerd service profile based on proto files, default path regex looks like this:

`/Package\.Service/Method`

When proto file is missing package name it looks like this:

`/\.Service/Method`

What it should look like:

`/Service/Method`

**Solution**

Check package name, change path regex accordingly

**Validation**

Generate service profiles based on proto files without package name.