### PR TITLE
Hide development flags in release builds

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -516,9 +516,8 @@ func (options *installOptions) recordableFlagSet() *pflag.FlagSet {
 		"Enables installing the SMI-Metrics controller",
 	)
 
-	flags.StringVarP(&options.controlPlaneVersion, "control-plane-version", "", options.controlPlaneVersion, "(Development) Tag to be used for the control plane component images")
+	flags.StringVarP(&options.controlPlaneVersion, "control-plane-version", "", options.controlPlaneVersion, "Tag to be used for the control plane component images")
 	flags.StringVar(&options.smiMetricsImage, "smi-metrics-image", options.smiMetricsImage, "SMI Metrics image")
-	flags.MarkHidden("control-plane-version")
 	flags.MarkHidden("control-plane-tracing")
 	flags.MarkHidden("smi-metrics")
 	flags.MarkHidden("smi-metrics-image")

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -518,6 +518,21 @@ func (options *installOptions) recordableFlagSet() *pflag.FlagSet {
 
 	flags.StringVarP(&options.controlPlaneVersion, "control-plane-version", "", options.controlPlaneVersion, "Tag to be used for the control plane component images")
 	flags.StringVar(&options.smiMetricsImage, "smi-metrics-image", options.smiMetricsImage, "SMI Metrics image")
+
+	// Hide developer focused flags in release builds.
+	release, err := version.IsReleaseChannel(version.Version)
+	if err != nil {
+		log.Errorf("Unable to parse version: %s", version.Version)
+	}
+	if release {
+		flags.MarkHidden("control-plane-version")
+		flags.MarkHidden("proxy-image")
+		flags.MarkHidden("proxy-version")
+		flags.MarkHidden("image-pull-policy")
+		flags.MarkHidden("init-image")
+		flags.MarkHidden("init-image-version")
+	}
+
 	flags.MarkHidden("control-plane-tracing")
 	flags.MarkHidden("smi-metrics")
 	flags.MarkHidden("smi-metrics-image")

--- a/pkg/version/channelversion.go
+++ b/pkg/version/channelversion.go
@@ -27,3 +27,13 @@ func parseChannelVersion(cv string) (channelVersion, error) {
 	}
 	return channelVersion{}, fmt.Errorf("unsupported version format: %s", cv)
 }
+
+// IsReleaseChannel returns true if the channel of the version is "edge" or
+// "stable".
+func IsReleaseChannel(version string) (bool, error) {
+	cv, err := parseChannelVersion(version)
+	if err != nil {
+		return false, err
+	}
+	return cv.channel == "edge" || cv.channel == "stable", nil
+}


### PR DESCRIPTION
Certain install flags are intended to help with Linkerd development and generally are not useful (and are potentially confusing) to users.

We hide these flags in release (edge or stable) builds of the CLI but show them in all other builds.  The list of affected flags is:

* control-plane-version
* proxy-image
* proxy-version
* image-pull-policy
* init-image
* init-image-version

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
