### PR TITLE
Make gateway require TLS for incoming requests

### DIFF
--- a/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
@@ -29,6 +29,13 @@ data:
             return 200 "healthy\n";
           }
       }
+      server {
+          listen     {{.Values.localProbePort}};
+          location {{.Values.localProbePath}} {
+            access_log off;
+            return 200 "healthy\n";
+          }
+      }    
     }
 ---    
 apiVersion: apps/v1
@@ -53,6 +60,7 @@ spec:
       annotations:
         {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}        
         linkerd.io/inject: enabled
+        config.linkerd.io/proxy-require-identity-inbound-ports: "{{.Values.probePort}},{{.Values.incomingPort}}"
       labels:
         app: {{.Values.gatewayName}}
     spec:
@@ -65,19 +73,21 @@ spec:
           readinessProbe:
             failureThreshold: 7
             httpGet:
-              path: {{.Values.probePath}}
-              port: {{.Values.probePort}}
+              path: {{.Values.localProbePath}}
+              port: {{.Values.localProbePort}}
           livenessProbe:
             httpGet:
-              path: {{.Values.probePath}}
-              port: {{.Values.probePort}}
-            initialDelaySeconds: 10  
+              path: {{.Values.localProbePath}}
+              port: {{.Values.localProbePort}}
+            initialDelaySeconds: 10
           image: {{.Values.nginxImage}}:{{.Values.nginxImageVersion}}
           ports:
             - name: incoming-port
               containerPort: {{.Values.incomingPort}}
             - name: probe-port
-              containerPort: {{.Values.probePort}}             
+              containerPort: {{.Values.probePort}}
+            - name: local-probe
+              containerPort: {{.Values.localProbePort}}              
           volumeMounts:
             - name: config
               mountPath: /etc/nginx

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -13,3 +13,5 @@ createdByAnnotation: linkerd.io/created-by
 nginxImageVersion: 1.17
 nginxImage: nginx
 proxyOutboundPort: 4140
+localProbePath: /health-local
+localProbePort: 8888

--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -48,6 +48,8 @@ spec:
       {{.Values.controllerComponentLabel}}: linkerd-service-mirror
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: enabled
       labels:
         {{.Values.controllerComponentLabel}}: linkerd-service-mirror
     spec:

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -48,6 +48,7 @@ global:
     # See https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
     # for more info on container lifecycle hooks.
     waitBeforeExitSeconds: 0
+    requireIdentityOnInboundPorts: ""
 
   # proxy-init configuration
   proxyInit:

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -2,7 +2,7 @@
 env:
 {{ if .Values.global.proxy.requireIdentityOnInboundPorts -}}
 - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_IDENTITY
-  value: {{.Values.global.proxy.requireIdentityOnInboundPorts}}
+  value: "{{.Values.global.proxy.requireIdentityOnInboundPorts}}"
 {{ end -}}  
 - name: LINKERD2_PROXY_LOG
   value: {{.Values.global.proxy.logLevel}}

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -1,5 +1,9 @@
 {{ define "partials.proxy" -}}
 env:
+{{ if .Values.global.proxy.requireIdentityOnInboundPorts -}}
+- name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_IDENTITY
+  value: {{.Values.global.proxy.requireIdentityOnInboundPorts}}
+{{ end -}}  
 - name: LINKERD2_PROXY_LOG
   value: {{.Values.global.proxy.logLevel}}
 - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -111,6 +111,10 @@ func buildMulticlusterSetupValues(opts *setupRemoteClusterOptions) (*multicluste
 		return nil, err
 	}
 
+	if opts.probePort == defaults.LocalProbePort {
+		return nil, fmt.Errorf("The probe port needs to be different from %d which is the local probe port", defaults.LocalProbePort)
+	}
+
 	defaults.GatewayName = opts.gatewayName
 	defaults.GatewayNamespace = opts.gatewayNamespace
 	defaults.IdentityTrustDomain = global.Global.IdentityContext.TrustDomain

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -131,6 +131,9 @@ sub-folders, or coming from stdin.`,
 	flags.StringVar(&options.traceCollectorSvcAccount, "trace-collector-svc-account", options.traceCollectorSvcAccount,
 		"Service account associated with the Trace collector instance")
 
+	flags.StringSliceVar(&options.requireIdentityOnInboundPorts, "require-identity-on-inbound-ports", options.requireIdentityOnInboundPorts,
+		"Inbound ports on which the proxy should require identity")
+
 	cmd.PersistentFlags().AddFlagSet(flags)
 
 	return cmd
@@ -416,6 +419,10 @@ func (options *proxyConfigOptions) overrideConfigs(configs *cfg.All, overrideAnn
 	if options.disableIdentity {
 		configs.Global.IdentityContext = nil
 		overrideAnnotations[k8s.ProxyDisableIdentityAnnotation] = strconv.FormatBool(true)
+	}
+
+	if len(options.requireIdentityOnInboundPorts) > 0 {
+		overrideAnnotations[k8s.ProxyRequireIdentityOnInboundPortsAnnotation] = strings.Join(options.requireIdentityOnInboundPorts, ",")
 	}
 
 	if options.disableTap {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -216,36 +217,42 @@ func getDefaultNamespace() string {
 // install and inject commands. All fields in this struct should have
 // corresponding flags added in the addProxyConfigFlags func later in this file.
 type proxyConfigOptions struct {
-	proxyVersion             string
-	proxyImage               string
-	initImage                string
-	initImageVersion         string
-	debugImage               string
-	debugImageVersion        string
-	dockerRegistry           string
-	imagePullPolicy          string
-	ignoreInboundPorts       []string
-	ignoreOutboundPorts      []string
-	proxyUID                 int64
-	proxyLogLevel            string
-	proxyInboundPort         uint
-	proxyOutboundPort        uint
-	proxyControlPort         uint
-	proxyAdminPort           uint
-	proxyCPURequest          string
-	proxyMemoryRequest       string
-	proxyCPULimit            string
-	proxyMemoryLimit         string
-	enableExternalProfiles   bool
-	traceCollector           string
-	traceCollectorSvcAccount string
-	waitBeforeExitSeconds    uint64
-	ignoreCluster            bool // not validated by validate()
-	disableIdentity          bool
-	disableTap               bool
+	proxyVersion                  string
+	proxyImage                    string
+	initImage                     string
+	initImageVersion              string
+	debugImage                    string
+	debugImageVersion             string
+	dockerRegistry                string
+	imagePullPolicy               string
+	ignoreInboundPorts            []string
+	ignoreOutboundPorts           []string
+	proxyUID                      int64
+	proxyLogLevel                 string
+	proxyInboundPort              uint
+	proxyOutboundPort             uint
+	proxyControlPort              uint
+	proxyAdminPort                uint
+	proxyCPURequest               string
+	proxyMemoryRequest            string
+	proxyCPULimit                 string
+	proxyMemoryLimit              string
+	enableExternalProfiles        bool
+	traceCollector                string
+	traceCollectorSvcAccount      string
+	waitBeforeExitSeconds         uint64
+	ignoreCluster                 bool // not validated by validate()
+	disableIdentity               bool
+	requireIdentityOnInboundPorts []string
+	disableTap                    bool
 }
 
 func (options *proxyConfigOptions) validate() error {
+
+	if options.disableIdentity && len(options.requireIdentityOnInboundPorts) > 0 {
+		return errors.New("Identity must be enabled when  --require-identity-on-inbound-ports is specified")
+	}
+
 	if options.proxyVersion != "" && !alphaNumDashDot.MatchString(options.proxyVersion) {
 		return fmt.Errorf("%s is not a valid version", options.proxyVersion)
 	}

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -131,6 +131,7 @@ func gatewayToProbeSpec(gatewaySpec GatewaySpec) *probeSpec {
 		path:            gatewaySpec.path,
 		port:            gatewaySpec.port,
 		periodInSeconds: gatewaySpec.periodInSeconds,
+		gatewayIdentity: gatewaySpec.identity,
 	}
 }
 

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -13,12 +13,14 @@ import (
 )
 
 const httpGatewayTimeoutMillis = 50000
+const requireIDHeader = "l5d-require-id"
 
 type probeSpec struct {
 	ips             []string
 	path            string
 	port            uint32
 	periodInSeconds uint32
+	gatewayIdentity string
 }
 
 // ProbeWorker is responsible for monitoring gateways using a probe specification
@@ -128,8 +130,16 @@ func (pw *ProbeWorker) doProbe() {
 		client := http.Client{
 			Timeout: httpGatewayTimeoutMillis * time.Millisecond,
 		}
+
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d/%s", ipToTry, pw.probeSpec.port, pw.probeSpec.path), nil)
+		if err != nil {
+			pw.log.Debugf("Could not create a GET request to gateway: %s", err)
+			return
+		}
+
+		req.Header.Set(requireIDHeader, pw.probeSpec.gatewayIdentity)
 		start := time.Now()
-		resp, err := client.Get(fmt.Sprintf("http://%s:%d/%s", ipToTry, pw.probeSpec.port, pw.probeSpec.path))
+		resp, err := client.Do(req)
 		end := time.Since(start)
 		if err != nil {
 			pw.log.Errorf("Problem connecting with gateway. Marking as unhealthy %s", err)

--- a/controller/cmd/service-mirror/probe_worker.go
+++ b/controller/cmd/service-mirror/probe_worker.go
@@ -7,13 +7,12 @@ import (
 	"sync"
 	"time"
 
+	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/prometheus/client_golang/prometheus"
-
 	logging "github.com/sirupsen/logrus"
 )
 
 const httpGatewayTimeoutMillis = 50000
-const requireIDHeader = "l5d-require-id"
 
 type probeSpec struct {
 	ips             []string
@@ -137,7 +136,7 @@ func (pw *ProbeWorker) doProbe() {
 			return
 		}
 
-		req.Header.Set(requireIDHeader, pw.probeSpec.gatewayIdentity)
+		req.Header.Set(consts.RequireIDHeader, pw.probeSpec.gatewayIdentity)
 		start := time.Now()
 		resp, err := client.Do(req)
 		end := time.Since(start)

--- a/controller/tap/server.go
+++ b/controller/tap/server.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const requireIDHeader = "l5d-require-id"
 const ipIndex = "ip"
 const defaultMaxRps = 100.0
 
@@ -139,7 +138,7 @@ func (s *GRPCTapServer) TapByResource(req *public.TapByResourceRequest, stream p
 
 		// pass the header metadata into the request context
 		ctx := stream.Context()
-		ctx = metadata.AppendToOutgoingContext(ctx, requireIDHeader, name)
+		ctx = metadata.AppendToOutgoingContext(ctx, pkgK8s.RequireIDHeader, name)
 
 		// initiate a tap on the pod
 		go s.tapProxy(ctx, rpsPerPod, match, extract, pod.Status.PodIP, events)

--- a/controller/tap/server_test.go
+++ b/controller/tap/server_test.go
@@ -392,8 +392,8 @@ status:
 					t.Fatalf("FromIncomingContext failed given: %+v", mockProxyTapServer.ctx)
 				}
 
-				if !reflect.DeepEqual(md.Get(requireIDHeader), []string{exp.requireID}) {
-					t.Fatalf("Unexpected l5d-require-id header [%+v] expected [%+v]", md.Get(requireIDHeader), []string{exp.requireID})
+				if !reflect.DeepEqual(md.Get(pkgK8s.RequireIDHeader), []string{exp.requireID}) {
+					t.Fatalf("Unexpected l5d-require-id header [%+v] expected [%+v]", md.Get(pkgK8s.RequireIDHeader), []string{exp.requireID})
 				}
 			}
 

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -99,19 +99,20 @@ type (
 
 	// Proxy contains the fields to set the proxy sidecar container
 	Proxy struct {
-		Capabilities           *Capabilities `json:"capabilities"`
-		Component              string        `json:"component"`
-		DisableIdentity        bool          `json:"disableIdentity"`
-		DisableTap             bool          `json:"disableTap"`
-		EnableExternalProfiles bool          `json:"enableExternalProfiles"`
-		Image                  *Image        `json:"image"`
-		LogLevel               string        `json:"logLevel"`
-		SAMountPath            *SAMountPath  `json:"saMountPath"`
-		Ports                  *Ports        `json:"ports"`
-		Resources              *Resources    `json:"resources"`
-		Trace                  *Trace        `json:"trace"`
-		UID                    int64         `json:"uid"`
-		WaitBeforeExitSeconds  uint64        `json:"waitBeforeExitSeconds"`
+		Capabilities                  *Capabilities `json:"capabilities"`
+		Component                     string        `json:"component"`
+		DisableIdentity               bool          `json:"disableIdentity"`
+		DisableTap                    bool          `json:"disableTap"`
+		EnableExternalProfiles        bool          `json:"enableExternalProfiles"`
+		Image                         *Image        `json:"image"`
+		LogLevel                      string        `json:"logLevel"`
+		SAMountPath                   *SAMountPath  `json:"saMountPath"`
+		Ports                         *Ports        `json:"ports"`
+		Resources                     *Resources    `json:"resources"`
+		Trace                         *Trace        `json:"trace"`
+		UID                           int64         `json:"uid"`
+		WaitBeforeExitSeconds         uint64        `json:"waitBeforeExitSeconds"`
+		RequireIdentityOnInboundPorts string        `json:"requireIdentityOnInboundPorts"`
 	}
 
 	// ProxyInit contains the fields to set the proxy-init container

--- a/pkg/charts/multicluster/values.go
+++ b/pkg/charts/multicluster/values.go
@@ -29,6 +29,8 @@ type Values struct {
 	NginxImage              string `json:"nginxImage"`
 	LinkerdVersion          string `json:"linkerdVersion"`
 	CreatedByAnnotation     string `json:"createdByAnnotation"`
+	LocalProbePath          string `json:"localProbePath"`
+	LocalProbePort          uint32 `json:"localProbePort"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -16,24 +16,25 @@ import (
 )
 
 type expectedProxyConfigs struct {
-	identityContext            *config.IdentityContext
-	image                      string
-	imagePullPolicy            string
-	proxyVersion               string
-	controlPort                int32
-	inboundPort                int32
-	adminPort                  int32
-	outboundPort               int32
-	proxyWaitBeforeExitSeconds uint64
-	logLevel                   string
-	resourceRequirements       *l5dcharts.Resources
-	proxyUID                   int64
-	initImage                  string
-	initImagePullPolicy        string
-	initVersion                string
-	inboundSkipPorts           string
-	outboundSkipPorts          string
-	trace                      *l5dcharts.Trace
+	identityContext               *config.IdentityContext
+	image                         string
+	imagePullPolicy               string
+	proxyVersion                  string
+	controlPort                   int32
+	inboundPort                   int32
+	adminPort                     int32
+	outboundPort                  int32
+	proxyWaitBeforeExitSeconds    uint64
+	logLevel                      string
+	resourceRequirements          *l5dcharts.Resources
+	proxyUID                      int64
+	initImage                     string
+	initImagePullPolicy           string
+	initVersion                   string
+	inboundSkipPorts              string
+	outboundSkipPorts             string
+	requireIdentityOnInboundPorts string
+	trace                         *l5dcharts.Trace
 }
 
 func TestConfigAccessors(t *testing.T) {
@@ -89,27 +90,28 @@ func TestConfigAccessors(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							k8s.ProxyDisableIdentityAnnotation:          "true",
-							k8s.ProxyImageAnnotation:                    "gcr.io/linkerd-io/proxy",
-							k8s.ProxyImagePullPolicyAnnotation:          "Always",
-							k8s.ProxyInitImageAnnotation:                "gcr.io/linkerd-io/proxy-init",
-							k8s.ProxyControlPortAnnotation:              "4000",
-							k8s.ProxyInboundPortAnnotation:              "5000",
-							k8s.ProxyAdminPortAnnotation:                "5001",
-							k8s.ProxyOutboundPortAnnotation:             "5002",
-							k8s.ProxyIgnoreInboundPortsAnnotation:       "4222,6222",
-							k8s.ProxyIgnoreOutboundPortsAnnotation:      "8079,8080",
-							k8s.ProxyCPURequestAnnotation:               "0.15",
-							k8s.ProxyMemoryRequestAnnotation:            "120",
-							k8s.ProxyCPULimitAnnotation:                 "1.5",
-							k8s.ProxyMemoryLimitAnnotation:              "256",
-							k8s.ProxyUIDAnnotation:                      "8500",
-							k8s.ProxyLogLevelAnnotation:                 "debug,linkerd2_proxy=debug",
-							k8s.ProxyEnableExternalProfilesAnnotation:   "false",
-							k8s.ProxyVersionOverrideAnnotation:          proxyVersionOverride,
-							k8s.ProxyTraceCollectorSvcAddrAnnotation:    "oc-collector.tracing:55678",
-							k8s.ProxyTraceCollectorSvcAccountAnnotation: "default",
-							k8s.ProxyWaitBeforeExitSecondsAnnotation:    "123",
+							k8s.ProxyDisableIdentityAnnotation:               "true",
+							k8s.ProxyImageAnnotation:                         "gcr.io/linkerd-io/proxy",
+							k8s.ProxyImagePullPolicyAnnotation:               "Always",
+							k8s.ProxyInitImageAnnotation:                     "gcr.io/linkerd-io/proxy-init",
+							k8s.ProxyControlPortAnnotation:                   "4000",
+							k8s.ProxyInboundPortAnnotation:                   "5000",
+							k8s.ProxyAdminPortAnnotation:                     "5001",
+							k8s.ProxyOutboundPortAnnotation:                  "5002",
+							k8s.ProxyIgnoreInboundPortsAnnotation:            "4222,6222",
+							k8s.ProxyIgnoreOutboundPortsAnnotation:           "8079,8080",
+							k8s.ProxyCPURequestAnnotation:                    "0.15",
+							k8s.ProxyMemoryRequestAnnotation:                 "120",
+							k8s.ProxyCPULimitAnnotation:                      "1.5",
+							k8s.ProxyMemoryLimitAnnotation:                   "256",
+							k8s.ProxyUIDAnnotation:                           "8500",
+							k8s.ProxyLogLevelAnnotation:                      "debug,linkerd2_proxy=debug",
+							k8s.ProxyEnableExternalProfilesAnnotation:        "false",
+							k8s.ProxyVersionOverrideAnnotation:               proxyVersionOverride,
+							k8s.ProxyTraceCollectorSvcAddrAnnotation:         "oc-collector.tracing:55678",
+							k8s.ProxyTraceCollectorSvcAccountAnnotation:      "default",
+							k8s.ProxyWaitBeforeExitSecondsAnnotation:         "123",
+							k8s.ProxyRequireIdentityOnInboundPortsAnnotation: "8888,9999",
 						},
 					},
 					Spec: corev1.PodSpec{},
@@ -145,6 +147,7 @@ func TestConfigAccessors(t *testing.T) {
 					CollectorSvcAddr:    "oc-collector.tracing:55678",
 					CollectorSvcAccount: "default.tracing",
 				},
+				requireIdentityOnInboundPorts: "8888,9999",
 			},
 		},
 		{id: "use defaults",
@@ -413,6 +416,13 @@ func TestConfigAccessors(t *testing.T) {
 			t.Run("proxyOutboundSkipPorts", func(t *testing.T) {
 				expected := testCase.expected.outboundSkipPorts
 				if actual := resourceConfig.proxyOutboundSkipPorts(); expected != actual {
+					t.Errorf("Expected: %v Actual: %v", expected, actual)
+				}
+			})
+
+			t.Run("proxyRequireIdentityOnInboundPorts", func(t *testing.T) {
+				expected := testCase.expected.requireIdentityOnInboundPorts
+				if actual := resourceConfig.requireIdentityOnInboundPorts(); expected != actual {
 					t.Errorf("Expected: %v Actual: %v", expected, actual)
 				}
 			})

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -187,6 +187,10 @@ const (
 	// ProxyVersionOverrideAnnotation can be used to override the proxy version config.
 	ProxyVersionOverrideAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-version"
 
+	// ProxyRequireIdentityOnInboundPortsAnnotation can be used to configure the proxy
+	// to always require identity on inbound ports
+	ProxyRequireIdentityOnInboundPortsAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-require-identity-inbound-ports"
+
 	// ProxyDisableIdentityAnnotation can be used to disable identity on the injected proxy.
 	ProxyDisableIdentityAnnotation = ProxyConfigAnnotationsPrefix + "/disable-identity"
 

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -38,6 +38,10 @@ const (
 	// contains the value of the "--requestheader-client-ca-file" flag.
 	ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey = "requestheader-client-ca-file"
 
+	// RequireIDHeader signals to the proxy that a certain identity should be expected
+	// of the remote peer
+	RequireIDHeader = "l5d-require-id"
+
 	// ControllerNSLabel is injected into mesh-enabled apps, identifying the
 	// namespace of the Linkerd control plane.
 	ControllerNSLabel = Prefix + "/control-plane-ns"


### PR DESCRIPTION
This PR introduces a few changes with the aim of making the multicluster setup a bit more secure:

- The service mirror controller will now be injected
- The proxy on the gateway will require identity on the two ports that are exposed through the gateway (the incoming port and the probes port)
- The probe worker now uses the `l5d-require-id` when doing the HTTP get requests to the gateways to  inform the outbound proxy of the expected identity of the remote peer (the gateway)
- There are two sets of probes on two different ports. One is local and can work without identity (this is for Kubelet) and the other is remote and requires identity (for the prober that is part of service mirror).

This all should guarantee that non TLSed traffic coming from outside the cluster will be banned by the proxy that is injected on the gateway pod. I have tested that and it works. No port skipping is happening anywhere

This all depends on https://github.com/linkerd/linkerd2-proxy/pull/507