### PR TITLE
update helm chart to use proxyInit version v1.3.1

### DIFF
--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -193,4 +193,3 @@ tracing:
     name: linkerd-jaeger
     image: jaegertracing/all-in-one:1.8
     resources:
-

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -56,7 +56,7 @@ global:
     image:
       name: gcr.io/linkerd-io/proxy-init
       pullPolicy: *image_pull_policy
-      version: v1.1.0
+      version: v1.3.1
     resources:
       cpu:
         limit: 100m


### PR DESCRIPTION
I noticed the helm chart install uses an old version of the proxyInit container while the linkerd install command uses the latest version