### PR TITLE
Fix bin/root-tag when applied to annotated tags

### DIFF
--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -17,7 +17,9 @@ clean_head() {
 }
 
 named_tag() {
-    echo "$(git name-rev --tags --name-only $(git_sha_head))"
+    tag="$(git name-rev --tags --name-only $(git_sha_head))"
+    tag=${tag%"^0"}
+    echo "${tag}"
 }
 
 head_root_tag() {


### PR DESCRIPTION
Fixes #4298

Since we started using using annotated tags for releases (because they
need to be signed), `bin/root-tag` will append `^0` to them when used
after checking out a release tag. E.g.:

```
$ bin/root-tag
edge-20.4.4^0
```

which breaks version checking by the CLI.

This PR removes that trailing `^0` whenever it's present
