### PR TITLE
Add more owners to Dockerfiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,8 @@ MAINTAINERS.md @klingerf @olix0r
 
 /pkg @adleong @alpeb
 
+Dockerfile* @adleong @alpeb @klingerf @olix0r @siggy
+
 # These do not have clear owners today
 # /grafana
 # /proto


### PR DESCRIPTION
Fixes #4179 

Changes to Go dependencies will touch all Dockerfiles in the repo which requires approval from the codeowners of each subdirectory.

We revise the codeowners to add more owners for the Dockerfiles so that approval is not required from the subdirectory owners specifically.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
