### PR TITLE
Add check for validating that remote clusters share the same trust an…

### DIFF
--- a/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
@@ -12,10 +12,13 @@ metadata:
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 rules:
-- apiGroups:
-  - ""
-  resources: ["services", "configmaps"]
+- apiGroups: [""]
+  resources: ["services"]
   verbs: ["list", "get", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+  resourceNames: ["linkerd-config"]  
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/service-mirror-rbac.yaml
@@ -14,12 +14,8 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  resources:
-  - services
-  verbs:
-  - list
-  - get
-  - watch
+  resources: ["services", "configmaps"]
+  verbs: ["list", "get", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/linkerd/linkerd2/cli/table"
+	configPb "github.com/linkerd/linkerd2/controller/gen/config"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/charts"
 	"github.com/linkerd/linkerd2/pkg/charts/multicluster"
@@ -91,14 +92,23 @@ func newSetupRemoteClusterOptionsWithDefault() (*setupRemoteClusterOptions, erro
 
 }
 
-func buildMulticlusterSetupValues(opts *setupRemoteClusterOptions) (*multicluster.Values, error) {
-
+func getLinkerdConfigMap() (*configPb.All, error) {
 	kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return nil, err
 	}
 
 	_, global, err := healthcheck.FetchLinkerdConfigMap(kubeAPI, controlPlaneNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return global, nil
+}
+
+func buildMulticlusterSetupValues(opts *setupRemoteClusterOptions) (*multicluster.Values, error) {
+
+	global, err := getLinkerdConfigMap()
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil, errors.New("you need Linkerd to be installed in order to setup a remote cluster")
@@ -235,6 +245,15 @@ func newGetCredentialsCommand() *cobra.Command {
 		Short:  "Get cluster credentials as a secret",
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			_, err := getLinkerdConfigMap()
+			if err != nil {
+				if kerrors.IsNotFound(err) {
+					return errors.New("you need Linkerd to be installed on a cluster in order to get its credentials")
+				}
+				return err
+			}
+
 			rules := clientcmd.NewDefaultClientConfigLoadingRules()
 			rules.ExplicitPath = kubeconfigPath
 			loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
@@ -310,8 +329,9 @@ func newGetCredentialsCommand() *cobra.Command {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("cluster-credentials-%s", opts.clusterName),
 					Annotations: map[string]string{
-						k8s.RemoteClusterNameLabel:        opts.clusterName,
-						k8s.RemoteClusterDomainAnnotation: opts.remoteClusterDomain,
+						k8s.RemoteClusterNameLabel:                  opts.clusterName,
+						k8s.RemoteClusterDomainAnnotation:           opts.remoteClusterDomain,
+						k8s.RemoteClusterLinkerdNamespaceAnnotation: controlPlaneNamespace,
 					},
 				},
 				Data: map[string][]byte{

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -362,18 +362,19 @@ type HealthChecker struct {
 	*Options
 
 	// these fields are set in the process of running checks
-	kubeAPI          *k8s.KubernetesAPI
-	kubeVersion      *k8sVersion.Info
-	controlPlanePods []corev1.Pod
-	apiClient        public.APIClient
-	latestVersions   version.Channels
-	serverVersion    string
-	linkerdConfig    *configPb.All
-	uuid             string
-	issuerCert       *tls.Cred
-	trustAnchors     []*x509.Certificate
-	cniDaemonSet     *appsv1.DaemonSet
-	serviceMirrorNs  string
+	kubeAPI              *k8s.KubernetesAPI
+	kubeVersion          *k8sVersion.Info
+	controlPlanePods     []corev1.Pod
+	apiClient            public.APIClient
+	latestVersions       version.Channels
+	serverVersion        string
+	linkerdConfig        *configPb.All
+	uuid                 string
+	issuerCert           *tls.Cred
+	trustAnchors         []*x509.Certificate
+	cniDaemonSet         *appsv1.DaemonSet
+	serviceMirrorNs      string
+	remoteClusterConfigs []*sm.WatchedClusterConfig
 }
 
 // NewHealthChecker returns an initialized HealthChecker
@@ -1302,6 +1303,14 @@ func (hc *HealthChecker) allCategories() []category {
 						return hc.checkRemoteClusterGatewaysHealth(ctx)
 					},
 				},
+				{
+					description: "clusters share trust anchors",
+					hintAnchor:  "l5d-clusters-share-anchors",
+					fatal:       true,
+					check: func(ctx context.Context) error {
+						return hc.checkRemoteClusterAnchors()
+					},
+				},
 			},
 		},
 	}
@@ -1651,6 +1660,63 @@ func (hc *HealthChecker) checkServiceMirrorLocalRBAC() error {
 	return &SkipError{Reason: "not checking muticluster"}
 }
 
+func (hc *HealthChecker) checkRemoteClusterAnchors() error {
+	if len(hc.remoteClusterConfigs) == 0 {
+		return &SkipError{Reason: "no remote cluster configs"}
+	}
+
+	localAnchors, err := tls.DecodePEMCertificates(hc.linkerdConfig.Global.IdentityContext.TrustAnchorsPem)
+	if err != nil {
+		return fmt.Errorf("Cannot parse local trust acnhors: %s", err)
+	}
+
+	var offendingClusters []string
+	for _, cfg := range hc.remoteClusterConfigs {
+
+		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(cfg.APIConfig)
+		if err != nil {
+			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s: unable to parse api config", cfg.ClusterName))
+			continue
+		}
+
+		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, requestTimeout)
+		if err != nil {
+			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s: unable to instantiate api", cfg.ClusterName))
+			continue
+		}
+
+		_, cfMap, err := FetchLinkerdConfigMap(remoteAPI, cfg.LinkerdNamespace)
+		if err != nil {
+			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s: unable to fetch anchors: %s", cfg.ClusterName, err))
+			continue
+		}
+		remoteAnchors, err := tls.DecodePEMCertificates(cfMap.Global.IdentityContext.TrustAnchorsPem)
+		if err != nil {
+			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s: cannot parse trust anchors", cfg.ClusterName))
+			continue
+		}
+
+		if len(remoteAnchors) != len(localAnchors) {
+			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s", cfg.ClusterName))
+			continue
+		}
+
+		for i := 0; i < len(remoteAnchors); i++ {
+			if !remoteAnchors[i].Equal(localAnchors[i]) {
+				offendingClusters = append(offendingClusters, fmt.Sprintf("* %s", cfg.ClusterName))
+				break
+			}
+		}
+
+	}
+
+	if len(offendingClusters) > 0 {
+		return fmt.Errorf("Problematic clusters:\n\t%s", strings.Join(offendingClusters, "\n\t"))
+	}
+
+	return nil
+}
+
 func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
 	if hc.Options.ShouldCheckMulticluster {
 		options := metav1.ListOptions{
@@ -1702,6 +1768,8 @@ func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
 			if err := comparePermissions(expectedServiceMirrorRemoteClusterPolicyVerbs, verbs); err != nil {
 				errors = append(errors, fmt.Sprintf("* cluster: [%s]: Insufficient Service permissions: %s", config.ClusterName, err))
 			}
+
+			hc.remoteClusterConfigs = append(hc.remoteClusterConfigs, config)
 
 		}
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1701,13 +1701,18 @@ func (hc *HealthChecker) checkRemoteClusterAnchors() error {
 			continue
 		}
 
-		for i := 0; i < len(remoteAnchors); i++ {
-			if !remoteAnchors[i].Equal(localAnchors[i]) {
+		localAnchorsMap := make(map[string]*x509.Certificate)
+		for _, c := range localAnchors {
+			localAnchorsMap[string(c.Signature)] = c
+		}
+
+		for _, remote := range remoteAnchors {
+			local, ok := localAnchorsMap[string(remote.Signature)]
+			if !ok || !local.Equal(remote) {
 				offendingClusters = append(offendingClusters, fmt.Sprintf("* %s", cfg.ClusterName))
 				break
 			}
 		}
-
 	}
 
 	if len(offendingClusters) > 0 {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1667,7 +1667,7 @@ func (hc *HealthChecker) checkRemoteClusterAnchors() error {
 
 	localAnchors, err := tls.DecodePEMCertificates(hc.linkerdConfig.Global.IdentityContext.TrustAnchorsPem)
 	if err != nil {
-		return fmt.Errorf("Cannot parse local trust acnhors: %s", err)
+		return fmt.Errorf("Cannot parse local trust anchors: %s", err)
 	}
 
 	var offendingClusters []string
@@ -1696,6 +1696,9 @@ func (hc *HealthChecker) checkRemoteClusterAnchors() error {
 			continue
 		}
 
+		// we fail early if the lens are not the same. If they are the
+		// same, we can only compare certs one way and be sure we have
+		// identical anchors
 		if len(remoteAnchors) != len(localAnchors) {
 			offendingClusters = append(offendingClusters, fmt.Sprintf("* %s", cfg.ClusterName))
 			continue

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -369,6 +369,10 @@ const (
 	// using custom cluster domains
 	RemoteClusterDomainAnnotation = SvcMirrorPrefix + "/remote-cluster-domain"
 
+	// RemoteClusterLinkerdNamespaceAnnotation is present on the secret
+	// carrying the config of the remote cluster
+	RemoteClusterLinkerdNamespaceAnnotation = SvcMirrorPrefix + "/remote-cluster-ld5-ns"
+
 	// RemoteResourceVersionAnnotation is the last observed remote resource
 	// version of a mirrored resource. Useful when doing updates
 	RemoteResourceVersionAnnotation = SvcMirrorPrefix + "/remote-resource-version"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -371,7 +371,7 @@ const (
 
 	// RemoteClusterLinkerdNamespaceAnnotation is present on the secret
 	// carrying the config of the remote cluster
-	RemoteClusterLinkerdNamespaceAnnotation = SvcMirrorPrefix + "/remote-cluster-ld5-ns"
+	RemoteClusterLinkerdNamespaceAnnotation = SvcMirrorPrefix + "/remote-cluster-l5d-ns"
 
 	// RemoteResourceVersionAnnotation is the last observed remote resource
 	// version of a mirrored resource. Useful when doing updates

--- a/pkg/servicemirror/util.go
+++ b/pkg/servicemirror/util.go
@@ -9,9 +9,10 @@ import (
 
 // WatchedClusterConfig contains the needed data to identify a remote cluster
 type WatchedClusterConfig struct {
-	APIConfig     []byte
-	ClusterName   string
-	ClusterDomain string
+	APIConfig        []byte
+	ClusterName      string
+	ClusterDomain    string
+	LinkerdNamespace string
 }
 
 // ParseRemoteClusterSecret extracts the credentials used to access the remote cluster
@@ -19,6 +20,8 @@ func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, err
 	clusterName, hasClusterName := secret.Annotations[consts.RemoteClusterNameLabel]
 	config, hasConfig := secret.Data[consts.ConfigKeyName]
 	domain, hasDomain := secret.Annotations[consts.RemoteClusterDomainAnnotation]
+	ld5Namespace, hasLd5Namespace := secret.Annotations[consts.RemoteClusterLinkerdNamespaceAnnotation]
+
 	if !hasClusterName {
 		return nil, fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
 	}
@@ -29,9 +32,14 @@ func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, err
 		return nil, fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
 	}
 
+	if !hasLd5Namespace {
+		return nil, fmt.Errorf("secret should contain remote linkerd installation namespace as annotation %s", consts.RemoteClusterLinkerdNamespaceAnnotation)
+	}
+
 	return &WatchedClusterConfig{
-		APIConfig:     config,
-		ClusterName:   clusterName,
-		ClusterDomain: domain,
+		APIConfig:        config,
+		ClusterName:      clusterName,
+		ClusterDomain:    domain,
+		LinkerdNamespace: ld5Namespace,
 	}, nil
 }

--- a/pkg/servicemirror/util.go
+++ b/pkg/servicemirror/util.go
@@ -20,7 +20,7 @@ func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, err
 	clusterName, hasClusterName := secret.Annotations[consts.RemoteClusterNameLabel]
 	config, hasConfig := secret.Data[consts.ConfigKeyName]
 	domain, hasDomain := secret.Annotations[consts.RemoteClusterDomainAnnotation]
-	ld5Namespace, hasLd5Namespace := secret.Annotations[consts.RemoteClusterLinkerdNamespaceAnnotation]
+	l5dNamespace, hasL5dNamespace := secret.Annotations[consts.RemoteClusterLinkerdNamespaceAnnotation]
 
 	if !hasClusterName {
 		return nil, fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
@@ -32,7 +32,7 @@ func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, err
 		return nil, fmt.Errorf("secret should contain remote cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
 	}
 
-	if !hasLd5Namespace {
+	if !hasL5dNamespace {
 		return nil, fmt.Errorf("secret should contain remote linkerd installation namespace as annotation %s", consts.RemoteClusterLinkerdNamespaceAnnotation)
 	}
 
@@ -40,6 +40,6 @@ func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, err
 		APIConfig:        config,
 		ClusterName:      clusterName,
 		ClusterDomain:    domain,
-		LinkerdNamespace: ld5Namespace,
+		LinkerdNamespace: l5dNamespace,
 	}, nil
 }


### PR DESCRIPTION
In order to enable TLS across cluster boundaries, we need to ensure that the issuer certs can all be verified with a common trust acnhors. In roder to ensure that all remote cluster that are monitored, share the same anchors, we add them as annotation to the remote cluster config secret. This allows us to easily compre the anchors of all currently watched clusters to the local ones. This PR makes this process part of the `check` command

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
