### PR TITLE
Fix bin/kind-load for pull requests

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -98,7 +98,6 @@ jobs:
         ! -name docker-retag-all \
         ! -name _docker.sh \
         ! -name fmt \
-        ! -name kind-load \
         ! -name lint \
         ! -name _log.sh \
         ! -name minikube-start-hyperv.bat \

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -73,7 +73,8 @@ rm -f load_fail
 for img in proxy controller web grafana cli-bin debug cni-plugin ; do
   if [ $images ]; then
     if [ "$images_host" ]; then
-      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > $img.tar
+      mkdir -p image-archives
+      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > image-archives/$img.tar
     fi
     cmd=(image-archive "image-archives/$img.tar")
   else

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -19,7 +19,7 @@ do
       echo "    # Load images from the local docker instance"
       echo "    bin/kind-load"
       echo ""
-      echo "    # Load images from tar files located in the current directory"
+      echo "    # Load images from tar files located under the 'image-archives' directory"
       echo "    bin/kind-load --images"
       echo ""
       echo "    # Retrieve images from a remote docker instance and then load them into KinD"
@@ -65,13 +65,17 @@ bindir=$( cd "${0%/*}" && pwd )
 
 TAG=${TAG:-$(head_root_tag)}
 
+# This is really to load the kind binary synchronously, before
+# the parallel executions below attempt doing so
+"$bindir"/kind version
+
 rm -f load_fail
 for img in proxy controller web grafana cli-bin debug cni-plugin ; do
   if [ $images ]; then
     if [ "$images_host" ]; then
       DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > $img.tar
     fi
-    cmd=(image-archive "$img.tar")
+    cmd=(image-archive "image-archives/$img.tar")
   else
     cmd=(docker-image "$DOCKER_REGISTRY/$img:$TAG")
   fi


### PR DESCRIPTION
Followup to #4212

External PRs were failing because:

1) The image tarballs weren't being loaded from the `images-archives`
directory
2) Concurrent calls to `bin/kind` were attempting to download the KinD
binary simultaneously, resulting in a "text file busy" error. To avoid
that, now we just call `bin/kind` synchronously one time beforehand.