### PR TITLE
Improve proxy version diagnostics

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -96,21 +96,21 @@ func configureAndRunVersion(
 			defer cancel()
 			resp, err := client.ListPods(ctx, req)
 			if err != nil {
-				fmt.Println(stdout, "Proxy versions: unavailable")
+				fmt.Fprintln(stdout, "Proxy versions: unavailable")
 			} else {
 				counts := make(map[string]int)
 				for _, pod := range resp.GetPods() {
 					if pod.ControllerNamespace == controlPlaneNamespace {
-						if count, ok := counts[pod.GetProxyVersion()]; ok {
-							counts[pod.GetProxyVersion()] = count + 1
-						} else {
-							counts[pod.GetProxyVersion()] = 1
-						}
+						counts[pod.GetProxyVersion()]++
 					}
 				}
-				fmt.Println("Proxy versions:")
-				for version, count := range counts {
-					fmt.Printf("\t%s (%d pods)\n", version, count)
+				if len(counts) == 0 {
+					fmt.Fprintln(stdout, "Proxy versions: unavailable")
+				} else {
+					fmt.Fprintln(stdout, "Proxy versions:")
+					for version, count := range counts {
+						fmt.Fprintf(stdout, "\t%s (%d pods)\n", version, count)
+					}
 				}
 			}
 		}

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -18,12 +18,16 @@ const defaultVersionString = "unavailable"
 type versionOptions struct {
 	shortVersion      bool
 	onlyClientVersion bool
+	proxy             bool
+	namespace         string
 }
 
 func newVersionOptions() *versionOptions {
 	return &versionOptions{
 		shortVersion:      false,
 		onlyClientVersion: false,
+		proxy:             false,
+		namespace:         "",
 	}
 }
 
@@ -41,6 +45,8 @@ func newCmdVersion() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&options.shortVersion, "short", options.shortVersion, "Print the version number(s) only, with no additional output")
 	cmd.PersistentFlags().BoolVar(&options.onlyClientVersion, "client", options.onlyClientVersion, "Print the client version only")
+	cmd.PersistentFlags().BoolVar(&options.proxy, "proxy", options.proxy, "Print data-plane versions")
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy versions (default: all namespaces)")
 
 	return cmd
 }
@@ -73,6 +79,40 @@ func configureAndRunVersion(
 			fmt.Fprintln(stdout, serverVersion)
 		} else {
 			fmt.Fprintf(stdout, "Server version: %s\n", serverVersion)
+		}
+
+		if options.proxy {
+
+			req := &pb.ListPodsRequest{}
+			if options.namespace != "" {
+				req.Selector = &pb.ResourceSelection{
+					Resource: &pb.Resource{
+						Namespace: options.namespace,
+					},
+				}
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			resp, err := client.ListPods(ctx, req)
+			if err != nil {
+				fmt.Println(stdout, "Proxy versions: unavailable")
+			} else {
+				counts := make(map[string]int)
+				for _, pod := range resp.GetPods() {
+					if pod.ControllerNamespace == controlPlaneNamespace {
+						if count, ok := counts[pod.GetProxyVersion()]; ok {
+							counts[pod.GetProxyVersion()] = count + 1
+						} else {
+							counts[pod.GetProxyVersion()] = 1
+						}
+					}
+				}
+				fmt.Println("Proxy versions:")
+				for version, count := range counts {
+					fmt.Printf("\t%s (%d pods)\n", version, count)
+				}
+			}
 		}
 	}
 }

--- a/cli/cmd/version_test.go
+++ b/cli/cmd/version_test.go
@@ -34,17 +34,17 @@ func TestConfigureAndRunVersion(t *testing.T) {
 			fmt.Sprintf("Client version: %s\nServer version: %s\n", version.Version, "server-version"),
 		},
 		{
-			&versionOptions{false, true},
+			&versionOptions{false, true, false, ""},
 			mkMockClient("", nil, nil),
 			fmt.Sprintf("Client version: %s\n", version.Version),
 		},
 		{
-			&versionOptions{true, true},
+			&versionOptions{true, true, false, ""},
 			mkMockClient("", nil, nil),
 			fmt.Sprintf("%s\n", version.Version),
 		},
 		{
-			&versionOptions{true, false},
+			&versionOptions{true, false, false, ""},
 			mkMockClient("server-version", nil, nil),
 			fmt.Sprintf("%s\n%s\n", version.Version, "server-version"),
 		},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1147,11 +1147,16 @@ func (hc *HealthChecker) allCategories() []category {
 							return err
 						}
 
+						outdatedPods := []string{}
 						for _, pod := range pods {
 							err = hc.latestVersions.Match(pod.ProxyVersion)
 							if err != nil {
-								return fmt.Errorf("%s: %s", pod.Name, err)
+								outdatedPods = append(outdatedPods, fmt.Sprintf("\t* %s (%s)", pod.Name, pod.ProxyVersion))
 							}
+						}
+						if len(outdatedPods) > 0 {
+							podList := strings.Join(outdatedPods, "\n")
+							return fmt.Errorf("Some data plane pods are not running the current version:\n%s", podList)
 						}
 						return nil
 					},


### PR DESCRIPTION
It can be difficult to know which versions of the proxy are running in your cluster, especially when you have pods running at multiple different proxy versions.

We add two pieces of CLI functionality to assist with this:

The `linkerd check --proxy` command will now list all data plane pods which are not up-to-date rather than just printing the first one it encounters:

```
‼ data plane is up-to-date
    Some data plane pods are not running the current version:
	* default/books-84958fff5-95j75 (git-ca760bdd)
	* default/authors-57c6dc9b47-djldq (git-ca760bdd)
	* default/traffic-85f58ccb66-vxr49 (git-ca760bdd)
	* default/release-name-smi-metrics-899c68958-5ctpz (git-ca760bdd)
	* default/webapp-6975dc796f-2ngh4 (git-ca760bdd)
	* default/webapp-6975dc796f-z4bc4 (git-ca760bdd)
	* emojivoto/voting-54ffc5787d-wj6cp (git-ca760bdd)
	* emojivoto/vote-bot-7b54d6999b-57srw (git-ca760bdd)
	* emojivoto/emoji-5cb99f85d8-5bhvm (git-ca760bdd)
	* emojivoto/web-7988674b8b-zfvvm (git-ca760bdd)
	* default/webapp-6975dc796f-d2fbc (git-ca760bdd)
	* default/curl (git-7f6bbc73)
    see https://linkerd.io/checks/#l5d-data-plane-version for hints
```

The `linkerd version` command now supports a `--proxy` flag which will list all proxy versions running in the cluster and the number of pods running each version:

```
linkerd version --proxy
Client version: dev-7b9d475f-alex
Server version: edge-20.4.1
Proxy versions:
	edge-20.4.1 (10 pods)
	git-ca760bdd (11 pods)
	git-7f6bbc73 (1 pods)
```

Signed-off-by: Alex Leong <alex@buoyant.io>
