### PR TITLE
New test for checking SA lists are synced

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -175,22 +175,25 @@ var linkerdHAControlPlaneComponents = []string{
 	"linkerd-tap",
 }
 
+// ExpectedServiceAccountNames is a list of the service accounts that a healthy
+// Linkerd installation should have. Note that linkerd-heartbeat is optional,
+// so it doesn't appear here.
+var ExpectedServiceAccountNames = []string{
+	"linkerd-controller",
+	"linkerd-destination",
+	"linkerd-grafana",
+	"linkerd-identity",
+	"linkerd-prometheus",
+	"linkerd-proxy-injector",
+	"linkerd-smi-metrics",
+	"linkerd-sp-validator",
+	"linkerd-web",
+	"linkerd-tap",
+}
+
 var (
 	retryWindow    = 5 * time.Second
 	requestTimeout = 30 * time.Second
-
-	expectedServiceAccountNames = []string{
-		"linkerd-controller",
-		"linkerd-destination",
-		"linkerd-grafana",
-		"linkerd-identity",
-		"linkerd-prometheus",
-		"linkerd-proxy-injector",
-		"linkerd-smi-metrics",
-		"linkerd-sp-validator",
-		"linkerd-web",
-		"linkerd-tap",
-	}
 )
 
 // Resource provides a way to describe a Kubernetes object, kind, and name.
@@ -705,7 +708,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-sa",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.checkServiceAccounts(expectedServiceAccountNames)
+						return hc.checkServiceAccounts(ExpectedServiceAccountNames)
 					},
 				},
 				{

--- a/test/serviceaccounts/serviceaccounts_test.go
+++ b/test/serviceaccounts/serviceaccounts_test.go
@@ -1,0 +1,74 @@
+package serviceaccounts
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/testutil"
+)
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+func namesMatch(names []string) bool {
+	for _, name := range names {
+		if name == "default" || name == "linkerd-heartbeat" {
+			continue
+		}
+		found := false
+		for _, expectedName := range healthcheck.ExpectedServiceAccountNames {
+			if name == expectedName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestServiceAccountsMatch(t *testing.T) {
+	expectedNames := healthcheck.ExpectedServiceAccountNames
+
+	res, err := TestHelper.Kubectl("",
+		"-n", TestHelper.GetLinkerdNamespace(),
+		"get", "serviceaccounts",
+		"--output", "name",
+	)
+	if err != nil {
+		t.Fatalf("Error retrieving list of service accounts: %s", err)
+	}
+	names := strings.Split(strings.TrimSpace(res), "\n")
+	var saNames []string
+	for _, name := range names {
+		saNames = append(saNames, strings.TrimPrefix(name, "serviceaccount/"))
+	}
+	// disregard `default` and `linkerd-heartbeat`
+	if len(saNames)-2 != len(expectedNames) || !namesMatch(saNames) {
+		t.Fatalf("The service account list doesn't match the expected list: %s", expectedNames)
+	}
+
+	res, err = TestHelper.Kubectl("",
+		"-n", TestHelper.GetLinkerdNamespace(),
+		"get", "rolebindings", "linkerd-psp",
+		"--output", "jsonpath={.subjects[*].name}",
+	)
+	if err != nil {
+		t.Fatalf("Error retrieving list of linkerd-psp rolebindings: %s", err)
+	}
+	saNamesPSP := strings.Split(res, " ")
+	// disregard `linkerd-heartbeat`
+	if len(saNamesPSP)-1 != len(expectedNames) || !namesMatch(saNamesPSP) {
+		t.Fatalf(
+			"The service accounts in the linkerd-psp rolebindings don't match the expected list: %s",
+			expectedNames)
+	}
+}


### PR DESCRIPTION
Followup to #4193

This is to verify that the list of SA installed, as well as the list of
SA in the linkerd-psp RoleBinding match the list of expected SA defined
in `healthcheck.go`.