### PR TITLE
Use SHAs instead of tags when referring to GH Actions libs

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Setup SSH config for Packet
       run: |
         mkdir -p ~/.ssh/
@@ -36,13 +37,15 @@ jobs:
     needs: [docker_build]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
     - name: Configure gcloud
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         gcp_project: ${{ secrets.GCP_PROJECT }}
@@ -71,9 +74,11 @@ jobs:
     needs: [docker_push]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Try to load cached Go modules
-      uses: actions/cache@v1
+      # actions/cache@v1.1.2
+      uses: actions/cache@70655ec
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -92,7 +97,8 @@ jobs:
         echo "Installed Linkerd CLI version: $TAG"
         echo "::set-output name=tag::$TAG"
     - name: Create GKE cluster
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         gcp_project: ${{ secrets.GCP_PROJECT }}

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
@@ -58,7 +59,8 @@ jobs:
     # https://github.com/actions/upload-artifact/issues/8
     - name: Upload artifact (Forked repositories)
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      uses: actions/upload-artifact@v1
+      # actions/upload-artifact@v1
+      uses: actions/upload-artifact@3446296
       with:
         name: image-archives
         path: /home/runner/archives
@@ -72,9 +74,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Try to load cached Go modules
-      uses: actions/cache@v1
+      # actions/cache@v1.1.2
+      uses: actions/cache@70655ec
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -97,7 +101,8 @@ jobs:
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
     - name: Download image archives (Forked repositories)
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
-      uses: actions/download-artifact@v1
+      # actions/download-artifact@v1
+      uses: actions/download-artifact@18f0f59
       with:
         name: image-archives
     - name: Load cli-bin image into local docker images
@@ -122,12 +127,14 @@ jobs:
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Setup default KinD cluster
       if: matrix.integration_test != 'custom_domain'
-      uses: engineerd/setup-kind@v0.3.0
+      # engineerd/setup-kind@v0.3.0
+      uses: engineerd/setup-kind@d0e9be1
       with:
         version: "v0.6.1"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
-      uses: engineerd/setup-kind@v0.3.0
+      # engineerd/setup-kind@v0.3.0
+      uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
         version: "v0.6.1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Setup SSH config for Packet
       run: |
         mkdir -p ~/.ssh/
@@ -41,13 +42,15 @@ jobs:
     needs: [docker_build]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
     - name: Configure gcloud
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         gcp_project: ${{ secrets.GCP_PROJECT }}
@@ -79,9 +82,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Try to load cached Go modules
-      uses: actions/cache@v1
+      # actions/cache@v1.1.2
+      uses: actions/cache@70655ec
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -119,12 +124,14 @@ jobs:
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Setup default KinD cluster
       if: matrix.integration_test != 'custom_domain'
-      uses: engineerd/setup-kind@v0.3.0
+      # engineerd/setup-kind@v0.3.0
+      uses: engineerd/setup-kind@d0e9be1
       with:
         version: "v0.6.1"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
-      uses: engineerd/setup-kind@v0.3.0
+      # engineerd/setup-kind@v0.3.0
+      uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
         version: "v0.6.1"
@@ -168,9 +175,11 @@ jobs:
     needs: [docker_push]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Try to load cached Go modules
-      uses: actions/cache@v1
+      # actions/cache@v1.1.2
+      uses: actions/cache@70655ec
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -189,7 +198,8 @@ jobs:
         echo "Installed Linkerd CLI version: $TAG"
         echo "::set-output name=tag::$TAG"
     - name: Create GKE cluster
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         gcp_project: ${{ secrets.GCP_PROJECT }}
@@ -215,7 +225,8 @@ jobs:
     needs: [kind_integration_tests, cloud_integration_tests]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
@@ -224,6 +235,7 @@ jobs:
       run : bin/docker-pull-binaries $TAG
     - name: Create release
       id: create_release
+      # softprops/action-gh-release@v1
       uses: softprops/action-gh-release@91409e7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -244,7 +256,8 @@ jobs:
     needs: [kind_integration_tests, cloud_integration_tests]
     steps:
     - name: Create linkerd/website repository dispatch event
-      uses: peter-evans/repository-dispatch@v1
+      # peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@0ae1c4b
       with:
         token: ${{ secrets.RELEASE_TOKEN }}
         repository: linkerd/website
@@ -256,7 +269,8 @@ jobs:
     needs: [website_publish]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
@@ -284,9 +298,11 @@ jobs:
     needs: [gh_release]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Configure gsutils
-      uses: linkerd/linkerd2-action-gcloud@v1.0.1
+      # linkerd/linkerd2-action-gcloud@v1.0.1
+      uses: linkerd/linkerd2-action-gcloud@308c4df
       with:
         cloud_sdk_service_account_key: ${{ secrets.LINKERD_SITE_TOKEN }}
         gcp_project: ${{ secrets.LINKERD_SITE_PROJECT }}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Dump env
       run: env | sort
     - name: Dump GitHub context
@@ -37,7 +38,8 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Go lint
       env:
         GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
@@ -51,7 +53,8 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Format
       env:
         GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,8 @@ jobs:
       image: golang:1.13.4
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Go unit tests
       env:
         GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
@@ -30,7 +31,8 @@ jobs:
       image: node:10.16.0-stretch
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
     - name: Yarn setup
       run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
     - name: JS unit tests


### PR DESCRIPTION
When adding an action we can quickly vet it and fix it to a SHA. Whereas
if we use a tag, the 3rd party can change the code and retag it without us noticing.