### PR TITLE
Don't trigger pod ip watch updates for host network pods

### DIFF
--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -149,6 +149,10 @@ func (iw *IPWatcher) addPod(obj interface{}) {
 		// Pod has not yet been assigned an IP address.
 		return
 	}
+	if pod.Spec.HostNetwork {
+		// Don't trigger updates for watches on host IP addresses.
+		return
+	}
 	ss := iw.getOrNewServiceSubscriptions(pod.Status.PodIP)
 	ss.updatePod(iw.podToAddressSet(pod))
 }
@@ -245,10 +249,6 @@ func (iw *IPWatcher) getServiceSubscriptions(clusterIP string) (ss *serviceSubsc
 }
 
 func (iw *IPWatcher) podToAddressSet(pod *corev1.Pod) AddressSet {
-	if pod.Spec.HostNetwork {
-		return AddressSet{}
-	}
-
 	ownerKind, ownerName := iw.k8sAPI.GetOwnerKindAndName(pod, true)
 	return AddressSet{
 		Addresses: map[PodID]Address{


### PR DESCRIPTION
Fixes #4331 

When a destination Get lookup is done for the IP address of a pod with host networking, the destination controller simply returns a singleton address with no pod metadata.  This is a reasonable thing to do because multiple pods might be associated with that single address and we cannot know which pod metadata to return.

However, when the destination controller receives a pod update event for one of these pods, it incorrectly sends a NoEndpoints message to watches on that IP address.  This causes 503 errors when attempting to send requests to these pods.

We simply skip taking any action when one of these pods updates instead of sending a NoEndpoints message.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
