### PR TITLE
Fix shellcheck warning

### DIFF
--- a/bin/_release.sh
+++ b/bin/_release.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# shellcheck disable=SC2120
+# (disabling SC2120 so that we can use functions with optional args
+# see https://github.com/koalaman/shellcheck/wiki/SC2120#exceptions )
 
 set -eu
 


### PR DESCRIPTION
This is a followup to #4129, fixing this warning:
```
In ./bin/create-release-tag line 32:
tmp=$(. "$bindir"/_release.sh; extract_release_notes)
                               ^-------------------^ SC2119: Use
                               extract_release_notes "$@" if function's
                               $1 should mean script's $1.
```

In order to use functions in bash that use optional arguments that don't
generate this warning, we have to disable the SC2120 check, as explained here:
https://github.com/koalaman/shellcheck/wiki/SC2120#exceptions
