### PR TITLE
Fix error when injecting Cronjobs that have no metadata

### DIFF
--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -1,5 +1,12 @@
 {{ $prefix := .Values.pathPrefix -}}
 [
+  {{- if .Values.addRootMetadata }}
+  {
+    "op": "add",
+    "path": "{{$prefix}}/metadata",
+    "value": {}
+  },
+  {{- end }}
   {{- if .Values.addRootAnnotations }}
   {
     "op": "add",

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -206,6 +206,20 @@ func TestUninjectAndInject(t *testing.T) {
 			testInjectConfig: defaultConfig,
 		},
 		{
+			inputFileName:    "inject_emojivoto_cronjob.input.yml",
+			goldenFileName:   "inject_emojivoto_cronjob.golden.yml",
+			reportFileName:   "inject_emojivoto_cronjob.report",
+			injectProxy:      false,
+			testInjectConfig: defaultConfig,
+		},
+		{
+			inputFileName:    "inject_emojivoto_cronjob_nometa.input.yml",
+			goldenFileName:   "inject_emojivoto_cronjob_nometa.golden.yml",
+			reportFileName:   "inject_emojivoto_cronjob.report",
+			injectProxy:      false,
+			testInjectConfig: defaultConfig,
+		},
+		{
 			inputFileName:    "inject_emojivoto_pod.input.yml",
 			goldenFileName:   "inject_emojivoto_pod.golden.yml",
 			reportFileName:   "inject_emojivoto_pod.report",

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.golden.yml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+  namespace: emojivoto
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            linkerd.io/inject: enabled
+          labels:
+            foo: bar
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+---

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.input.yml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  namespace: emojivoto
+  name: hello
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            foo: bar
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.report
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.report
@@ -1,0 +1,3 @@
+
+cronjob "hello" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
@@ -1,0 +1,9 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+√ at least one resource injected
+√ pod specs do not include UDP ports
+
+cronjob "hello" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_cronjob_nometa.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob_nometa.golden.yml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+  namespace: emojivoto
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            linkerd.io/inject: enabled
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+---

--- a/cli/cmd/testdata/inject_emojivoto_cronjob_nometa.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob_nometa.input.yml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  namespace: emojivoto
+  name: hello
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure


### PR DESCRIPTION
When injecting a Cronjob with no
`spec.jobTemplate.spec.template.metadata` we were getting the following
error:

```
Error transforming resources: jsonpatch add operation does not apply:
doc is missing path:
"/spec/jobTemplate/spec/template/metadata/annotations"
```

This only happens to Cronjobs because other workloads force having at
least a label there that is used in `spec.selector` (at least as of v1
workloads).

With this fix, if no metadata is detected, then we add it in the json patch when
injecting, prior to adding the injection annotation.

I've added a couple of new unit tests, one that verifies that this
doesn't remove metadata contents in Cronjobs that do have that metadata,
and another one that tests injection in Cronjobs that don't have
metadata (which I verified it failed prior to this fix).