### PR TITLE
Flaky tests: increase timeout for 'linkerd edges'

### DIFF
--- a/test/edges/edges_test.go
+++ b/test/edges/edges_test.go
@@ -129,7 +129,7 @@ func TestDirectEdges(t *testing.T) {
 	}
 
 	// check edges
-	err = TestHelper.RetryFor(20*time.Second, func() error {
+	err = TestHelper.RetryFor(50*time.Second, func() error {
 		out, stderr, err = TestHelper.LinkerdRun("-n", testNamespace, "-o", "json", "edges", "deploy")
 		if err != nil {
 			return fmt.Errorf("linkerd %s command failed with %s: %s", "edges", err.Error(), stderr)


### PR DESCRIPTION
The `linkerd edges` test was being flaky, so gave more slack for it to succeed.