### PR TITLE
Update kind version

### DIFF
--- a/bin/kind
+++ b/bin/kind
@@ -2,7 +2,7 @@
 
 set -eu
 
-kindversion=v0.6.1
+kindversion=v0.7.0
 
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin


### PR DESCRIPTION
#4195 relaxed the clock skew check to match the Kubernetes 1.17 default
heartbeat interval.

This is the same issue that was preventing an update to the `kind` version
used.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>