### PR TITLE
Service Mirroring Component (no queue)

### DIFF
--- a/charts/linkerd2-service-mirror/README.md
+++ b/charts/linkerd2-service-mirror/README.md
@@ -18,4 +18,3 @@ The following table lists the configurable parameters of the linkerd2-service-mi
 |`namespace`                           | Service Mirror component namespace                                                |`linkerd-service-mirror`|
 |`serviceMirrorUID`                    | User id under which the Service Mirror shall be ran                               |`2103`|
 |`logLevel`                            | Log level for the Service Mirror component                                        |`info`|
-|`eventRequeueLimit`                   | Number of times update from the remote cluster is allowed to be requeued (retried)|`3`|

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -55,7 +55,6 @@ spec:
       - args:
         - service-mirror
         - -log-level={{.Values.logLevel}}
-        - -event-requeue-limit={{.Values.eventRequeueLimit}}
         image: {{.Values.controllerImage}}:{{default .Values.linkerdVersion .Values.controllerImageVersion}}
         name: service-mirror
         securityContext:

--- a/charts/linkerd2-service-mirror/values.yaml
+++ b/charts/linkerd2-service-mirror/values.yaml
@@ -1,6 +1,5 @@
 namespace: default
 serviceMirrorUID: 2103
 logLevel: info
-eventRequeueLimit: 3
 controllerImage: gcr.io/linkerd-io/controller
 linkerdVersion: {version}

--- a/cli/cmd/install-service-mirror.go
+++ b/cli/cmd/install-service-mirror.go
@@ -21,7 +21,6 @@ type installServiceMirrorOptions struct {
 	dockerRegistry      string
 	logLevel            string
 	uid                 int64
-	requeueLimit        int32
 }
 
 const helmServiceMirrorDefaultChartName = "linkerd2-service-mirror"
@@ -47,7 +46,6 @@ func newCmdInstallServiceMirror() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&options.dockerRegistry, "registry", options.dockerRegistry, "Docker registry to pull images from")
 	cmd.PersistentFlags().StringVarP(&options.logLevel, "log-level", "", options.logLevel, "Log level for the Service Mirror Component")
 	cmd.PersistentFlags().Int64Var(&options.uid, "uid", options.uid, "Run the Service Mirror component under this user ID")
-	cmd.PersistentFlags().Int32Var(&options.requeueLimit, "event-requeue-limit", options.requeueLimit, "The number of times a failed update from the remote cluster is allowed to be requeued (retried)")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "", options.namespace, "The namespace in which the Service Mirror Component is to be installed")
 
 	return cmd
@@ -64,7 +62,6 @@ func newInstallServiceMirrorOptionsWithDefaults() (*installServiceMirrorOptions,
 		dockerRegistry:      defaultDockerRegistry,
 		logLevel:            defaults.LogLevel,
 		uid:                 defaults.ServiceMirrorUID,
-		requeueLimit:        defaults.EventRequeueLimit,
 	}, nil
 }
 
@@ -78,7 +75,6 @@ func (options *installServiceMirrorOptions) buildValues() (*servicemirror.Values
 	installValues.ControllerImageVersion = options.controlPlaneVersion
 	installValues.ControllerImage = fmt.Sprintf("%s/controller", options.dockerRegistry)
 	installValues.ServiceMirrorUID = options.uid
-	installValues.EventRequeueLimit = options.requeueLimit
 
 	return installValues, nil
 }

--- a/controller/cmd/service-mirror/config_watcher.go
+++ b/controller/cmd/service-mirror/config_watcher.go
@@ -18,16 +18,14 @@ import (
 type RemoteClusterConfigWatcher struct {
 	k8sAPI          *k8s.API
 	clusterWatchers map[string]*RemoteClusterServiceWatcher
-	requeueLimit    int
 	sync.RWMutex
 }
 
 // NewRemoteClusterConfigWatcher Creates a new config watcher
-func NewRemoteClusterConfigWatcher(k8sAPI *k8s.API, requeueLimit int) *RemoteClusterConfigWatcher {
+func NewRemoteClusterConfigWatcher(k8sAPI *k8s.API) *RemoteClusterConfigWatcher {
 	rcw := &RemoteClusterConfigWatcher{
 		k8sAPI:          k8sAPI,
 		clusterWatchers: map[string]*RemoteClusterServiceWatcher{},
-		requeueLimit:    requeueLimit,
 	}
 	k8sAPI.Secret().Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
@@ -122,7 +120,7 @@ func (rcw *RemoteClusterConfigWatcher) registerRemoteCluster(secret *corev1.Secr
 		return fmt.Errorf("there is already a cluster with name %s being watcher. Please delete its config before attempting to register a new one", name)
 	}
 
-	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, name, rcw.requeueLimit, domain)
+	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, name, domain)
 	if err != nil {
 		return err
 	}

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -16,7 +16,6 @@ func Main(args []string) {
 	cmd := flag.NewFlagSet("service-mirror", flag.ExitOnError)
 
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to the local kube config")
-	requeueLimit := cmd.Int("event-requeue-limit", 3, "requeue limit for events")
 
 	flags.ConfigureAndParse(cmd, args)
 
@@ -37,7 +36,7 @@ func Main(args []string) {
 	}
 
 	k8sAPI.Sync(nil)
-	watcher := NewRemoteClusterConfigWatcher(k8sAPI, *requeueLimit)
+	watcher := NewRemoteClusterConfigWatcher(k8sAPI)
 	log.Info("Started cluster config watcher")
 
 	<-stop

--- a/pkg/charts/servicemirror/values.go
+++ b/pkg/charts/servicemirror/values.go
@@ -19,7 +19,6 @@ type Values struct {
 	ControllerImageVersion string `json:"controllerImageVersion"`
 	ServiceMirrorUID       int64  `json:"serviceMirrorUID"`
 	LogLevel               string `json:"logLevel"`
-	EventRequeueLimit      int32  `json:"eventRequeueLimit"`
 }
 
 // NewValues returns a new instance of the Values type.


### PR DESCRIPTION
This is a version that removes the queue and leaves it to the func handlers of the informers to call the corresponding methods synchronously. I am no convinced that this simplifies things all that much. Futrthermore: 

- Its a universal recommendation that the funcs in the handlers should be returning rather quickly, while now we start calling k8s api methods on our local and remote clusters. 
-  I was hoping that the queue approah can give us a bit more _principled_ error handling, where we can requeue and try again instead of passivelly log things.
- If we encaunter some kind of intermittent failures with processing our updates, we need to wait till the next resync (currently configured at 10 min) and hope that we can effectivelly `retry` at that point
- Not sure this approach lowers the cognitive burdon of following the code. 

Note: I have not updated the comment to reflect we are not using a queue approach. If we decide to merge that one instead, I can do that. 