### PR TITLE
Add -A flag to alpha stat

### DIFF
--- a/cli/cmd/alpha_stat.go
+++ b/cli/cmd/alpha_stat.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -87,7 +88,7 @@ Examples:
 
 			namespace := options.namespace
 			if options.allNamespaces {
-				namespace = ""
+				namespace = corev1.NamespaceAll
 			}
 			target, err := util.BuildResource(namespace, args[0])
 			if err != nil {

--- a/cli/cmd/alpha_stat.go
+++ b/cli/cmd/alpha_stat.go
@@ -309,5 +309,7 @@ func buildTable(outbound, allNamespaces bool) table.Table {
 			Width:  11,
 		},
 	}
-	return table.NewTable(columns, []table.Row{})
+	t := table.NewTable(columns, []table.Row{})
+	t.Sort = []int{0, 1} // Sort by namespace, then name.
+	return t
 }

--- a/cli/cmd/alpha_stat.go
+++ b/cli/cmd/alpha_stat.go
@@ -263,7 +263,7 @@ func buildTable(outbound, allNamespaces bool) table.Table {
 	columns := []table.Column{
 		table.Column{
 			Header:    "NAMESPACE",
-			Width:     4,
+			Width:     9,
 			Hide:      !allNamespaces,
 			Flexible:  true,
 			LeftAlign: true,

--- a/pkg/smimetrics/client.go
+++ b/pkg/smimetrics/client.go
@@ -51,6 +51,10 @@ type (
 
 const apiBase = "/apis/metrics.smi-spec.io/v1alpha1"
 
+func (r Resource) String() string {
+	return fmt.Sprintf("%s.%s", r.Name, r.Namespace)
+}
+
 // GetTrafficMetrics returns the inbound traffic metrics for a specific named
 // resource.
 func GetTrafficMetrics(k8sAPI *k8s.KubernetesAPI, namespace, kind, name string, params map[string]string) (*TrafficMetrics, error) {


### PR DESCRIPTION
Add an `--all-namespaces` flag to `linkerd alpha stat`.  This flag ignore the value of the `--namespace` flag and looks up resources across all namespaces.

Some example usage:

```
> linkerd alpha stat po -A
NAMESPACE  NAME                                    SUCCESS        RPS  LATENCY_P50  LATENCY_P90  LATENCY_P99
default    curl                                    100.00%     0.6rps          1ms          1ms          1ms
emojivoto  emoji-ffd474b7b-nq8wc                   100.00%     2.0rps          1ms          1ms          1ms
emojivoto  vote-bot-74c4867dc6-d5j4d                90.00%     2.0rps          3ms          4ms          4ms
emojivoto  voting-6b69659f5b-6hpvx                  78.95%     0.9rps          1ms          1ms          1ms
emojivoto  web-6cfccddd6b-vrq2q                     92.86%     5.6rps          1ms          3ms          4ms
linkerd    linkerd-controller-54bbb5d485-4p9w2     100.00%     0.3rps          1ms          1ms          1ms
linkerd    linkerd-destination-69fb65c4fb-7mthj    100.00%     0.3rps          1ms          1ms          1ms
linkerd    linkerd-grafana-ffc4d969-gf5cz          100.00%     0.3rps          1ms          2ms          2ms
linkerd    linkerd-identity-6456988769-tbkx9       100.00%     0.3rps          1ms          1ms          1ms
linkerd    linkerd-prometheus-5469d5d8fd-kskc6     100.00%     2.5rps          1ms          2ms          3ms
linkerd    linkerd-proxy-injector-658f8c4cd-pfgbt  100.00%     0.3rps          1ms          1ms          1ms
linkerd    linkerd-smi-metrics-86567c5ff4-dh7rn          -     0.0rps          0ms          0ms          0ms
linkerd    linkerd-sp-validator-54c8d7dcf9-wq6jv   100.00%     0.3rps          1ms          2ms          2ms
linkerd    linkerd-tap-574b74c964-cwm6l            100.00%     0.3rps          1ms          1ms          1ms
linkerd    linkerd-web-577755788d-95slx            100.00%     0.3rps          1ms          1ms          1ms
```

```
> linkerd alpha stat po/curl --to po
FROM  TO                              SUCCESS        RPS  LATENCY_P50  LATENCY_P90  LATENCY_P99
curl  web-6cfccddd6b-vrq2q.emojivoto  100.00%     0.9rps          1ms          2ms          2ms
```

Signed-off-by: Alex Leong <alex@buoyant.io>


