### PR TITLE
Flaky tests: increase timeout for 'kubectl wait'

### DIFF
--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -134,7 +134,7 @@ func TestInjectAutoNamespaceOverrideAnnotations(t *testing.T) {
 		t.Fatalf("failed to create deploy/%s in namespace %s for  %s: %s", deployName, ns, err, o)
 	}
 
-	o, err = TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=available", "--timeout=30s", "deploy/"+deployName)
+	o, err = TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=available", "--timeout=120s", "deploy/"+deployName)
 	if err != nil {
 		t.Fatalf("failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", deployName, ns, err, o)
 	}
@@ -221,7 +221,7 @@ func TestInjectAutoAnnotationPermutations(t *testing.T) {
 				name = fmt.Sprintf("%s-%s", name, podAnnotation)
 			}
 
-			o, err := TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=available", "--timeout=30s", "deploy/"+name)
+			o, err := TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=available", "--timeout=120s", "deploy/"+name)
 			if err != nil {
 				t.Fatalf("failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", name, ns, err, o)
 			}
@@ -306,7 +306,7 @@ func TestInjectAutoPod(t *testing.T) {
 		t.Fatalf("failed to create pod/%s in namespace %s for %s: %s", podName, ns, err, o)
 	}
 
-	o, err = TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=initialized", "--timeout=30s", "pod/"+podName)
+	o, err = TestHelper.Kubectl("", "--namespace", ns, "wait", "--for=condition=initialized", "--timeout=120s", "pod/"+podName)
 	if err != nil {
 		t.Fatalf("failed to wait for condition=initialized for pod/%s in namespace %s: %s: %s", podName, ns, err, o)
 	}


### PR DESCRIPTION
Sometimes for no clear reason pods are taking their time to become
available. The `kubectl wait --for=condition=available` command in
`inject_test.go` is failing sporadically because of this.

e.g in
https://github.com/linkerd/linkerd2/runs/652159504?check_suite_focus=true#step:14:56

I could reproduce this and even though I couldn't see any errors in the logs
or events, I could confirm how long it's taking for the pod to come up:

```
$ k -n l5d-integration-inject-test describe po inject-test-terminus-enabled
...
Events:
  Type    Reason     Age    From                                               Message
  ----    ------     ----   ----                                               -------
  Normal  Scheduled  7m12s  default-scheduler                                  Successfully assigned l5d-integration-inject-test/inject-test-terminus-enabled-96fd5f5dc-5qlpb to gke-alpeb-dev-default-pool-b94ca25c-h84p
  Normal  Pulled     6m55s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Container image "gcr.io/linkerd-io/proxy-init:v1.3.2" already present on machine
  Normal  Created    6m54s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Created container linkerd-init
  Normal  Started    6m47s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Started container linkerd-init
  Normal  Pulled     6m28s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Container image "buoyantio/bb:v0.0.5" already present on machine
  Normal  Created    6m27s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Created container bb-terminus
  Normal  Started    6m27s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Started container bb-terminus
  Normal  Pulled     6m27s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Container image "gcr.io/linkerd-io/proxy:git-2a95d373" already present on machine
  Normal  Created    6m27s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Created container linkerd-proxy
  Normal  Started    6m27s  kubelet, gke-alpeb-dev-default-pool-b94ca25c-h84p  Started container linkerd-proxy
```

here the pod took 45s to start!
