### PR TITLE
Add `operationID` field to tap openapi response

### DIFF
--- a/controller/tap/handlers.go
+++ b/controller/tap/handlers.go
@@ -330,6 +330,7 @@ func mkPathItem(desc string) spec.PathItem {
 							},
 						},
 					},
+					ID: "tapResourceV0",
 				},
 			},
 		},


### PR DESCRIPTION
This fixes an issue users are experiencing when upgrading from from Linkerd
2.6 to 2.7 and use the [kubernetes-external-secrets]() project.

The change introduced by #3700 resulted in the tap service showing up in the
`/openapi/v2` API response. I confirmed this with a local build.

A dependency within the project expects the `operationID` field to be present
in the swagger definition. It is optional as stated in the
[spec](https://swagger.io/docs/specification/paths-and-operations/). It's
purpose is to identify an operation and should be unique.

This change adds that field to tap service swagger spec. While this can be
fixed in the KES dependency, it certainly does not hurt to add and other
libraries may similarly expect this field.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
