### PR TITLE
Fix `bin/fetch-proxy` on Linux

### DIFF
--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -28,7 +28,7 @@ curl -sLO "$assetbase/$shafile"
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")
-if [ $(uname) == "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ]; then
   computed=$(openssl dgst -sha256 "$pkgfile" | awk '{print $2}')
 else
   computed=$(sha256sum "$pkgfile" | awk '{print $1}')


### PR DESCRIPTION
`bin/fetch-proxy` was failing on Linux:

```bash
$ bin/fetch-proxy
linkerd2-proxy-v2.87.0/
linkerd2-proxy-v2.87.0/LICENSE
linkerd2-proxy-v2.87.0/bin/
linkerd2-proxy-v2.87.0/bin/linkerd2-proxy
bin/fetch-proxy: 31: [: Linux: unexpected operator
/home/siggy/code/linkerd2/target/proxy/linkerd2-proxy-v2.87.0
```

Also in CI:
https://github.com/linkerd/linkerd2/runs/473746447?check_suite_focus=true#step:5:32

Unfortunately `bin/fetch-proxy` still returned a zero exit status, because
`set -e` does not apply to commands that are part of `if` statements.
From https://ss64.com/bash/set.html:
```
-e  Exit immediately if a simple command exits with a non-zero status, unless
    the command that fails is part of an until or  while loop, part of an
    if statement, part of a && or || list, or if the command's return status
    is being inverted using !.  -o errexit
```
Fortunately when the `if` command failed, it fell through to the `else` clause
for Linux, and copied `linkerd-proxy` successfully.

Root cause was a `==` instead of `=`. `shellcheck` confirms, and also
recommends quoting:

```bash
$ shellcheck bin/fetch-proxy

In bin/fetch-proxy line 31:
if [ $(uname) == "Darwin" ]; then
     ^-- SC2046: Quote this to prevent word splitting.
              ^-- SC2039: In POSIX sh, == in place of = is undefined.
```

Apply `shellcheck` recommendations.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
