### PR TITLE
Add Kubeconfig contex namespace to cli commands' options (#4197)

### DIFF
--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -23,7 +23,7 @@ type edgesOptions struct {
 
 func newEdgesOptions() *edgesOptions {
 	return &edgesOptions{
-		namespace:     "",
+		namespace:     getDefaultNamespace(),
 		outputFormat:  tableOutput,
 		allNamespaces: false,
 	}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -18,7 +18,7 @@ type getOptions struct {
 
 func newGetOptions() *getOptions {
 	return &getOptions{
-		namespace:     "default",
+		namespace:     getDefaultNamespace(),
 		allNamespaces: false,
 	}
 }

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -22,7 +22,7 @@ type metricsOptions struct {
 
 func newMetricsOptions() *metricsOptions {
 	return &metricsOptions{
-		namespace: "default",
+		namespace: getDefaultNamespace(),
 		pod:       "",
 	}
 }

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -27,7 +27,7 @@ type profileOptions struct {
 func newProfileOptions() *profileOptions {
 	return &profileOptions{
 		name:          "",
-		namespace:     "default",
+		namespace:     getDefaultNamespace(),
 		template:      false,
 		openAPI:       "",
 		proto:         "",

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
@@ -139,7 +141,7 @@ type statOptionsBase struct {
 
 func newStatOptionsBase() *statOptionsBase {
 	return &statOptionsBase{
-		namespace:    "default",
+		namespace:    getDefaultNamespace(),
 		timeWindow:   "1m",
 		outputFormat: tableOutput,
 	}
@@ -187,6 +189,27 @@ func getSuccessRate(success, failure uint64) float64 {
 		return 0.0
 	}
 	return float64(success) / float64(success+failure)
+}
+
+// getDefaultNamespace fetches the default namespace
+// used in the current KubeConfig context
+func getDefaultNamespace() string {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: kubeContext}
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
+	ns, _, err := kubeCfg.Namespace()
+
+	if err != nil {
+		log.Errorf("failed to set namespace from config context:%v", err)
+		return corev1.NamespaceDefault
+	}
+
+	return ns
 }
 
 // proxyConfigOptions holds values for command line flags that apply to both the

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -103,7 +103,7 @@ type tapEvent struct {
 
 func newTapOptions() *tapOptions {
 	return &tapOptions{
-		namespace:     "default",
+		namespace:     getDefaultNamespace(),
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -259,7 +259,7 @@ const (
 
 func newTopOptions() *topOptions {
 	return &topOptions{
-		namespace:     "default",
+		namespace:     getDefaultNamespace(),
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -105,6 +105,28 @@ func TestCliGet(t *testing.T) {
 			t.Fatalf("Pod output check failed:\n%s\nCommand output:\n%s", err, out)
 		}
 	})
+
+	t.Run("get pods from the default namespace of current context", func(t *testing.T) {
+		out, err := TestHelper.Kubectl("", "config", "set-context", "--namespace="+TestHelper.GetLinkerdNamespace(), "--current")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+		}
+
+		out, stderr, err = TestHelper.LinkerdRun("get", "pods")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v output:\n%s\n%s", err, out, stderr)
+		}
+
+		err = checkPodOutput(out, linkerdPods, "linkerd-heartbeat", TestHelper.GetLinkerdNamespace())
+		if err != nil {
+			t.Fatalf("Pod output check failed:\n%s\nCommand output:\n%s", err, out)
+		}
+
+		out, err = TestHelper.Kubectl("", "config", "set-context", "--namespace=default", "--current")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+		}
+	})
 }
 
 func checkPodOutput(cmdOutput string, expectedPodCounts map[string]int, optionalPod string, namespace string) error {

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -116,6 +116,28 @@ func TestCliTap(t *testing.T) {
 		}
 	})
 
+	t.Run("tap a deployment using context namespace", func(t *testing.T) {
+		out, err := TestHelper.Kubectl("", "config", "set-context", "--namespace="+prefixedNs, "--current")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+		}
+
+		events, err := tap("deploy/t1")
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		err = validateExpected(events, expectedT1)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		out, err = TestHelper.Kubectl("", "config", "set-context", "--namespace=default", "--current")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v output:\n%s", err, out)
+		}
+	})
+
 	t.Run("tap a disabled deployment", func(t *testing.T) {
 		out, stderr, err := TestHelper.LinkerdRun("tap", "deploy/t4", "--namespace", prefixedNs)
 		if out != "" {


### PR DESCRIPTION
### Issue: #4197 
---

### What

According to the original issue, when using a `cli` command that operates on namespaced resources, the `-n` flag has to be used even when the resources are in the __default namespace of the Kubeconfig context__.  For example, if the currently used context by the Kubeconfig has the default namespace as `emojivoto`, doing `kubectl get pods` should list everything under the `emojivoto namespace`. Issue #4197 requested similar behaviour out of the `cli` commands. 
 

### How

* The `cli` has a set of options for each command. In implementing this feature, my first step was to compile a list of commands that act on namespaced resources and accept an `-n` flag. The command names are listed below:
```
(linkerd)
1. metrics
2. edges
3. get
4. profile
5. routes
6. top
7. tap
```

* I added a new function in `cli/cmd/root.go` called `getDefaultNamespace()` that infers the default namespace based on the currently active context. To do, it makes use of loading rules and and a `DeferredLoadingClient`. Once the loader is initialised with the loading rules, we can get access to the client configuration (i.e kubeconfig) and find the namespace associated with the currently active context (through the `Namespace()` function).
* For each command previously listed, in the `options` structure, instead of hardcoding the default namespace as `default` or `""`, I initialise it using the `getDefaultNamespace()` function.

* I thought in this case unit tests are trivial, since it would only test if a string = another string, and mostly test the functionality of `client-go`. Instead, I wrote a new function in the integration test helper that allows changing the default namespace of the currently used context. 
* I thought a full integration test might not be the best use of space, so I have instead added two new cases to the integration tests of `linkerd get` and `linkerd tap` respectively. My rationale is that if it works for these two, it will work for the rest since it's the same principle. I chose `get` and `tap` because they included more than one case each and it made the most sense (from a design perspective).

Looking forward to some feedback :) 

Signed-off-by: Matei David <matei.david.35@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
