### PR TITLE
Fix component label value for smi-metrics anti-affinity

### DIFF
--- a/charts/linkerd2/templates/smi-metrics.yaml
+++ b/charts/linkerd2/templates/smi-metrics.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "tap" "label" .Values.global.controllerComponentLabel -}}
+      {{- $local := dict "component" "smi-metrics" "label" .Values.global.controllerComponentLabel -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       serviceAccountName: linkerd-smi-metrics


### PR DESCRIPTION
Fixes an issue caused by the `linkerd-smi-metrics` pod having an anti-affinity
value that prevents tap pods from being scheduled on the same node as it.

This sometimes prevents `linkerd upgrade` from completing on a 4 node cluster
when the tap pod needs to be scheduled on the same node as the SMI metrics
pod.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>