### PR TITLE
Added missing annotations to addon test fixtures

### DIFF
--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -84,6 +84,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-identity
     spec:
       nodeSelector:
@@ -302,6 +303,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: controller
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-controller
     spec:
       nodeSelector:
@@ -518,6 +520,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-destination
     spec:
       nodeSelector:
@@ -708,6 +711,7 @@ spec:
         metadata:
           labels:
             linkerd.io/control-plane-component: heartbeat
+            linkerd.io/workload-ns: linkerd
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
@@ -782,6 +786,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: web
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-web
     spec:
       nodeSelector:
@@ -1128,6 +1133,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: prometheus
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-prometheus
     spec:
       nodeSelector:
@@ -1410,6 +1416,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: grafana
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-grafana
     spec:
       nodeSelector:
@@ -1611,6 +1618,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-proxy-injector
     spec:
       nodeSelector:
@@ -1847,6 +1855,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: sp-validator
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-sp-validator
     spec:
       nodeSelector:
@@ -2064,6 +2073,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: tap
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-tap
     spec:
       nodeSelector:
@@ -2350,6 +2360,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-collector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-collector
     spec:
       containers:
@@ -2565,6 +2576,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-jaeger
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-jaeger
     spec:
       containers:

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -84,6 +84,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-identity
     spec:
       nodeSelector:
@@ -304,6 +305,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: controller
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-controller
     spec:
       nodeSelector:
@@ -522,6 +524,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-destination
     spec:
       nodeSelector:
@@ -714,6 +717,7 @@ spec:
         metadata:
           labels:
             linkerd.io/control-plane-component: heartbeat
+            linkerd.io/workload-ns: linkerd
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
@@ -788,6 +792,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: web
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-web
     spec:
       nodeSelector:
@@ -1136,6 +1141,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: prometheus
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-prometheus
     spec:
       nodeSelector:
@@ -1420,6 +1426,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: grafana
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-grafana
     spec:
       nodeSelector:
@@ -1623,6 +1630,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-proxy-injector
     spec:
       nodeSelector:
@@ -1861,6 +1869,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: sp-validator
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-sp-validator
     spec:
       nodeSelector:
@@ -2080,6 +2089,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: tap
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-tap
     spec:
       nodeSelector:
@@ -2368,6 +2378,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-collector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-collector
     spec:
       containers:
@@ -2585,6 +2596,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-jaeger
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-jaeger
     spec:
       containers:

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -924,6 +924,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-identity
     spec:
       nodeSelector:
@@ -1144,6 +1145,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: controller
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-controller
     spec:
       nodeSelector:
@@ -1362,6 +1364,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-destination
     spec:
       nodeSelector:
@@ -1554,6 +1557,7 @@ spec:
         metadata:
           labels:
             linkerd.io/control-plane-component: heartbeat
+            linkerd.io/workload-ns: linkerd
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
@@ -1628,6 +1632,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: web
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-web
     spec:
       nodeSelector:
@@ -1976,6 +1981,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: prometheus
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-prometheus
     spec:
       nodeSelector:
@@ -2260,6 +2266,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: grafana
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-grafana
     spec:
       nodeSelector:
@@ -2463,6 +2470,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-proxy-injector
     spec:
       nodeSelector:
@@ -2701,6 +2709,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: sp-validator
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-sp-validator
     spec:
       nodeSelector:
@@ -2920,6 +2929,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: tap
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-tap
     spec:
       nodeSelector:
@@ -3234,6 +3244,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: overwrite-collector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: overwrite-collector
     spec:
       containers:
@@ -3449,6 +3460,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-jaeger
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-jaeger
     spec:
       containers:

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -924,6 +924,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-identity
     spec:
       nodeSelector:
@@ -1144,6 +1145,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: controller
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-controller
     spec:
       nodeSelector:
@@ -1362,6 +1364,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-destination
     spec:
       nodeSelector:
@@ -1554,6 +1557,7 @@ spec:
         metadata:
           labels:
             linkerd.io/control-plane-component: heartbeat
+            linkerd.io/workload-ns: linkerd
           annotations:
             linkerd.io/created-by: linkerd/cli dev-undefined
         spec:
@@ -1628,6 +1632,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: web
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-web
     spec:
       nodeSelector:
@@ -1976,6 +1981,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: prometheus
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-prometheus
     spec:
       nodeSelector:
@@ -2260,6 +2266,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: grafana
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-grafana
     spec:
       nodeSelector:
@@ -2463,6 +2470,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-proxy-injector
     spec:
       nodeSelector:
@@ -2701,6 +2709,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: sp-validator
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-sp-validator
     spec:
       nodeSelector:
@@ -2920,6 +2929,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: tap
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-tap
     spec:
       nodeSelector:
@@ -3234,6 +3244,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-collector
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-collector
     spec:
       containers:
@@ -3451,6 +3462,7 @@ spec:
       labels:
         linkerd.io/control-plane-component: linkerd-jaeger
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/workload-ns: linkerd
         linkerd.io/proxy-deployment: linkerd-jaeger
     spec:
       containers:


### PR DESCRIPTION
Followup to #4271

Add missing annotation `linkerd.io/workload-ns: linkerd` in in the
addons test fixtures, introduced by the downward work from #4199

CI for #4271 didn't catch the problem because that PR went green before #4199 was merged.