### PR TITLE
Additional Jest reporter for GH Annotations

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,4 +40,4 @@ jobs:
         export PATH="$HOME/.yarn/bin:$PATH"
         export NODE_ENV=test
         bin/web
-        bin/web test --reporters=jest-dot-reporter
+        bin/web test --reporters="jest-dot-reporter" --reporters="./gh_ann_reporter.js"

--- a/bin/web
+++ b/bin/web
@@ -103,7 +103,7 @@ setup() {
 
 function test {
   cd "$ROOT"/web/app
-  yarn jest "$*"
+  yarn jest $*
 }
 
 integration() {

--- a/web/app/gh_ann_reporter.js
+++ b/web/app/gh_ann_reporter.js
@@ -1,0 +1,26 @@
+class GhAnnReporter {
+  /* eslint-disable class-methods-use-this */
+  onRunComplete(contexts, results) {
+    // only pick the first line of the error
+    const msgRe = /^(.+)$/m;
+    const pathRe = /^.+\/linkerd2\/(.+)$/;
+    results.testResults.forEach(item => {
+      if (item.numFailingTests > 0) {
+        const msgArr = msgRe.exec(item.failureMessage);
+        let msg = 'Unknown';
+        if (msgArr.length > 0) {
+          msg = msgArr[1];
+        }
+        const pathArr = pathRe.exec(item.testFilePath);
+        let path = 'Unknown';
+        if (pathArr.length > 0) {
+          path = pathArr[1];
+        }
+        /* eslint-disable no-console */
+        console.log(`::error file=${path}::${msg}`);
+      }
+    });
+  }
+}
+
+module.exports = GhAnnReporter;


### PR DESCRIPTION
Second part of #4176

Added extra Jest reporter when running js tests from CI, which will send
to stdout a GH annotation for each test failure, something like:

```
::error file=web/app/js/components/Navigation.test.jsx::Navigation › checks state when versions do not match
```

See the [health metrics RFC](https://github.com/linkerd/rfc/blob/master/design/0002-ci-health-metrics.md) for more context.
