### PR TITLE
Don't include git SHA in cloud_integration_tests namespaces

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -112,7 +112,7 @@ jobs:
         export PATH="`pwd`/bin:$PATH"
         echo "$GITCOOKIE_SH" | bash
         version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
-        bin/test-run $HOME/.linkerd linkerd-$version
+        bin/test-run $HOME/.linkerd
     - name: CNI tests
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"


### PR DESCRIPTION
The `cloud_integration_tests` job was creating its tests under
namespaces containing the git SHA. This is a left-over from when all the
tests ran in the same cluster, which is no longer the case, and thus no
longer needed.

This fixes the [current CI failure](https://github.com/linkerd/linkerd2/runs/556330879?check_suite_focus=true#step:6:24) in master.
