### PR TITLE
Upgrade to go 1.14.2

### DIFF
--- a/Dockerfile-go-deps
+++ b/Dockerfile-go-deps
@@ -5,7 +5,7 @@
 #
 # When this file is changed, run `bin/update-go-deps-shas`.
 
-FROM golang:1.13.4
+FROM golang:1.14.2
 
 WORKDIR /linkerd-build
 

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:e387f3b8 as golang
+FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -9,7 +9,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version)) && \
     mv "$proxy" linkerd2-proxy)
 
 ## compile proxy-identity agent
-FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
+FROM gcr.io/linkerd-io/go-deps:8c47576d as golang
 WORKDIR /linkerd-build
 COPY pkg/flags pkg/flags
 COPY pkg/tls pkg/tls

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
+FROM gcr.io/linkerd-io/go-deps:8c47576d as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,5 +1,5 @@
 ## compile binaries
-FROM gcr.io/linkerd-io/go-deps:e387f3b8 as golang
+FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:e387f3b8 as golang
+FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,5 +1,5 @@
 ## compile cni-plugin utility
-FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
+FROM gcr.io/linkerd-io/go-deps:8c47576d as golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller service
-FROM gcr.io/linkerd-io/go-deps:e387f3b8 as golang
+FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,5 @@
 ## compile controller service
-FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
+FROM gcr.io/linkerd-io/go-deps:8c47576d as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.13
+go 1.14
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:e387f3b8 as golang
+FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -21,7 +21,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM gcr.io/linkerd-io/go-deps:6e68fb24 as golang
+FROM gcr.io/linkerd-io/go-deps:8c47576d as golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
Upgrade Linkerd's base docker image to use go 1.14.2 in order to stay modern.

The only code change required was to update a test which was checking the error message of a `crypto/x509.CertificateInvalidError`.  The error message of this error changed between go versions.  We update the test to not check for the specific error string so that this test passes regardless of go version.