### PR TITLE
Don't send NoEndpoints during pod updates for ip watches 

### DIFF
--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -314,7 +314,9 @@ func (ss *serviceSubscriptions) updatePod(podSet AddressSet) {
 	defer ss.Unlock()
 
 	for listener, port := range ss.listeners {
-		listener.NoEndpoints(true) // Clear out previous endpoints.
+		// Pod IP addresses never change. Therefore, we don't need to send a
+		// NoEndpoints update to clear our the previous address; sending an
+		// Add with the same address will replace the previous one.
 		if len(podSet.Addresses) != 0 {
 			podSetWithPort := withPort(podSet, port)
 			listener.Add(podSetWithPort)

--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -149,6 +149,10 @@ func (iw *IPWatcher) addPod(obj interface{}) {
 		// Pod has not yet been assigned an IP address.
 		return
 	}
+	if pod.Spec.HostNetwork {
+		// Don't trigger updates for watches on host IP addresses.
+		return
+	}
 	ss := iw.getOrNewServiceSubscriptions(pod.Status.PodIP)
 	ss.updatePod(iw.podToAddressSet(pod))
 }
@@ -245,10 +249,6 @@ func (iw *IPWatcher) getServiceSubscriptions(clusterIP string) (ss *serviceSubsc
 }
 
 func (iw *IPWatcher) podToAddressSet(pod *corev1.Pod) AddressSet {
-	if pod.Spec.HostNetwork {
-		return AddressSet{}
-	}
-
 	ownerKind, ownerName := iw.k8sAPI.GetOwnerKindAndName(pod, true)
 	return AddressSet{
 		Addresses: map[PodID]Address{


### PR DESCRIPTION
When the proxy has an IP watch on a pod and the destination controller gets a pod update event, the destination controller sends a NoEndpoints message to all listeners followed by an Add with the new pod state.  This can result in the proxy's load balancer being briefly empty and could result in failing requests in the period.  

Since consecutive Add events with the same address will override each other, we can simply send the Adds without needing to clear the previous state with a NoEndpoints message.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
