### PR TITLE
Extract common logic in scripts and CI to load images into KinD

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -142,20 +142,8 @@ jobs:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1
         PROMETHEUS_IMAGE_NAME: prom/prometheus:v2.15.2
       run: |
-        # For each container, load the image archive into the KinD cluster.
-        #
-        # `kind load` cannot take input from STDIN, so `<(command)` syntax is
-        # used to load the output into the KinD cluster. Set `DOCKER_HOST` for
-        # a single command, and `docker save` the container from the Packet
-        # host.
-        for image in proxy controller web cni-plugin debug grafana; do
-          kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save "$DOCKER_REGISTRY/$image:$TAG") || tee load_fail &
-        done
-
-        # Wait for `kind load` background processes to complete. Exit early if
-        # any job failed.
-        wait < <(jobs -p)
-        test -f load_fail && exit 1 || true
+        # Fetch images from the Packet host and load them into the local KinD cluster
+        bin/kind-load --images --images-host ssh://linkerd-docker
 
         # Load proxy-init and prometheus images into KinD while it is
         # available. Allow these commands to fail since they will be cached
@@ -165,14 +153,7 @@ jobs:
     - name: Load image archives into the local KinD cluster (Forked repositories)
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
       run: |
-        for image in proxy controller web cni-plugin debug grafana; do
-          kind load image-archive image-archives/$image.tar || tee load_fail &
-        done
-
-        # Wait for `kind load` background processes to complete. Exit early if
-        # any job failed.
-        wait < <(jobs -p)
-        test -f load_fail && exit 1 || true
+        bin/kind-load --images
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,20 +140,8 @@ jobs:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1
         PROMETHEUS_IMAGE_NAME: prom/prometheus:v2.15.2
       run: |
-        # For each container, load the image archive into the KinD cluster.
-        #
-        # `kind load` cannot take input from STDIN, so `<(command)` syntax is
-        # used to load the output into the KinD cluster. Set `DOCKER_HOST` for
-        # a single command, and `docker save` the container from the Packet
-        # host.
-        for image in proxy controller web cni-plugin debug grafana; do
-          kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save "$DOCKER_REGISTRY/$image:$TAG") || tee load_fail &
-        done
-
-        # Wait for `kind load` background processes to complete. Exit early if
-        # any job failed.
-        wait < <(jobs -p)
-        test -f load_fail && exit 1 || true
+        # Fetch images from the Packet host and load them into the local KinD cluster
+        bin/kind-load --images --images-host ssh://linkerd-docker
 
         # Load proxy-init and prometheus images into KinD while it is
         # available. Allow these commands to fail since they will be cached

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -95,19 +95,7 @@ then
     name=$(echo "$context" | sed -n -E "s/(kind)-(.*)/\2/p")
   fi
 
-  for image in cni-plugin controller debug grafana proxy web
-  do
-    "$bindir"/kind load image-archive ${name:+'--name' "$name"} $image.tar || touch load_fail &
-  done
-
-  # Wait for `kind load` background processes to complete; exit early if any
-  # job failed
-  wait < <(jobs -p)
-  if [ -f load_fail ]
-  then
-    echo "Loading docker images into KinD cluster failed."
-    exit 1
-  fi
+  "$bindir"/kind-load --images ${name:+'--name' "$name"}
 else
   for image in cni-plugin controller debug grafana proxy web
   do

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -1,17 +1,87 @@
-#!/bin/sh
+#!/bin/bash
 
-set -eu
+set -eo pipefail
 
-# If cluster name is unset or null, default to $USER.
-cluster=${1:-$USER}
+images=""
+images_host=""
+
+while :
+do
+  case $1 in
+    -h|--help)
+      echo "Load into KinD the images for Linkerd's proxy, controller, web, grafana, cli-bin, debug and cni-plugin."
+      echo ""
+      echo "Usage:"
+      echo "    bin/kind-load [--images] [--images-host ssh://linkerd-docker]"
+      echo ""
+      echo "Examples:"
+      echo ""
+      echo "    # Load images from the local docker instance"
+      echo "    bin/kind-load"
+      echo ""
+      echo "    # Load images from tar files located in the current directory"
+      echo "    bin/kind-load --images"
+      echo ""
+      echo "    # Retrieve images from a remote docker instance and then load them into KinD"
+      echo "    bin/kind-load --images --images-host ssh://linkerd-docker"
+      echo ""
+      echo "Available Commands:"
+      echo "    --images: use 'kind load image-archive' to load the images from local .tar files in the current directory."
+      echo "    --images-host: the argument to this option is used as the remote docker instance from which images are first retrieved"
+      echo "                   (using 'docker save') to be then loaded into KinD. This command requires --images."
+      exit 0
+      ;;
+    --images)
+      images=1
+      ;;
+    --images-host)
+      images_host=$2
+      if [ -z "$images_host" ]; then
+        echo "Error: the argument for --images-host was not specified"
+        exit 1
+      fi
+      shift
+      ;;
+    *)
+      break
+  esac
+  shift
+done
+
+if [ "$images_host" ] && [ -z "$images" ]; then
+  echo "Error: --images-host needs to be used with --images" >&2
+  exit 1
+fi
+
+# If cluster name is unset or null, default to "kind".
+cluster=${1:-"kind"}
 
 bindir=$( cd "${0%/*}" && pwd )
 
+# shellcheck source=bin/_tag.sh
 . "$bindir"/_tag.sh
+# shellcheck source=bin/_docker.sh
+. "$bindir"/_docker.sh
 
-tag=$(head_root_tag)
-org_repo=gcr.io/linkerd-io
+TAG=${TAG:-$(head_root_tag)}
 
-for img in proxy controller web grafana ; do
-    "$bindir"/kind load docker-image "$org_repo/$img:$tag" --name $cluster
+rm -f load_fail
+for img in proxy controller web grafana cli-bin debug cni-plugin ; do
+  if [ $images ]; then
+    if [ "$images_host" ]; then
+      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > $img.tar
+    fi
+    cmd=(image-archive "$img.tar")
+  else
+    cmd=(docker-image "$DOCKER_REGISTRY/$img:$TAG")
+  fi
+
+  "$bindir"/kind --name "$cluster" load "${cmd[@]}" || touch load_fail &
 done
+
+wait < <(jobs -p)
+if [ -f load_fail ]; then
+  echo "Loading docker images into KinD cluster failed."
+  rm load_fail
+  exit 1
+fi


### PR DESCRIPTION
Fixes #4206 Followup to #4167

Extract common logic to load images into KinD, from `bin/kind-load`, `bin/install-pr`, `.github/workflows/kind_integration.yml` and `.github/workflows/release.yml`.

Besides removing the duplication, `bin/kind-load` will benefit in performance by having each image be loaded in parallel.

```
$ bin/kind-load -h

Load into KinD the images for Linkerd's proxy, controller, web, grafana, debug and cni-plugin.

Usage:
    bin/kind-load [--images] [--images-host ssh://linkerd-docker]

Examples:

    # Load images from the local docker instance
    bin/kind-load

    # Load images from tar files located in the current directory
    bin/kind-load --images

    # Retrieve images from a remote docker instance and then load them into KinD
    bin/kind-load --images --images-host ssh://linkerd-docker

Available Commands:
    --images: use 'kind load image-archive' to load the images from local .tar files in the current directory.
    --images-host: the argument to this option is used as the remote docker instance from which images are first retrieved
                   (using 'docker save') to be then loaded into KinD. This command requires --images.
```
