### PR TITLE
Set the published version check to sleep for 30 seconds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
         until RES=$(curl -sL https://run.linkerd.io/$INSTALL | grep "LINKERD2_VERSION=\${LINKERD2_VERSION:-$TAG}") \
           || (( count++ >= 10 ))
         do
-          sleep 5
+          sleep 30
         done
         if [[ -z $RES ]]; then
           echo "::error::The version '$TAG' was NOT found published in the website"


### PR DESCRIPTION
Configures the "Check published version" step in the Release github action to wait for 30 seconds instead of 5

Signed-off-by: Charles Pretzer <charles@buoyant.io>
