### PR TITLE
Add missing SAs to linkerd check

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -181,10 +181,12 @@ var (
 
 	expectedServiceAccountNames = []string{
 		"linkerd-controller",
+		"linkerd-destination",
 		"linkerd-grafana",
 		"linkerd-identity",
 		"linkerd-prometheus",
 		"linkerd-proxy-injector",
+		"linkerd-smi-metrics",
 		"linkerd-sp-validator",
 		"linkerd-web",
 		"linkerd-tap",

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -750,6 +750,15 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: linkerd-destination
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
@@ -769,6 +778,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-smi-metrics
   namespace: test-ns
   labels:
     linkerd.io/control-plane-ns: test-ns
@@ -943,6 +961,15 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: linkerd-destination
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
@@ -962,6 +989,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-smi-metrics
   namespace: test-ns
   labels:
     linkerd.io/control-plane-ns: test-ns
@@ -1145,6 +1181,15 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: linkerd-destination
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
@@ -1164,6 +1209,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-smi-metrics
   namespace: test-ns
   labels:
     linkerd.io/control-plane-ns: test-ns
@@ -1356,6 +1410,15 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: linkerd-destination
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
@@ -1375,6 +1438,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-smi-metrics
   namespace: test-ns
   labels:
     linkerd.io/control-plane-ns: test-ns
@@ -1576,6 +1648,15 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: linkerd-destination
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
   name: linkerd-identity
   namespace: test-ns
   labels:
@@ -1595,6 +1676,15 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
+  namespace: test-ns
+  labels:
+    linkerd.io/control-plane-ns: test-ns
+`,
+				`
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-smi-metrics
   namespace: test-ns
   labels:
     linkerd.io/control-plane-ns: test-ns

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -416,6 +416,24 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 	if TestHelper.UpgradeHelmFromVersion() == "" {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
+
+	// TODO: remove when 2.8.0 is released
+	_, err := TestHelper.Kubectl("",
+		"--namespace", TestHelper.GetLinkerdNamespace(),
+		"create", "serviceaccount", "linkerd-smi-metrics",
+	)
+	if err != nil {
+		t.Fatalf("linkerd-smi-metrics SA creation failed: %s", err)
+	}
+	_, err = TestHelper.Kubectl("",
+		"--namespace", TestHelper.GetLinkerdNamespace(),
+		"label", "serviceaccount", "linkerd-smi-metrics",
+		"linkerd.io/control-plane-ns="+TestHelper.GetLinkerdNamespace(),
+	)
+	if err != nil {
+		t.Fatalf("linkerd-smi-metrics SA labeling failed: %s", err)
+	}
+
 	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion())
 }
 
@@ -423,6 +441,16 @@ func TestUpgradeHelm(t *testing.T) {
 	if TestHelper.UpgradeHelmFromVersion() == "" {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
+
+	// TODO: remove when 2.8.0 is released
+	_, err := TestHelper.Kubectl("",
+		"--namespace", TestHelper.GetLinkerdNamespace(),
+		"delete", "serviceaccount", "linkerd-smi-metrics",
+	)
+	if err != nil {
+		t.Fatalf("linkerd-smi-metrics SA deletion failed: %s", err)
+	}
+	time.Sleep(3 * time.Second)
 
 	args := []string{
 		"--reset-values",


### PR DESCRIPTION
This adds the service accounts `linkerd-destination` and
`linkerd-smi-metrics` that were missing from the "control plane
ServiceAccounts exist" check.