### PR TITLE
Add KinD option to `install-pr` script

### DIFF
--- a/bin/install-pr
+++ b/bin/install-pr
@@ -113,8 +113,8 @@ fi
 
 # Get the URL for downloading the artifacts archive.
 auth="Authorization: token $GITHUB_TOKEN"
-branch=$(curl -sL "$linkerd2_pulls_url/$pr" | jq -r '.head.ref')
-artifacts=$(curl -sL "$linkerd2_kind_integration_url/runs?branch=$branch" | jq -r '.workflow_runs[0].artifacts_url')
+branch=$(curl -sL -H "$auth" "$linkerd2_pulls_url/$pr" | jq -r '.head.ref')
+artifacts=$(curl -sL -H "$auth" "$linkerd2_kind_integration_url/runs?branch=$branch" | jq -r '.workflow_runs[0].artifacts_url')
 archive=$(curl -sL -H "$auth" "$artifacts" | jq -r '.artifacts[0].archive_download_url')
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
@@ -147,7 +147,7 @@ docker cp "$container_id":/out/linkerd-"$platform" "$rootdir"/target/cli/"$platf
 installed_cli=1
 
 # Load images into local docker images
-if [ $is_kind ]
+if [ $is_kind -eq 1 ]
 then
   # Create new KinD cluster
   cluster_name="pr-$pr"
@@ -186,7 +186,7 @@ fi
 
 cd -
 
-if [ $is_kind ]
+if [ $is_kind -eq 1 ]
 then
   "$bindir"/linkerd "${context_flag[@]}" check --pre
   "$bindir"/linkerd "${context_flag[@]}" install | kubectl "${context_flag[@]}" apply -f -

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -141,8 +141,8 @@ echo "### Pre checks ###"
 
 # shellcheck disable=SC2086
 (
-  set -x"$linkerd"
-  $context_flag check --pre
+  set -x
+  "$linkerd" $context_flag check --pre
 )
 
 echo "### Installing $tag ###"

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -13,27 +13,25 @@ cleanup() {
   # Remove temporary directory.
   rm -rf "$archive_tmp"
   
-  if [ "$installed_cli" -eq 1 ]
+  if [ "$installed_cli" ]
   then
     echo ""
     echo "Linkerd CLI installed!"
     echo "Usage:"
     echo "    bin/linkerd $context_flag version"
-  elif [ "$installed_cli" -eq 0 ]
-  then
+  else [ "$installed_cli" ]
     echo ""
     echo "Linkerd CLI install failed!"
   fi
 
-  if [ "$linkerd_check" -eq 1 ]
+  if [ "$linkerd_check" ]
   then
     echo ""
     echo "'linkerd check' passed!"
     echo "Usage:"
     echo "    bin/linkerd ${context_flag[*]} check"
     echo "    kubectl ${context_flag[*]} -n linkerd get pods"
-  elif [ "$linkerd_check" -eq 0 ]
-  then
+  else
     echo ""
     echo "'linkerd check' failed!"
     echo "Check again before debugging:"
@@ -42,22 +40,20 @@ cleanup() {
     echo "    kubectl ${context_flag[*]} -n linkerd get pods"
   fi
 
-  if [[ $is_kind -eq 1 && $kind_setup -eq 0 ]]
+  if [[ $is_kind && $kind_setup ]]
   then
     echo "Script failed at or before KinD cluster creation."
   fi
 }
 
-trap cleanup EXIT
-
 # Initialize variables used throughout script.
 archive_tmp=
 context_flag=
 
-installed_cli=0
-kind_setup=0
-linkerd_check=0
-is_kind=0
+installed_cli=
+kind_setup=
+linkerd_check=
+is_kind=
 
 linkerd2_pulls_url="https://api.github.com/repos/linkerd/linkerd2/pulls"
 linkerd2_kind_integration_url="https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml"
@@ -79,8 +75,6 @@ do
       echo ""
       echo "    # Install Linkerd into a new KinD cluster"
       echo "    bin/install-pr [-k|--kind] ####"
-      installed_cli=2
-      linkerd_check=2
       exit 0
       ;;
     -k|--kind)
@@ -95,6 +89,8 @@ do
   esac
   shift
 done
+
+trap cleanup EXIT
 
 pr=$1
 
@@ -147,7 +143,7 @@ docker cp "$container_id":/out/linkerd-"$platform" "$rootdir"/target/cli/"$platf
 installed_cli=1
 
 # Load images into local docker images
-if [ $is_kind -eq 1 ]
+if [ $is_kind ]
 then
   # Create new KinD cluster
   cluster_name="pr-$pr"
@@ -186,7 +182,7 @@ fi
 
 cd -
 
-if [ $is_kind -eq 1 ]
+if [ $is_kind ]
 then
   "$bindir"/linkerd "${context_flag[@]}" check --pre
   "$bindir"/linkerd "${context_flag[@]}" install | kubectl "${context_flag[@]}" apply -f -

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -9,63 +9,189 @@
 
 set -eo pipefail
 
+cleanup() {
+  # Remove temporary directory.
+  rm -rf "$archive_tmp"
+  
+  if [ "$installed_cli" ]
+  then
+    echo ""
+    echo "Linkerd CLI installed!"
+    echo "Usage:"
+    echo "    bin/linkerd ${context_flag[@]} version"
+  else
+    echo ""
+    echo "Linkerd CLI install failed!"
+  fi
+
+  if [ "$linkerd_check" ]
+  then
+    echo ""
+    echo "'linkerd check' passed!"
+    echo "Usage:"
+    echo "    bin/linkerd ${context_flag[@]} check"
+    echo "    kubectl ${context_flag[@]} -n linkerd get pods"
+  else
+    echo ""
+    echo "'linkerd check' failed!"
+    echo "Check again before debugging:"
+    echo "    bin/linkerd ${context_flag[@]} check --pre"
+    echo "    bin/linkerd ${context_flag[@]} check"
+    echo "    kubectl ${context_flag[@]} -n linkerd get pods"
+  fi
+
+  if [[ $is_kind && ! $kind_setup ]]
+  then
+    echo "Script failed at or before KinD cluster creation."
+  fi
+}
+
+trap cleanup EXIT
+
+# Initialize variables used throughout script.
+archive_tmp=
+context_flag=
+
+installed_cli=
+kind_setup=
+linkerd_check=
+is_kind=
+
+linkerd2_pulls_url="https://api.github.com/repos/linkerd/linkerd2/pulls"
+linkerd2_kind_integration_url="https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml"
+
+# Read script flags and arguments.
+while :
+do
+  case $1 in
+    -h|--help)
+      echo "Install Linkerd with the changes made in a GitHub Pull Request."
+      echo ""
+      echo "Note:"
+      echo "    If installing into an existing Kubernetes cluster, this script"
+      echo "    assumes the cluster is not a KinD cluster."
+      echo ""
+      echo "Usage:"
+      echo "    # Install Linkerd into the 'kubectl' current cluster"
+      echo "    bin/install-pr ####"
+      echo ""
+      echo "    # Install Linkerd into a new KinD cluster"
+      echo "    bin/install-pr [-k|--kind] ####"
+      exit 0
+      ;;
+    -k|--kind)
+      is_kind=1
+      ;;
+    -?*)
+      echo "Error: Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      break
+  esac
+  shift
+done
+
 pr=$1
 
 if [ -z "$pr" ]
 then
-  echo "usage: ${0##*/} (PR number)" >&2
+  echo "Usage: ${0##*/} (PR number)" >&2
   exit 1
 fi
 
 if [ -z "$GITHUB_TOKEN" ]
 then
   # shellcheck disable=SC2016
-  echo 'Generate a personal access token at https://github.com/settings/tokens and set it in the $GITHUB_TOKEN env var'
+  echo 'Error: Generate a personal access token at https://github.com/settings/tokens and set it in the $GITHUB_TOKEN env var'
   exit 1
 fi
 
+# Get the URL for downloading the artifacts archive.
 auth="Authorization: token $GITHUB_TOKEN"
+branch=$(curl -sL "$linkerd2_pulls_url/$pr" | jq -r '.head.ref')
+artifacts=$(curl -sL "$linkerd2_kind_integration_url/runs?branch=$branch" | jq -r '.workflow_runs[0].artifacts_url')
+archive=$(curl -sL -H "$auth" "$artifacts" | jq -r '.artifacts[0].archive_download_url')
 
-branch=$(curl -s -H "$auth" "https://api.github.com/repos/linkerd/linkerd2/pulls/$pr" | jq -r '.head.ref')
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+archive_tmp=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
 
-artifacts=$(curl -s -H "$auth" "https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml/runs?branch=$branch" | jq -r '.workflow_runs[0].artifacts_url')
+# Change directory temporarily and download artifact.
+cd "$archive_tmp"
 
-archive_url=$(curl -s -H "$auth" "$artifacts" | jq -r '.artifacts[0].archive_download_url')
-
-dir=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
-
-cd "$dir" || exit
-
-echo "### Downloading images ###"
-
-curl -L -o archive.zip -H "$auth" "$archive_url"
-
+curl -L -o archive.zip -H "$auth" "$archive"
 unzip -o archive.zip
 
-echo "### Pushing images ###"
+# Install the Linkerd CLI.
+image=$(docker load -i cli-bin.tar | sed 's/Loaded image: //')
+container_id=$(docker create "$image")
 
-for archive in cli-bin cni-plugin controller debug grafana proxy web
-do 
-  image=$(docker load -i "$archive.tar" | sed "s/Loaded image: //")
-  docker push "$image"
-  tag=$(echo "$image" | cut -f 2 -d ":")
-done
+case $(uname) in
+  Darwin)
+    platform="darwin"
+    ;;
+  Linux)
+    platform="linux"
+    ;;
+  *)
+    platform="windows"
+    ;;
+esac
+
+docker cp "$container_id":/out/linkerd-"$platform" "$rootdir"/target/cli/"$platform"/linkerd
+installed_cli=1
+
+# Load images into local docker images
+if [ $is_kind ]
+then
+  # Create new KinD cluster
+  cluster_name="pr-$pr"
+  context_flag=(--context kind-$cluster_name)
+
+  if "$bindir"/kind get clusters | grep "$cluster_name"
+  then
+    echo "Error: KinD cluster '$cluster_name' exists"
+    exit 1
+  fi
+  
+  "$bindir"/kind create cluster --name "$cluster_name"
+
+  # Load images into cluster
+  for image in cni-plugin controller debug grafana proxy web
+  do
+    echo "Loading $image image into cluster.."
+    "$bindir"/kind load image-archive --name "$cluster_name" $image.tar || tee load_fail &
+  done
+
+  # Wait for `kind load` background processes to copmlete. Exit early if any
+  # job failed.
+  wait < <(jobs -p)
+  if [ -f load_fail ]
+  then
+    echo "Loading docker images into KinD cluster failed."
+    exit 1
+  fi
+  kind_setup=1
+else
+  for image in cni-plugin controller debug grafana proxy web
+  do
+    docker load -i "$image.tar"
+  done
+fi
 
 cd -
 
-rm -rf "$dir"
+if [ $is_kind ]
+then
+  "$bindir"/linkerd "${context_flag[@]}" check --pre
+  "$bindir"/linkerd "${context_flag[@]}" install | kubectl "${context_flag[@]}" apply -f -
+  "$bindir"/linkerd "${context_flag[@]}" check
+else
+  "$bindir"/linkerd check --pre
+  "$bindir"/linkerd install | kubectl apply -f -
+  "$bindir"/linkerd check
+fi
+linkerd_check=1
 
-linkerd=$(bin/docker-pull-binaries "$tag" | head -n 1)
-
-echo "### Pre checks ###"
-
-$linkerd check --pre
-
-echo "### Installing $tag ###"
-
-$linkerd install | kubectl apply -f -
-
-$linkerd check
-
-echo "### Linkerd installed. CLI available: "
-echo "$linkerd"
+exit 0

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -140,14 +140,20 @@ linkerd=$("$bindir"/docker-pull-binaries "$tag" | awk -v platform=$platform '$0 
 echo "### Pre checks ###"
 
 # shellcheck disable=SC2086
-(set -x; "$linkerd" $context_flag check --pre)
+(
+  set -x"$linkerd"
+  $context_flag check --pre
+)
 
 echo "### Installing $tag ###"
 
-# shellcheck disable=SC2086
-(set -x; "$linkerd" $context_flag install | kubectl $context_flag apply -f -)
-# shellcheck disable=SC2086
-(set -x; "$linkerd" $context_flag check)
+(
+  set -x
+  # shellcheck disable=SC2086
+  "$linkerd" $context_flag install | kubectl $context_flag apply -f -
+  # shellcheck disable=SC2086
+  "$linkerd" $context_flag check
+)
 
 echo ""
 echo "Linkerd installed. CLI available:"

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -21,12 +21,22 @@ do
       echo "    assumes the cluster is not a KinD cluster."
       echo ""
       echo "Usage:"
-      echo "    # Install Linkerd into the 'kubectl' current cluster"
+      echo "    --context='': The name of the kubeconfig context to use"
+      echo ""
+      echo "    # Install Linkerd into the current cluster"
       echo "    bin/install-pr ####"
       echo ""
-      echo "    # Install Linkerd into a new KinD cluster"
+      echo "    # Install Linkerd into the current KinD cluster"
       echo "    bin/install-pr [-k|--kind] ####"
+      echo ""
+      echo "    # Install Linkerd into the context's KinD cluster"
+      echo "    bin/install-pr [-k|--kind] --context kind ####"
       exit 0
+      ;;
+    --context)
+      context=$2
+      context_flag="--context $context"
+      shift
       ;;
     -k|--kind)
       is_kind=1
@@ -45,7 +55,9 @@ pr=$1
 
 if [ -z "$pr" ]
 then
-  echo "Usage: ${0##*/} (PR number)" >&2
+  echo "Error: ${0##*/} accepts 1 argument" >&2
+  echo "Usage:" >&2
+  echo "    ${0##*/} ####" >&2
   exit 1
 fi
 
@@ -68,40 +80,35 @@ archive=$(curl -sL -H "$auth" "$artifacts" | jq -r '.artifacts[0].archive_downlo
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 dir=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
 
-# Change directory temporarily and download artifact
 cd "$dir" || exit
+
+echo "### Downloading images ###"
 
 curl -L -o archive.zip -H "$auth" "$archive"
 unzip -o archive.zip
 
-# Push the Linkerd CLI
+echo "### Loading images into Docker ###"
+
 image=$(docker load -i cli-bin.tar | sed 's/Loaded image: //')
-docker push "$image"
 tag=$(echo "$image" | cut -f 2 -d ":")
 
-# Load images into local docker images
 if [ $is_kind ]
 then
-  # Create new KinD cluster
-  cluster_name="pr-$pr"
-  context_flag=(--context kind-"$cluster_name")
-
-  if "$bindir"/kind get clusters | grep "$cluster_name"
+  # KinD context strings are created by prepending `kind-` to the cluster name
+  # shellcheck disable=SC2086
+  if [ $context ]
   then
-    echo "Error: KinD cluster '$cluster_name' exists"
-    exit 1
+    name=$(echo "$context" | sed -n -E "s/(kind)-(.*)/\2/p")
+    name_flag="--name $name"
   fi
-  
-  "$bindir"/kind create cluster --name "$cluster_name"
 
-  # Load images into cluster
   for image in cni-plugin controller debug grafana proxy web
   do
-    echo "Loading $image image into cluster.."
-    "$bindir"/kind load image-archive --name "$cluster_name" $image.tar || tee load_fail &
+    # shellcheck disable=SC2086
+    "$bindir"/kind load image-archive $name_flag $image.tar || touch load_fail &
   done
 
-  # Wait for `kind load` background processes to copmlete; exit early if any
+  # Wait for `kind load` background processes to complete; exit early if any
   # job failed
   wait < <(jobs -p)
   if [ -f load_fail ]
@@ -117,6 +124,7 @@ else
 fi
 
 cd -
+
 rm -rf "$dir"
 
 case $(uname) in
@@ -131,16 +139,20 @@ case $(uname) in
     ;;
 esac
 
-# Install the Linkerd CLI
 linkerd=$("$bindir"/docker-pull-binaries "$tag" | awk -v platform=$platform '$0 ~ platform')
 
-# shellcheck disable=SC2068
-"$linkerd" ${context_flag[@]} check --pre
-# shellcheck disable=SC2068
-"$linkerd" ${context_flag[@]} install | kubectl ${context_flag[@]} apply -f -
-# shellcheck disable=SC2068
-"$linkerd" ${context_flag[@]} check
+echo "### Pre checks ###"
+
+# shellcheck disable=SC2086
+(set -x; "$linkerd" $context_flag check --pre)
+
+echo "### Installing $tag ###"
+
+# shellcheck disable=SC2086
+(set -x; "$linkerd" $context_flag install | kubectl $context_flag apply -f -)
+# shellcheck disable=SC2086
+(set -x; "$linkerd" $context_flag check)
 
 echo ""
 echo "Linkerd installed. CLI available:"
-echo "$linkerd ${context_flag[*]}"
+echo "$linkerd"

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -69,7 +69,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 dir=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
 
 # Change directory temporarily and download artifact
-cd "$dir"
+cd "$dir" || exit
 
 curl -L -o archive.zip -H "$auth" "$archive"
 unzip -o archive.zip

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -31,7 +31,6 @@ do
       ;;
     --context)
       context=$2
-      context_flag="--context $context"
       shift
       ;;
     -k|--kind)
@@ -91,17 +90,14 @@ tag=$(echo "$image" | cut -f 2 -d ":")
 if [ $is_kind ]
 then
   # KinD context strings are created by prepending `kind-` to the cluster name
-  # shellcheck disable=SC2086
-  if [ $context ]
+  if [ "$context" ]
   then
     name=$(echo "$context" | sed -n -E "s/(kind)-(.*)/\2/p")
-    name_flag="--name $name"
   fi
 
   for image in cni-plugin controller debug grafana proxy web
   do
-    # shellcheck disable=SC2086
-    "$bindir"/kind load image-archive $name_flag $image.tar || touch load_fail &
+    "$bindir"/kind load image-archive ${name:+'--name' "$name"} $image.tar || touch load_fail &
   done
 
   # Wait for `kind load` background processes to complete; exit early if any
@@ -115,7 +111,8 @@ then
 else
   for image in cni-plugin controller debug grafana proxy web
   do
-    docker load -i "$image.tar"
+    image=$(docker load -i "$image.tar" | sed 's/Loaded image: //')
+    docker push "$image"
   done
 fi
 
@@ -139,20 +136,17 @@ linkerd=$("$bindir"/docker-pull-binaries "$tag" | awk -v platform=$platform '$0 
 
 echo "### Pre checks ###"
 
-# shellcheck disable=SC2086
 (
   set -x
-  "$linkerd" $context_flag check --pre
+  "$linkerd" ${context:+'--context' "$context"} check --pre
 )
 
 echo "### Installing $tag ###"
 
 (
   set -x
-  # shellcheck disable=SC2086
-  "$linkerd" $context_flag install | kubectl $context_flag apply -f -
-  # shellcheck disable=SC2086
-  "$linkerd" $context_flag check
+  "$linkerd" ${context:+'--context' "$context"} install | kubectl ${context:+'--context' "$context"} apply -f -
+  "$linkerd" ${context:+'--context' "$context"} check
 )
 
 echo ""

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -9,56 +9,7 @@
 
 set -eo pipefail
 
-cleanup() {
-  # Remove temporary directory.
-  rm -rf "$archive_tmp"
-  
-  if [ "$installed_cli" ]
-  then
-    echo ""
-    echo "Linkerd CLI installed!"
-    echo "Usage:"
-    echo "    bin/linkerd $context_flag version"
-  else [ "$installed_cli" ]
-    echo ""
-    echo "Linkerd CLI install failed!"
-  fi
-
-  if [ "$linkerd_check" ]
-  then
-    echo ""
-    echo "'linkerd check' passed!"
-    echo "Usage:"
-    echo "    bin/linkerd ${context_flag[*]} check"
-    echo "    kubectl ${context_flag[*]} -n linkerd get pods"
-  else
-    echo ""
-    echo "'linkerd check' failed!"
-    echo "Check again before debugging:"
-    echo "    bin/linkerd ${context_flag[*]} check --pre"
-    echo "    bin/linkerd ${context_flag[*]} check"
-    echo "    kubectl ${context_flag[*]} -n linkerd get pods"
-  fi
-
-  if [[ $is_kind && $kind_setup ]]
-  then
-    echo "Script failed at or before KinD cluster creation."
-  fi
-}
-
-# Initialize variables used throughout script.
-archive_tmp=
-context_flag=
-
-installed_cli=
-kind_setup=
-linkerd_check=
-is_kind=
-
-linkerd2_pulls_url="https://api.github.com/repos/linkerd/linkerd2/pulls"
-linkerd2_kind_integration_url="https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml"
-
-# Read script flags and arguments.
+# Read script flags and arguments
 while :
 do
   case $1 in
@@ -90,8 +41,6 @@ do
   shift
 done
 
-trap cleanup EXIT
-
 pr=$1
 
 if [ -z "$pr" ]
@@ -107,40 +56,28 @@ then
   exit 1
 fi
 
-# Get the URL for downloading the artifacts archive.
+linkerd2_pulls_url="https://api.github.com/repos/linkerd/linkerd2/pulls"
+linkerd2_kind_integration_url="https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml"
+
+# Get the URL for downloading the artifacts archive
 auth="Authorization: token $GITHUB_TOKEN"
 branch=$(curl -sL -H "$auth" "$linkerd2_pulls_url/$pr" | jq -r '.head.ref')
 artifacts=$(curl -sL -H "$auth" "$linkerd2_kind_integration_url/runs?branch=$branch" | jq -r '.workflow_runs[0].artifacts_url')
 archive=$(curl -sL -H "$auth" "$artifacts" | jq -r '.artifacts[0].archive_download_url')
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
-rootdir=$( cd "$bindir"/.. && pwd )
-archive_tmp=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
+dir=$(mktemp -d -t "linkerd-pr-$pr.XXXXXXXXXX")
 
-# Change directory temporarily and download artifact.
-cd "$archive_tmp"
+# Change directory temporarily and download artifact
+cd "$dir"
 
 curl -L -o archive.zip -H "$auth" "$archive"
 unzip -o archive.zip
 
-# Install the Linkerd CLI.
+# Push the Linkerd CLI
 image=$(docker load -i cli-bin.tar | sed 's/Loaded image: //')
-container_id=$(docker create "$image")
-
-case $(uname) in
-  Darwin)
-    platform="darwin"
-    ;;
-  Linux)
-    platform="linux"
-    ;;
-  *)
-    platform="windows"
-    ;;
-esac
-
-docker cp "$container_id":/out/linkerd-"$platform" "$rootdir"/target/cli/"$platform"/linkerd
-installed_cli=1
+docker push "$image"
+tag=$(echo "$image" | cut -f 2 -d ":")
 
 # Load images into local docker images
 if [ $is_kind ]
@@ -164,15 +101,14 @@ then
     "$bindir"/kind load image-archive --name "$cluster_name" $image.tar || tee load_fail &
   done
 
-  # Wait for `kind load` background processes to copmlete. Exit early if any
-  # job failed.
+  # Wait for `kind load` background processes to copmlete; exit early if any
+  # job failed
   wait < <(jobs -p)
   if [ -f load_fail ]
   then
     echo "Loading docker images into KinD cluster failed."
     exit 1
   fi
-  kind_setup=1
 else
   for image in cni-plugin controller debug grafana proxy web
   do
@@ -181,17 +117,30 @@ else
 fi
 
 cd -
+rm -rf "$dir"
 
-if [ $is_kind ]
-then
-  "$bindir"/linkerd "${context_flag[@]}" check --pre
-  "$bindir"/linkerd "${context_flag[@]}" install | kubectl "${context_flag[@]}" apply -f -
-  "$bindir"/linkerd "${context_flag[@]}" check
-else
-  "$bindir"/linkerd check --pre
-  "$bindir"/linkerd install | kubectl apply -f -
-  "$bindir"/linkerd check
-fi
-linkerd_check=1
+case $(uname) in
+  Darwin)
+    platform="darwin"
+    ;;
+  Linux)
+    platform="linux"
+    ;;
+  *)
+    platform="windows"
+    ;;
+esac
 
-exit 0
+# Install the Linkerd CLI
+linkerd=$("$bindir"/docker-pull-binaries "$tag" | awk -v platform=$platform '$0 ~ platform')
+
+# shellcheck disable=SC2068
+"$linkerd" ${context_flag[@]} check --pre
+# shellcheck disable=SC2068
+"$linkerd" ${context_flag[@]} install | kubectl ${context_flag[@]} apply -f -
+# shellcheck disable=SC2068
+"$linkerd" ${context_flag[@]} check
+
+echo ""
+echo "Linkerd installed. CLI available:"
+echo "$linkerd ${context_flag[*]}"

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -16,21 +16,17 @@ do
     -h|--help)
       echo "Install Linkerd with the changes made in a GitHub Pull Request."
       echo ""
-      echo "Note:"
-      echo "    If installing into an existing Kubernetes cluster, this script"
-      echo "    assumes the cluster is not a KinD cluster."
-      echo ""
       echo "Usage:"
-      echo "    --context='': The name of the kubeconfig context to use"
+      echo "    --context: The name of the kubeconfig context to use"
       echo ""
       echo "    # Install Linkerd into the current cluster"
-      echo "    bin/install-pr ####"
+      echo "    bin/install-pr 1234"
       echo ""
       echo "    # Install Linkerd into the current KinD cluster"
-      echo "    bin/install-pr [-k|--kind] ####"
+      echo "    bin/install-pr [-k|--kind] 1234"
       echo ""
-      echo "    # Install Linkerd into the context's KinD cluster"
-      echo "    bin/install-pr [-k|--kind] --context kind ####"
+      echo "    # Install Linkerd into the 'kind-pr-1234' KinD cluster"
+      echo "    bin/install-pr [-k|--kind] --context kind-pr-1234 1234"
       exit 0
       ;;
     --context)

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -13,34 +13,36 @@ cleanup() {
   # Remove temporary directory.
   rm -rf "$archive_tmp"
   
-  if [ "$installed_cli" ]
+  if [ "$installed_cli" -eq 1 ]
   then
     echo ""
     echo "Linkerd CLI installed!"
     echo "Usage:"
-    echo "    bin/linkerd ${context_flag[@]} version"
-  else
+    echo "    bin/linkerd $context_flag version"
+  elif [ "$installed_cli" -eq 0 ]
+  then
     echo ""
     echo "Linkerd CLI install failed!"
   fi
 
-  if [ "$linkerd_check" ]
+  if [ "$linkerd_check" -eq 1 ]
   then
     echo ""
     echo "'linkerd check' passed!"
     echo "Usage:"
-    echo "    bin/linkerd ${context_flag[@]} check"
-    echo "    kubectl ${context_flag[@]} -n linkerd get pods"
-  else
+    echo "    bin/linkerd ${context_flag[*]} check"
+    echo "    kubectl ${context_flag[*]} -n linkerd get pods"
+  elif [ "$linkerd_check" -eq 0 ]
+  then
     echo ""
     echo "'linkerd check' failed!"
     echo "Check again before debugging:"
-    echo "    bin/linkerd ${context_flag[@]} check --pre"
-    echo "    bin/linkerd ${context_flag[@]} check"
-    echo "    kubectl ${context_flag[@]} -n linkerd get pods"
+    echo "    bin/linkerd ${context_flag[*]} check --pre"
+    echo "    bin/linkerd ${context_flag[*]} check"
+    echo "    kubectl ${context_flag[*]} -n linkerd get pods"
   fi
 
-  if [[ $is_kind && ! $kind_setup ]]
+  if [[ $is_kind -eq 1 && $kind_setup -eq 0 ]]
   then
     echo "Script failed at or before KinD cluster creation."
   fi
@@ -52,10 +54,10 @@ trap cleanup EXIT
 archive_tmp=
 context_flag=
 
-installed_cli=
-kind_setup=
-linkerd_check=
-is_kind=
+installed_cli=0
+kind_setup=0
+linkerd_check=0
+is_kind=0
 
 linkerd2_pulls_url="https://api.github.com/repos/linkerd/linkerd2/pulls"
 linkerd2_kind_integration_url="https://api.github.com/repos/linkerd/linkerd2/actions/workflows/kind_integration.yml"
@@ -77,6 +79,8 @@ do
       echo ""
       echo "    # Install Linkerd into a new KinD cluster"
       echo "    bin/install-pr [-k|--kind] ####"
+      installed_cli=2
+      linkerd_check=2
       exit 0
       ;;
     -k|--kind)
@@ -147,7 +151,7 @@ if [ $is_kind ]
 then
   # Create new KinD cluster
   cluster_name="pr-$pr"
-  context_flag=(--context kind-$cluster_name)
+  context_flag=(--context kind-"$cluster_name")
 
   if "$bindir"/kind get clusters | grep "$cluster_name"
   then


### PR DESCRIPTION
## Motivation

After #4147 added the `install-pr` script, installing PRs into existing
clusters does not work if that cluster is a KinD cluster

Changing the script to be able to use KinD, and specifically automate `kind
load` would be helpful!

## Solution

The script can now be used in the following ways.

```
❯ bin/install-pr --help
Install Linkerd with the changes made in a GitHub Pull Request.

Usage:
    --context: The name of the kubeconfig context to use

    # Install Linkerd into the current cluster
    bin/install-pr 1234

    # Install Linkerd into the current KinD cluster
    bin/install-pr [-k|--kind] 1234

    # Install Linkerd into the 'kind-pr-1234' KinD cluster
    bin/install-pr [-k|--kind] --context kind-pr-1234 1234
```

The script assumes that the cluster (KinD or not) has already been created. If
the cluster is a KinD cluster, the `-k|--kind` flag should be passed.

If the `--context` flag is not passsed, the install defaults to the current
context (`kubectl config current-context`).

I also added a [`-h|--help]` option that describes how to use the script.
