### PR TITLE
remove admin server timeouts

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -28,6 +28,7 @@ func StartServer(addr string) {
 		Handler:      h,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  1 * time.Minute,
 	}
 
 	log.Fatal(s.ListenAndServe())

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -23,15 +22,7 @@ func StartServer(addr string) {
 		promHandler: promhttp.Handler(),
 	}
 
-	s := &http.Server{
-		Addr:         addr,
-		Handler:      h,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  1 * time.Minute,
-	}
-
-	log.Fatal(s.ListenAndServe())
+	log.Fatal(http.ListenAndServe(addr, h))
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The Linkerd control plane components' admin servers have an idle connection timeout of 10 seconds.  This means that they will close connections which have been idle for 10 seconds.  These components are also configured with a 10 second period for liveness checks.  This introduces a race condition where connections will be idle for approximately 10 seconds between liveness checks and can idle out, potentially causing the next liveness check to fail.

We remove the idle timeout so that the connection stays alive.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
