### PR TITLE
Multicluster gateway and remote setup command

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -20,6 +20,8 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
 "$bindir"/helm init --client-only
+"$bindir"/helm lint "$rootdir"/charts/linkerd2-multicluster-remote-setup
+"$bindir"/helm init --client-only
 "$bindir"/helm lint "$rootdir"/charts/linkerd2-service-mirror
 "$bindir"/helm lint "$rootdir"/charts/partials
 "$bindir"/helm dep up "$rootdir"/charts/linkerd2-cni
@@ -52,6 +54,7 @@ if [ "$1" = package ]; then
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     # TODO: When ready to publish, uncomment
     #"$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-service-mirror
+    #"$bindir"/helm --version $version --app-version $tag -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-multicluster-remote-setup
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-"$version".yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm
 

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -6,6 +6,7 @@ setValues() {
     sed -i "s/$1/$2/" charts/linkerd2/values.yaml
     sed -i "s/$1/$2/" charts/linkerd2-cni/values.yaml
     sed -i "s/$1/$2/" charts/linkerd2-service-mirror/values.yaml
+    sed -i "s/$1/$2/" charts/linkerd2-multicluster-remote-setup/values.yaml
 }
 
 showErr() {
@@ -21,7 +22,6 @@ rootdir=$( cd "$bindir"/.. && pwd )
 
 "$bindir"/helm init --client-only
 "$bindir"/helm lint "$rootdir"/charts/linkerd2-multicluster-remote-setup
-"$bindir"/helm init --client-only
 "$bindir"/helm lint "$rootdir"/charts/linkerd2-service-mirror
 "$bindir"/helm lint "$rootdir"/charts/partials
 "$bindir"/helm dep up "$rootdir"/charts/linkerd2-cni

--- a/charts/linkerd2-multicluster-remote-setup/.helmignore
+++ b/charts/linkerd2-multicluster-remote-setup/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+OWNERS
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/linkerd2-multicluster-remote-setup/Chart.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: edge-XX.X.X
+description: A helm chart containing the resources to enable mirroring of services on remote clusters
+kubeVersion: ">=1.13.0-0"
+icon: https://linkerd.io/images/logo-only-200h.png
+name: "linkerd2-multicluster-remote-setup"
+version: 0.1.0

--- a/charts/linkerd2-multicluster-remote-setup/README.md
+++ b/charts/linkerd2-multicluster-remote-setup/README.md
@@ -1,5 +1,5 @@
 
-# Linkerd2-multicluster-remote-sertup Helm Chart
+# Linkerd2-multicluster-remote-setup Helm Chart
 
 Linkerd is a *service mesh*, designed to give platform-wide observability,
 reliability, and security without requiring configuration or code changes.
@@ -9,7 +9,7 @@ communication and service discovery
 
 ## Configuration
 
-The following table lists the configurable parameters of the linkerd2-multicluster-remote-sertup chart and their default values.
+The following table lists the configurable parameters of the linkerd2-multicluster-remote-setup chart and their default values.
 
 | Parameter                | Description                                                                                                     | Default                |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------|
@@ -20,7 +20,7 @@ The following table lists the configurable parameters of the linkerd2-multiclust
 |`linkerdNamespace`        | The namespace of the existing Linkerd installation                                                              |`linkerd`               |
 |`nginxImage`              | The Nginx image                                                                                                 |`nginx`                 |
 |`nginxImageVersion`       | The version of the Nginx image                                                                                  |`1.17`                  |
-|`probePath`               | The path tha that will be used by remote clusters for determining whether the gateway is alive                  |`/health`               |
+|`probePath`               | The path that will be used by remote clusters for determining whether the gateway is alive                  |`/health`               |
 |`probePeriodSeconds`      | The interval (in seconds) between liveness probes                                                               |`3`                     |
 |`probePort`               | The port used for liveliness probing                                                                            |`81`                    |
 |`serviceAccountName`      | The name of the service account that will be created and used by remote clusters, attempting to mirror services |`linkerd-service-mirror`|

--- a/charts/linkerd2-multicluster-remote-setup/README.md
+++ b/charts/linkerd2-multicluster-remote-setup/README.md
@@ -18,6 +18,8 @@ The following table lists the configurable parameters of the linkerd2-multiclust
 |`identityTrustDomain`     | Trust domain used for identity of the existing linkerd installation                                             |`cluster.local`         |
 |`incomingPort`            | The port on which all the gateway will accept incoming traffic                                                  |`80`                    |
 |`linkerdNamespace`        | The namespace of the existing Linkerd installation                                                              |`linkerd`               |
+|`nginxImage`              | The Nginx image                                                                                                 |`nginx`                 |
+|`nginxImageVersion`       | The version of the Nginx image                                                                                  |`1.17`                  |
 |`probePath`               | The path tha that will be used by remote clusters for determining whether the gateway is alive                  |`/health`               |
 |`probePeriodSeconds`      | The interval (in seconds) between liveness probes                                                               |`3`                     |
 |`probePort`               | The port used for liveliness probing                                                                            |`81`                    |

--- a/charts/linkerd2-multicluster-remote-setup/README.md
+++ b/charts/linkerd2-multicluster-remote-setup/README.md
@@ -1,0 +1,25 @@
+
+# Linkerd2-multicluster-remote-sertup Helm Chart
+
+Linkerd is a *service mesh*, designed to give platform-wide observability,
+reliability, and security without requiring configuration or code changes.
+This chart provides a reference cluster gateway implementation, which coupled
+with Linkerd and the Service Mirror component can enable multicluster 
+communication and service discovery
+
+## Configuration
+
+The following table lists the configurable parameters of the linkerd2-multicluster-remote-sertup chart and their default values.
+
+| Parameter                | Description                                                                                                     | Default                |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------|------------------------|
+|`gatewayName`             | The name of the gateway that will be installed                                                                  | `linkerd-gateway`      |
+|`gatewayNamespace`        | The namespace in which the gateway will be created                                                              |`linkerd-gateway`       |
+|`identityTrustDomain`     | Trust domain used for identity of the existing linkerd installation                                             |`cluster.local`         |
+|`incomingPort`            | The port on which all the gateway will accept incoming traffic                                                  |`80`                    |
+|`linkerdNamespace`        | The namespace of the existing Linkerd installation                                                              |`linkerd`               |
+|`probePath`               | The path tha that will be used by remote clusters for determining whether the gateway is alive                  |`/health`               |
+|`probePeriodSeconds`      | The interval (in seconds) between liveness probes                                                               |`3`                     |
+|`probePort`               | The port used for liveliness probing                                                                            |`81`                    |
+|`serviceAccountName`      | The name of the service account that will be created and used by remote clusters, attempting to mirror services |`linkerd-service-mirror`|
+|`serviceAccountNamespace` | The namespace in which the service account will be created                                                      |`linkerd-service-mirror`|

--- a/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
@@ -8,6 +8,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-configuration
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
   namespace: {{.Values.gatewayNamespace}}
 data:
   nginx.conf: |-
@@ -32,7 +34,12 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
   labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: {{.Values.linkerdVersion}}
     app: {{.Values.gatewayName}}
   name: {{.Values.gatewayName}}
   namespace: {{.Values.gatewayNamespace}}
@@ -44,6 +51,7 @@ spec:
   template:
     metadata:
       annotations:
+        {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}        
         linkerd.io/inject: enabled
       labels:
         app: {{.Values.gatewayName}}
@@ -54,7 +62,17 @@ spec:
             name: nginx-configuration   
       containers:
         - name: nginx
-          image: nginx:1.17
+          readinessProbe:
+            failureThreshold: 7
+            httpGet:
+              path: {{.Values.probePath}}
+              port: {{.Values.probePort}}
+          livenessProbe:
+            httpGet:
+              path: {{.Values.probePath}}
+              port: {{.Values.probePort}}
+            initialDelaySeconds: 10  
+          image: {{.Values.nginxImage}}:{{.Values.nginxImageVersion}}
           ports:
             - name: incoming-port
               containerPort: {{.Values.incomingPort}}
@@ -75,6 +93,7 @@ metadata:
     mirror.linkerd.io/probe-port: {{.Values.probePort}}
     mirror.linkerd.io/probe-period: {{.Values.probePeriodSeconds}}
     mirror.linkerd.io/probe-path: {{.Values.probePath}}
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:
   ports:
   - name: incoming-port

--- a/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
@@ -90,8 +90,8 @@ metadata:
   namespace: {{.Values.gatewayNamespace}}
   annotations: 
     mirror.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.gatewayNamespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
-    mirror.linkerd.io/probe-port: {{.Values.probePort}}
-    mirror.linkerd.io/probe-period: {{.Values.probePeriodSeconds}}
+    mirror.linkerd.io/probe-port: "{{.Values.probePort}}"
+    mirror.linkerd.io/probe-period: "{{.Values.probePeriodSeconds}}"
     mirror.linkerd.io/probe-path: {{.Values.probePath}}
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:

--- a/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
@@ -1,0 +1,95 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Values.gatewayNamespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-configuration
+  namespace: {{.Values.gatewayNamespace}}
+data:
+  nginx.conf: |-
+    events {
+    }
+    stream {
+      server {
+          listen     {{.Values.incomingPort}};
+          proxy_pass 127.0.0.1:{{.Values.proxyOutboundPort}};
+      }
+    }
+    http {
+      server {
+          listen     {{.Values.probePort}};
+          location {{.Values.probePath}} {
+            access_log off;
+            return 200 "healthy\n";
+          }
+      }
+    }
+---    
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.Values.gatewayName}}
+  name: {{.Values.gatewayName}}
+  namespace: {{.Values.gatewayNamespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Values.gatewayName}}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: {{.Values.gatewayName}}
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: nginx-configuration   
+      containers:
+        - name: nginx
+          image: nginx:1.17
+          ports:
+            - name: incoming-port
+              containerPort: {{.Values.incomingPort}}
+            - name: probe-port
+              containerPort: {{.Values.probePort}}             
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx
+      serviceAccountName: {{.Values.gatewayName}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Values.gatewayName}}
+  namespace: {{.Values.gatewayNamespace}}
+  annotations: 
+    mirror.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.gatewayNamespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
+    mirror.linkerd.io/probe-port: {{.Values.probePort}}
+    mirror.linkerd.io/probe-period: {{.Values.probePeriodSeconds}}
+    mirror.linkerd.io/probe-path: {{.Values.probePath}}
+spec:
+  ports:
+  - name: incoming-port
+    port: {{.Values.incomingPort}}    
+    protocol: TCP
+  - name: probe-port
+    port: {{.Values.probePort}}    
+    protocol: TCP
+  selector:
+    app: {{.Values.gatewayName}}
+  type: LoadBalancer
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{.Values.gatewayName}}
+  namespace: {{.Values.gatewayNamespace}}
+  

--- a/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
@@ -1,0 +1,39 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{ .Values.serviceAccountNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Values.serviceAccountName}}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - get
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.serviceAccountName}}
+  namespace: {{.Values.serviceAccountNamespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.serviceAccountName}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.serviceAccountName}}
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.serviceAccountName}}
+  namespace: {{.Values.serviceAccountNamespace}}
+

--- a/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
@@ -8,6 +8,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{.Values.serviceAccountName}}
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 rules:
 - apiGroups:
   - ""
@@ -23,11 +25,15 @@ kind: ServiceAccount
 metadata:
   name: {{.Values.serviceAccountName}}
   namespace: {{.Values.serviceAccountNamespace}}
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.Values.serviceAccountName}}
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
@@ -8,6 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{.Values.serviceAccountName}}
+  namespace: {{.Values.serviceAccountNamespace}}
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 rules:
@@ -32,6 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.Values.serviceAccountName}}
+  namespace: {{.Values.serviceAccountNamespace}}
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 roleRef:

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -12,3 +12,4 @@ linkerdVersion: {version}
 createdByAnnotation: linkerd.io/created-by
 nginxImageVersion: 1.17
 nginxImage: nginx
+proxyOutboundPort: 4140

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -8,3 +8,7 @@ probePeriodSeconds: 3
 probePort: 81
 serviceAccountName: linkerd-service-mirror
 serviceAccountNamespace: linkerd-service-mirror
+linkerdVersion: {version}
+createdByAnnotation: linkerd.io/created-by
+nginxImageVersion: 1.17
+nginxImage: nginx

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -1,0 +1,10 @@
+gatewayName: linkerd-gateway
+gatewayNamespace: linkerd-gateway
+identityTrustDomain: cluster.local
+incomingPort: 80
+linkerdNamespace: linkerd
+probePath: /health
+probePeriodSeconds: 3
+probePort: 81
+serviceAccountName: linkerd-service-mirror
+serviceAccountNamespace: linkerd-service-mirror

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -117,7 +117,7 @@ func buildMulticlusterSetupValues(opts *setupRemoteClusterOptions) (*multicluste
 	defaults.LinkerdNamespace = controlPlaneNamespace
 	defaults.ProbePath = opts.probePath
 	defaults.ProbePeriodSeconds = opts.probePeriodSeconds
-	defaults.ProbePort = global.Proxy.OutboundPort.Port
+	defaults.ProbePort = opts.probePort
 	defaults.ProxyOutboundPort = global.Proxy.OutboundPort.Port
 	defaults.ServiceAccountName = opts.serviceAccountName
 	defaults.ServiceAccountNamespace = opts.serviceAccountNamespace

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -117,7 +117,7 @@ func buildMulticlusterSetupValues(opts *setupRemoteClusterOptions) (*multicluste
 	defaults.LinkerdNamespace = controlPlaneNamespace
 	defaults.ProbePath = opts.probePath
 	defaults.ProbePeriodSeconds = opts.probePeriodSeconds
-	defaults.ProbePort = opts.probePort
+	defaults.ProbePort = global.Proxy.OutboundPort.Port
 	defaults.ProxyOutboundPort = global.Proxy.OutboundPort.Port
 	defaults.ServiceAccountName = opts.serviceAccountName
 	defaults.ServiceAccountNamespace = opts.serviceAccountNamespace
@@ -200,7 +200,7 @@ func newSetupRemoteCommand() *cobra.Command {
 				RawValues: rawValues,
 				Files:     files,
 			}
-			buf, err := chart.RenderRemoteClusterSetup()
+			buf, err := chart.RenderNoPartials()
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -345,6 +345,23 @@ func newExportServiceCommand() *cobra.Command {
 		Short:  "Exposes a remote service to be mirrored",
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if opts.service == "" {
+				return errors.New("The --service-name flag needs to be set")
+			}
+
+			if opts.namespace == "" {
+				return errors.New("The --service-name flag needs to be set")
+			}
+
+			if opts.gatewayName == "" {
+				return errors.New("The --gateway-name flag needs to be set")
+			}
+
+			if opts.gatewayNamespace == "" {
+				return errors.New("The --gateway-namespace flag needs to be set")
+			}
+
 			rules := clientcmd.NewDefaultClientConfigLoadingRules()
 			rules.ExplicitPath = kubeconfigPath
 			loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
@@ -389,8 +406,8 @@ func newExportServiceCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.service, "service-name", "", "the name of the service to be exported")
 	cmd.Flags().StringVar(&opts.namespace, "service-namespace", "", "the namespace in which the service to be exported resides")
-	cmd.Flags().StringVar(&opts.gatewayName, "gateway-name", "", "the name of the gateway")
-	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", "", "the namespace of the gateway")
+	cmd.Flags().StringVar(&opts.gatewayName, "gateway-name", "linkerd-gateway", "the name of the gateway")
+	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", "linkerd-gateway", "the namespace of the gateway")
 
 	return cmd
 }

--- a/cli/cmd/install-service-mirror.go
+++ b/cli/cmd/install-service-mirror.go
@@ -127,7 +127,7 @@ func renderServiceMirror(w io.Writer, config *installServiceMirrorOptions) error
 		RawValues: rawValues,
 		Files:     files,
 	}
-	buf, err := chart.RenderServiceMirror()
+	buf, err := chart.RenderNoPartials()
 	if err != nil {
 		return err
 	}

--- a/controller/api/public/gateways.go
+++ b/controller/api/public/gateways.go
@@ -12,7 +12,7 @@ import (
 const (
 	gatewayAliveQuery           = "sum(gateway_alive%s) by (%s)"
 	numMirroredServicesQuery    = "sum(num_mirrored_services%s) by (%s)"
-	gatewayLatencyQuantileQuery = "histogram_quantile(%s, sum(irate(gateway_probe_latency_ms%s[%s])) by (le, %s))"
+	gatewayLatencyQuantileQuery = "histogram_quantile(%s, sum(irate(gateway_probe_latency_ms_bucket%s[%s])) by (le, %s))"
 )
 
 func (s *grpcServer) Gateways(ctx context.Context, req *pb.GatewaysRequest) (*pb.GatewaysResponse, error) {

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -99,13 +99,8 @@ func (chart *Chart) RenderCNI() (bytes.Buffer, error) {
 	return chart.render(cniPartials)
 }
 
-// RenderServiceMirror returns a bytes buffer with the result of rendering a Helm chart
-func (chart *Chart) RenderServiceMirror() (bytes.Buffer, error) {
-	return chart.render([]*chartutil.BufferedFile{})
-}
-
-// RenderRemoteClusterSetup returns a bytes buffer with the result of rendering a Helm chart
-func (chart *Chart) RenderRemoteClusterSetup() (bytes.Buffer, error) {
+// RenderNoPartials returns a bytes buffer with the result of rendering a Helm chart with no partials
+func (chart *Chart) RenderNoPartials() (bytes.Buffer, error) {
 	return chart.render([]*chartutil.BufferedFile{})
 }
 

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -104,6 +104,11 @@ func (chart *Chart) RenderServiceMirror() (bytes.Buffer, error) {
 	return chart.render([]*chartutil.BufferedFile{})
 }
 
+// RenderRemoteClusterSetup returns a bytes buffer with the result of rendering a Helm chart
+func (chart *Chart) RenderRemoteClusterSetup() (bytes.Buffer, error) {
+	return chart.render([]*chartutil.BufferedFile{})
+}
+
 // ReadFile updates the buffered file with the data read from disk
 func ReadFile(dir string, f *chartutil.BufferedFile) error {
 	filename := dir + f.Name

--- a/pkg/charts/multicluster/values.go
+++ b/pkg/charts/multicluster/values.go
@@ -1,0 +1,16 @@
+package multicluster
+
+// Values contains the top-level elements in the Helm charts
+type Values struct {
+	GatewayName             string `json:"gatewayName"`
+	GatewayNamespace        string `json:"gatewayNamespace"`
+	IdentityTrustDomain     string `json:"identityTrustDomain"`
+	IncomingPort            uint32 `json:"incomingPort"`
+	LinkerdNamespace        string `json:"linkerdNamespace"`
+	ProbePath               string `json:"probePath"`
+	ProbePeriodSeconds      uint32 `json:"probePeriodSeconds"`
+	ProbePort               uint32 `json:"probePort"`
+	ProxyOutboundPort       uint32 `json:"proxyOutboundPort"`
+	ServiceAccountName      string `json:"serviceAccountName"`
+	ServiceAccountNamespace string `json:"serviceAccountNamespace"`
+}

--- a/pkg/charts/multicluster/values.go
+++ b/pkg/charts/multicluster/values.go
@@ -1,7 +1,19 @@
 package multicluster
 
+import (
+	"fmt"
+
+	"github.com/linkerd/linkerd2/pkg/charts"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"k8s.io/helm/pkg/chartutil"
+	"sigs.k8s.io/yaml"
+)
+
+const helmDefaultChartDir = "linkerd2-multicluster-remote-setup"
+
 // Values contains the top-level elements in the Helm charts
 type Values struct {
+	CliVersion              string `json:"cliVersion"`
 	GatewayName             string `json:"gatewayName"`
 	GatewayNamespace        string `json:"gatewayNamespace"`
 	IdentityTrustDomain     string `json:"identityTrustDomain"`
@@ -13,4 +25,36 @@ type Values struct {
 	ProxyOutboundPort       uint32 `json:"proxyOutboundPort"`
 	ServiceAccountName      string `json:"serviceAccountName"`
 	ServiceAccountNamespace string `json:"serviceAccountNamespace"`
+	NginxImageVersion       string `json:"nginxImageVersion"`
+	NginxImage              string `json:"nginxImage"`
+	LinkerdVersion          string `json:"linkerdVersion"`
+	CreatedByAnnotation     string `json:"createdByAnnotation"`
+}
+
+// NewValues returns a new instance of the Values type.
+func NewValues() (*Values, error) {
+	chartDir := fmt.Sprintf("%s/", helmDefaultChartDir)
+	v, err := readDefaults(chartDir)
+	if err != nil {
+		return nil, err
+	}
+
+	v.CliVersion = k8s.CreatedByAnnotationValue()
+	return v, nil
+}
+
+// readDefaults read all the default variables from the values.yaml file.
+// chartDir is the root directory of the Helm chart where values.yaml is.
+func readDefaults(chartDir string) (*Values, error) {
+	file := &chartutil.BufferedFile{
+		Name: chartutil.ValuesfileName,
+	}
+	if err := charts.ReadFile(chartDir, file); err != nil {
+		return nil, err
+	}
+	values := Values{}
+	if err := yaml.Unmarshal(charts.InsertVersion(file.Data), &values); err != nil {
+		return nil, err
+	}
+	return &values, nil
 }


### PR DESCRIPTION
This PR introduces two notable things: 

- We add a helm chart that contains setup for the remote cluster in a multicluster setting. That includes a helm chart with a reference implementation of a gateway as well as credentials for accessing the cluster remotely (by the service mirror component)
- We substitute the `cluster create-credentials` command with `cluster setup-remote`, which outputs the yaml needed for setting up the remote cluster (gateway + credentials)

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
