### PR TITLE
Increase timeout for Helm cleanup in integration tests

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -228,7 +228,7 @@ helm_cleanup() {
         # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
         # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
         # We don't have that problem with global resources, so no need to wait for them to be gone.
-        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=60s
+        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=120s
         # `helm reset` deletes the tiller pod in $tiller_namespace
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace reset
         kubectl --context=$k8s_context delete clusterrolebinding ${tiller_namespace}:tiller-cluster-admin

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -228,7 +228,7 @@ helm_cleanup() {
         # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
         # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
         # We don't have that problem with global resources, so no need to wait for them to be gone.
-        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=40s
+        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=60s
         # `helm reset` deletes the tiller pod in $tiller_namespace
         "$helm_path" --kube-context=$k8s_context --tiller-namespace=$tiller_namespace reset
         kubectl --context=$k8s_context delete clusterrolebinding ${tiller_namespace}:tiller-cluster-admin


### PR DESCRIPTION
Tests were failing sporadically, waiting for the Helm namespace to get
cleaned up. I verified that it is getting cleaned up, but taking more
time sometimes.