### PR TITLE
Bump Versions of Trace components

### DIFF
--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -182,6 +182,7 @@ tracing:
   collector:
     name: linkerd-collector
     image: omnition/opencensus-collector:0.1.11
+    resources:
   jaeger:
     name: linkerd-jaeger
     image: jaegertracing/all-in-one:1.17.1

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -184,5 +184,5 @@ tracing:
     image: omnition/opencensus-collector:0.1.11
   jaeger:
     name: linkerd-jaeger
-    image: jaegertracing/all-in-one:1.8
+    image: jaegertracing/all-in-one:1.17.1
     resources:

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -181,7 +181,7 @@ tracing:
   enabled: false
   collector:
     name: linkerd-collector
-    image: omnition/opencensus-collector:0.1.10
+    image: omnition/opencensus-collector:0.1.11
     resources:
       cpu:
         limit: 1
@@ -191,5 +191,5 @@ tracing:
         request: 400Mi
   jaeger:
     name: linkerd-jaeger
-    image: jaegertracing/all-in-one:1.8
+    image: jaegertracing/all-in-one:1.17.1
     resources:

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -182,14 +182,7 @@ tracing:
   collector:
     name: linkerd-collector
     image: omnition/opencensus-collector:0.1.11
-    resources:
-      cpu:
-        limit: 1
-        request: 200m
-      memory:
-        limit: 2Gi
-        request: 400Mi
   jaeger:
     name: linkerd-jaeger
-    image: jaegertracing/all-in-one:1.17.1
+    image: jaegertracing/all-in-one:1.8
     resources:

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -3544,17 +3544,11 @@ data:
     tracing:
       enabled: true
       collector:
-        image: omnition/opencensus-collector:0.1.10
+        image: omnition/opencensus-collector:0.1.11
         name: linkerd-collector
-        resources:
-          cpu:
-            limit: 1
-            request: 200m
-          memory:
-            limit: 2Gi
-            request: 400Mi
+        resources: null
       jaeger:
-        image: jaegertracing/all-in-one:1.8
+        image: jaegertracing/all-in-one:1.17.1
         name: linkerd-jaeger
         resources: null
 ---
@@ -3682,7 +3676,7 @@ spec:
         env:
         - name: GOGC
           value: "80"
-        image: omnition/opencensus-collector:0.1.10
+        image: omnition/opencensus-collector:0.1.11
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3696,13 +3690,6 @@ spec:
           httpGet:
             path: /
             port: 13133
-        resources:
-          limits:
-            cpu: "1"
-            memory: "2Gi"
-          requests:
-            cpu: "200m"
-            memory: "400Mi"
         volumeMounts:
         - mountPath: /conf
           name: linkerd-collector-config-val
@@ -3898,7 +3885,7 @@ spec:
         linkerd.io/proxy-deployment: linkerd-jaeger
     spec:
       containers:
-      - image: jaegertracing/all-in-one:1.8
+      - image: jaegertracing/all-in-one:1.17.1
         imagePullPolicy: IfNotPresent
         name: jaeger
         ports:


### PR DESCRIPTION
This PR
- Bumps Jaeger version to `1.17.1`
- Bumps Open Census collector to `0.1.11`
- Also, Changes to saner default resource values for collector.

The Jaeger UI improvements look pretty good, also helps with #4177, as `--query.base-path` is required to allow access to jaeger through reverse-proxy.


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
