### PR TITLE
Fix script argument regex

### DIFF
--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -15,7 +15,7 @@ fi
 release_channel="$1"
 
 # Verify the release channel.
-release_channel_regex="(edge|stable)"
+release_channel_regex="^(edge|stable)$"
 if [[ ! $release_channel =~ $release_channel_regex ]]; then
     echo "Error: valid release channels: edge, stable"
     echo "Usage:"


### PR DESCRIPTION
Currently the release tag regex matches against arguments that have `edge` or
`stable` as a substring.

It should only match against arguments that are either `edge` or `stable`.

For example, the graceful error handling is not triggered for the following:
```
❯ bin/create-release-tag edge-20.3.3
bin/create-release-tag: line 92: release_tag: unbound variable
```

This PR fixes the regex so that the above results in graceful error handling.

```
❯ bin/create-release-tag edge-20.3.3
Error: valid release channels: edge, stable
Usage:
    bin/create-release-tag edge
    bin/create-release-tag stable 2.4.8
```
