### PR TITLE
Use gotestsum in CI unit test workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,8 +22,9 @@ jobs:
         GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
       run: |
         echo "$GITCOOKIE_SH" | bash
+        go get gotest.tools/gotestsum@v0.4.2
         # TODO: validate bin/protoc-go.sh does not dirty the repo
-        go test -cover -race -v -mod=readonly ./...
+        gotestsum -- -cover -race -v -mod=readonly ./...
   js_unit_tests:
     name: JS unit tests
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Use [gotestsum](https://github.com/gotestyourself/gotestsum) for running unit tests in CI, so we get a summary result at the end, instead of having to scroll up to find failures.

Doesn't apply for integration tests, as only failures are shown there, and they're easily visible.
