### PR TITLE
Upgrade golangci-lint to v1.23.8

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@
 
 run:
   deadline: 5m
+  skip-dirs:
+  - controller/gen
 issues:
   exclude-use-default: false
 linters:

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.24.0
+lintversion=1.23.8
 
 cd "$(pwd -P)"
 

--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.19.1
+lintversion=1.24.0
 
 cd "$(pwd -P)"
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -300,7 +300,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 			if r.Kind != "" {
 				output.Write([]byte(fmt.Sprintf("%s \"%s\" skipped\n", r.Kind, r.Name)))
 			} else {
-				output.Write([]byte(fmt.Sprintf("document missing \"kind\" field, skipped\n")))
+				output.Write([]byte(fmt.Sprintln("document missing \"kind\" field, skipped")))
 			}
 		}
 	}

--- a/cli/cmd/uninject.go
+++ b/cli/cmd/uninject.go
@@ -96,7 +96,7 @@ func (resourceTransformerUninject) generateReport(reports []inject.Report, outpu
 			if r.Kind != "" {
 				output.Write([]byte(fmt.Sprintf("%s \"%s\" skipped\n", r.Kind, r.Name)))
 			} else {
-				output.Write([]byte(fmt.Sprintf("document missing \"kind\" field, skipped\n")))
+				output.Write([]byte(fmt.Sprintln("document missing \"kind\" field, skipped")))
 			}
 		}
 	}

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -115,6 +115,7 @@ func NewFakeClientSets(configs ...string) (
 // newFakeClientSetsFromManifests reads from a slice of readers, each
 // representing a manifest or collection of manifests, and returns a mock
 // Kubernetes ClientSet.
+//nolint:unparam
 func newFakeClientSetsFromManifests(readers []io.Reader) (
 	kubernetes.Interface,
 	apiextensionsclient.Interface,


### PR DESCRIPTION
This should help with some timeouts we're seeing in CI.

I fixed some new warnings found in `inject.go` and `uninject.go`.
Also we now have to explicitly disable linting `/controller/gen`.

The linter was also complaining that in `/pkg/k8s/fake.go` the
`spClient.Interface` and `tsclient.Interface` returned in the function
`newFakeClientSetsFromManifests()` aren't used, but I opted to ignore
that to leave them available for future tests.