### PR TITLE
Remove target port requirement in port resolution

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -570,9 +570,9 @@ func (pp *portPublisher) unsubscribe(listener EndpointUpdateListener) {
 
 // getTargetPort returns the port specified as an argument if no service is
 // present. If the service is present and it has a port spec matching the
-// specified port and a target port configured, it returns the name of the
-// service's port (not the name of the target pod port), so that it can be
-// looked up in the endpoints API response, which uses service port names.
+// specified port, it returns the name of the service's port (not the name
+// of the target pod port), so that it can be looked up in the endpoints API
+// response, which uses service port names.
 func getTargetPort(service *corev1.Service, port Port) namedPort {
 	// Use the specified port as the target port by default
 	targetPort := intstr.FromInt(int(port))
@@ -581,10 +581,10 @@ func getTargetPort(service *corev1.Service, port Port) namedPort {
 		return targetPort
 	}
 
-	// If a port spec exists with a port matching the specified port and a target
-	// port configured, use that port spec's name as the target port
+	// If a port spec exists with a port matching the specified port use that
+	// port spec's name as the target port
 	for _, portSpec := range service.Spec.Ports {
-		if portSpec.Port == int32(port) && portSpec.TargetPort != intstr.FromInt(0) {
+		if portSpec.Port == int32(port) {
 			return intstr.FromString(portSpec.Name)
 		}
 	}

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -736,7 +736,7 @@ subsets:
 			},
 			serviceType: "mirrored service with remapped port in endpoints",
 			id:          ServiceID{Name: "name1-remote", Namespace: "ns"},
-			port:        9999,
+			port:        8989,
 			expectedAddresses: []string{
 				"172.17.0.12:9999/gateway-identity-1",
 			},


### PR DESCRIPTION
This change removes the target port requirement when resolving ports in the dst service. Based on the comments, it seems that we ***need*** to have a target port defined in the port spec in order to resolve to the port in the Endpoints. In reality if target port is note defined when creating the service, k8s will set the port and the target port to the same value. Seems to me that checking for the targetPort to be different than 0, is a no-op.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
