### PR TITLE
Multicluster checks

### DIFF
--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -32,7 +32,7 @@ metadata:
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirrors
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -32,7 +32,7 @@ metadata:
   name: linkerd-service-mirror
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+    {{.Values.controllerComponentLabel}}: linkerd-service-mirrors
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -21,6 +21,7 @@ import (
 type checkOptions struct {
 	versionOverride    string
 	preInstallOnly     bool
+	multicluster       bool
 	dataPlaneOnly      bool
 	wait               time.Duration
 	namespace          string
@@ -31,6 +32,7 @@ type checkOptions struct {
 
 func newCheckOptions() *checkOptions {
 	return &checkOptions{
+		multicluster:       false,
 		versionOverride:    "",
 		preInstallOnly:     false,
 		dataPlaneOnly:      false,
@@ -50,6 +52,7 @@ func (options *checkOptions) nonConfigFlagSet() *pflag.FlagSet {
 	flags.StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 	flags.BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
 	flags.BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
+	flags.BoolVar(&options.multicluster, "multicluster", options.multicluster, "Run multicluster checks")
 
 	return flags
 }
@@ -185,6 +188,9 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			}
 			checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
 			checks = append(checks, healthcheck.LinkerdHAChecks)
+			if options.multicluster {
+				checks = append(checks, healthcheck.LinkerdMulticlusterChecks)
+			}
 		}
 	}
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -188,25 +188,25 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			}
 			checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
 			checks = append(checks, healthcheck.LinkerdHAChecks)
-			if options.multicluster {
-				checks = append(checks, healthcheck.LinkerdMulticlusterChecks)
-			}
+			checks = append(checks, healthcheck.LinkerdMulticlusterChecks)
+
 		}
 	}
 
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
-		ControlPlaneNamespace: controlPlaneNamespace,
-		CNINamespace:          cniNamespace,
-		DataPlaneNamespace:    options.namespace,
-		KubeConfig:            kubeconfigPath,
-		KubeContext:           kubeContext,
-		Impersonate:           impersonate,
-		ImpersonateGroup:      impersonateGroup,
-		APIAddr:               apiAddr,
-		VersionOverride:       options.versionOverride,
-		RetryDeadline:         time.Now().Add(options.wait),
-		CNIEnabled:            options.cniEnabled,
-		InstallManifest:       installManifest,
+		ControlPlaneNamespace:   controlPlaneNamespace,
+		CNINamespace:            cniNamespace,
+		DataPlaneNamespace:      options.namespace,
+		KubeConfig:              kubeconfigPath,
+		KubeContext:             kubeContext,
+		Impersonate:             impersonate,
+		ImpersonateGroup:        impersonateGroup,
+		APIAddr:                 apiAddr,
+		VersionOverride:         options.versionOverride,
+		RetryDeadline:           time.Now().Add(options.wait),
+		CNIEnabled:              options.cniEnabled,
+		InstallManifest:         installManifest,
+		ShouldCheckMulticluster: options.multicluster,
 	})
 
 	success := runChecks(wout, werr, hc, options.output)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/linkerd/linkerd2/pkg/issuercerts"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
@@ -20,6 +23,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/config"
 	"github.com/linkerd/linkerd2/pkg/identity"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	sm "github.com/linkerd/linkerd2/pkg/servicemirror"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
@@ -137,15 +141,20 @@ const (
 	/// plugin is installed and ready
 	LinkerdCNIPluginChecks CategoryID = "linkerd-cni-plugin"
 
+	// LinkerdMulticlusterChecks adds a series of checks to validate
+	// that the multicluster setup is working as expected
+	LinkerdMulticlusterChecks CategoryID = "linkerd-multicluster"
+
 	// LinkerdCNIResourceLabel is the label key that is used to identify
 	// whether a Kubernetes resource is related to the install-cni command
 	// The value is expected to be "true", "false" or "", where "false" and
 	// "" are equal, making "false" the default
 	LinkerdCNIResourceLabel = "linkerd.io/cni-resource"
 
-	linkerdCNIDisabledSkipReason = "skipping check because CNI is not enabled"
-	linkerdCNIResourceName       = "linkerd-cni"
-	linkerdCNIConfigMapName      = "linkerd-cni-config"
+	linkerdCNIDisabledSkipReason      = "skipping check because CNI is not enabled"
+	linkerdCNIResourceName            = "linkerd-cni"
+	linkerdCNIConfigMapName           = "linkerd-cni-config"
+	linkerdServiceMirrorComponentName = "linkerd-service-mirror"
 
 	// linkerdTapAPIServiceName is the name of the tap api service
 	// This key is passed to checkApiSercice method to check whether
@@ -188,6 +197,14 @@ var ExpectedServiceAccountNames = []string{
 	"linkerd-sp-validator",
 	"linkerd-web",
 	"linkerd-tap",
+}
+
+var expectedServiceMirrorPolicyVerbs = []string{
+	"list", "get", "watch", "create", "delete", "update",
+}
+
+var expectedServiceMirrorPolicyResources = []string{
+	"endpoints", "services", "secrets", "namespaces",
 }
 
 var (
@@ -349,6 +366,7 @@ type HealthChecker struct {
 	issuerCert       *tls.Cred
 	trustAnchors     []*x509.Certificate
 	cniDaemonSet     *appsv1.DaemonSet
+	serviceMirrorNs  string
 }
 
 // NewHealthChecker returns an initialized HealthChecker
@@ -538,14 +556,14 @@ func (hc *HealthChecker) allCategories() []category {
 					description: "no ClusterRoles exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						return hc.checkClusterRoles(false)
+						return hc.checkClusterRoles(false, hc.expectedRBACNames(), hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
 					description: "no ClusterRoleBindings exist",
 					hintAnchor:  "pre-l5d-existence",
 					check: func(context.Context) error {
-						return hc.checkClusterRoleBindings(false)
+						return hc.checkClusterRoleBindings(false, hc.expectedRBACNames(), hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
@@ -601,7 +619,7 @@ func (hc *HealthChecker) allCategories() []category {
 						if hc.isHeartbeatDisabled() {
 							return nil
 						}
-						return hc.checkServiceAccounts([]string{"linkerd-heartbeat"})
+						return hc.checkServiceAccounts([]string{"linkerd-heartbeat"}, hc.ControlPlaneNamespace, hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
@@ -691,7 +709,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-cr",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.checkClusterRoles(true)
+						return hc.checkClusterRoles(true, hc.expectedRBACNames(), hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
@@ -699,7 +717,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-crb",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.checkClusterRoleBindings(true)
+						return hc.checkClusterRoleBindings(true, hc.expectedRBACNames(), hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
@@ -707,7 +725,7 @@ func (hc *HealthChecker) allCategories() []category {
 					hintAnchor:  "l5d-existence-sa",
 					fatal:       true,
 					check: func(context.Context) error {
-						return hc.checkServiceAccounts(ExpectedServiceAccountNames)
+						return hc.checkServiceAccounts(ExpectedServiceAccountNames, hc.ControlPlaneNamespace, hc.controlPlaneComponentsSelector())
 					},
 				},
 				{
@@ -1209,6 +1227,67 @@ func (hc *HealthChecker) allCategories() []category {
 				},
 			},
 		},
+		{
+			id: LinkerdMulticlusterChecks,
+			checkers: []checker{
+				{
+					description: "service mirror controller exists",
+					hintAnchor:  "l5d-smc-existence",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkServiceMirrorController()
+					},
+				},
+				{
+					description: "service mirror controller ClusterRoles exist",
+					hintAnchor:  "l5d-smc-existence-cr",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkClusterRoles(true, []string{linkerdServiceMirrorComponentName}, hc.serviceMirrorComponentsSelector())
+					},
+				},
+				{
+					description: "service mirror controller ClusterRoleBindings exist",
+					hintAnchor:  "l5d-smc-existence-crb",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkClusterRoleBindings(true, []string{linkerdServiceMirrorComponentName}, hc.serviceMirrorComponentsSelector())
+					},
+				},
+				{
+					description: "service mirror controller ServiceAccounts exist",
+					hintAnchor:  "l5d-smc-existence-sa",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkServiceAccounts([]string{linkerdServiceMirrorComponentName}, hc.serviceMirrorNs, hc.serviceMirrorComponentsSelector())
+					},
+				},
+				{
+					description: "service mirror controller has required permissions",
+					hintAnchor:  "l5d-smc-local-rbac-existence",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkServiceMirrorLocalRBAC()
+					},
+				},
+				{
+					description: "service mirror controller can access remote clusters",
+					hintAnchor:  "l5d-smc-remote-remote-clusters-access",
+					fatal:       true,
+					check: func(context.Context) error {
+						return hc.checkRemoteClusterConnectivity()
+					},
+				},
+				{
+					description: "all remote cluster gateways are alive",
+					hintAnchor:  "l5d-remote-gateways-alive",
+					fatal:       true,
+					check: func(ctx context.Context) error {
+						return hc.checkRemoteClusterGatewaysHealth(ctx)
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -1385,6 +1464,10 @@ func (hc *HealthChecker) controlPlaneComponentsSelector() string {
 	return fmt.Sprintf("%s,!%s", k8s.ControllerNSLabel, LinkerdCNIResourceLabel)
 }
 
+func (hc *HealthChecker) serviceMirrorComponentsSelector() string {
+	return fmt.Sprintf("%s=%s", k8s.ControllerComponentLabel, linkerdServiceMirrorComponentName)
+}
+
 // PublicAPIClient returns a fully configured public API client. This client is
 // only configured if the KubernetesAPIChecks and LinkerdAPIChecks are
 // configured and run first.
@@ -1463,6 +1546,169 @@ func FetchLinkerdConfigMap(k kubernetes.Interface, controlPlaneNamespace string)
 	return cm, configPB, nil
 }
 
+func (hc *HealthChecker) checkServiceMirrorController() error {
+	options := metav1.ListOptions{
+		LabelSelector: hc.serviceMirrorComponentsSelector(),
+	}
+	result, err := hc.kubeAPI.AppsV1().Deployments(corev1.NamespaceAll).List(options)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Items) < 1 {
+		return errors.New("Service mirror controller is not present")
+	}
+
+	if len(result.Items) > 1 {
+		var errors []string
+		for _, smc := range result.Items {
+			errors = append(errors, fmt.Sprintf("%s/%s", smc.Namespace, smc.Name))
+		}
+		return fmt.Errorf("There are more than one service mirror controllers:\n\t%s", strings.Join(errors, "\n\t"))
+
+	}
+
+	controller := result.Items[0]
+	if controller.Status.AvailableReplicas < 1 {
+		return fmt.Errorf("Service mirror controller is not available: %s/%s", controller.Namespace, controller.Name)
+	}
+	hc.serviceMirrorNs = controller.Namespace
+	return nil
+}
+
+func (hc *HealthChecker) checkServiceMirrorLocalRBAC() error {
+	compare := func(expected, actual []string) error {
+		sort.Strings(expected)
+		sort.Strings(actual)
+
+		expectedStr := strings.Join(expected, ",")
+		actualStr := strings.Join(actual, ",")
+
+		if expectedStr != actualStr {
+			return fmt.Errorf("expected %s, got %s", expectedStr, actualStr)
+		}
+
+		return nil
+	}
+
+	cr, err := hc.kubeAPI.RbacV1().ClusterRoles().Get(linkerdServiceMirrorComponentName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("Could not obtain service mirror ClusterRole: %s", err)
+	}
+
+	var policyRule *v1.PolicyRule
+
+	for _, r := range cr.Rules {
+		if len(r.APIGroups) == 1 && r.APIGroups[0] == "" {
+			rule := r
+			policyRule = &rule
+		}
+	}
+
+	if policyRule == nil {
+		return fmt.Errorf("Service mirror ClusterRole is missing expected policy rule")
+	}
+
+	if err := compare(expectedServiceMirrorPolicyVerbs, policyRule.Verbs); err != nil {
+		return fmt.Errorf("Service mirror ClusterRole is missing verbs: %s", err)
+	}
+
+	if err := compare(expectedServiceMirrorPolicyResources, policyRule.Resources); err != nil {
+		return fmt.Errorf("Service mirror ClusterRole is missing required resources: %s", err)
+	}
+
+	return nil
+}
+
+func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
+	options := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("%s=%s", "type", k8s.MirrorSecretType),
+	}
+	secrets, err := hc.kubeAPI.CoreV1().Secrets(corev1.NamespaceAll).List(options)
+	if err != nil {
+		return err
+	}
+
+	if len(secrets.Items) == 0 {
+		return &SkipError{Reason: "no remote cluster configs"}
+	}
+
+	var errors []string
+	for _, s := range secrets.Items {
+		secret := s
+		config, err := sm.ParseRemoteClusterSecret(&secret)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("*  secret: [%s/%s]: could not parse config secret: %s", secret.Namespace, secret.Name, err))
+			continue
+		}
+
+		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config.APIConfig)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			continue
+		}
+
+		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, requestTimeout)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: could not instantiate remote api: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			continue
+		}
+
+		canGet := false
+		canList := false
+		canWatch := false
+		if err := hc.checkCanPerformAction(remoteAPI, "get", corev1.NamespaceAll, "", "v1", "services"); err == nil {
+			canGet = true
+		}
+
+		if err := hc.checkCanPerformAction(remoteAPI, "list", corev1.NamespaceAll, "", "v1", "services"); err == nil {
+			canList = true
+		}
+
+		if err := hc.checkCanPerformAction(remoteAPI, "watch", corev1.NamespaceAll, "", "v1", "services"); err == nil {
+			canWatch = true
+		}
+
+		if !canGet || !canList || !canWatch {
+			errors = append(errors, fmt.Sprintf("* cluster: [%s]: Insufficient permissions GET: %v, LIST: %v, WATCH: %v", config.ClusterName, canGet, canList, canWatch))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("Problematic clusters:\n\t%s", strings.Join(errors, "\n\t"))
+	}
+	return nil
+}
+
+func (hc *HealthChecker) checkRemoteClusterGatewaysHealth(ctx context.Context) error {
+
+	if hc.apiClient == nil {
+		return errors.New("public api client uninitialized")
+	}
+	req := &pb.GatewaysRequest{
+		TimeWindow: "1m",
+	}
+	rsp, err := hc.apiClient.Gateways(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	var deadGateways []string
+	if len(rsp.GetOk().GatewaysTable.Rows) == 0 {
+		return &SkipError{Reason: "no remote gateways"}
+	}
+	for _, gtw := range rsp.GetOk().GatewaysTable.Rows {
+		if !gtw.Alive {
+			deadGateways = append(deadGateways, fmt.Sprintf("* cluster: [%s], gateway: [%s/%s]", gtw.ClusterName, gtw.Namespace, gtw.Name))
+		}
+	}
+
+	if len(deadGateways) > 0 {
+		return fmt.Errorf("Some gateways are not alive:\n\t%s", strings.Join(deadGateways, "\n\t"))
+	}
+	return nil
+}
+
 // checkNamespace checks whether the given namespace exists, and returns an
 // error if it does not match `shouldExist`.
 func (hc *HealthChecker) checkNamespace(namespace string, shouldExist bool) error {
@@ -1490,9 +1736,9 @@ func (hc *HealthChecker) expectedRBACNames() []string {
 	}
 }
 
-func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
+func (hc *HealthChecker) checkClusterRoles(shouldExist bool, expectedNames []string, labelSelector string) error {
 	options := metav1.ListOptions{
-		LabelSelector: hc.controlPlaneComponentsSelector(),
+		LabelSelector: labelSelector,
 	}
 	crList, err := hc.kubeAPI.RbacV1().ClusterRoles().List(options)
 	if err != nil {
@@ -1506,12 +1752,12 @@ func (hc *HealthChecker) checkClusterRoles(shouldExist bool) error {
 		objects = append(objects, &item)
 	}
 
-	return checkResources("ClusterRoles", objects, hc.expectedRBACNames(), shouldExist)
+	return checkResources("ClusterRoles", objects, expectedNames, shouldExist)
 }
 
-func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
+func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool, expectedNames []string, labelSelector string) error {
 	options := metav1.ListOptions{
-		LabelSelector: hc.controlPlaneComponentsSelector(),
+		LabelSelector: labelSelector,
 	}
 	crbList, err := hc.kubeAPI.RbacV1().ClusterRoleBindings().List(options)
 	if err != nil {
@@ -1525,7 +1771,7 @@ func (hc *HealthChecker) checkClusterRoleBindings(shouldExist bool) error {
 		objects = append(objects, &item)
 	}
 
-	return checkResources("ClusterRoleBindings", objects, hc.expectedRBACNames(), shouldExist)
+	return checkResources("ClusterRoleBindings", objects, expectedNames, shouldExist)
 }
 
 func (hc *HealthChecker) isHA() bool {
@@ -1546,11 +1792,11 @@ func (hc *HealthChecker) isHeartbeatDisabled() bool {
 	return false
 }
 
-func (hc *HealthChecker) checkServiceAccounts(saNames []string) error {
+func (hc *HealthChecker) checkServiceAccounts(saNames []string, ns, labelSelector string) error {
 	options := metav1.ListOptions{
-		LabelSelector: hc.controlPlaneComponentsSelector(),
+		LabelSelector: labelSelector,
 	}
-	saList, err := hc.kubeAPI.CoreV1().ServiceAccounts(hc.ControlPlaneNamespace).List(options)
+	saList, err := hc.kubeAPI.CoreV1().ServiceAccounts(ns).List(options)
 	if err != nil {
 		return err
 	}
@@ -1776,14 +2022,14 @@ func (hc *HealthChecker) getDataPlanePods(ctx context.Context) ([]*pb.Pod, error
 	return pods, nil
 }
 
-func (hc *HealthChecker) checkCanPerformAction(verb, namespace, group, version, resource string) error {
-	if hc.kubeAPI == nil {
+func (hc *HealthChecker) checkCanPerformAction(api *k8s.KubernetesAPI, verb, namespace, group, version, resource string) error {
+	if api == nil {
 		// we should never get here
 		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
 	}
 
 	return k8s.ResourceAuthz(
-		hc.kubeAPI,
+		api,
 		namespace,
 		verb,
 		group,
@@ -1808,7 +2054,7 @@ func (hc *HealthChecker) checkHAMetadataPresentOnKubeSystemNamespace() error {
 }
 
 func (hc *HealthChecker) checkCanCreate(namespace, group, version, resource string) error {
-	return hc.checkCanPerformAction("create", namespace, group, version, resource)
+	return hc.checkCanPerformAction(hc.kubeAPI, "create", namespace, group, version, resource)
 }
 
 func (hc *HealthChecker) checkCanCreateNonNamespacedResources() error {
@@ -1859,7 +2105,7 @@ func (hc *HealthChecker) checkCanCreateNonNamespacedResources() error {
 }
 
 func (hc *HealthChecker) checkCanGet(namespace, group, version, resource string) error {
-	return hc.checkCanPerformAction("get", namespace, group, version, resource)
+	return hc.checkCanPerformAction(hc.kubeAPI, "get", namespace, group, version, resource)
 }
 
 func (hc *HealthChecker) checkAPIService(serviceName string) error {

--- a/pkg/servicemirror/util.go
+++ b/pkg/servicemirror/util.go
@@ -1,0 +1,37 @@
+package servicemirror
+
+import (
+	"fmt"
+
+	consts "github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// WatchedClusterConfig contains the needed data to identify a remote cluster
+type WatchedClusterConfig struct {
+	APIConfig     []byte
+	ClusterName   string
+	ClusterDomain string
+}
+
+// ParseRemoteClusterSecret extracts the credentials used to access the remote cluster
+func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, error) {
+	clusterName, hasClusterName := secret.Annotations[consts.RemoteClusterNameLabel]
+	config, hasConfig := secret.Data[consts.ConfigKeyName]
+	domain, hasDomain := secret.Annotations[consts.RemoteClusterDomainAnnotation]
+	if !hasClusterName {
+		return nil, fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
+	}
+	if !hasConfig {
+		return nil, fmt.Errorf("secret should contain remote cluster name as annotation %s", consts.RemoteClusterNameLabel)
+	}
+	if !hasDomain {
+		return nil, fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
+	}
+
+	return &WatchedClusterConfig{
+		APIConfig:     config,
+		ClusterName:   clusterName,
+		ClusterDomain: domain,
+	}, nil
+}


### PR DESCRIPTION
Adds multicluster checks that: 

- check that a service mirror controller exists (1 only)
- check that the expected ClusterRoles, ClusterRoleBindings and ServiceAccounts for the controller exist locally
- for each secret of type `remote-kubeconfig` we check that we can parse the contents into a k8s RestConfig object, can instantiate API connection to the remote cluster AND can LIST, WATCH and GET services in all namespace on this cluster. This is done for all clusters and if there is anything wrong a list of clusters violating these constraints is printed
- checks that each of the gateways (for which we have metrics in Prometheus) is alive and if not it prints a list of problematic cluster gateways