### PR TITLE
Upload artifacts for all PRs

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -38,8 +38,7 @@ jobs:
       run: |
         export PATH="`pwd`/bin:$PATH"
         bin/docker-build
-    - name: Create artifact with CLI and image archives (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+    - name: Create artifact with CLI and image archives
       env:
         ARCHIVES: /home/runner/archives
       run: |
@@ -57,8 +56,7 @@ jobs:
     # absolute path is used here.
     #
     # https://github.com/actions/upload-artifact/issues/8
-    - name: Upload artifact (Forked repositories)
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+    - name: Upload artifact
       # actions/upload-artifact@v1
       uses: actions/upload-artifact@3446296
       with:


### PR DESCRIPTION
## Motivation

#4147 adds a script for setting up a local cluster that uses the images built
from the changes introduced in a forked PR. This would be useful for all PRs.

In order to install Linkerd from a PR into a local cluster, the images still
need to be built at some point. If you happen to have SSH config setup for our
Packet host, you can pull them from there. That is not very
accessible--requiring that someone adds you as a user--so we can take a
similar approach to forked PRs.

## Solution

All PRs now make an artifact directory that is uploaded as part of the KinD
integration tests. This way, the `install-pr` script can use those images no
matter if the PR is a fork or not.
