### PR TITLE
Fix namespace-scoped Grafana links

### DIFF
--- a/web/app/js/components/GrafanaLink.jsx
+++ b/web/app/js/components/GrafanaLink.jsx
@@ -1,11 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import _isEmpty from 'lodash/isEmpty';
 import { grafanaIcon } from './util/SvgWrappers.jsx';
 
 const GrafanaLink = ({ PrefixedLink, name, namespace, resource }) => {
+  let link = `/grafana/dashboard/db/linkerd-${resource}?var-${resource}=${name}`;
+  if (!_isEmpty(namespace)) {
+    link += `&var-namespace=${namespace}`;
+  }
   return (
     <PrefixedLink
-      to={`/grafana/dashboard/db/linkerd-${resource}?var-namespace=${namespace}&var-${resource}=${name}`}
+      to={link}
       targetBlank>
       &nbsp;&nbsp;
       {grafanaIcon}
@@ -15,9 +20,13 @@ const GrafanaLink = ({ PrefixedLink, name, namespace, resource }) => {
 
 GrafanaLink.propTypes = {
   name: PropTypes.string.isRequired,
-  namespace: PropTypes.string.isRequired,
+  namespace: PropTypes.string,
   PrefixedLink: PropTypes.func.isRequired,
   resource: PropTypes.string.isRequired,
+};
+
+GrafanaLink.defaultProps = {
+  namespace: '',
 };
 
 export default GrafanaLink;

--- a/web/app/js/components/GrafanaLink.test.jsx
+++ b/web/app/js/components/GrafanaLink.test.jsx
@@ -26,4 +26,25 @@ describe('GrafanaLink', () => {
     expect(href).toContain(expectedNsStr);
     expect(href).toContain(expectedVarNameStr);
   });
+
+  it('makes a link without a namespace', () => {
+    let api = ApiHelpers('');
+    let linkProps = {
+      resource: "replicationcontroller",
+      name: "aldksf-3409823049823",
+      PrefixedLink: api.PrefixedLink
+    };
+    let component = mount(routerWrap(GrafanaLink, linkProps));
+
+    let expectedDashboardNameStr = "/linkerd-replicationcontroller";
+    let expectedVarNameStr = "var-replicationcontroller=aldksf-3409823049823";
+
+    expect(component.find("GrafanaLink")).toHaveLength(1);
+
+    const href = component.find('a').props().href;
+
+    expect(href).toContain(expectedDashboardNameStr);
+    expect(href).not.toContain("namespace");
+    expect(href).toContain(expectedVarNameStr);
+  });
 });


### PR DESCRIPTION
The `/namespaces` page in the web dashboard was rendering broken Grafana
links, containing an extra `var-namespace=` param, for example:
```
/grafana/dashboard/db/linkerd-namespace?var-namespace=&var-namespace=emojivoto
```

Root cause was the `GrafanaLink` component taking both `resource` and
`namespace` properties, but not special-casing when
`resource === 'namespace' && namespace === ''`.

Modify the `GrafanaLink` component to omit the `var-namespace` param
when a `namespace` property is not provided.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<img width="1275" alt="Screen Shot 2020-02-27 at 11 35 47 PM" src="https://user-images.githubusercontent.com/236915/75520314-1d626c00-59ba-11ea-8ec7-51ee74f8c120.png">

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
