### PR TITLE
CI: Adjustments to the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,9 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
+        . bin/_release.sh
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        extract_release_notes NOTES.md
     - name: Pull CLI binaries
       run : bin/docker-pull-binaries $TAG
     - name: Create release
@@ -230,6 +232,7 @@ jobs:
       with:
         draft: false
         prelease: false
+        body_path: NOTES.md
         files: |
           ./target/release/linkerd2-cli-*-darwin
           ./target/release/linkerd2-cli-*-darwin.sha256
@@ -241,7 +244,7 @@ jobs:
     name: Linkerd website publish
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
-    needs: [kind_integration_tests, cloud_integration_tests]
+    needs: [gh_release]
     steps:
     - name: Create linkerd/website repository dispatch event
       uses: peter-evans/repository-dispatch@v1

--- a/bin/_release.sh
+++ b/bin/_release.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+extract_release_notes() {
+  bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+  rootdir=$( cd "$bindir"/.. && pwd )
+
+  if [ $# -eq 0 ]
+  then
+    # Make temporary file to save the release commit message into.
+    tmp=$(mktemp -t release-commit-message.XXX.txt)
+  else
+    tmp="$rootdir/$1"
+  fi
+
+  # Save commit message into temporary file.
+  #
+  # Match each occurence of the regex and increment `n` by 1. While n == 1
+  # (which is true only for the first section) print that line of `CHANGES.md`.
+  # This ends up being the first section of release changes.
+  awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' "$rootdir"/CHANGES.md > "$tmp"
+
+  echo "$tmp"
+}

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -27,17 +27,9 @@ fi
 
 # todo: Verify the tag version increment.
 
-rootdir=$( cd "${0%/*}"/.. && pwd )
-
-# Make temporary file to save the release commit message into.
-tmp=$(mktemp -t release-commit-message.XXX.txt)
-
-# Save commit message into temporary file.
-#
-# Match each occurence of the regex and increment `n` by 1. While n == 1
-# (which is true only for the first section) print that line of `CHANGES.md`.
-# This ends up being the first section of release changes.
-awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' "$rootdir"/CHANGES.md > "$tmp"
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+# shellcheck source=bin/_release.sh
+tmp=$(. "$bindir"/_release.sh; extract_release_notes)
 
 # Create an unsigned tag with the commit message.
 git tag -s -F "$tmp" "$tag"


### PR DESCRIPTION
Extracted the logic to pull the latest release notes, out of
`bin/create-release-tag` into `bin/_release.sh` so that it can be reused
in the `release.yml` workflow, which needs to use that inside
`gh_release` when creating the github release in order to have prettier
markup release notes instead of a plaintext message pulled out of the tag
message.
The new extracted function also receives an optional argument with the
name of the file to put the release notes into, because the `body_path`
parameter in `softprops/action-gh-release` doesn't work with dynamic
vars.
    
Finally, now the `website_publish` job will only launch until the `gh_release`
has succeeded.
