### PR TITLE
Add integration test to validate updated config is applied by kubectl

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/linkerd/linkerd2/testutil"
+)
+
+//////////////////////
+///   TEST SETUP   ///
+//////////////////////
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+func TestUpgradeWithUpdatedConfig(t *testing.T) {
+	cmd := "upgrade"
+	out, stderr, err := TestHelper.LinkerdRun(cmd)
+	if err != nil {
+		t.Fatalf("Update command failed\n%s\n%s", out, stderr)
+	}
+
+	match, _ := regexp.MatchString("linkerd.io/control-plane-ns", out)
+	if !match {
+		t.Fatalf("Linkerd control plane namespace label not found in yaml.\n%s", out)
+	}
+}


### PR DESCRIPTION
Add integration test to validate updated config is applied by `kubectl`
Kubectl's dropping of config objects was tackled in [this](https://github.com/linkerd/linkerd2/pull/4061) PR. This is a cleaned up PR of [this](https://github.com/linkerd/linkerd2/pull/4107) closed. An integration test was required to ensure its effect.

An integration test which compares a known kubectl apply config with generated one on updating config with custom value is (here it is foo: bar) is implemented
```
go test -v ./test/upgrade -integration-tests -linkerd `pwd`/bin/linkerd
```
gives all tests passed. It validates its success.

Signed-off-by: Supratik Das <rick.das08@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
