### PR TITLE
Linkerd CLI Chocolatey Package

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -114,4 +114,6 @@ jobs:
         ! -name test-scale \
         ! -name update-go-deps-shas \
         ! -name web \
+        ! -name *.nuspec \
+        ! -name *.ps1 \
         | xargs -I {} bin/shellcheck -x {}

--- a/bin/win/linkerd.nuspec
+++ b/bin/win/linkerd.nuspec
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>linkerd</id>
+    <version>${LINKERD_VERSION}</version>
+    
+    <title>Linkerd</title>
+    <authors>Linkerd</authors>
+    <summary>Ultralight service mesh for Kubernetes and beyond</summary>
+    <description>
+    Linkerd is an ultralight service mesh for Kubernetes. 
+    It gives you observability, reliability, and security without requiring any code changes.
+
+    Package Parameters
+    - `path`: Specify path for linkerd-cli installation. If not specified, uses environment variable `linkerdPath`. Uses default chocolatey install path if none provided. 
+    - `checksum`: Specify the checksum for linkerd-cli. If not specified, uses environment variable `linkerdCheckSum`. Defaults to `null` if no checksum provided and skips verification. Do ensure to use the correct checksum for the version of install. 
+    </description>
+
+    <projectUrl>https://github.com/linkerd/linkerd2</projectUrl>
+    <licenseUrl>https://github.com/linkerd/linkerd2/blob/master/LICENSE</licenseUrl>
+    <releaseNotes>https://github.com/linkerd/linkerd2/releases</releaseNotes>
+    <docsUrl>https://linkerd.io/docs</docsUrl>
+
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.1.0" />
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="bin\win\tools\**" target="tools" />
+    </files>
+</package>

--- a/bin/win/tools/chocolateyinstall.ps1
+++ b/bin/win/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $version = $env:chocolateyPackageVersion
 $pp = Get-PackageParameters
 
-if ($pp['path'] -ne $null){
+if ($null -ne $pp['path']){
 	$lpath = $pp['path']
 }
 elseif (Test-Path env:linkerdPath) {
@@ -14,7 +14,7 @@ else {
 	$lpath = $toolsPath
 }
 
-if ($pp['checksum'] -ne $null){
+if ($null -ne $pp['checksum']){
 	$checksum = $pp['checksum']
 }
 else{

--- a/bin/win/tools/chocolateyinstall.ps1
+++ b/bin/win/tools/chocolateyinstall.ps1
@@ -24,7 +24,7 @@ else{
 $packageArgs = @{
   packageName    = 'linkerd'
   fileFullPath   = "$lpath\linkerd.exe"
-  url64          = "https://github.com/linkerd/linkerd2/releases/download/$version/linkerd2-cli-$version-windows.exe"
+  url64          = "https://github.com/linkerd/linkerd2/releases/download/stable-$version/linkerd2-cli-stable-$version-windows.exe"
   checksum       = $checksum
   checksumType   = 'sha256'
 }

--- a/bin/win/tools/chocolateyinstall.ps1
+++ b/bin/win/tools/chocolateyinstall.ps1
@@ -1,0 +1,33 @@
+﻿$ErrorActionPreference = 'Stop';
+$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$version = $env:chocolateyPackageVersion
+$pp = Get-PackageParameters
+
+if ($pp['path'] -ne $null){
+	$lpath = $pp['path']
+}
+elseif (Test-Path env:linkerdPath) {
+	$lpath = $env:linkerdPath
+}
+else {
+	$lpath = $toolsPath
+}
+
+if ($pp['checksum'] -ne $null){
+	$checksum = $pp['checksum']
+}
+else{
+	$checksum = $env:linkerdCheckSum
+}
+
+$packageArgs = @{
+  packageName    = 'linkerd'
+  fileFullPath   = "$lpath\linkerd.exe"
+  url64          = "https://github.com/linkerd/linkerd2/releases/download/$version/linkerd2-cli-$version-windows.exe"
+  checksum       = $checksum
+  checksumType   = 'sha256'
+}
+
+Get-ChocolateyWebFile @packageArgs
+Install-ChocolateyPath $packageArgs.fileFullPath 'User'


### PR DESCRIPTION
This PR partially fixes #3063 by building a chocolatey package for Linkerd2's Windows CLI
It adds the build scripts for the Linkerd chocolatey package and based on discussions in
https://github.com/linkerd/linkerd2/pull/3921

The package currently exists in the `bin/win` folder
The `.nuspec` script has been modified for easy integration with the workflow
done by @ihcsim here: https://github.com/ihcsim/linkerd-chocolatey

To build outside of workflow environment (on windows system):
   - Modify `linkerd.nuspec` version tag to an available stable version of Linkerd2's cli
     eg: 2.7.0 and file tag's `src` to `tools\**`
   - Install chocolatey
   - cd into `bin/win/`
   - Run `choco pack`
   - Run `choco install linkerd -s .`  (make sure cmd/ powershell is running as administrator)
   - Run refreshenv to add `linkerd.exe` path to system
   - To unistall run `choco uninstall linkerd`

Tackling requirements discussed in https://github.com/linkerd/linkerd2/pull/3921
(specifically: https://github.com/linkerd/linkerd2/pull/3921#issuecomment-599634476)

- Followed folder structure as described here: https://github.com/ihcsim/linkerd-chocolatey
- Modified package to accept version through the metadata available in `.nuspec` file
- Modified package to override install path with command line arg/ env variable
    To run with command line argument:
    - Run `choco install linkerd -s . --params="/path:<YOUR_PATH_HERE>"`
    To run with environment variable:
    - Run `$env:linkerdPath = "<YOUR_PATH_HERE>"` in powershell
    Uses default chocolatey install path if none of the above provided.
- Modified package to accept command line args/ env variable for checksum
    To run with command line argument:
    - Run `choco install linkerd -s . --params="/checksum:<VERSION_CHECKSUM>"`
    (Keep params space seperated when specifying multiple)
    To run with environment variable:
    - Run `$env:linkerdCheckSum = "<VERSION_CHECKSUM>"`
    If no checksum provided, default null value assigned and package ignores verification step
- This package is compatible in a non-administrative environment but one must install chocolatey
in a non-administrative path.
(Steps explained here: https://chocolatey.org/docs/installation#non-administrative-install)

Further plans:
This PR is part of a set of planned PRs based on the discussions in
https://github.com/linkerd/linkerd2/pull/3921
(specifically: https://github.com/linkerd/linkerd2/pull/3921#issuecomment-599099615)

Signed-off-by: Animesh Narayan Dangwal animesh.leo@gmail.com

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
