### PR TITLE
Detect windows nodes and skip injection of proxies

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -26,7 +26,7 @@ const (
 	hostNetworkDesc                  = "pods do not use host networking"
 	sidecarDesc                      = "pods do not have a 3rd party proxy or initContainer already injected"
 	injectDisabledDesc               = "pods are not annotated to disable injection"
-	uncompatbleNodeOSDesc				 = "pods do not run on a windows node"
+	unsupportedOSDesc    			 = "pods do not run on a windows node"
 	unsupportedDesc                  = "at least one resource injected"
 	udpDesc                          = "pod specs do not include UDP ports"
 	slash                            = "/"
@@ -219,7 +219,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 	sidecar := []string{}
 	udp := []string{}
 	injectDisabled := []string{}
-	uncompatbleNodeOS := []string{}
+	unsupportedOS := []string{}
 	warningsPrinted := verbose
 
 	for _, r := range reports {
@@ -248,7 +248,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 		}
 
 		if r.NodeOS {
-			uncompatbleNodeOS = append(uncompatbleNodeOS, r.ResName())
+			unsupportedOS = append(unsupportedOS, r.ResName())
 			warningsPrinted = true
 		}
 
@@ -280,10 +280,10 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 		output.Write([]byte(fmt.Sprintf("%s %s\n", okStatus, injectDisabledDesc)))
 	}
 
-	if len(uncompatbleNodeOS) > 0 {
-		output.Write([]byte(fmt.Sprintf("%sfollowing node image(s) is Windows %s\n", warnStatus, strings.Join(uncompatbleNodeOS, ", "))))
+	if len(unsupportedOS) > 0 {
+		output.Write([]byte(fmt.Sprintf("%sWindows is currently unsupported %s\n", warnStatus, strings.Join(unsupportedOS, ", "))))
 	} else if verbose {
-		output.Write([]byte(fmt.Sprintf("%s %s\n", okStatus, uncompatbleNodeOSDesc)))
+		output.Write([]byte(fmt.Sprintf("%s %s\n", okStatus, unsupportedOSDesc)))
 	}
 
 	if len(injected) == 0 {

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -26,7 +26,7 @@ const (
 	hostNetworkDesc                  = "pods do not use host networking"
 	sidecarDesc                      = "pods do not have a 3rd party proxy or initContainer already injected"
 	injectDisabledDesc               = "pods are not annotated to disable injection"
-	unsupportedOSDesc    			 = "pods do not run on a windows node"
+	unsupportedOSDesc                = "pods do not run on a windows node"
 	unsupportedDesc                  = "at least one resource injected"
 	udpDesc                          = "pod specs do not include UDP ports"
 	slash                            = "/"

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -281,7 +281,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 	}
 
 	if len(uncompatbleNodeOS) > 0 {
-		output.Write([]byte(fmt.Sprintf("%s node image is Windows%s\n", warnStatus, strings.Join(uncompatbleNodeOS, ", "))))
+		output.Write([]byte(fmt.Sprintf("%sfollowing node image(s) is Windows %s\n", warnStatus, strings.Join(uncompatbleNodeOS, ", "))))
 	} else if verbose {
 		output.Write([]byte(fmt.Sprintf("%s %s\n", okStatus, uncompatbleNodeOSDesc)))
 	}

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -348,6 +348,20 @@ func TestUninjectAndInject(t *testing.T) {
 				k8s.ProxyTraceCollectorSvcAccountAnnotation: "linkerd-collector.linkerd",
 			},
 		},
+		{
+			inputFileName:    "inject_emojivoto_windowstainted.input.yml",
+			goldenFileName:   "inject_emojivoto_windowstainted.golden.yml",
+			reportFileName:   "inject_emojivoto_windowstainted.report",
+			injectProxy:      true,
+			testInjectConfig: defaultConfig,
+		},
+		{
+			inputFileName:    "inject_emojivoto_windowsnodeselector.input.yml",
+			goldenFileName:   "inject_emojivoto_windowsnodeselector.golden.yml",
+			reportFileName:   "inject_emojivoto_windowsnodeselector.report",
+			injectProxy:      true,
+			testInjectConfig: defaultConfig,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 
@@ -11,6 +12,7 @@ deployment "redis" injected
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.report.verbose
@@ -2,6 +2,7 @@
 ‼ "hostNetwork: true" detected in deployment/web
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 ‼ no supported objects found
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 ‼ "linkerd.io/inject: disabled" annotation set on deployment/web
+√ pods do not run on a windows node
 ‼ no supported objects found
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_trace.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_trace.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 ‼ deployment/web uses "protocol: UDP"
 

--- a/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_istio.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 ‼ known 3rd party sidecar detected in deployment/web
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 ‼ no supported objects found
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.golden.yml
@@ -1,0 +1,610 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    linkerd.io/inject: enabled
+  name: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: emoji
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: voting
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: web
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801
+  selector:
+    app: emoji-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: voting-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801
+  selector:
+    app: voting-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: web-svc
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: emoji
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: emoji
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emoji-svc
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+      labels:
+        app: emoji-svc
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: emoji
+        linkerd.io/workload-ns: emojivoto
+    spec:
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: buoyantio/emojivoto-emoji-svc:v10
+        name: emoji-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-dst.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_DESTINATION_GET_NETWORKS
+          value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_TAP_SVC_NAME
+          value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:v1.3.2
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: emoji
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: vote-bot
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-bot
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+      labels:
+        app: vote-bot
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: vote-bot
+        linkerd.io/workload-ns: emojivoto
+    spec:
+      containers:
+      - command:
+        - emojivoto-vote-bot
+        env:
+        - name: WEB_HOST
+          value: web-svc.emojivoto:80
+        image: buoyantio/emojivoto-web:v10
+        name: vote-bot
+        resources:
+          requests:
+            cpu: 10m
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-dst.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_DESTINATION_GET_NETWORKS
+          value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_TAP_SVC_NAME
+          value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:v1.3.2
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: voting
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: voting
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: voting-svc
+  template:
+    metadata:
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/identity-mode: default
+        linkerd.io/proxy-version: test-inject-proxy-version
+      labels:
+        app: voting-svc
+        linkerd.io/control-plane-ns: linkerd
+        linkerd.io/proxy-deployment: voting
+        linkerd.io/workload-ns: emojivoto
+    spec:
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: buoyantio/emojivoto-voting-svc:v10
+        name: voting-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+      - env:
+        - name: LINKERD2_PROXY_LOG
+          value: warn,linkerd=info
+        - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+          value: linkerd-dst.linkerd.svc.cluster.local:8086
+        - name: LINKERD2_PROXY_DESTINATION_GET_NETWORKS
+          value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+        - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+          value: 0.0.0.0:4190
+        - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+          value: 0.0.0.0:4191
+        - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+          value: 127.0.0.1:4140
+        - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+          value: 0.0.0.0:4143
+        - name: LINKERD2_PROXY_DESTINATION_GET_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+          value: svc.cluster.local.
+        - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+          value: 10000ms
+        - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+          value: 10000ms
+        - name: _pod_ns
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+          value: ns:$(_pod_ns)
+        - name: LINKERD2_PROXY_IDENTITY_DIR
+          value: /var/run/linkerd/identity/end-entity
+        - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+          value: |
+            -----BEGIN CERTIFICATE-----
+            MIIBYDCCAQegAwIBAgIBATAKBggqhkjOPQQDAjAYMRYwFAYDVQQDEw1jbHVzdGVy
+            LmxvY2FsMB4XDTE5MDMwMzAxNTk1MloXDTI5MDIyODAyMDM1MlowGDEWMBQGA1UE
+            AxMNY2x1c3Rlci5sb2NhbDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAChpAt0
+            xtgO9qbVtEtDK80N6iCL2Htyf2kIv2m5QkJ1y0TFQi5hTVe3wtspJ8YpZF0pl364
+            6TiYeXB8tOOhIACjQjBAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNHADBE
+            AiBQ/AAwF8kG8VOmRSUTPakSSa/N4mqK2HsZuhQXCmiZHwIgZEzI5DCkpU7w3SIv
+            OLO4Zsk1XrGZHGsmyiEyvYF9lpY=
+            -----END CERTIFICATE-----
+        - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+        - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+          value: linkerd-identity.linkerd.svc.cluster.local:8080
+        - name: _pod_sa
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: _l5d_ns
+          value: linkerd
+        - name: _l5d_trustdomain
+          value: cluster.local
+        - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+          value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+          value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+          value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - name: LINKERD2_PROXY_TAP_SVC_NAME
+          value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        image: gcr.io/linkerd-io/proxy:test-inject-proxy-version
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 4191
+          initialDelaySeconds: 10
+        name: linkerd-proxy
+        ports:
+        - containerPort: 4143
+          name: linkerd-proxy
+        - containerPort: 4191
+          name: linkerd-admin
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 4191
+          initialDelaySeconds: 2
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 2102
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/linkerd/identity/end-entity
+          name: linkerd-identity-end-entity
+      initContainers:
+      - args:
+        - --incoming-proxy-port
+        - "4143"
+        - --outgoing-proxy-port
+        - "4140"
+        - --proxy-uid
+        - "2102"
+        - --inbound-ports-to-ignore
+        - 4190,4191
+        image: gcr.io/linkerd-io/proxy-init:v1.3.2
+        imagePullPolicy: IfNotPresent
+        name: linkerd-init
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: voting
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: linkerd-identity-end-entity
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "8080"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v10
+        name: web-svc
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+      nodeSelector:
+        kubernetes.io/os: Windows
+      serviceAccountName: web
+---

--- a/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.input.yml
@@ -1,0 +1,216 @@
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: emoji
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: voting
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: web
+  namespace: emojivoto
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801
+  selector:
+    app: emoji-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: voting-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801
+  selector:
+    app: voting-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  namespace: emojivoto
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: web-svc
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: emoji
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: emoji
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emoji-svc
+  template:
+    metadata:
+      labels:
+        app: emoji-svc
+    spec:
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: buoyantio/emojivoto-emoji-svc:v10
+        name: emoji-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+      serviceAccountName: emoji
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: vote-bot
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-bot
+  template:
+    metadata:
+      labels:
+        app: vote-bot
+    spec:
+      containers:
+      - command:
+        - emojivoto-vote-bot
+        env:
+        - name: WEB_HOST
+          value: web-svc.emojivoto:80
+        image: buoyantio/emojivoto-web:v10
+        name: vote-bot
+        resources:
+          requests:
+            cpu: 10m
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: voting
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: voting
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: voting-svc
+  template:
+    metadata:
+      labels:
+        app: voting-svc
+    spec:
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: buoyantio/emojivoto-voting-svc:v10
+        name: voting-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+      serviceAccountName: voting
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/part-of: emojivoto
+    app.kubernetes.io/version: v10
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "8080"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v10
+        name: web-svc
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+      nodeSelector:
+        kubernetes.io/os: Windows
+      serviceAccountName: web
+---

--- a/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.report
+++ b/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.report
@@ -1,0 +1,15 @@
+
+‼Windows is currently unsupported deployment/web
+
+namespace "emojivoto" injected
+serviceaccount "emoji" skipped
+serviceaccount "voting" skipped
+serviceaccount "web" skipped
+service "emoji-svc" skipped
+service "voting-svc" skipped
+service "web-svc" skipped
+deployment "emoji" injected
+deployment "vote-bot" injected
+deployment "voting" injected
+deployment "web" skipped
+

--- a/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_windowsnodeselector.report.verbose
@@ -1,0 +1,20 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+‼Windows is currently unsupported deployment/web
+√ at least one resource injected
+√ pod specs do not include UDP ports
+
+namespace "emojivoto" injected
+serviceaccount "emoji" skipped
+serviceaccount "voting" skipped
+serviceaccount "web" skipped
+service "emoji-svc" skipped
+service "voting-svc" skipped
+service "web-svc" skipped
+deployment "emoji" injected
+deployment "vote-bot" injected
+deployment "voting" injected
+deployment "web" skipped
+

--- a/cli/cmd/testdata/inject_emojivoto_windowstainted.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_windowstainted.golden.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      annotations:
+        experimental.windows.kubernetes.io/isolation-type: hyperv
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+      tolerations:
+      - effect: NoSchedule
+        key: OS
+        operator: Equal
+        value: Windows
+---

--- a/cli/cmd/testdata/inject_emojivoto_windowstainted.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_windowstainted.input.yml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      labels:
+        app: web-svc
+      annotations:
+        experimental.windows.kubernetes.io/isolation-type: hyperv
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v3
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+      tolerations:
+        - key: "OS"
+          operator: "Equal"
+          value: "Windows"
+          effect: "NoSchedule"
+
+---

--- a/cli/cmd/testdata/inject_emojivoto_windowstainted.report
+++ b/cli/cmd/testdata/inject_emojivoto_windowstainted.report
@@ -1,0 +1,6 @@
+
+‼Windows is currently unsupported deployment/web
+‼ no supported objects found
+
+deployment "web" skipped
+

--- a/cli/cmd/testdata/inject_emojivoto_windowstainted.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_windowstainted.report.verbose
@@ -1,0 +1,10 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+‼Windows is currently unsupported deployment/web
+‼ no supported objects found
+√ pod specs do not include UDP ports
+
+deployment "web" skipped
+

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/cli/cmd/testdata/inject_tap_deployment_debug.report.verbose
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.report.verbose
@@ -2,6 +2,7 @@
 √ pods do not use host networking
 √ pods do not have a 3rd party proxy or initContainer already injected
 √ pods are not annotated to disable injection
+√ pods do not run on a windows node
 √ at least one resource injected
 √ pod specs do not include UDP ports
 

--- a/controller/gen/public/public.pb.go
+++ b/controller/gen/public/public.pb.go
@@ -1290,8 +1290,10 @@ type TapByResourceRequest_Extract_Http_Headers struct {
 func (m *TapByResourceRequest_Extract_Http_Headers) Reset() {
 	*m = TapByResourceRequest_Extract_Http_Headers{}
 }
-func (m *TapByResourceRequest_Extract_Http_Headers) String() string { return proto.CompactTextString(m) }
-func (*TapByResourceRequest_Extract_Http_Headers) ProtoMessage()    {}
+func (m *TapByResourceRequest_Extract_Http_Headers) String() string {
+	return proto.CompactTextString(m)
+}
+func (*TapByResourceRequest_Extract_Http_Headers) ProtoMessage() {}
 func (*TapByResourceRequest_Extract_Http_Headers) Descriptor() ([]byte, []int) {
 	return fileDescriptor_413a91106d7bcce8, []int{9, 1, 0, 0}
 }

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -8,8 +8,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
 
-	log "github.com/sirupsen/logrus"
-
 )
 
 const (
@@ -157,9 +155,7 @@ func checkNodeOS(t *v1.PodSpec) bool {
 	// Check any pods run a windows image, which is currently unsupported
 	//check the NodeSelector 
 	osimage := t.NodeSelector["kubernetes.io/os"]
-	log.Debugf(osimage)
 	if strings.Contains(strings.ToLower(osimage),"windows") == true {
-		log.Debugf("in loop w ")
 		return false
 	}
 	//check if Node has been tainted

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -21,7 +21,7 @@ const (
 	invalidInjectAnnotationWorkload      = "invalid_inject_annotation_at_workload"
 	invalidInjectAnnotationNamespace     = "invalid_inject_annotation_at_ns"
 	disabledAutomountServiceAccountToken = "disabled_automount_service_account_token_account"
-	UncompatbleNodeOS					 = "node_os_is_windows"
+	uncompatbleNodeOS					 = "node_os_is_windows"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 		invalidInjectAnnotationWorkload:      fmt.Sprintf("invalid value for annotation \"%s\" at workload", k8s.ProxyInjectAnnotation),
 		invalidInjectAnnotationNamespace:     fmt.Sprintf("invalid value for annotation \"%s\" at namespace", k8s.ProxyInjectAnnotation),
 		disabledAutomountServiceAccountToken: fmt.Sprintf("automountServiceAccountToken set to \"false\""),
-		UncompatbleNodeOS:					  fmt.Sprintf("unsupported node image\"%s\"",k8s.Pod),
+		uncompatbleNodeOS:					  fmt.Sprintf("unsupported node image\"%s\"",k8s.Pod),
 	}
 )
 
@@ -130,7 +130,7 @@ func (r *Report) Injectable() (bool, []string) {
 	}
 
 	if r.NodeOS{
-		reasons = append(reasons, UncompatbleNodeOS)
+		reasons = append(reasons, uncompatbleNodeOS)
 	}
 
 	if len(reasons) > 0 {
@@ -155,7 +155,7 @@ func checkNodeOS(t *v1.PodSpec) bool {
 	// Check any pods run a windows image, which is currently unsupported
 	//check the NodeSelector 
 	osimage := t.NodeSelector["kubernetes.io/os"]
-	if strings.Contains(strings.ToLower(osimage),"windows") == true {
+	if strings.Contains(strings.ToLower(osimage),"windows"){
 		return true
 	}
 	//check if Node has been tainted

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -7,7 +7,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
-
 )
 
 const (
@@ -21,7 +20,7 @@ const (
 	invalidInjectAnnotationWorkload      = "invalid_inject_annotation_at_workload"
 	invalidInjectAnnotationNamespace     = "invalid_inject_annotation_at_ns"
 	disabledAutomountServiceAccountToken = "disabled_automount_service_account_token_account"
-	uncompatbleNodeOS					 = "node_os_is_windows"
+	uncompatbleNodeOS                    = "node_os_is_windows"
 )
 
 var (
@@ -35,7 +34,7 @@ var (
 		invalidInjectAnnotationWorkload:      fmt.Sprintf("invalid value for annotation \"%s\" at workload", k8s.ProxyInjectAnnotation),
 		invalidInjectAnnotationNamespace:     fmt.Sprintf("invalid value for annotation \"%s\" at namespace", k8s.ProxyInjectAnnotation),
 		disabledAutomountServiceAccountToken: fmt.Sprintf("automountServiceAccountToken set to \"false\""),
-		uncompatbleNodeOS:					  fmt.Sprintf("unsupported node image\"%s\"",k8s.Pod),
+		uncompatbleNodeOS:                    fmt.Sprintf("unsupported node image\"%s\"", k8s.Pod),
 	}
 )
 
@@ -53,7 +52,7 @@ type Report struct {
 	InjectAnnotationAt           string
 	TracingEnabled               bool
 	AutomountServiceAccountToken bool
-	NodeOS						 bool
+	NodeOS                       bool
 
 	// Uninjected consists of two boolean flags to indicate if a proxy and
 	// proxy-init containers have been uninjected in this report
@@ -129,7 +128,7 @@ func (r *Report) Injectable() (bool, []string) {
 		reasons = append(reasons, disabledAutomountServiceAccountToken)
 	}
 
-	if r.NodeOS{
+	if r.NodeOS {
 		reasons = append(reasons, uncompatbleNodeOS)
 	}
 
@@ -153,15 +152,15 @@ func checkUDPPorts(t *v1.PodSpec) bool {
 
 func checkNodeOS(t *v1.PodSpec) bool {
 	// Check any pods run a windows image, which is currently unsupported
-	//check the NodeSelector 
+	//check the NodeSelector
 	osimage := t.NodeSelector["kubernetes.io/os"]
-	if strings.Contains(strings.ToLower(osimage),"windows"){
+	if strings.Contains(strings.ToLower(osimage), "windows") {
 		return true
 	}
 	//check if Node has been tainted
 	for _, toleration := range t.Tolerations {
 		if strings.ToLower(toleration.Key) == "os" {
-			if toleration.Operator == "Equal" && toleration.Value == "Windows"{
+			if toleration.Operator == "Equal" && toleration.Value == "Windows" {
 				return true
 			}
 		}

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -156,17 +156,17 @@ func checkNodeOS(t *v1.PodSpec) bool {
 	//check the NodeSelector 
 	osimage := t.NodeSelector["kubernetes.io/os"]
 	if strings.Contains(strings.ToLower(osimage),"windows") == true {
-		return false
+		return true
 	}
 	//check if Node has been tainted
 	for _, toleration := range t.Tolerations {
 		if strings.ToLower(toleration.Key) == "os" {
 			if toleration.Operator == "Equal" && toleration.Value == "Windows"{
-				return false
+				return true
 			}
 		}
 	}
-	return true
+	return false
 }
 
 // disabledByAnnotation checks annotations for both workload, namespace and returns


### PR DESCRIPTION
Add a function to detect windows nodes and skip deploying proxies on them

begins implementation to fix #2882 

I have tried to find a solution to this issue but since this is my first time contributing to linkerd as well as my first contribution in golang, I was anxious to get some feedback before I went any further. I am not sure this is the solution you were looking for ... Please forgive me for the mistakes I have probably made and provide as much criticism as you feel necessary :)  
I shall try and implement the suggestions and come up with a final pull request. 

**Implementation**
A field added to the report given to the inject function, indicating when the node has a windows image, and that it should skip the injection of proxy.

The function checks for a windows node image or checks for applied taints with the field 'os'. If neither is found it concludes there are no windows node images. 

Both these are optional fields though, so I think it would be helpful to add this to the documentation if this proposed solution is adopted :)

*TO-DO*
- add documentation on taints
- provide a more elegant warning 

Signed-off-by: Vani Singh <vanisingh@live.co.uk>