### PR TITLE
Update integration tests to use kind 0.7.0

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -128,14 +128,14 @@ jobs:
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
-        version: "v0.6.1"
+        version: "v0.7.0"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
-        version: "v0.6.1"
+        version: "v0.7.0"
     - name: Load image archives into the local KinD cluster
       if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,14 +127,14 @@ jobs:
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
-        version: "v0.6.1"
+        version: "v0.7.0"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
-        version: "v0.6.1"
+        version: "v0.7.0"
     - name: Load image archives into the local KinD cluster
       env:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1


### PR DESCRIPTION
I missed these integration test version bumps in #4280 

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>