### PR TITLE
Add liveliness checks and metrics for multicluster gateway

### DIFF
--- a/charts/linkerd2-service-mirror/README.md
+++ b/charts/linkerd2-service-mirror/README.md
@@ -13,7 +13,7 @@ The following table lists the configurable parameters of the linkerd2-service-mi
 
 | Parameter                            | Description                                                                       | Default                       |
 |--------------------------------------|-----------------------------------------------------------------------------------|-------------------------------|
-|`controllerComponentLabel`    | Control plane label. Do not edit                                                   | `linkerd.io/control-plane-component` |
+|`controllerComponentLabel`            | Control plane label. Do not edit                                                  | `linkerd.io/control-plane-component`|
 |`controllerImage`                     | Docker image for the Service mirror component (uses the Linkerd controller image) |`gcr.io/linkerd-io/controller`|
 |`controllerImageVersion`              | Tag for the Service Mirror container Docker image                                 |latest version|
 |`namespace`                           | Service Mirror component namespace                                                |`linkerd-service-mirror`|

--- a/charts/linkerd2-service-mirror/README.md
+++ b/charts/linkerd2-service-mirror/README.md
@@ -13,6 +13,7 @@ The following table lists the configurable parameters of the linkerd2-service-mi
 
 | Parameter                            | Description                                                                       | Default                       |
 |--------------------------------------|-----------------------------------------------------------------------------------|-------------------------------|
+|`controllerComponentLabel`    | Control plane label. Do not edit                                                   | `linkerd.io/control-plane-component` |
 |`controllerImage`                     | Docker image for the Service mirror component (uses the Linkerd controller image) |`gcr.io/linkerd-io/controller`|
 |`controllerImageVersion`              | Tag for the Service Mirror container Docker image                                 |latest version|
 |`namespace`                           | Service Mirror component namespace                                                |`linkerd-service-mirror`|

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -60,4 +60,7 @@ spec:
         name: service-mirror
         securityContext:
           runAsUser: {{.Values.serviceMirrorUID}}
+        ports:
+        - containerPort: 9999
+          name: admin-http
       serviceAccountName: linkerd-service-mirror

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -16,7 +16,7 @@ metadata:
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
   labels:
-    ControllerComponentLabel: service-mirror
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -4,7 +4,7 @@ metadata:
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
   labels:
-    ControllerComponentLabel: service-mirror
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
 rules:
 - apiGroups: [""]
   resources: ["endpoints", "services", "secrets", "namespaces"]
@@ -32,24 +32,24 @@ metadata:
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
   labels:
-    ControllerComponentLabel: service-mirror
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    ControllerComponentLabel: service-mirror
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      ControllerComponentLabel: service-mirror
+      {{.Values.controllerComponentLabel}}: linkerd-service-mirror
   template:
     metadata:
       labels:
-        ControllerComponentLabel: service-mirror
+        {{.Values.controllerComponentLabel}}: linkerd-service-mirror
     spec:
       containers:
       - args:

--- a/charts/linkerd2-service-mirror/values.yaml
+++ b/charts/linkerd2-service-mirror/values.yaml
@@ -4,3 +4,4 @@ logLevel: info
 eventRequeueLimit: 3
 controllerImage: gcr.io/linkerd-io/controller
 controllerImageVersion: {version}
+controllerComponentLabel: linkerd.io/control-plane-component

--- a/charts/linkerd2/templates/prometheus.yaml
+++ b/charts/linkerd2/templates/prometheus.yaml
@@ -81,6 +81,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -1033,6 +1033,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -1033,6 +1033,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1933,6 +1933,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -2001,6 +2001,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -2001,6 +2001,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1784,6 +1784,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1939,6 +1939,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -1939,6 +1939,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -2067,6 +2067,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1738,6 +1738,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1869,6 +1869,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -1808,6 +1808,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -1041,6 +1041,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -1881,6 +1881,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -1881,6 +1881,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1881,6 +1881,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -1867,6 +1867,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -2009,6 +2009,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -1859,6 +1859,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -1873,6 +1873,19 @@ data:
         action: replace
         target_label: component
 
+    - job_name: 'linkerd-service-mirror'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: linkerd-service-mirror;admin-http$
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: component
+
     - job_name: 'linkerd-proxy'
       kubernetes_sd_configs:
       - role: pod

--- a/controller/cmd/service-mirror/cluster_watcher_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test.go
@@ -53,6 +53,7 @@ func runTestCase(tc *testCase, t *testing.T) {
 			log:             logging.WithFields(logging.Fields{"cluster": clusterName}),
 			eventsQueue:     q,
 			requeueLimit:    0,
+			probeChan:       make(chan interface{}, probeChanBufferSize),
 		}
 
 		for _, ev := range tc.events {
@@ -270,6 +271,10 @@ func TestRemoteServiceDeleted(t *testing.T) {
 				&RemoteServiceDeleted{
 					Name:      "test-service-remote-to-delete",
 					Namespace: "test-namespace-to-delete",
+					GatewayData: &gatewayMetadata{
+						Name:      "gateway",
+						Namespace: "gateway-ns",
+					},
 				},
 			},
 
@@ -1075,6 +1080,10 @@ func TestOnDelete(t *testing.T) {
 				&RemoteServiceDeleted{
 					Name:      "test-service",
 					Namespace: "test-namespace",
+					GatewayData: &gatewayMetadata{
+						Name:      "gateway",
+						Namespace: "gateway-ns",
+					},
 				},
 			},
 		},

--- a/controller/cmd/service-mirror/cluster_watcher_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test.go
@@ -45,15 +45,15 @@ func runTestCase(tc *testCase, t *testing.T) {
 		q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 		watcher := RemoteClusterServiceWatcher{
-			clusterName:     clusterName,
-			clusterDomain:   clusterDomain,
-			remoteAPIClient: remoteAPI,
-			localAPIClient:  localAPI,
-			stopper:         nil,
-			log:             logging.WithFields(logging.Fields{"cluster": clusterName}),
-			eventsQueue:     q,
-			requeueLimit:    0,
-			probeChan:       make(chan interface{}, probeChanBufferSize),
+			clusterName:       clusterName,
+			clusterDomain:     clusterDomain,
+			remoteAPIClient:   remoteAPI,
+			localAPIClient:    localAPI,
+			stopper:           nil,
+			log:               logging.WithFields(logging.Fields{"cluster": clusterName}),
+			eventsQueue:       q,
+			requeueLimit:      0,
+			enqueueProbeEvent: func(event interface{}) {},
 		}
 
 		for _, ev := range tc.events {

--- a/controller/cmd/service-mirror/cluster_watcher_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test.go
@@ -271,7 +271,7 @@ func TestRemoteServiceDeleted(t *testing.T) {
 				&RemoteServiceDeleted{
 					Name:      "test-service-remote-to-delete",
 					Namespace: "test-namespace-to-delete",
-					GatewayData: &gatewayMetadata{
+					GatewayData: gatewayMetadata{
 						Name:      "gateway",
 						Namespace: "gateway-ns",
 					},
@@ -331,7 +331,7 @@ func TestRemoteServiceUpdated(t *testing.T) {
 							Protocol: "TCP",
 						},
 					}),
-					gatewayData: &gatewayMetadata{
+					gatewayData: gatewayMetadata{
 						Name:      "gateway-new",
 						Namespace: "gateway-ns",
 					},
@@ -442,7 +442,7 @@ func TestRemoteServiceUpdated(t *testing.T) {
 							Protocol: "TCP",
 						},
 					}),
-					gatewayData: &gatewayMetadata{
+					gatewayData: gatewayMetadata{
 						Name:      "gateway",
 						Namespace: "gateway-ns",
 					},
@@ -530,13 +530,16 @@ func TestRemoteGatewayUpdated(t *testing.T) {
 			testDescription: "endpoints ports are updated on gateway change",
 			events: []interface{}{
 				&RemoteGatewayUpdated{
-					newPort:              999,
-					newEndpointAddresses: []corev1.EndpointAddress{{IP: "0.0.0.0"}},
-					gatewayData: &gatewayMetadata{
-						Name:      "gateway",
-						Namespace: "gateway-ns",
+
+					gatewaySpec: GatewaySpec{
+						gatewayName:      "gateway",
+						gatewayNamespace: "gateway-ns",
+						clusterName:      "remote",
+						addresses:        []corev1.EndpointAddress{{IP: "0.0.0.0"}},
+						incomingPort:     999,
+						resourceVersion:  "currentGatewayResVersion",
+						ProbeConfig:      nil,
 					},
-					newResourceVersion: "currentGatewayResVersion",
 					affectedServices: []*corev1.Service{
 						mirroredService("test-service-1-remote", "test-namespace", "gateway", "gateway-ns", "", "pastGatewayResVersion",
 							[]corev1.ServicePort{
@@ -629,13 +632,14 @@ func TestRemoteGatewayUpdated(t *testing.T) {
 			testDescription: "endpoints addresses are updated on gateway change",
 			events: []interface{}{
 				&RemoteGatewayUpdated{
-					newPort:              888,
-					newEndpointAddresses: []corev1.EndpointAddress{{IP: "0.0.0.1"}},
-					gatewayData: &gatewayMetadata{
-						Name:      "gateway",
-						Namespace: "gateway-ns",
+					gatewaySpec: GatewaySpec{
+						gatewayName:      "gateway",
+						gatewayNamespace: "gateway-ns",
+						clusterName:      "remote",
+						addresses:        []corev1.EndpointAddress{{IP: "0.0.0.1"}},
+						incomingPort:     888,
+						resourceVersion:  "currentGatewayResVersion",
 					},
-					newResourceVersion: "currentGatewayResVersion",
 					affectedServices: []*corev1.Service{
 						mirroredService("test-service-1-remote", "test-namespace", "gateway", "gateway-ns", "", "pastGatewayResVersion",
 							[]corev1.ServicePort{
@@ -726,14 +730,16 @@ func TestRemoteGatewayUpdated(t *testing.T) {
 			testDescription: "identity is updated on gateway change",
 			events: []interface{}{
 				&RemoteGatewayUpdated{
-					identity:             "new-identity",
-					newPort:              888,
-					newEndpointAddresses: []corev1.EndpointAddress{{IP: "0.0.0.0"}},
-					gatewayData: &gatewayMetadata{
-						Name:      "gateway",
-						Namespace: "gateway-ns",
+					gatewaySpec: GatewaySpec{
+						gatewayName:      "gateway",
+						gatewayNamespace: "gateway-ns",
+						clusterName:      "",
+						addresses:        []corev1.EndpointAddress{{IP: "0.0.0.0"}},
+						incomingPort:     888,
+						resourceVersion:  "currentGatewayResVersion",
+						identity:         "new-identity",
+						ProbeConfig:      nil,
 					},
-					newResourceVersion: "currentGatewayResVersion",
 					affectedServices: []*corev1.Service{
 						mirroredService("test-service-1-remote", "test-namespace", "gateway", "gateway-ns", "", "pastGatewayResVersion",
 							[]corev1.ServicePort{
@@ -830,7 +836,7 @@ func TestRemoteGatewayDeleted(t *testing.T) {
 			testDescription: "removes endpoint subsets when gateway is deleted",
 			events: []interface{}{
 				&RemoteGatewayDeleted{
-					gatewayData: &gatewayMetadata{
+					gatewayData: gatewayMetadata{
 						Name:      "gateway",
 						Namespace: "gateway-ns",
 					},
@@ -1000,7 +1006,7 @@ func onAddOrUpdateTestCases(t *testing.T, isAdd bool) []testCase {
 				localService:   mirroredService("test-service-remote", "test-namespace", "gateway", "gateway-ns", "pastResourceVersion", "gatewayResVersion", nil),
 				localEndpoints: endpoints("test-service-remote", "test-namespace", "gateway", "gateway-ns", "0.0.0.0", "", nil),
 				remoteUpdate:   remoteService("test-service", "test-namespace", "gateway", "gateway-ns", "currentResVersion", nil),
-				gatewayData: &gatewayMetadata{
+				gatewayData: gatewayMetadata{
 					Name:      "gateway",
 					Namespace: "gateway-ns",
 				},
@@ -1080,7 +1086,7 @@ func TestOnDelete(t *testing.T) {
 				&RemoteServiceDeleted{
 					Name:      "test-service",
 					Namespace: "test-namespace",
-					GatewayData: &gatewayMetadata{
+					GatewayData: gatewayMetadata{
 						Name:      "gateway",
 						Namespace: "gateway-ns",
 					},
@@ -1096,7 +1102,7 @@ func TestOnDelete(t *testing.T) {
 			},
 			expectedEventsInQueue: []interface{}{
 				&RemoteGatewayDeleted{
-					gatewayData: &gatewayMetadata{
+					gatewayData: gatewayMetadata{
 						Name:      "gateway",
 						Namespace: "test-namespace",
 					},

--- a/controller/cmd/service-mirror/cluster_watcher_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test.go
@@ -27,6 +27,10 @@ type testCase struct {
 	expectedEventsInQueue  []interface{}
 }
 
+type NoOpProbeEventSink struct{}
+
+func (s *NoOpProbeEventSink) send(event interface{}) {}
+
 func runTestCase(tc *testCase, t *testing.T) {
 	t.Run(tc.testDescription, func(t *testing.T) {
 		remoteAPI, err := k8s.NewFakeAPI(tc.remoteResources...)
@@ -45,15 +49,15 @@ func runTestCase(tc *testCase, t *testing.T) {
 		q := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 		watcher := RemoteClusterServiceWatcher{
-			clusterName:       clusterName,
-			clusterDomain:     clusterDomain,
-			remoteAPIClient:   remoteAPI,
-			localAPIClient:    localAPI,
-			stopper:           nil,
-			log:               logging.WithFields(logging.Fields{"cluster": clusterName}),
-			eventsQueue:       q,
-			requeueLimit:      0,
-			enqueueProbeEvent: func(event interface{}) {},
+			clusterName:     clusterName,
+			clusterDomain:   clusterDomain,
+			remoteAPIClient: remoteAPI,
+			localAPIClient:  localAPI,
+			stopper:         nil,
+			log:             logging.WithFields(logging.Fields{"cluster": clusterName}),
+			eventsQueue:     q,
+			requeueLimit:    0,
+			probeEventsSink: &NoOpProbeEventSink{},
 		}
 
 		for _, ev := range tc.events {

--- a/controller/cmd/service-mirror/config_watcher.go
+++ b/controller/cmd/service-mirror/config_watcher.go
@@ -20,14 +20,16 @@ type RemoteClusterConfigWatcher struct {
 	clusterWatchers map[string]*RemoteClusterServiceWatcher
 	requeueLimit    int
 	sync.RWMutex
+	probeEvents chan interface{}
 }
 
 // NewRemoteClusterConfigWatcher Creates a new config watcher
-func NewRemoteClusterConfigWatcher(k8sAPI *k8s.API, requeueLimit int) *RemoteClusterConfigWatcher {
+func NewRemoteClusterConfigWatcher(k8sAPI *k8s.API, requeueLimit int, probeEvents chan interface{}) *RemoteClusterConfigWatcher {
 	rcw := &RemoteClusterConfigWatcher{
 		k8sAPI:          k8sAPI,
 		clusterWatchers: map[string]*RemoteClusterServiceWatcher{},
 		requeueLimit:    requeueLimit,
+		probeEvents:     probeEvents,
 	}
 	k8sAPI.Secret().Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
@@ -105,12 +107,12 @@ func (rcw *RemoteClusterConfigWatcher) Stop() {
 }
 
 func (rcw *RemoteClusterConfigWatcher) registerRemoteCluster(secret *corev1.Secret) error {
-	config, name, domain, err := parseRemoteClusterSecret(secret)
+	config, err := parseRemoteClusterSecret(secret)
 	if err != nil {
 		return err
 	}
 
-	clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config)
+	clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config.apiConfig)
 	if err != nil {
 		return fmt.Errorf("unable to parse kube config: %s", err)
 	}
@@ -118,50 +120,68 @@ func (rcw *RemoteClusterConfigWatcher) registerRemoteCluster(secret *corev1.Secr
 	rcw.Lock()
 	defer rcw.Unlock()
 
-	if _, ok := rcw.clusterWatchers[name]; ok {
-		return fmt.Errorf("there is already a cluster with name %s being watcher. Please delete its config before attempting to register a new one", name)
+	if _, ok := rcw.clusterWatchers[config.clusterName]; ok {
+		return fmt.Errorf("there is already a cluster with name %s being watcher. Please delete its config before attempting to register a new one", config.clusterName)
 	}
 
-	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, name, rcw.requeueLimit, domain)
+	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, config.clusterName, rcw.requeueLimit, config.clusterDomain, config.probePort, config.probePath, config.probePeriodSeconds, rcw.probeEvents)
 	if err != nil {
 		return err
 	}
 
-	rcw.clusterWatchers[name] = watcher
+	rcw.clusterWatchers[config.clusterName] = watcher
 	watcher.Start()
 	return nil
 
 }
 
 func (rcw *RemoteClusterConfigWatcher) unregisterRemoteCluster(secret *corev1.Secret, cleanState bool) error {
-	_, name, _, err := parseRemoteClusterSecret(secret)
+	config, err := parseRemoteClusterSecret(secret)
 	if err != nil {
 		return err
 	}
 	rcw.Lock()
 	defer rcw.Unlock()
-	if watcher, ok := rcw.clusterWatchers[name]; ok {
+	if watcher, ok := rcw.clusterWatchers[config.clusterName]; ok {
 		watcher.Stop(cleanState)
 	} else {
-		return fmt.Errorf("cannot find watcher for cluser: %s", name)
+		return fmt.Errorf("cannot find watcher for cluser: %s", config.clusterName)
 	}
-	delete(rcw.clusterWatchers, name)
+	delete(rcw.clusterWatchers, config.clusterName)
 
 	return nil
 }
 
-func parseRemoteClusterSecret(secret *corev1.Secret) ([]byte, string, string, error) {
+type watchedClusterConfig struct {
+	apiConfig          []byte
+	clusterName        string
+	clusterDomain      string
+	probePort          int32
+	probePath          string
+	probePeriodSeconds int32
+}
+
+func parseRemoteClusterSecret(secret *corev1.Secret) (*watchedClusterConfig, error) {
 	clusterName, hasClusterName := secret.Annotations[consts.RemoteClusterNameLabel]
 	config, hasConfig := secret.Data[consts.ConfigKeyName]
 	domain, hasDomain := secret.Annotations[consts.RemoteClusterDomainAnnotation]
 	if !hasClusterName {
-		return nil, "", "", fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
+		return nil, fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
 	}
 	if !hasConfig {
-		return nil, "", "", fmt.Errorf("secret should contain remote cluster name as annotation %s", consts.RemoteClusterNameLabel)
+		return nil, fmt.Errorf("secret should contain remote cluster name as annotation %s", consts.RemoteClusterNameLabel)
 	}
 	if !hasDomain {
-		return nil, "", "", fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
+		return nil, fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
 	}
-	return config, clusterName, domain, nil
+
+	//TODO Externalize the port,path and period through  the get-credentials command
+	return &watchedClusterConfig{
+		apiConfig:          config,
+		clusterName:        clusterName,
+		clusterDomain:      domain,
+		probePort:          80,
+		probePath:          "/nginx-health",
+		probePeriodSeconds: 3,
+	}, nil
 }

--- a/controller/cmd/service-mirror/config_watcher.go
+++ b/controller/cmd/service-mirror/config_watcher.go
@@ -124,7 +124,7 @@ func (rcw *RemoteClusterConfigWatcher) registerRemoteCluster(secret *corev1.Secr
 		return fmt.Errorf("there is already a cluster with name %s being watcher. Please delete its config before attempting to register a new one", config.clusterName)
 	}
 
-	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, config.clusterName, rcw.requeueLimit, config.clusterDomain, config.probePort, config.probePath, config.probePeriodSeconds, rcw.enqueueProbeEvent)
+	watcher, err := NewRemoteClusterServiceWatcher(rcw.k8sAPI, clientConfig, config.clusterName, rcw.requeueLimit, config.clusterDomain, rcw.enqueueProbeEvent)
 	if err != nil {
 		return err
 	}
@@ -153,12 +153,9 @@ func (rcw *RemoteClusterConfigWatcher) unregisterRemoteCluster(secret *corev1.Se
 }
 
 type watchedClusterConfig struct {
-	apiConfig          []byte
-	clusterName        string
-	clusterDomain      string
-	probePort          int32
-	probePath          string
-	probePeriodSeconds int32
+	apiConfig     []byte
+	clusterName   string
+	clusterDomain string
 }
 
 func parseRemoteClusterSecret(secret *corev1.Secret) (*watchedClusterConfig, error) {
@@ -175,13 +172,9 @@ func parseRemoteClusterSecret(secret *corev1.Secret) (*watchedClusterConfig, err
 		return nil, fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
 	}
 
-	//TODO Externalize the port,path and period through  the get-credentials command
 	return &watchedClusterConfig{
-		apiConfig:          config,
-		clusterName:        clusterName,
-		clusterDomain:      domain,
-		probePort:          80,
-		probePath:          "/nginx-health",
-		probePeriodSeconds: 3,
+		apiConfig:     config,
+		clusterName:   clusterName,
+		clusterDomain: domain,
 	}, nil
 }

--- a/controller/cmd/service-mirror/jittered_ticker.go
+++ b/controller/cmd/service-mirror/jittered_ticker.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicemirror
+
+import (
+	"math/rand"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Ticker tries to emit events on channel C at minDuration intervals plus up to maxJitter.
+type Ticker struct {
+	C           <-chan time.Time
+	stop        chan bool
+	MinDuration time.Duration
+	MaxJitter   time.Duration
+}
+
+// NewTicker creates a new Ticker
+func NewTicker(minDuration time.Duration, maxJitter time.Duration) *Ticker {
+	if minDuration < 0 {
+		log.WithField("duration", minDuration).Panic("Negative duration")
+	}
+	if maxJitter < 0 {
+		log.WithField("jitter", minDuration).Panic("Negative jitter")
+	}
+	c := make(chan time.Time, 1)
+	ticker := &Ticker{
+		C:           c,
+		stop:        make(chan bool),
+		MinDuration: minDuration,
+		MaxJitter:   maxJitter,
+	}
+	go ticker.loop(c)
+	return ticker
+}
+
+func (t *Ticker) loop(c chan time.Time) {
+tickLoop:
+	for {
+		time.Sleep(t.calculateDelay())
+		// Send best-effort then go back to sleep.
+		select {
+		case <-t.stop:
+			log.Info("Stopping jittered ticker")
+			close(c)
+			break tickLoop
+		case c <- time.Now():
+		default:
+		}
+	}
+}
+
+func (t *Ticker) calculateDelay() time.Duration {
+	jitter := time.Duration(rand.Int63n(int64(t.MaxJitter)))
+	delay := t.MinDuration + jitter
+	return delay
+}
+
+// Stop the ticker
+func (t *Ticker) Stop() {
+	t.stop <- true
+}

--- a/controller/cmd/service-mirror/jittered_ticker.go
+++ b/controller/cmd/service-mirror/jittered_ticker.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//NB: This file was copied from: https://github.com/projectcalico/felix/blob/master/jitter/jittered_ticker.go
 
 package servicemirror
 

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -2,10 +2,11 @@ package servicemirror
 
 import (
 	"flag"
-	"github.com/linkerd/linkerd2/pkg/admin"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/linkerd/linkerd2/pkg/admin"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/flags"

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -6,9 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/linkerd/linkerd2/pkg/admin"
-
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	log "github.com/sirupsen/logrus"
 )

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -13,6 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const probeChanBufferSize = 500
+
 // Main executes the tap service-mirror
 func Main(args []string) {
 	cmd := flag.NewFlagSet("service-mirror", flag.ExitOnError)
@@ -39,7 +41,7 @@ func Main(args []string) {
 		log.Fatalf("Failed to initialize K8s API: %s", err)
 	}
 
-	probeEvents := make(chan interface{}, 500)
+	probeEvents := make(chan interface{}, probeChanBufferSize)
 	probeManager := NewProbeManager(probeEvents, k8sAPI)
 	probeManager.Start()
 

--- a/controller/cmd/service-mirror/metrics.go
+++ b/controller/cmd/service-mirror/metrics.go
@@ -1,0 +1,72 @@
+package servicemirror
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var labelNames = []string{
+	"gateway_name", "gateway_namespace", "remote_cluster_name",
+}
+
+type probeMetricVecs struct {
+	services  *prometheus.GaugeVec
+	alive     *prometheus.GaugeVec
+	latencies *prometheus.HistogramVec
+}
+
+type probeMetrics struct {
+	services  prometheus.Gauge
+	alive     prometheus.Gauge
+	latencies prometheus.Observer
+}
+
+func newProbeMetricVecs() probeMetricVecs {
+	services := promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "num_mirrored_services",
+			Help: "A gauge for the current number of mirrored services associated with a gateway",
+		},
+		labelNames,
+	)
+
+	alive := promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gateway_alive",
+			Help: "A gauge which is 1 if the gateway is alive and 0 if it is not.",
+		},
+		labelNames,
+	)
+
+	latencies := promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "gateway_request_latency_seconds",
+			Help: "A histogram of latencies to a remote gateway.",
+			Buckets: append(append(append(append(
+				prometheus.LinearBuckets(0.01, 0.01, 5),
+				prometheus.LinearBuckets(0.1, 0.1, 5)...),
+				prometheus.LinearBuckets(1, 1, 5)...),
+				prometheus.LinearBuckets(10, 10, 5)...),
+			),
+		},
+		labelNames)
+
+	return probeMetricVecs{
+		services:  services,
+		alive:     alive,
+		latencies: latencies,
+	}
+}
+func (mv probeMetricVecs) newMetrics(gatewayNamespace, gatewayName, remoteClusterName string) probeMetrics {
+
+	labels := prometheus.Labels{
+		"gateway_name":        gatewayName,
+		"gateway_namespace":   gatewayNamespace,
+		"remote_cluster_name": remoteClusterName,
+	}
+	return probeMetrics{
+		services:  mv.services.With(labels),
+		alive:     mv.alive.With(labels),
+		latencies: mv.latencies.With(labels),
+	}
+}

--- a/controller/cmd/service-mirror/metrics.go
+++ b/controller/cmd/service-mirror/metrics.go
@@ -40,14 +40,15 @@ func newProbeMetricVecs() probeMetricVecs {
 
 	latencies := promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "gateway_request_latency_seconds",
+			Name: "gateway_request_latency_ms",
 			Help: "A histogram of latencies to a remote gateway.",
-			Buckets: append(append(append(append(
-				prometheus.LinearBuckets(0.01, 0.01, 5),
-				prometheus.LinearBuckets(0.1, 0.1, 5)...),
-				prometheus.LinearBuckets(1, 1, 5)...),
-				prometheus.LinearBuckets(10, 10, 5)...),
-			),
+			Buckets: []float64{
+				1, 2, 3, 4, 5,
+				10, 20, 30, 40, 50,
+				100, 200, 300, 400, 500,
+				1000, 2000, 3000, 4000, 5000,
+				10000, 20000, 30000, 40000, 50000,
+			},
 		},
 		labelNames)
 

--- a/controller/cmd/service-mirror/metrics.go
+++ b/controller/cmd/service-mirror/metrics.go
@@ -74,7 +74,7 @@ func newProbeMetricVecs() probeMetricVecs {
 
 	latencies := promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "gateway_request_latency_ms",
+			Name: "gateway_probe_latency_ms",
 			Help: "A histogram of latencies to a remote gateway.",
 			Buckets: []float64{
 				1, 2, 3, 4, 5,

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -2,6 +2,7 @@ package servicemirror
 
 import (
 	"fmt"
+
 	"github.com/linkerd/linkerd2/controller/k8s"
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	log "github.com/sirupsen/logrus"

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -102,12 +102,12 @@ func (m *ProbeManager) handleMirroredServicePaired(event *MirroredServicePaired)
 	worker, ok := m.probeWorkers[probeKey]
 	if ok {
 		log.Debugf("Probe worker %s already exists", probeKey)
-		worker.IncNumServices()
+		worker.PairService(event.serviceName, event.serviceNamespace)
 	} else {
 		log.Debugf("Creating probe worker %s", probeKey)
 		probeMetrics := m.metricVecs.newMetrics(event.gatewayNs, event.gatewayName, event.clusterName)
 		worker = NewProbeWorker(event.GatewayProbeSpec, &probeMetrics, probeKey)
-		worker.IncNumServices()
+		worker.PairService(event.serviceName, event.serviceNamespace)
 		m.probeWorkers[probeKey] = worker
 		worker.Start()
 	}
@@ -117,8 +117,8 @@ func (m *ProbeManager) handleMirroredServiceUnpaired(event *MirroredServiceUnpai
 	probeKey := probeKey(event.gatewayNs, event.gatewayName, event.clusterName)
 	worker, ok := m.probeWorkers[probeKey]
 	if ok {
-		worker.DcrNumServices()
-		if worker.numAssociatedServices < 1 {
+		worker.UnPairService(event.serviceName, event.serviceNamespace)
+		if worker.NumPairedServices() < 1 {
 			log.Debugf("Probe worker's %s associated services dropped to 0, cleaning up", probeKey)
 			worker.Stop()
 			delete(m.probeWorkers, probeKey)

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -1,0 +1,193 @@
+package servicemirror
+
+import (
+	"fmt"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	consts "github.com/linkerd/linkerd2/pkg/k8s"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// NewProbeManager creates a new probe manager
+func NewProbeManager(events chan interface{}, k8sAPI *k8s.API) *ProbeManager {
+	metricVecs := newProbeMetricVecs()
+	return &ProbeManager{
+		k8sAPI:       k8sAPI,
+		probeWorkers: make(map[string]*ProbeWorker),
+		events:       events,
+		metricVecs:   &metricVecs,
+		done:         make(chan struct{}, 1),
+	}
+}
+
+// ProbeManager takes care of managing the lifecycle of probe workers
+type ProbeManager struct {
+	k8sAPI       *k8s.API
+	probeWorkers map[string]*ProbeWorker
+
+	events     chan interface{}
+	metricVecs *probeMetricVecs
+	done       chan struct{}
+}
+
+// GatewayProbeSpec is the specification of a probe that will be executed by the worker
+type GatewayProbeSpec struct {
+	clusterName   string
+	gatewayName   string
+	gatewayNs     string
+	gatewayIps    []string
+	port          int32
+	path          string
+	periodSeconds int32
+}
+
+// MirroredServiceUnpaired is emitted when a service is no longer mirrored
+type MirroredServiceUnpaired struct {
+	serviceName      string
+	serviceNamespace string
+	gatewayName      string
+	gatewayNs        string
+	clusterName      string
+}
+
+// MirroredServicePaired is emitted when a new mirrored service is created
+type MirroredServicePaired struct {
+	serviceName      string
+	serviceNamespace string
+	*GatewayProbeSpec
+}
+
+// ClusterRegistered is emitted when a new cluster becomes registred for mirroring
+type ClusterRegistered struct {
+	clusterName   string
+	port          int32
+	path          string
+	periodSeconds int32
+}
+
+// GatewayUpdated is emitted when something about the gateway is updated (i.e. its external IP(s))
+type GatewayUpdated struct {
+	*GatewayProbeSpec
+}
+
+func probeKey(gatewayNamespace string, gatewayName string, clusterName string) string {
+	return fmt.Sprintf("%s-%s-%s", gatewayNamespace, gatewayName, clusterName)
+}
+
+func (m *ProbeManager) handleEvent(ev interface{}) {
+	switch ev := ev.(type) {
+	case *MirroredServicePaired:
+		m.handleMirroredServicePaired(ev)
+	case *MirroredServiceUnpaired:
+		m.handleMirroredServiceUnpaired(ev)
+	case *GatewayUpdated:
+		m.handleGatewayUpdated(ev)
+	case *ClusterRegistered:
+		m.handleClusterRegistered(ev)
+	}
+}
+
+func (m *ProbeManager) handleMirroredServicePaired(event *MirroredServicePaired) {
+	probeKey := probeKey(event.gatewayNs, event.gatewayName, event.clusterName)
+	worker, ok := m.probeWorkers[probeKey]
+	if ok {
+		log.Debugf("Probe worker %s already exists", probeKey)
+		worker.IncNumServices()
+	} else {
+		log.Debugf("Creating probe worker %s", probeKey)
+		probeMetrics := m.metricVecs.newMetrics(event.gatewayNs, event.gatewayName, event.clusterName)
+		worker = NewProbeWorker(event.GatewayProbeSpec, &probeMetrics, probeKey)
+		worker.IncNumServices()
+		m.probeWorkers[probeKey] = worker
+		worker.Start()
+	}
+}
+
+func (m *ProbeManager) handleMirroredServiceUnpaired(event *MirroredServiceUnpaired) {
+	probeKey := probeKey(event.gatewayNs, event.gatewayName, event.clusterName)
+	worker, ok := m.probeWorkers[probeKey]
+	if ok {
+		worker.DcrNumServices()
+		if worker.numAssociatedServices < 1 {
+			log.Debugf("Probe worker's %s associated services dropped to 0, cleaning up", probeKey)
+			worker.Stop()
+			delete(m.probeWorkers, probeKey)
+		}
+	}
+}
+
+func (m *ProbeManager) handleGatewayUpdated(event *GatewayUpdated) {
+	probeKey := probeKey(event.gatewayNs, event.gatewayName, event.clusterName)
+	worker, ok := m.probeWorkers[probeKey]
+	if ok {
+		worker.UpdateProbeSpec(event.GatewayProbeSpec)
+	}
+}
+
+func (m *ProbeManager) handleClusterRegistered(event *ClusterRegistered) {
+	matchLabels := map[string]string{
+		consts.MirroredResourceLabel:  "true",
+		consts.RemoteClusterNameLabel: event.clusterName,
+	}
+
+	services, err := m.k8sAPI.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+	if err != nil {
+		log.Errorf("Was not able to sync cluster %s, %s", event.clusterName, err)
+	}
+
+	for _, svc := range services {
+		ips := []string{}
+		if endp, err := m.k8sAPI.Endpoint().Lister().Endpoints(svc.Namespace).Get(svc.Name); err == nil {
+			if len(endp.Subsets) == 1 {
+				for _, addr := range endp.Subsets[0].Addresses {
+					ips = append(ips, addr.IP)
+				}
+			}
+		}
+
+		log.Debugf("Syncing service %s", svc.Name)
+
+		paired := MirroredServicePaired{
+			serviceName:      svc.Name,
+			serviceNamespace: svc.Namespace,
+			GatewayProbeSpec: &GatewayProbeSpec{
+				clusterName:   event.clusterName,
+				gatewayName:   svc.Labels[consts.RemoteGatewayNameLabel],
+				gatewayNs:     svc.Labels[consts.RemoteGatewayNsLabel],
+				gatewayIps:    ips,
+				port:          event.port,
+				path:          event.path,
+				periodSeconds: event.periodSeconds,
+			},
+		}
+		m.events <- &paired
+	}
+
+}
+
+func (m *ProbeManager) run() {
+	for {
+		select {
+		case event := <-m.events:
+			log.Debugf("Received event: %v", event)
+			m.handleEvent(event)
+		case <-m.done:
+			log.Debug("Shutting down ProbeManager")
+			for key, worker := range m.probeWorkers {
+				worker.Stop()
+				delete(m.probeWorkers, key)
+			}
+			return
+		}
+	}
+}
+
+// Start starts the probe manager
+func (m *ProbeManager) Start() {
+	go m.run()
+}
+
+// Stop stops the probe manager
+func (m *ProbeManager) Stop() {
+	close(m.done)
+}

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -114,6 +114,8 @@ func (m *ProbeManager) handleMirroredServiceUnpaired(event *MirroredServiceUnpai
 			worker.Stop()
 			delete(m.probeWorkers, probeKey)
 		}
+	} else {
+		log.Debugf("Could not find a worker for %s while handling MirroredServiceUnpaired event", probeKey)
 	}
 }
 
@@ -122,6 +124,8 @@ func (m *ProbeManager) handleGatewayUpdated(event *GatewayUpdated) {
 	worker, ok := m.probeWorkers[probeKey]
 	if ok {
 		worker.UpdateProbeSpec(event.GatewayProbeSpec)
+	} else {
+		log.Debugf("Could not find a worker for %s while handling MirroredServiceUnpaired event", probeKey)
 	}
 }
 

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -2,11 +2,12 @@ package servicemirror
 
 import (
 	"fmt"
-	logging "github.com/sirupsen/logrus"
 	"math/rand"
 	"net/http"
 	"sync"
 	"time"
+
+	logging "github.com/sirupsen/logrus"
 )
 
 // ProbeWorker is responsible for monitoring gateways using a probe specification

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -113,7 +113,7 @@ func (pw *ProbeWorker) doProbe() {
 		} else {
 			pw.log.Debug("Gateway is healthy")
 			pw.metrics.alive.Set(1)
-			pw.metrics.latencies.Observe(end.Seconds())
+			pw.metrics.latencies.Observe(float64(end.Milliseconds()))
 		}
 
 		if err := resp.Body.Close(); err != nil {

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -46,20 +46,20 @@ func (pw *ProbeWorker) DcrNumServices() {
 	pw.metrics.services.Dec()
 }
 
-// UpdateProbeSpec  is used to update the probe specification when something about the gateway changes
+// UpdateProbeSpec is used to update the probe specification when something about the gateway changes
 func (pw *ProbeWorker) UpdateProbeSpec(spec *GatewayProbeSpec) {
 	pw.Lock()
 	pw.probe = spec
 	pw.Unlock()
 }
 
-// Stop stops this probe worker
+// Stop this probe worker
 func (pw *ProbeWorker) Stop() {
 	pw.log.Debug("Stopping probe worker for")
 	close(pw.stopCh)
 }
 
-// Start starts this probe worker
+// Start this probe worker
 func (pw *ProbeWorker) Start() {
 	pw.log.Debug("Starting probe worker")
 	go pw.run()

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -1,0 +1,123 @@
+package servicemirror
+
+import (
+	"fmt"
+	logging "github.com/sirupsen/logrus"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ProbeWorker is responsible for monitoring gateways using a probe specification
+type ProbeWorker struct {
+	*sync.RWMutex
+	probe                 *GatewayProbeSpec
+	numAssociatedServices int32
+	stopCh                chan struct{}
+	metrics               *probeMetrics
+	log                   *logging.Entry
+}
+
+// NewProbeWorker creates a new probe worker associated with a particular gateway
+func NewProbeWorker(probe *GatewayProbeSpec, metrics *probeMetrics, probekey string) *ProbeWorker {
+	return &ProbeWorker{
+		RWMutex:               &sync.RWMutex{},
+		probe:                 probe,
+		numAssociatedServices: 0,
+		stopCh:                make(chan struct{}, 1),
+		metrics:               metrics,
+		log: logging.WithFields(logging.Fields{
+			"probe-key": probekey,
+		}),
+	}
+}
+
+// IncNumServices increments the number of services that are routed by the gateway
+func (pw *ProbeWorker) IncNumServices() {
+	pw.numAssociatedServices = pw.numAssociatedServices + 1
+	pw.metrics.services.Inc()
+}
+
+// DcrNumServices decrements the number of services that are routed by the gateway
+func (pw *ProbeWorker) DcrNumServices() {
+	pw.numAssociatedServices = pw.numAssociatedServices - 1
+	pw.metrics.services.Dec()
+}
+
+// UpdateProbeSpec  is used to update the probe specification when something about the gateway changes
+func (pw *ProbeWorker) UpdateProbeSpec(spec *GatewayProbeSpec) {
+	pw.Lock()
+	pw.probe = spec
+	pw.Unlock()
+}
+
+// Stop stops this probe worker
+func (pw *ProbeWorker) Stop() {
+	pw.log.Debug("Stopping probe worker for")
+	close(pw.stopCh)
+}
+
+// Start starts this probe worker
+func (pw *ProbeWorker) Start() {
+	pw.log.Debug("Starting probe worker")
+	go pw.run()
+}
+
+func (pw *ProbeWorker) run() {
+	probeTickerPeriod := time.Duration(pw.probe.periodSeconds) * time.Second
+
+	// Introduce some randomness to avoid bursts of probes
+	time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
+
+	probeTicker := time.NewTicker(probeTickerPeriod)
+
+probeLoop:
+	for {
+		select {
+		case <-pw.stopCh:
+			break probeLoop
+		case <-probeTicker.C:
+			pw.doProbe()
+		}
+	}
+}
+
+func (pw *ProbeWorker) pickAnIP() string {
+	numIps := len(pw.probe.gatewayIps)
+	if numIps == 0 {
+		return ""
+	}
+	return pw.probe.gatewayIps[rand.Int()%numIps]
+}
+
+func (pw *ProbeWorker) doProbe() {
+	pw.RLock()
+	defer pw.RUnlock()
+
+	ipToTry := pw.pickAnIP()
+	if ipToTry == "" {
+		pw.log.Debug("No ips. Marking as unhealthy")
+		pw.metrics.alive.Set(0)
+	} else {
+		start := time.Now()
+		resp, err := http.Get(fmt.Sprintf("http://%s:%d/%s", ipToTry, pw.probe.port, pw.probe.path))
+		end := time.Since(start)
+		if err != nil {
+			pw.log.Errorf("Problem connecting with gateway. Marking as unhealthy %s", err)
+			pw.metrics.alive.Set(0)
+		} else if resp.StatusCode != 200 {
+			pw.log.Debugf("Gateway returned unexpected status %d. Marking as unhealthy", resp.StatusCode)
+			pw.metrics.alive.Set(0)
+		} else {
+			pw.log.Debug("Gateway is healthy")
+			pw.metrics.alive.Set(1)
+			pw.metrics.latencies.Observe(end.Seconds())
+		}
+
+		if err := resp.Body.Close(); err != nil {
+			pw.log.Debugf("Failed to close response body %s", err)
+		}
+
+	}
+}

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -127,6 +127,7 @@ func (pw *ProbeWorker) doProbe() {
 			pw.log.Errorf("Problem connecting with gateway. Marking as unhealthy %s", err)
 			pw.metrics.alive.Set(0)
 			pw.metrics.probes.With(notSuccessLabel).Inc()
+			return
 		} else if resp.StatusCode != 200 {
 			pw.log.Debugf("Gateway returned unexpected status %d. Marking as unhealthy", resp.StatusCode)
 			pw.metrics.alive.Set(0)

--- a/pkg/charts/servicemirror/values.go
+++ b/pkg/charts/servicemirror/values.go
@@ -14,12 +14,13 @@ const (
 
 // Values contains the top-level elements in the Helm charts
 type Values struct {
-	Namespace              string `json:"namespace"`
-	ControllerImage        string `json:"controllerImage"`
-	ControllerImageVersion string `json:"controllerImageVersion"`
-	ServiceMirrorUID       int64  `json:"serviceMirrorUID"`
-	LogLevel               string `json:"logLevel"`
-	EventRequeueLimit      int32  `json:"eventRequeueLimit"`
+	Namespace                string `json:"namespace"`
+	ControllerImage          string `json:"controllerImage"`
+	ControllerImageVersion   string `json:"controllerImageVersion"`
+	ControllerComponentLabel string `json:"controllerComponentLabel"`
+	ServiceMirrorUID         int64  `json:"serviceMirrorUID"`
+	LogLevel                 string `json:"logLevel"`
+	EventRequeueLimit        int32  `json:"eventRequeueLimit"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -388,6 +388,15 @@ const (
 	// GatewayIdentity can be found on the remote gateway service
 	GatewayIdentity = SvcMirrorPrefix + "/gateway-identity"
 
+	// GatewayProbePort the port on which the gateway can be probed
+	GatewayProbePort = SvcMirrorPrefix + "/probe-port"
+
+	// GatewayProbePeriod the interval at which the health of the gateway should be probed
+	GatewayProbePeriod = SvcMirrorPrefix + "/probe-period"
+
+	// GatewayProbePath the path at which the health of the gateway should be probed
+	GatewayProbePath = SvcMirrorPrefix + "/probe-path"
+
 	// ConfigKeyName is the key in the secret that stores the kubeconfig needed to connect
 	// to a remote cluster
 	ConfigKeyName = "kubeconfig"


### PR DESCRIPTION
This PR adds liveliness checks for remote gateways. The way its is done is by maintaining probes for each gateway. The probes track whether the gateway is alive by issuing an HTTP request to an endpoint. Additionally the probes publish Prometheus metrics such as number of mirrored services per gateway and histogram latencies. 

Next steps (coming in different PRs): 

- Externalize the port, path and period through  the `get-credentials` command
- Add unit tests
- Enable Prometheus to scrape the `/metrics` endpoint
- Enable users to retreive the stats of the gateways via a CLI command (similar to `stat`)

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
