### PR TITLE
Don't include git SHA in cloud_integration_tests names - part 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         export PATH="`pwd`/bin:$PATH"
         echo "$GITCOOKIE_SH" | bash
         version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
-        bin/test-run $HOME/.linkerd linkerd-$version
+        bin/test-run $HOME/.linkerd
     - name: CNI tests
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"


### PR DESCRIPTION
Followup to #4230

I forgot to make the same change to the `release.yml` workflow.