### PR TITLE
Fix `fetch-proxy` script on macos

### DIFF
--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -28,7 +28,11 @@ curl -sLO "$assetbase/$shafile"
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
-computed=$(sha256sum "$pkgfile" | awk '{print $1}')
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  computed=$(openssl dgst -sha256 "$pkgfile" | awk '{print $2}')
+else
+  computed=$(sha256sum "$pkgfile" | awk '{print $1}')
+fi
 if [ "$computed" != "$expected" ]; then
   echo 'sha mismatch' >&2
   exit 1

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -28,11 +28,7 @@ curl -sLO "$assetbase/$shafile"
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
-if [ $(uname) == "Darwin" ]; then
-  computed=$(openssl dgst -sha256 "$pkgfile" | awk '{print $2}')
-else
-  computed=$(sha256sum "$pkgfile" | awk '{print $1}')
-fi
+computed=$(shasum -a 256 "$pkgfile" | awk '{print $1}')
 if [ "$computed" != "$expected" ]; then
   echo 'sha mismatch' >&2
   exit 1

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -28,7 +28,7 @@ curl -sLO "$assetbase/$shafile"
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [ $(uname) == "Darwin" ]; then
   computed=$(openssl dgst -sha256 "$pkgfile" | awk '{print $2}')
 else
   computed=$(sha256sum "$pkgfile" | awk '{print $1}')

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -28,7 +28,11 @@ curl -sLO "$assetbase/$shafile"
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
-computed=$(shasum -a 256 "$pkgfile" | awk '{print $1}')
+if [ $(uname) == "Darwin" ]; then
+  computed=$(openssl dgst -sha256 "$pkgfile" | awk '{print $2}')
+else
+  computed=$(sha256sum "$pkgfile" | awk '{print $1}')
+fi
 if [ "$computed" != "$expected" ]; then
   echo 'sha mismatch' >&2
   exit 1


### PR DESCRIPTION
`sha256sum` is not installed by default. Use `openssl dgst -sha256` instead.
