### PR TITLE
Introduce `bin/shellcheck`, add to ci

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -97,7 +97,6 @@ jobs:
         ! -name docker-push-deps \
         ! -name docker-retag-all \
         ! -name _docker.sh \
-        ! -name fetch-proxy \
         ! -name fmt \
         ! -name helm-build \
         ! -name kind-load \

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -68,38 +68,52 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: shellcheck
-      # TODO: fix our shell scripts and re-enable checks
+      # TODO: Each file listed here is excluded from shellcheck because it
+      # fails. As we fix files we can remove them from this list.
+      #
+      # Once we have this list paired down signficantly, we can switch to
+      # disabling specific checks across all files, for example:
+      # bin/shellcheck bin/* --exclude=SC1000
+      #
+      # For more information on shellcheck failures:
+      # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
-        bin/shellcheck bin/* --exclude="\
-        SC1036,\
-        SC1061,\
-        SC1062,\
-        SC1072,\
-        SC1073,\
-        SC1081,\
-        SC1088,\
-        SC1090,\
-        SC2001,\
-        SC2005,\
-        SC2013,\
-        SC2027,\
-        SC2034,\
-        SC2039,\
-        SC2046,\
-        SC2048,\
-        SC2064,\
-        SC2068,\
-        SC2086,\
-        SC2089,\
-        SC2090,\
-        SC2116,\
-        SC2120,\
-        SC2124,\
-        SC2155,\
-        SC2175,\
-        SC2119,\
-        SC2148,\
-        SC2154,\
-        SC2215,\
-        SC2220,\
-        SC2236"
+        find ./bin -type f \
+        ! -name build-cli-bin \
+        ! -name docker-build-base \
+        ! -name docker-build-cli-bin \
+        ! -name docker-build-cni-plugin \
+        ! -name docker-build-controller \
+        ! -name docker-build-debug \
+        ! -name docker-build-go-deps \
+        ! -name docker-build-grafana \
+        ! -name docker-build-proxy \
+        ! -name docker-build-web \
+        ! -name docker-images \
+        ! -name docker-pull \
+        ! -name docker-pull-binaries \
+        ! -name docker-pull-deps \
+        ! -name docker-push \
+        ! -name docker-push-deps \
+        ! -name docker-retag-all \
+        ! -name _docker.sh \
+        ! -name fetch-proxy \
+        ! -name fmt \
+        ! -name helm-build \
+        ! -name kind-load \
+        ! -name lint \
+        ! -name _log.sh \
+        ! -name minikube-start-hyperv.bat \
+        ! -name mkube \
+        ! -name protoc-go.sh \
+        ! -name root-tag \
+        ! -name _tag.sh \
+        ! -name test-cleanup \
+        ! -name test-clouds-cleanup \
+        ! -name test-clouds \
+        ! -name test-run \
+        ! -name _test-run.sh \
+        ! -name test-scale \
+        ! -name update-go-deps-shas \
+        ! -name web \
+        | xargs -I {} bin/shellcheck {}

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -61,3 +61,45 @@ jobs:
       run: |
         echo "$GITCOOKIE_SH" | bash
         bin/fmt
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: shellcheck
+      # TODO: fix our shell scripts and re-enable checks
+      run: |
+        bin/shellcheck bin/* --exclude="\
+        SC1036,\
+        SC1061,\
+        SC1062,\
+        SC1072,\
+        SC1073,\
+        SC1081,\
+        SC1088,\
+        SC1090,\
+        SC2001,\
+        SC2005,\
+        SC2013,\
+        SC2027,\
+        SC2034,\
+        SC2039,\
+        SC2046,\
+        SC2048,\
+        SC2064,\
+        SC2068,\
+        SC2086,\
+        SC2089,\
+        SC2090,\
+        SC2116,\
+        SC2120,\
+        SC2124,\
+        SC2155,\
+        SC2175,\
+        SC2119,\
+        SC2148,\
+        SC2154,\
+        SC2215,\
+        SC2220,\
+        SC2236"

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -98,7 +98,6 @@ jobs:
         ! -name docker-retag-all \
         ! -name _docker.sh \
         ! -name fmt \
-        ! -name helm-build \
         ! -name kind-load \
         ! -name lint \
         ! -name _log.sh \
@@ -115,4 +114,4 @@ jobs:
         ! -name test-scale \
         ! -name update-go-deps-shas \
         ! -name web \
-        | xargs -I {} bin/shellcheck {}
+        | xargs -I {} bin/shellcheck -x {}

--- a/TEST.md
+++ b/TEST.md
@@ -13,6 +13,7 @@ of this repo, unless otherwise indicated by a `cd` command.
 - [Unit tests](#unit-tests)
   - [Go](#go)
   - [Javascript](#javascript)
+  - [Shell](#shell)
 - [Integration tests](#integration-tests)
   - [Prerequisites](#prerequisites)
   - [Running tests](#running-tests)
@@ -78,6 +79,12 @@ Run watch mode:
 ```bash
 bin/web test --watch # runs -o by default (tests only files changed since last commit)
 bin/web test --watchAll # runs all tests after a change to a file
+```
+
+## Shell
+
+```bash
+bin/shellcheck bin/*
 ```
 
 # Integration tests

--- a/TEST.md
+++ b/TEST.md
@@ -84,7 +84,7 @@ bin/web test --watchAll # runs all tests after a change to a file
 ## Shell
 
 ```bash
-bin/shellcheck bin/*
+bin/shellcheck -x bin/*
 ```
 
 # Integration tests

--- a/bin/shellcheck
+++ b/bin/shellcheck
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -eu
+
+scversion=v0.7.0
+
+bindir=$( cd "${0%/*}" && pwd )
+targetbin=$( cd "$bindir"/.. && pwd )/target/bin
+scbin=$targetbin/.shellcheck-$scversion
+
+if [ ! -f "$scbin" ]; then
+  if [ "$(uname -s)" = Darwin ]; then
+    file=darwin.x86_64.tar.xz
+  elif [ "$(uname -o)" = Msys ]; then
+    # TODO: work on windows
+    file=zip
+  else
+    case $(uname -m) in
+      x86_64) file=linux.x86_64.tar.xz ;;
+      arm) file=linux.aarch64.tar.xz ;;
+    esac
+  fi
+
+  mkdir -p "$targetbin"
+  wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.$file" | tar -OxJv "shellcheck-${scversion}/shellcheck" > "$scbin"
+  chmod +x "$scbin"
+fi
+
+"$scbin" "$@"


### PR DESCRIPTION
PR #4117 was root-caused with the help of `shellcheck`.

This change introduces a `bin/shellcheck` script, and adds it to CI. In
CI, many checks are disabled to allow it to pass. This will at least
prevent introduction of new classes of shell issue, and should motivate
re-enabling more checks over time.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
