### PR TITLE
Changes for edge-20.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,13 @@ This release brings a number of CLI fixes and Controller improvements.
   * Improved the anti-affinity of `linkerd-smi-metrics` deployment to avoid
     pod scheduling problems during `upgrade`
   * Improved endpoints change detection in the `linkerd-destination` service, enabling
-    mirrored remote services to change cluster gateways      
+    mirrored remote services to change cluster gateways
+  * Added `operationID` field to tap OpenAPI response to prevent issues during
+    upgrade from 2.6 to 2.7 
+* Proxy
+  * Added a new protocol detection timeout to prevent clients from consuming
+    resources indefinitely when not sending any data
+  * Added a `/live` endpoint for checking liveness  
 
 ## edge-20.4.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+## edge-20.4.2
+
+This release brings a number of CLI fixes and Controller improvements.
+
+* CLI
+  * Fixed a bug that caused the proxy to crash after upgrade if
+    `--skip-outbound-ports` or `--skip-inbound-ports` were used
+  * Added `unmeshed` flag to the `stat` command, such that unmeshed resources
+    are only displayed if the user opts-in
+  * Added a `--smi-metrics` flag to `install`, to allow installation of the
+    experimental `linkerd-smi-metrics` component
+  * Fixed a bug in `linkerd stat`, causing incorrect output formatting when using
+    the `wide` flag
+  * Fixed a bug, causing `linkerd uninstall` to fail when attempting to delete
+    PSPs
+* Controller
+  * Improved the anti-affinity of `linkerd-smi-metrics` deployment to avoid
+    pod scheduling problems during `upgrade`
+  * Improved endpoints change detection in the `destinations` service, enabling
+    mirrored remote services to change cluster gateways      
+
 ## edge-20.4.1
 
 This release introduces some cool new functionalities, all provided by our

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,6 @@ This release brings a number of CLI fixes and Controller improvements.
 * Proxy
   * Added a new protocol detection timeout to prevent clients from consuming
     resources indefinitely when not sending any data
-  * Added a `/live` endpoint for checking liveness  
 
 ## edge-20.4.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,20 +3,20 @@
 This release brings a number of CLI fixes and Controller improvements.
 
 * CLI
-  * Fixed a bug that caused the proxy to crash after upgrade if
+  * Fixed a bug that caused pods to crash after upgrade if
     `--skip-outbound-ports` or `--skip-inbound-ports` were used
   * Added `unmeshed` flag to the `stat` command, such that unmeshed resources
     are only displayed if the user opts-in
   * Added a `--smi-metrics` flag to `install`, to allow installation of the
     experimental `linkerd-smi-metrics` component
   * Fixed a bug in `linkerd stat`, causing incorrect output formatting when using
-    the `wide` flag
+    the `--o wide` flag
   * Fixed a bug, causing `linkerd uninstall` to fail when attempting to delete
     PSPs
 * Controller
   * Improved the anti-affinity of `linkerd-smi-metrics` deployment to avoid
     pod scheduling problems during `upgrade`
-  * Improved endpoints change detection in the `destinations` service, enabling
+  * Improved endpoints change detection in the `linkerd-destination` service, enabling
     mirrored remote services to change cluster gateways      
 
 ## edge-20.4.1


### PR DESCRIPTION
## edge-20.4.2

This release brings a number of CLI fixes and Controller improvements.

* CLI
  * Fixed a bug that caused the proxy to crash after upgrade if
    `--skip-outbound-ports` or `--skip-inbound-ports` were used
  * Added `unmeshed` flag to the `stat` command, such that unmeshed resources
    are only displayed if the user opts-in
  * Added a `--smi-metrics` flag to `install`, to allow installation of the
    experimental `linkerd-smi-metrics` component
  * Fixed a bug in `linkerd stat`, causing incorrect output formatting when using
    the `wide` flag
  * Fixed a bug, causing `linkerd uninstall` to fail when attempting to delete
    PSPs
* Controller
  * Improved the anti-affinity of `linkerd-smi-metrics` deployment to avoid
    pod scheduling problems during `upgrade`
  * Improved endpoints change detection in the `destinations` service, enabling
    mirrored remote services to change cluster gateways     

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
