### PR TITLE
Update linkerd/stern to fix go.mod

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:93ea34a8 as golang
+FROM gcr.io/linkerd-io/go-deps:d0918050 as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:93ea34a8 as golang
+FROM gcr.io/linkerd-io/go-deps:d0918050 as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:93ea34a8 as golang
+FROM gcr.io/linkerd-io/go-deps:d0918050 as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller service
-FROM gcr.io/linkerd-io/go-deps:93ea34a8 as golang
+FROM gcr.io/linkerd-io/go-deps:d0918050 as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	sigs.k8s.io/yaml v1.1.0
 )
 
-replace github.com/wercker/stern => github.com/linkerd/stern v0.0.0-20190907020106-201e8ccdff9c
+replace github.com/wercker/stern => github.com/linkerd/stern v0.0.0-20200316183041-1ab5375fb7e9
 
 replace k8s.io/apimachinery v0.0.0-20181127105237-2b1284ed4c93 => k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
 

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/linkerd/linkerd2-proxy-init v1.3.1 h1:KTvUvPlSKUkpzZM0L/EIk+EJaKk7dwy
 github.com/linkerd/linkerd2-proxy-init v1.3.1/go.mod h1:lK/sORPZDP6aFhPZps+AHMKphX5v9bKVDNESllz18C0=
 github.com/linkerd/stern v0.0.0-20190907020106-201e8ccdff9c h1:v8RmXOGO65HHLqcDpVNGGe3krA8FptfxcYS3wSS8bJU=
 github.com/linkerd/stern v0.0.0-20190907020106-201e8ccdff9c/go.mod h1:aaP5eLMmFcyJUsZB6FwAO+0eILWeBKvupuHeeEuY0qQ=
+github.com/linkerd/stern v0.0.0-20200316183041-1ab5375fb7e9 h1:xSfvUw8PVp+a+PBE8AYXiFjNcpE1p/KSpkza7KTm0F4=
+github.com/linkerd/stern v0.0.0-20200316183041-1ab5375fb7e9/go.mod h1:5524WGXWpnoZQyBjmfLhuV17TkioMrtCaQD8zWKG6gQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:93ea34a8 as golang
+FROM gcr.io/linkerd-io/go-deps:d0918050 as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
## Motivation

I noticed the Go language server stopped working in VS Code and narrowed it
down to `go build ./...` failing with the following:

```
❯ go build ./...
go: github.com/linkerd/stern@v0.0.0-20190907020106-201e8ccdff9c: parsing go.mod: go.mod:3: usage: go 1.23
```

This change updates `linkerd/stern` version with changes made in
linkerd/stern#3 to fix this issue.

This does not depend on #4170, but it is also needed in order to completely
fix `go build ./...`
