### PR TITLE
Create linkerd/website dispatch event on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,7 @@ jobs:
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
   website_publish:
     name: Linkerd website publish
+    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
     needs: [kind_integration_tests, cloud_integration_tests]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,17 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  website_publish:
+    name: Linkerd website publish
+    runs-on: ubuntu-18.04
+    needs: [kind_integration_tests, cloud_integration_tests]
+    steps:
+    - name: Create linkerd/website repository dispatch event
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
+        repository: linkerd/website
+        event-type: release
   chart_deploy:
     name: Helm chart deploy
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Motivation

A goal of the release automation project is to automate the website publish
that publishes a new install script that uses the new release version.

linkerd/website#668 removed the hard coded versions from the repo and moved
the version update into the `make publish` command.

That workflow now needs to be triggered by a release in `linkerd2`.

## Solution

Once `kind_integration_tests` and `cloud_integration_test` pass, a job runs
using the [repository-dispatch](https://github.com/marketplace/actions/repository-dispatch) action to create a repository dispatch event in
`linkerd/website`.

This dispatch event will (current PR: linkerd/website#670) trigger the
publish workflow.

## Testing

Tested in my fork [here](https://github.com/kleimkuhler/linkerd2/actions/runs/45165789)

## Additional steps needed

A new `RELEASE_TOKEN` secret needs to be added to this repo. It should be the
personal access token of [l5d-bot](https://github.com/l5d-bot) with `repo` access.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
