### PR TITLE
Add `unmeshed` flag to stat command

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -26,6 +26,7 @@ type statOptions struct {
 	fromResource  string
 	allNamespaces bool
 	labelSelector string
+	unmeshed      bool
 }
 
 type indexedResults struct {
@@ -43,6 +44,7 @@ func newStatOptions() *statOptions {
 		fromResource:    "",
 		allNamespaces:   false,
 		labelSelector:   "",
+		unmeshed:        false,
 	}
 }
 
@@ -184,6 +186,7 @@ If no resource name is specified, displays stats about all resources of the spec
 	cmd.PersistentFlags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", options.allNamespaces, "If present, returns stats across all namespaces, ignoring the \"--namespace\" flag")
 	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
 	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
+	cmd.PersistentFlags().BoolVar(&options.unmeshed, "unmeshed", options.unmeshed, "If present, include unmeshed resources in the output")
 	return cmd
 }
 
@@ -277,6 +280,10 @@ func writeStatsToBuffer(rows []*pb.StatTable_PodGroup_Row, w *tabwriter.Writer, 
 	}
 
 	for _, r := range rows {
+		if !options.unmeshed && r.GetMeshedPodCount() == 0 {
+			continue
+		}
+
 		name := r.Resource.Name
 		nameWithPrefix := name
 		if usePrefix {

--- a/test/trafficsplit/trafficsplit_test.go
+++ b/test/trafficsplit/trafficsplit_test.go
@@ -67,7 +67,7 @@ func parseStatTsRow(out string, expectedRowCount, expectedColumnCount int) (map[
 }
 
 func statTrafficSplit(from string, ns string) (map[string]*statTsRow, error) {
-	cmd := []string{"stat", "ts", "--from", from, "--namespace", ns, "-t", "30s"}
+	cmd := []string{"stat", "ts", "--from", from, "--namespace", ns, "-t", "30s", "--unmeshed"}
 	stdOut, _, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Motivation

Introduces an `unmeshed` flag to the `stat` command so that users can opt-in
to viewing unmeshed resources in the `stat` output.

This changes the existing behavior of the `stat` command such that unmeshed
resources no longer render by default in the output.

Before:

```
❯ bin/linkerd stat -A deploy
NAMESPACE     NAME                     MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN
kube-system   coredns                     0/1         -        -             -             -             -          -
kube-system   local-path-provisioner      0/1         -        -             -             -             -          -
kube-system   metrics-server              0/1         -        -             -             -             -          -
kube-system   traefik                     0/1         -        -             -             -             -          -
linkerd       linkerd-controller          1/1   100.00%   0.3rps           1ms           2ms           2ms          2
linkerd       linkerd-destination         1/1   100.00%   0.3rps           1ms           1ms           1ms         11
...
```

After:

```
❯ bin/linkerd stat -A deploy
NAMESPACE   NAME                     MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN
linkerd     linkerd-controller          1/1   100.00%   0.3rps           1ms           1ms           1ms          2
linkerd     linkerd-destination         1/1   100.00%   0.3rps           1ms           2ms           2ms         13
...
```

Closes #3871

## Solution

Using the meshed pod count in the stat response, resources with a count of `0`
are not rendered in the table.

The `-l`/`--selector` flag do not work for all resource types, so applying a
default label does not solve this problem. While it works for pods, it does
not work for deployments as the `linkerd.io/inject` is an annotation that
cannot be selected on.

I did not think a shorthand flag was necessary for this. I do not think users
will commonly pass this flag to the `stat` command, and I didn't think adding
an additional short flag such as `u` was necessary.
