### PR TITLE
Fix routes wide output formatting for empty values

### DIFF
--- a/cli/cmd/routes.go
+++ b/cli/cmd/routes.go
@@ -206,6 +206,7 @@ func printRouteTable(stats []*routeRowStats, w *tabwriter.Writer, options *route
 	templateString = templateString + "%dms\t%dms\t%dms\t\n"
 
 	emptyTemplateString := routeTemplate + "\t%s\t-\t-\t-\t-\t-\t\n"
+	emptyWideTemplateString := routeTemplate + "\t%s\t-\t-\t-\t-\t-\t-\t-\t\n"
 	for _, row := range stats {
 
 		values := []interface{}{
@@ -233,7 +234,11 @@ func printRouteTable(stats []*routeRowStats, w *tabwriter.Writer, options *route
 
 			fmt.Fprintf(w, templateString, values...)
 		} else {
-			fmt.Fprintf(w, emptyTemplateString, values...)
+			if outputActual {
+				fmt.Fprintf(w, emptyWideTemplateString, values...)
+			} else {
+				fmt.Fprintf(w, emptyTemplateString, values...)
+			}
 		}
 	}
 }

--- a/cli/cmd/routes.go
+++ b/cli/cmd/routes.go
@@ -205,8 +205,13 @@ func printRouteTable(stats []*routeRowStats, w *tabwriter.Writer, options *route
 	// p50, p95, p99
 	templateString = templateString + "%dms\t%dms\t%dms\t\n"
 
-	emptyTemplateString := routeTemplate + "\t%s\t-\t-\t-\t-\t-\t\n"
-	emptyWideTemplateString := routeTemplate + "\t%s\t-\t-\t-\t-\t-\t-\t-\t\n"
+	var emptyTemplateString string
+	if outputActual {
+		emptyTemplateString = routeTemplate + "\t%s\t-\t-\t-\t-\t-\t-\t-\t\n"
+	} else {
+		emptyTemplateString = routeTemplate + "\t%s\t-\t-\t-\t-\t-\t\n"
+	}
+
 	for _, row := range stats {
 
 		values := []interface{}{
@@ -234,11 +239,7 @@ func printRouteTable(stats []*routeRowStats, w *tabwriter.Writer, options *route
 
 			fmt.Fprintf(w, templateString, values...)
 		} else {
-			if outputActual {
-				fmt.Fprintf(w, emptyWideTemplateString, values...)
-			} else {
-				fmt.Fprintf(w, emptyTemplateString, values...)
-			}
+			fmt.Fprintf(w, emptyTemplateString, values...)
 		}
 	}
 }

--- a/cli/cmd/routes_test.go
+++ b/cli/cmd/routes_test.go
@@ -33,6 +33,18 @@ func TestRoutes(t *testing.T) {
 			file:    "routes_one_output_json.golden",
 		}, t)
 	})
+
+	wideOptions := newRoutesOptions()
+	wideOptions.toResource = "deploy/bar"
+	wideOptions.outputFormat = wideOutput
+	t.Run("Returns wider route stats", func(t *testing.T) {
+		testRoutesCall(routesParamsExp{
+			routes:  []string{"/a", "/b", "/c"},
+			counts:  []uint64{90, 60, 0, 30},
+			options: wideOptions,
+			file:    "routes_one_output_wide.golden",
+		}, t)
+	})
 }
 
 func testRoutesCall(exp routesParamsExp, t *testing.T) {

--- a/cli/cmd/testdata/routes_one_output_wide.golden
+++ b/cli/cmd/testdata/routes_one_output_wide.golden
@@ -1,0 +1,6 @@
+ROUTE       SERVICE   EFFECTIVE_SUCCESS   EFFECTIVE_RPS   ACTUAL_SUCCESS   ACTUAL_RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
+/a           foobar             100.00%          1.5rps          100.00%       1.5rps         123ms         123ms         123ms
+/b           foobar             100.00%          1.0rps          100.00%       1.0rps         123ms         123ms         123ms
+/c           foobar                   -               -                -            -             -             -             -
+[DEFAULT]    foobar             100.00%          0.5rps          100.00%       0.5rps         123ms         123ms         123ms
+


### PR DESCRIPTION
Fixes #4216 

Adds a wider templating string which is used when `outputActual` is enabled

Output:
```bash
./bin/go-run cli routes deploy/vote-bot --to service/web-svc -n emojivoto -o wide
ROUTE           SERVICE   EFFECTIVE_SUCCESS   EFFECTIVE_RPS   ACTUAL_SUCCESS   ACTUAL_RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
GET /api/list   web-svc             100.00%          1.0rps          100.00%       1.0rps           3ms           9ms          10ms
GET /api/vote   web-svc              81.36%          1.0rps           81.36%       1.0rps           4ms          15ms          19ms
[DEFAULT]       web-svc                   -               -                -            -             -             -             -

```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
