### PR TITLE
jaeger and grafana propType nits and tests

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -277,17 +277,18 @@ MetricsTable.propTypes = {
   metrics: PropTypes.arrayOf(processedMetricsPropType),
   resource: PropTypes.string.isRequired,
   selectedNamespace: PropTypes.string.isRequired,
-  jaeger: PropTypes.string,
   showName: PropTypes.bool,
   showNamespaceColumn: PropTypes.bool,
   title: PropTypes.string,
-  grafana: PropTypes.string.isRequired,
+  grafana: PropTypes.string,
+  jaeger: PropTypes.string,
 };
 
 MetricsTable.defaultProps = {
   showNamespaceColumn: true,
   showName: true,
   title: '',
+  grafana: '',
   jaeger: '',
   isTcpTable: false,
   metrics: [],

--- a/web/app/js/components/MetricsTable.test.js
+++ b/web/app/js/components/MetricsTable.test.js
@@ -26,7 +26,7 @@ describe('Tests for <MetricsTable>', () => {
 
     expect(table).toBeDefined();
     expect(table.props().tableRows).toHaveLength(1);
-    expect(table.props().tableColumns).toHaveLength(8);
+    expect(table.props().tableColumns).toHaveLength(7);
   });
 
   it('if enableFilter is true, user can filter rows by search term', () => {
@@ -67,7 +67,7 @@ describe('Tests for <MetricsTable>', () => {
     const table = component.find("BaseTable");
 
     expect(table).toBeDefined();
-    expect(table.props().tableColumns).toHaveLength(8);
+    expect(table.props().tableColumns).toHaveLength(7);
   });
 
   it('omits the namespace column when showNamespaceColumn is false', () => {
@@ -81,15 +81,44 @@ describe('Tests for <MetricsTable>', () => {
     const table = component.find("BaseTable");
 
     expect(table).toBeDefined();
-    expect(table.props().tableColumns).toHaveLength(8);
+    expect(table.props().tableColumns).toHaveLength(7);
   });
 
-  it('render table with all columens including jaeger', () => {
+  it('render table columns including jaeger', () => {
     let extraProps = _merge({}, defaultProps, {
       metrics: [],
       resource: "deployment",
       showNamespaceColumn: false,
       jaeger: 'jaeger.xyz'
+    });
+    const component = mount(routerWrap(MetricsTable, extraProps));
+    const table = component.find("BaseTable");
+
+    expect(table).toBeDefined();
+    expect(table.props().tableColumns).toHaveLength(8);
+  });
+
+  it('render table columns including grafana', () => {
+    let extraProps = _merge({}, defaultProps, {
+      metrics: [],
+      resource: "deployment",
+      showNamespaceColumn: false,
+      grafana: 'grafana.xyz'
+    });
+    const component = mount(routerWrap(MetricsTable, extraProps));
+    const table = component.find("BaseTable");
+
+    expect(table).toBeDefined();
+    expect(table.props().tableColumns).toHaveLength(8);
+  });
+
+  it('render all table columns', () => {
+    let extraProps = _merge({}, defaultProps, {
+      metrics: [],
+      resource: "deployment",
+      showNamespaceColumn: false,
+      jaeger: 'jaeger.xyz',
+      grafana: 'grafana.xyz'
     });
     const component = mount(routerWrap(MetricsTable, extraProps));
     const table = component.find("BaseTable");


### PR DESCRIPTION
Fixes #4349 

This changes makes both `grafana` and `jaeger` fields consist by making both of them. Here we make both  propTypes are not required, with corresponding defaultProps declarations.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
