### PR TITLE
Have the Cloud, KinD and Release workflows trigger a CI report creation

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -118,7 +118,6 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
-
   trigger-reports:
     name: Trigger CI reports
     runs-on: ubuntu-18.04

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -118,3 +118,10 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+    - name: Trigger CI reports
+      # peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@0ae1c4b
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
+        repository: linkerd/linkerd2-ci-metrics
+        event-type: trigger-report

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -120,6 +120,7 @@ jobs:
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
 
   trigger-reports:
+    name: Trigger CI reports
     needs: [cloud_integration_tests]
     if: always()
     - name: Trigger CI reports

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -121,8 +121,10 @@ jobs:
 
   trigger-reports:
     name: Trigger CI reports
+    runs-on: ubuntu-18.04
     needs: [cloud_integration_tests]
     if: always()
+    steps:
     - name: Trigger CI reports
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -119,6 +119,7 @@ jobs:
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
     - name: Trigger CI reports
+      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -118,8 +118,11 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+
+  trigger-reports:
+    needs: [cloud_integration_tests]
+    if: always()
     - name: Trigger CI reports
-      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -162,7 +162,6 @@ jobs:
 
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
-
   trigger-reports:
     name: Trigger CI reports
     runs-on: ubuntu-18.04

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -165,8 +165,10 @@ jobs:
 
   trigger-reports:
     name: Trigger CI reports
+    runs-on: ubuntu-18.04
     needs: [kind_integration_tests]
     if: always()
+    steps:
     - name: Trigger CI reports
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -162,3 +162,10 @@ jobs:
 
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
+    - name: Trigger CI reports
+      # peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@0ae1c4b
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
+        repository: linkerd/linkerd2-ci-metrics
+        event-type: trigger-report

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -162,8 +162,11 @@ jobs:
 
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
+
+  trigger-reports:
+    needs: [kind_integration_tests]
+    if: always()
     - name: Trigger CI reports
-      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -164,6 +164,7 @@ jobs:
         ${{ matrix.integration_test }}_integration_tests
 
   trigger-reports:
+    name: Trigger CI reports
     needs: [kind_integration_tests]
     if: always()
     - name: Trigger CI reports

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -163,6 +163,7 @@ jobs:
         init_test_run $HOME/.linkerd
         ${{ matrix.integration_test }}_integration_tests
     - name: Trigger CI reports
+      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,8 +207,10 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  trigger-reports:
+    needs: [cloud_integration_tests]
+    if: always()
     - name: Trigger CI reports
-      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,13 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+    - name: Trigger CI reports
+      # peter-evans/repository-dispatch@v1
+      uses: peter-evans/repository-dispatch@0ae1c4b
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
+        repository: linkerd/linkerd2-ci-metrics
+        event-type: trigger-report
   gh_release:
     name: Create GH release
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,7 @@ jobs:
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
   trigger-reports:
+    name: Trigger CI reports
     needs: [cloud_integration_tests]
     if: always()
     - name: Trigger CI reports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,7 @@ jobs:
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
     - name: Trigger CI reports
+      if: always()
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,8 +209,10 @@ jobs:
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
   trigger-reports:
     name: Trigger CI reports
+    runs-on: ubuntu-18.04
     needs: [cloud_integration_tests]
     if: always()
+    steps:
     - name: Trigger CI reports
       # peter-evans/repository-dispatch@v1
       uses: peter-evans/repository-dispatch@0ae1c4b


### PR DESCRIPTION
Third step for #4176.

Dispatch a Github event when the Cloud, KinD and Release workflows finish, that will get caught in the [linkerd2-ci-metrics repo](https://github.com/linkerd/linkerd2-ci-metrics) to trigger the build of a CI report.