### PR TITLE
Refactor TestRenderHelm to not need add-ons list

### DIFF
--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -23,14 +23,14 @@ func TestRenderHelm(t *testing.T) {
 
 	t.Run("Non-HA mode", func(t *testing.T) {
 		ha := false
-		chartControlPlane := chartControlPlane(t, ha, nil, "111", "222")
-		testRenderHelm(t, chartControlPlane, "", "install_helm_output.golden")
+		chartControlPlane := chartControlPlane(t, ha, "", "111", "222")
+		testRenderHelm(t, chartControlPlane, "install_helm_output.golden")
 	})
 
 	t.Run("HA mode", func(t *testing.T) {
 		ha := true
-		chartControlPlane := chartControlPlane(t, ha, nil, "111", "222")
-		testRenderHelm(t, chartControlPlane, "", "install_helm_output_ha.golden")
+		chartControlPlane := chartControlPlane(t, ha, "", "111", "222")
+		testRenderHelm(t, chartControlPlane, "install_helm_output_ha.golden")
 	})
 
 	t.Run("Non-HA with add-ons mode", func(t *testing.T) {
@@ -39,12 +39,12 @@ func TestRenderHelm(t *testing.T) {
 tracing:
   enabled: true
 `
-		chartControlPlane := chartControlPlane(t, ha, []l5dcharts.AddOn{l5dcharts.Tracing{}}, "111", "222")
-		testRenderHelm(t, chartControlPlane, addOnConfig, "install_helm_output_addons.golden")
+		chartControlPlane := chartControlPlane(t, ha, addOnConfig, "111", "222")
+		testRenderHelm(t, chartControlPlane, "install_helm_output_addons.golden")
 	})
 }
 
-func testRenderHelm(t *testing.T, chart *pb.Chart, addOnConfig string, goldenFileName string) {
+func testRenderHelm(t *testing.T, chart *pb.Chart, goldenFileName string) {
 	var (
 		chartName = "linkerd2"
 		namespace = "linkerd-dev"
@@ -102,14 +102,6 @@ func testRenderHelm(t *testing.T, chart *pb.Chart, addOnConfig string, goldenFil
   }
 }`
 
-	if addOnConfig != "" {
-		mergedConfig, err := mergeRaw([]byte(overrideJSON), []byte(addOnConfig))
-		if err != nil {
-			t.Fatal("Unexpected error", err)
-		}
-		overrideJSON = string(mergedConfig)
-	}
-
 	overrideConfig := &pb.Config{
 		Raw: fmt.Sprintf(overrideJSON, k8s.IdentityIssuerExpiryAnnotation),
 	}
@@ -156,10 +148,18 @@ func testRenderHelm(t *testing.T, chart *pb.Chart, addOnConfig string, goldenFil
 	diffTestdata(t, goldenFileName, buf.String())
 }
 
-func chartControlPlane(t *testing.T, ha bool, addons []l5dcharts.AddOn, ignoreOutboundPorts string, ignoreInboundPorts string) *pb.Chart {
-	values, err := readTestValues(t, ha, ignoreOutboundPorts, ignoreInboundPorts)
+func chartControlPlane(t *testing.T, ha bool, addOnConfig string, ignoreOutboundPorts string, ignoreInboundPorts string) *pb.Chart {
+	rawValues, err := readTestValues(t, ha, ignoreOutboundPorts, ignoreInboundPorts)
 	if err != nil {
 		t.Fatal("Unexpected error", err)
+	}
+
+	if addOnConfig != "" {
+		mergedConfig, err := mergeRaw(rawValues, []byte(addOnConfig))
+		if err != nil {
+			t.Fatal("Unexpected error", err)
+		}
+		rawValues = mergedConfig
 	}
 
 	partialPaths := []string{
@@ -190,8 +190,19 @@ func chartControlPlane(t *testing.T, ha bool, addons []l5dcharts.AddOn, ignoreOu
 			chartPartials,
 		},
 		Values: &pb.Config{
-			Raw: string(values),
+			Raw: string(rawValues),
 		},
+	}
+
+	var values l5dcharts.Values
+	err = yaml.Unmarshal(rawValues, &values)
+	if err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+
+	addons, err := l5dcharts.ParseAddOnValues(&values)
+	if err != nil {
+		t.Fatal("Unexpected error", err)
 	}
 
 	for _, addon := range addons {


### PR DESCRIPTION
As we already have `l5dcharts.parseAddOnValues` which takes a `values` and builds a list of enabled add-ons. We can use it, instead of passing a list of add-ons for each test.

**changes include**
- update `chartControlPlane` to take `addOnConfig` to build add-on list based of it.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
