### PR TITLE
Add missing PSP for linkerd-smi-metrics

### DIFF
--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -116,3 +116,6 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: {{.Values.global.namespace}}
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: {{.Values.global.namespace}}

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -793,6 +793,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -865,6 +865,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 # Source: linkerd2/templates/smi-metrics-rbac.yaml
 ---

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -865,6 +865,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 # Source: linkerd2/templates/smi-metrics-rbac.yaml
 ---

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -834,6 +834,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: Namespace
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: Namespace
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -772,6 +772,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_ha_config.golden
+++ b/cli/cmd/testdata/upgrade_ha_config.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -837,6 +837,9 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-smi-metrics
+  namespace: linkerd
 ---
 ###
 ### SMI-Metrics RBAC


### PR DESCRIPTION
The linkerd-smi-metrics ServiceAccount wasn't hooked into linkerd's PSP
resource, which resulted in the linkerd-smi-metrics ReplicaSet failing
to spawn pods:

```
Error creating: pods "linkerd-smi-metrics-574f57ffd4-" is forbidden:
unable to validate against any pod security policy: []
```

Edit: Obviously, this only happens in PSP-enabled clusters...