### PR TITLE
Refactor CNI integration tests to use annotations functions

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -6,6 +6,8 @@ on:
     - '**/*.md'
     branches:
     - master
+env:
+  GH_ANNOTATION: true
 jobs:
   # todo: Keep in sync with `release.yml`
   docker_build:

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -7,6 +7,8 @@ on:
     - '**/*.md'
     branches:
     - master
+env:
+  GH_ANNOTATION: true
 jobs:
   docker_build:
     name: Docker build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
   push:
     tags:
     - "*"
+env:
+  GH_ANNOTATION: true
 jobs:
   # todo: Keep in sync with `cloud_integration.yml`
   docker_build:


### PR DESCRIPTION
Followup to #4341

Replaced all the `t.Error`/`t.Fatal` calls in the integration tests with the
new functions defined in `testutil/annotations.go` as described in #4292,
in order for the errors to produce Github annotations.

This piece takes care of the CNI integration test suite.

This also enables the annotations for these and the general integration
tests, by setting the `GH_ANNOTATIONS` environment variable in the
workflows whose flakiness we're interested on catching: Kind
integration, Cloud integration and Release.

Re #4176

