### PR TITLE
Add kubectl-style label selectors

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,6 +25,8 @@ const (
 	jsonOutput  = "json"
 	tableOutput = "table"
 	wideOutput  = "wide"
+
+	maxRps = 100.0
 )
 
 var (

--- a/cli/cmd/routes.go
+++ b/cli/cmd/routes.go
@@ -19,9 +19,10 @@ import (
 
 type routesOptions struct {
 	statOptionsBase
-	toResource   string
-	toNamespace  string
-	dstIsService bool
+	toResource    string
+	toNamespace   string
+	dstIsService  bool
+	labelSelector string
 }
 
 type routeRowStats struct {
@@ -36,6 +37,7 @@ func newRoutesOptions() *routesOptions {
 		statOptionsBase: *newStatOptionsBase(),
 		toResource:      "",
 		toNamespace:     "",
+		labelSelector:   "",
 	}
 }
 
@@ -77,6 +79,7 @@ This command will only display traffic which is sent to a service that has a Ser
 	cmd.PersistentFlags().StringVar(&options.toResource, "to", options.toResource, "If present, shows outbound stats to the specified resource")
 	cmd.PersistentFlags().StringVar(&options.toNamespace, "to-namespace", options.toNamespace, "Sets the namespace used to lookup the \"--to\" resource; by default the current \"--namespace\" is used")
 	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, fmt.Sprintf("Output format; one of: \"%s\", \"%s\", or \"%s\"", tableOutput, wideOutput, jsonOutput))
+	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
 
 	return cmd
 }
@@ -318,6 +321,7 @@ func buildTopRoutesRequest(resource string, options *routesOptions) (*pb.TopRout
 			ResourceType: target.Type,
 			Namespace:    options.namespace,
 		},
+		LabelSelector: options.labelSelector,
 	}
 
 	options.dstIsService = !(target.GetType() == k8s.Authority)

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -32,6 +32,7 @@ type tapOptions struct {
 	authority   string
 	path        string
 	output      string
+	labelSelector string
 }
 
 type endpoint struct {
@@ -111,6 +112,7 @@ func newTapOptions() *tapOptions {
 		authority:   "",
 		path:        "",
 		output:      "",
+		labelSelector: "",
 	}
 }
 
@@ -179,6 +181,7 @@ func newCmdTap() *cobra.Command {
 				Authority:   options.authority,
 				Path:        options.path,
 				Extract:     options.output == jsonOutput,
+				LabelSelector: options.labelSelector,
 			}
 
 			err := options.validate()
@@ -218,6 +221,9 @@ func newCmdTap() *cobra.Command {
 		"Display requests with paths that start with this prefix")
 	cmd.PersistentFlags().StringVarP(&options.output, "output", "o", options.output,
 		fmt.Sprintf("Output format. One of: \"%s\", \"%s\"", wideOutput, jsonOutput))
+	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector,
+		"Selector (label query) to filter on, supports '=', '==', and '!='")
+
 
 	return cmd
 }

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -106,7 +106,7 @@ func newTapOptions() *tapOptions {
 		namespace:     "default",
 		toResource:    "",
 		toNamespace:   "",
-		maxRps:        100.0,
+		maxRps:        maxRps,
 		scheme:        "",
 		method:        "",
 		authority:     "",

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -23,15 +23,15 @@ import (
 type renderTapEventFunc func(*pb.TapEvent, string) string
 
 type tapOptions struct {
-	namespace   string
-	toResource  string
-	toNamespace string
-	maxRps      float32
-	scheme      string
-	method      string
-	authority   string
-	path        string
-	output      string
+	namespace     string
+	toResource    string
+	toNamespace   string
+	maxRps        float32
+	scheme        string
+	method        string
+	authority     string
+	path          string
+	output        string
 	labelSelector string
 }
 
@@ -103,15 +103,15 @@ type tapEvent struct {
 
 func newTapOptions() *tapOptions {
 	return &tapOptions{
-		namespace:   "default",
-		toResource:  "",
-		toNamespace: "",
-		maxRps:      100.0,
-		scheme:      "",
-		method:      "",
-		authority:   "",
-		path:        "",
-		output:      "",
+		namespace:     "default",
+		toResource:    "",
+		toNamespace:   "",
+		maxRps:        100.0,
+		scheme:        "",
+		method:        "",
+		authority:     "",
+		path:          "",
+		output:        "",
 		labelSelector: "",
 	}
 }
@@ -171,16 +171,16 @@ func newCmdTap() *cobra.Command {
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			requestParams := util.TapRequestParams{
-				Resource:    strings.Join(args, "/"),
-				Namespace:   options.namespace,
-				ToResource:  options.toResource,
-				ToNamespace: options.toNamespace,
-				MaxRps:      options.maxRps,
-				Scheme:      options.scheme,
-				Method:      options.method,
-				Authority:   options.authority,
-				Path:        options.path,
-				Extract:     options.output == jsonOutput,
+				Resource:      strings.Join(args, "/"),
+				Namespace:     options.namespace,
+				ToResource:    options.toResource,
+				ToNamespace:   options.toNamespace,
+				MaxRps:        options.maxRps,
+				Scheme:        options.scheme,
+				Method:        options.method,
+				Authority:     options.authority,
+				Path:          options.path,
+				Extract:       options.output == jsonOutput,
 				LabelSelector: options.labelSelector,
 			}
 
@@ -223,7 +223,6 @@ func newCmdTap() *cobra.Command {
 		fmt.Sprintf("Output format. One of: \"%s\", \"%s\"", wideOutput, jsonOutput))
 	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector,
 		"Selector (label query) to filter on, supports '=', '==', and '!='")
-
 
 	return cmd
 }

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -25,16 +25,16 @@ import (
 )
 
 type topOptions struct {
-	namespace   string
-	toResource  string
-	toNamespace string
-	maxRps      float32
-	scheme      string
-	method      string
-	authority   string
-	path        string
-	hideSources bool
-	routes      bool
+	namespace     string
+	toResource    string
+	toNamespace   string
+	maxRps        float32
+	scheme        string
+	method        string
+	authority     string
+	path          string
+	hideSources   bool
+	routes        bool
 	labelSelector string
 }
 
@@ -259,16 +259,16 @@ const (
 
 func newTopOptions() *topOptions {
 	return &topOptions{
-		namespace:   "default",
-		toResource:  "",
-		toNamespace: "",
-		maxRps:      100.0,
-		scheme:      "",
-		method:      "",
-		authority:   "",
-		path:        "",
-		hideSources: false,
-		routes:      false,
+		namespace:     "default",
+		toResource:    "",
+		toNamespace:   "",
+		maxRps:        100.0,
+		scheme:        "",
+		method:        "",
+		authority:     "",
+		path:          "",
+		hideSources:   false,
+		routes:        false,
 		labelSelector: "",
 	}
 }
@@ -319,15 +319,15 @@ func newCmdTop() *cobra.Command {
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			requestParams := util.TapRequestParams{
-				Resource:    strings.Join(args, "/"),
-				Namespace:   options.namespace,
-				ToResource:  options.toResource,
-				ToNamespace: options.toNamespace,
-				MaxRps:      options.maxRps,
-				Scheme:      options.scheme,
-				Method:      options.method,
-				Authority:   options.authority,
-				Path:        options.path,
+				Resource:      strings.Join(args, "/"),
+				Namespace:     options.namespace,
+				ToResource:    options.toResource,
+				ToNamespace:   options.toNamespace,
+				MaxRps:        options.maxRps,
+				Scheme:        options.scheme,
+				Method:        options.method,
+				Authority:     options.authority,
+				Path:          options.path,
 				LabelSelector: options.labelSelector,
 			}
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -262,7 +262,7 @@ func newTopOptions() *topOptions {
 		namespace:     "default",
 		toResource:    "",
 		toNamespace:   "",
-		maxRps:        100.0,
+		maxRps:        maxRps,
 		scheme:        "",
 		method:        "",
 		authority:     "",

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -35,6 +35,7 @@ type topOptions struct {
 	path        string
 	hideSources bool
 	routes      bool
+	labelSelector string
 }
 
 type topRequest struct {
@@ -268,6 +269,7 @@ func newTopOptions() *topOptions {
 		path:        "",
 		hideSources: false,
 		routes:      false,
+		labelSelector: "",
 	}
 }
 
@@ -326,6 +328,7 @@ func newCmdTop() *cobra.Command {
 				Method:      options.method,
 				Authority:   options.authority,
 				Path:        options.path,
+				LabelSelector: options.labelSelector,
 			}
 
 			if options.hideSources {
@@ -374,6 +377,7 @@ func newCmdTop() *cobra.Command {
 		"Display requests with paths that start with this prefix")
 	cmd.PersistentFlags().BoolVar(&options.hideSources, "hide-sources", options.hideSources, "Hide the source column")
 	cmd.PersistentFlags().BoolVar(&options.routes, "routes", options.routes, "Display data per route instead of per path")
+	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
 
 	return cmd
 }

--- a/controller/api/public/top_routes.go
+++ b/controller/api/public/top_routes.go
@@ -355,6 +355,7 @@ func processRouteMetrics(results []promResult, timeWindow string, table indexedT
 	}
 }
 
+//generate correct label.Selector object according to the request
 func getTopLabelSelector(req *pb.TopRoutesRequest) (labels.Selector, error) {
 	labelSelector := labels.Everything()
 	if s := req.GetSelector().GetLabelSelector(); s != "" {

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -94,24 +94,25 @@ type EdgesRequestParams struct {
 // requests.
 type TopRoutesRequestParams struct {
 	StatsBaseRequestParams
-	ToNamespace string
-	ToType      string
-	ToName      string
+	ToNamespace   string
+	ToType        string
+	ToName        string
+	LabelSelector string
 }
 
 // TapRequestParams contains parameters that are used to build a
 // TapByResourceRequest.
 type TapRequestParams struct {
-	Resource    string
-	Namespace   string
-	ToResource  string
-	ToNamespace string
-	MaxRps      float32
-	Scheme      string
-	Method      string
-	Authority   string
-	Path        string
-	Extract     bool
+	Resource      string
+	Namespace     string
+	ToResource    string
+	ToNamespace   string
+	MaxRps        float32
+	Scheme        string
+	Method        string
+	Authority     string
+	Path          string
+	Extract       bool
 	LabelSelector string
 }
 
@@ -302,6 +303,7 @@ func BuildTopRoutesRequest(p TopRoutesRequestParams) (*pb.TopRoutesRequest, erro
 				Name:      p.ResourceName,
 				Type:      resourceType,
 			},
+			LabelSelector: p.LabelSelector,
 		},
 		TimeWindow: window,
 	}
@@ -514,7 +516,7 @@ func BuildTapByResourceRequest(params TapRequestParams) (*pb.TapByResourceReques
 
 	return &pb.TapByResourceRequest{
 		Target: &pb.ResourceSelection{
-			Resource: &target,
+			Resource:      &target,
 			LabelSelector: params.LabelSelector,
 		},
 		MaxRps: params.MaxRps,

--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -112,6 +112,7 @@ type TapRequestParams struct {
 	Authority   string
 	Path        string
 	Extract     bool
+	LabelSelector string
 }
 
 // GRPCError generates a gRPC error code, as defined in
@@ -514,6 +515,7 @@ func BuildTapByResourceRequest(params TapRequestParams) (*pb.TapByResourceReques
 	return &pb.TapByResourceRequest{
 		Target: &pb.ResourceSelection{
 			Resource: &target,
+			LabelSelector: params.LabelSelector,
 		},
 		MaxRps: params.MaxRps,
 		Match: &pb.TapByResourceRequest_Match{


### PR DESCRIPTION
Second take on https://github.com/linkerd/linkerd2/issues/2734
Also, somewhat related to https://github.com/linkerd/gsoc/pull/2 , https://github.com/linkerd/linkerd2/issues/3871
This PR adds support for kubectl-style label selectors for the following cmds:
- tap
- top
- routes

Example:
```bash
# tap deployments with label sample.label=test
$ linkerd -n myns tap deploy -l sample.label=test

# display live traffic from all deployments with label sample.label=test
$ linkerd -n myns top deploy --selector sample.label=test

# display route stat from all deployments with label sample.label=test
$ linkerd -n myns routes deploy -l sample.label=test
```
> Note : Label selector for stat has been addressed in https://github.com/linkerd/linkerd2/pull/4040

### Unresolved Questions

- Do we need to add similar support for `metrics` cmd? It looks like the same can be achieved from : 
```bash
linkerd metrics -n linkerd $(
    kubectl --namespace linkerd get pod \
      --selector linkerd.io/control-plane-component=controller \
      --output name
  )
```

### TODO
A follow up PR shall be made for :
- Add support for `tap`,`top`,`routes`,`stat` to accept list of resources. Eg:
```bash
$ linkerd -n linkerd tap deploy linkerd-controller linkerd-identity
```

cc: @ihcsim 