### PR TITLE
Improve release tag script

### DIFF
--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -20,9 +20,9 @@ if [[ ! $release_channel =~ $release_channel_regex ]]; then
 fi
 
 stable_tag=${2:-}
-if [ ! -z $stable_tag ]; then
+if [ -n "$stable_tag" ]; then
     # Assert the release channel is not `edge`.
-    if [ $release_channel == "edge" ]; then
+    if [ "$release_channel" == "edge" ]; then
         echo "edge release channel does not take tag argument"
         exit 1
     fi
@@ -39,7 +39,7 @@ if [ ! -z $stable_tag ]; then
     release_tag="stable-$stable_tag"
 fi
 
-if [ $release_channel == "edge" ]; then
+if [ "$release_channel" == "edge" ]; then
     edge_tag_regex="(edge)-([0-9]{2})\.([0-9]{1,2})\.([0-9]+)"
     url="https://run.linkerd.io/install-edge"
 
@@ -48,8 +48,8 @@ if [ $release_channel == "edge" ]; then
 
     # Get the third and fourth groups of the regex; they are the month and
     # month minor values for the current edge version.
-    current_mm=$(echo $current_edge | sed -n -E "s/.*$edge_tag_regex}$/\3/p")
-    current_xx=$(echo $current_edge | sed -n -E "s/.*$edge_tag_regex}$/\4/p")
+    current_mm=$(echo "$current_edge" | sed -n -E "s/.*$edge_tag_regex}$/\3/p")
+    current_xx=$(echo "$current_edge" | sed -n -E "s/.*$edge_tag_regex}$/\4/p")
 
     yy=$(date +"%y")
     
@@ -57,7 +57,7 @@ if [ $release_channel == "edge" ]; then
     new_mm=$(date +"%-m")
 
     # If this is a new month, `new_xx` should be 1; otherwise increment it.
-    if [ ! $new_mm == $current_mm ]; then
+    if [ ! "$new_mm" == "$current_mm" ]; then
         new_xx="1"
     else
         new_xx=$((current_xx+1))

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -3,41 +3,82 @@
 set -o errexit
 set -o nounset
 
-if [[ $# -ne 1 ]]; then
-    echo "usage: ${0##*/} (edge|stable)-xx.xx.xx" >&2
+# Assert at least one argument was passed.
+if [[ $# -lt 1 ]]; then
+    echo "usage: ${0##*/} edge" >&2
+    echo "usage: ${0##*/} stable x.x.x" >&2
     exit 1
 fi
 
-tag="$1"
+release_channel="$1"
 
-# Verify the tag format
-tag_format="^(edge|stable)-([0-9]+)\.([0-9]+)\.([0-9]+)$"
-if [[ $tag =~ $tag_format ]]; then
-    # todo: Use these values to verify the tag version increment.
-    # release_channel="${BASH_REMATCH[1]}"
-    # release_major="${BASH_REMATCH[2]}"
-    # release_minor="${BASH_REMATCH[3]}"
-    # release_patch="${BASH_REMATCH[4]}"
-    :
-else
-    echo "tag format incorrect; expected: $tag_format"
-    echo "example: edge-20.12.2, stable-2.10.1"
+# Verify the release channel.
+release_channel_regex="(edge|stable)"
+if [[ ! $release_channel =~ $release_channel_regex ]]; then
+    echo "valid release channels: edge, stable"
     exit 1
 fi
 
-# todo: Verify the tag version increment.
+stable_tag=${2:-}
+if [ ! -z $stable_tag ]; then
+    # Assert the release channel is not `edge`.
+    if [ $release_channel == "edge" ]; then
+        echo "edge release channel does not take tag argument"
+        exit 1
+    fi
+
+    # Verify the stable tag format.
+    stable_tag_regex="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
+    if [[ ! $stable_tag =~ $stable_tag_regex ]]; then
+        echo "stable tag incorrect"
+        echo "expected example: 2.4.8"
+        exit 1
+    fi
+
+    # Set the script global `release_tag` variable.
+    release_tag="stable-$stable_tag"
+fi
+
+if [ $release_channel == "edge" ]; then
+    edge_tag_regex="(edge)-([0-9]{2})\.([0-9]{1,2})\.([0-9]+)"
+    url="https://run.linkerd.io/install-edge"
+
+    # Get the current edge version.
+    current_edge=$(curl -sL $url | awk -v tag_format="$edge_tag_regex" '$0 ~ tag_format {print}')
+
+    # Get the third and fourth groups of the regex; they are the month and
+    # month minor values for the current edge version.
+    current_mm=$(echo $current_edge | sed -n -E "s/.*$edge_tag_regex}$/\3/p")
+    current_xx=$(echo $current_edge | sed -n -E "s/.*$edge_tag_regex}$/\4/p")
+
+    yy=$(date +"%y")
+    
+    # Strip leading zero
+    new_mm=$(date +"%-m")
+
+    # If this is a new month, `new_xx` should be 1; otherwise increment it.
+    if [ ! $new_mm == $current_mm ]; then
+        new_xx="1"
+    else
+        new_xx=$((current_xx+1))
+    fi
+
+    # Set the script global `release_tag` variable.
+    new_edge_tag="edge-$yy.$new_mm.$new_xx"
+    release_tag=$new_edge_tag
+fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 # shellcheck source=bin/_release.sh
 tmp=$(. "$bindir"/_release.sh; extract_release_notes)
 
-# Create an unsigned tag with the commit message.
-git tag -s -F "$tmp" "$tag"
+# Create a signed tag with the commit message.
+git tag -s -F "$tmp" "$release_tag"
 
 # Success message
-echo "tag created and signed."
+echo "$release_tag tag created and signed."
 echo ""
-echo "tag: $tag"
+echo "tag: $release_tag"
 echo ""
 echo "To push tag, run:"
-echo "    git push origin $tag"
+echo "    git push origin $release_tag"

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -3,10 +3,12 @@
 set -o errexit
 set -o nounset
 
-# Assert at least one argument was passed.
-if [[ $# -lt 1 ]]; then
-    echo "usage: ${0##*/} edge" >&2
-    echo "usage: ${0##*/} stable x.x.x" >&2
+# Assert at least one and at most two arguments were passed.
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Error: ${0##*/} accepts 1 or 2 arguments" >&2
+    echo "Usage:" >&2
+    echo "    ${0##*/} edge" >&2
+    echo "    ${0##*/} stable x.x.x" >&2
     exit 1
 fi
 
@@ -15,23 +17,29 @@ release_channel="$1"
 # Verify the release channel.
 release_channel_regex="(edge|stable)"
 if [[ ! $release_channel =~ $release_channel_regex ]]; then
-    echo "valid release channels: edge, stable"
+    echo "Error: valid release channels: edge, stable"
+    echo "Usage:"
+    echo "    bin/create-release-tag edge"
+    echo "    bin/create-release-tag stable 2.4.8"
     exit 1
 fi
 
-stable_tag=${2:-}
-if [ -n "$stable_tag" ]; then
-    # Assert the release channel is not `edge`.
-    if [ "$release_channel" == "edge" ]; then
-        echo "edge release channel does not take tag argument"
+if [ "$release_channel" == "stable" ]; then
+    if [ $# -ne 2 ]; then
+        echo "Error: accepts 2 arguments"
+        echo "Usage:"
+        echo "    bin/create-release-tag stable 2.4.8"
         exit 1
     fi
+
+    stable_tag="$2"
 
     # Verify the stable tag format.
     stable_tag_regex="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
     if [[ ! $stable_tag =~ $stable_tag_regex ]]; then
-        echo "stable tag incorrect"
-        echo "expected example: 2.4.8"
+        echo "Error: version reference incorrect"
+        echo "Usage:"
+        echo "    bin/create-release-tag stable 2.4.8"
         exit 1
     fi
 
@@ -40,11 +48,20 @@ if [ -n "$stable_tag" ]; then
 fi
 
 if [ "$release_channel" == "edge" ]; then
-    edge_tag_regex="(edge)-([0-9]{2})\.([0-9]{1,2})\.([0-9]+)"
+if [ $# -ne 1 ]; then
+        echo "Error: accepts 1 argument"
+        echo "Usage:"
+        echo "    bin/create-release-tag edge"
+        exit 1
+    fi
+
+    # Some awks on Linux do no support quantifiers in regex, so this regex is
+    # explicit.
+    edge_tag_regex="(edge)-([0-9][0-9])\.([0-9]|[0-9][0-9])\.([0-9]+)"
     url="https://run.linkerd.io/install-edge"
 
     # Get the current edge version.
-    current_edge=$(curl -sL $url | awk -v tag_format="$edge_tag_regex" '$0 ~ tag_format {print}')
+    current_edge=$(curl -sL $url | awk -v tag_format="$edge_tag_regex" '$0 ~ tag_format')
 
     # Get the third and fourth groups of the regex; they are the month and
     # month minor values for the current edge version.
@@ -64,8 +81,7 @@ if [ "$release_channel" == "edge" ]; then
     fi
 
     # Set the script global `release_tag` variable.
-    new_edge_tag="edge-$yy.$new_mm.$new_xx"
-    release_tag=$new_edge_tag
+    release_tag="edge-$yy.$new_mm.$new_xx"
 fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )


### PR DESCRIPTION
## Motivation

Closes #4140

Automatically create new edge release tag:
```
❯ bin/create-release-tag edge
edge-20.3.2 tag created and signed.

tag: edge-20.3.2

To push tag, run:
    git push origin edge-20.3.2
```

Validate new stable release tag:
```
❯ bin/create-release-tag stable 2.7.1
stable-2.7.1 tag created and signed.

tag: stable-2.7.1

To push tag, run:
    git push origin stable-2.7.1
```

## Solution

The release tag script now takes a release channel argument. If the release
channel argument is `stable`, a second argument is required for the version.

If the release channel is `edge`, the script gets the current edge version and
creates a new edge version with the current year: `YY`, month: `MM`, and
increments the current month minor if it is not a new month.

If the release channel is `stable`, the script will only validate the version.

Example error cases:

```
❯ bin/create-release-tag
Error: create-release-tag accepts 1 or 2 arguments
Usage:
    create-release-tag edge
    create-release-tag stable x.x.x
```

```
❯ bin/create-release-tag foo
Error: valid release channels: edge, stable
Usage:
    bin/create-release-tag edge
    bin/create-release-tag stable 2.4.8
```

```
❯ bin/create-release-tag edge 2.7.1
Error: accepts 1 argument
Usage:
    bin/create-release-tag edge
```

```
❯ bin/create-release-tag stable
Error: accepts 2 arguments
Usage:
    bin/create-release-tag stable 2.4.8
```

```
❯ bin/create-release-tag stable 2.7
Error: version reference incorrect
Usage:
    bin/create-release-tag stable 2.4.8
```

```
❯ bin/create-release-tag stable 2.7.1.1
Error: version reference incorrect
Usage:
    bin/create-release-tag stable 2.4.8
```
