### PR TITLE
Add changes for edge-20.3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,24 +1,22 @@
 ## edge-20.3.1
 
-This release introduces new functionality mainly focused around 
-observability and multicluster support. 
+This release introduces new functionality mainly focused around
+observability and multi-cluster support.
 
 * CLI
   * Improved the `linkerd check` command to check for extension server
     certificate (thanks @christyjacob4!)
 * Controller
   * Removed restrictions preventing Linkerd from injecting proxies into
-    contour (thanks @alfatraining!)
-  * Added the SMI metrics API to the standard `linkerd install` flow. This
+    Contour (thanks @alfatraining!)
+  * Added the SMI metrics API to the standard `linkerd install` flow; this
     is the first step towards allowing Linkerd to consume the SMI metrics
     API in the CLI and Web dashboard.
   * Added an experimental version of a service mirroring controller, allowing
-    discovery of services on remote clusters  
+    discovery of services on remote clusters
 * Web UI
   * Fixed a bug causing incorrect Grafana links to be rendered in the web
     dashboard.
-* Internal
-  * Various CI and shell script fixes and improvements
 
 ## edge-20.2.3
 
@@ -179,13 +177,13 @@ Please see the [upgrade instructions](https://linkerd.io/2/tasks/upgrade/#upgrad
   * Fixed a race condition in the `linkerd-web` service
   * Updated Prometheus to 2.15.2 (thanks @Pothulapati)
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
-  * Added a pre-sign check to the identity service 
+  * Added a pre-sign check to the identity service
   * Fixed inject failures for pods with security context capabilities
   * Added `conntrack` to the `debug` container to help with connection tracking
     debugging
@@ -222,7 +220,7 @@ Please see the [upgrade instructions](https://linkerd.io/2/tasks/upgrade/#upgrad
 * Web UI
   * Fixed an error when refreshing an already open dashboard when the Linkerd
     version has changed
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
   * Added support for CronJobs and ReplicaSets, including new Grafana dashboards
     for them
@@ -240,7 +238,7 @@ Please see the [upgrade instructions](https://linkerd.io/2/tasks/upgrade/#upgrad
     the value of `linkerd.io/inject` is either `enabled` or `disabled`
     (thanks @mayankshah1607)
   * Upgraded the Prometheus Go client library to v1.2.1 (thanks @daxmc99!)
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
@@ -332,7 +330,7 @@ have installed Linkerd using Helm. In order to make the purpose of the
   * Added validation to incoming sidecar injection requests that ensures
     the value of `linkerd.io/inject` is either `enabled` or `disabled`
     (thanks @mayankshah1607)
-    
+
 ## edge-20.1.1
 
 This edge release includes experimental improvements to the Linkerd proxy's
@@ -368,23 +366,23 @@ might be stability issues.
 
 ## edge-19.12.3
 
-This edge release adds support for pod IP and service cluster IP lookups, 
-improves performance of the dashboard, and makes `linkerd check --pre` perform 
+This edge release adds support for pod IP and service cluster IP lookups,
+improves performance of the dashboard, and makes `linkerd check --pre` perform
 more comprehensive checks.
 
 The `--wait-before-exit-seconds` flag has been added to allow Linkerd users to
  opt in
-to `preStop hooks`. The details of this change are in 
+to `preStop hooks`. The details of this change are in
 [#3798](https://github.com/linkerd/linkerd2/pull/3798).
 
 Also, the proxy has been updated to `v2.82.0` which improves gRPC error
-classification and 
-[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are 
+classification and
+[ensures that resolutions](https://github.com/linkerd/linkerd2/pull/3848) are
 released when the associated balancer becomes idle.
 
 Finally, an update to follow best practices in the Helm charts has caused a
 *breaking change*. Users who have installed Linkerd using Helm must be
-certain to read the details of 
+certain to read the details of
 [#3822](https://github.com/linkerd/linkerd2/issues/3822)
 
 * CLI
@@ -392,15 +390,15 @@ certain to read the details of
   * Added TLS certificate validation to `check` and `upgrade` commands
 * Controller
   * Increased minimum kubernetes version to 1.13.0
-  * Added support for pod ip and service cluster ip lookups in the destination 
+  * Added support for pod ip and service cluster ip lookups in the destination
     service
   * Added recommended kubernetes labels to control-plane
-  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy 
-    sidecar to delay the start of its shutdown process (a huge commit from 
+  * Added the `--wait-before-exit-seconds` flag to linkerd inject for the proxy
+    sidecar to delay the start of its shutdown process (a huge commit from
     @KIVagant, thanks!)
   * Added a pre-sign check to the identity service
 * Web UI
-  * Increased the speed of the dashboard by pausing network activity when the 
+  * Increased the speed of the dashboard by pausing network activity when the
     dashboard is not visible to the user
 * Proxy
   * Added a timeout to release resolutions to idle balancers
@@ -408,7 +406,7 @@ certain to read the details of
 * Internal
   * **Breaking Change** Updated Helm charts to follow best practices using
     proper casing (thanks @Pothulapati!)
-  
+
 ## edge-19.12.2
 
 * CLI
@@ -448,11 +446,11 @@ certain to read the details of
   * Added a check that ensures using `--namespace` and `--all-namespaces`
     results in an error as they are mutually exclusive
 * Internal
-  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use 
+  * Fixed an issue causing `tap`, `injector` and `sp-validator` to use
     old certificates after `helm upgrade` due to not being restarted
   * Fixed incomplete Swagger definition of the tap api, causing benign
     error logging in the kube-apiserver
-    
+
 ## edge-19.11.2
 
 * CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,10 @@ experimenting with this feature, please join us in
 * Web UI
   * Fixed a bug causing incorrect Grafana links to be rendered in the web
     dashboard.
-
+* Proxy
+  * Fixed a bug that could cause the proxy's load balancer to stop processing
+    updates from service discovery.
+    
 ## edge-20.2.3
 
 This release introduces the first optional add-on `tracing`, added through the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## edge-20.3.1
+
+This release introduces new functionality mainly focused around 
+observability and multicluster support. 
+
+* CLI
+  * Improved the `linkerd check` command to check for extension server
+    certificate (thanks @christyjacob4!)
+* Controller
+  * Removed restrictions preventing Linkerd from injecting proxies into
+    contour (thanks @alfatraining!)
+  * Added the SMI metrics API to the standard `linkerd install` flow. This
+    is the first step towards allowing Linkerd to consume the SMI metrics
+    API in the CLI and Web dashboard.
+  * Added an experimental version of a service mirroring controller, allowing
+    discovery of services on remote clusters  
+* Web UI
+  * Fixed a bug causing incorrect Grafana links to be rendered in the web
+    dashboard.
+* Internal
+  * Various CI and shell script fixes and improvements
+
 ## edge-20.2.3
 
 This release introduces the first optional add-on `tracing`, added through the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 ## edge-20.3.1
 
 This release introduces new functionality mainly focused around
-observability and multi-cluster support.
+observability and multi-cluster support via `service mirroring`.
+
+If you would like to learn more about `service mirroring` or are interested in
+experimenting with this feature, please join us in
+[Linkerd Slack](https://slack.linkerd.io) for help and feedback.
 
 * CLI
   * Improved the `linkerd check` command to check for extension server
@@ -9,11 +13,8 @@ observability and multi-cluster support.
 * Controller
   * Removed restrictions preventing Linkerd from injecting proxies into
     Contour (thanks @alfatraining!)
-  * Added the SMI metrics API to the standard `linkerd install` flow; this
-    is the first step towards allowing Linkerd to consume the SMI metrics
-    API in the CLI and Web dashboard.
   * Added an experimental version of a service mirroring controller, allowing
-    discovery of services on remote clusters
+    discovery of services on remote clusters.
 * Web UI
   * Fixed a bug causing incorrect Grafana links to be rendered in the web
     dashboard.


### PR DESCRIPTION
This release introduces new functionality mainly focused around 
observability and multicluster support. 

* CLI
  * Improved the `linkerd check` command to check for extension server
    certificate (thanks @christyjacob4!)
* Controller
  * Removed restrictions preventing Linkerd from injecting proxies into
    contour (thanks @alfatraining!)
  * Added the SMI metrics API to the standard `linkerd install` flow. This
    is the first step towards allowing Linkerd to consume the SMI metrics
    API in the CLI and Web dashboard.
  * Added an experimental version of a service mirroring controller, allowing
    discovery of services on remote clusters  
* Web UI
  * Fixed a bug causing incorrect Grafana links to be rendered in the web
    dashboard.
* Internal
  * Various CI and shell script fixes and improvements


Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
