### PR TITLE
Upgrade to Helm v3

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -395,7 +395,7 @@ injector to inject the proxy container. Both charts depend on the partials
 subchart which can be found in the [`charts/partials`](charts/partials) folder.
 
 Note that the `charts/linkerd2/values.yaml` file contains a placeholder
-`{version}` that you need to replace with an appropriate string (like
+`linkerdVersionValue` that you need to replace with an appropriate string (like
 `edge-20.2.2`) before proceeding.
 
 During development, please use the [`bin/helm`](bin/helm) wrapper script to

--- a/bin/helm
+++ b/bin/helm
@@ -2,7 +2,7 @@
 
 set -eu
 
-helmversion=v2.16.1
+helmversion=v3.2.1
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin
 helmbin=$targetbin/helm-$helmversion

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -11,7 +11,7 @@ setValues() {
 
 showErr() {
   printf "Error on exit:\n  Exit code: %d\n  Failed command: \"%s\"\n" $? "$BASH_COMMAND"
-  setValues "$fullVersion" "{version}"
+  setValues "$fullVersion" "linkerdVersionValue"
 }
 
 # trap the last failed command
@@ -20,7 +20,6 @@ trap 'showErr' ERR
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
-"$bindir"/helm init --client-only
 "$bindir"/helm lint "$rootdir"/charts/linkerd2-multicluster-remote-setup
 "$bindir"/helm lint "$rootdir"/charts/linkerd2-service-mirror
 "$bindir"/helm lint "$rootdir"/charts/partials
@@ -48,7 +47,7 @@ if [ "$1" = package ]; then
     version=${BASH_REMATCH[2]}
 
     # set version in Values files
-    setValues "{version}" "$fullVersion"
+    setValues "linkerdVersionValue" "$fullVersion"
 
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
@@ -59,5 +58,5 @@ if [ "$1" = package ]; then
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm
 
     # restore version in Values files
-    setValues "$fullVersion" "{version}"
+    setValues "$fullVersion" "linkerdVersionValue"
 fi

--- a/charts/linkerd2-cni/requirements.lock
+++ b/charts/linkerd2-cni/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: partials
   repository: file://../partials
   version: 0.1.0
-digest: sha256:3a86b96a2966f03ba04518723838b49719a3277dfb9bea0b3f067e83d370e0b3
-generated: "2020-01-22T22:42:52.008744+02:00"
+digest: sha256:8e42f9c9d4a2dc883f17f94d6044c97518ced19ad0922f47b8760e47135369ba
+generated: "2020-05-11T14:13:53.188732034-05:00"

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -6,7 +6,7 @@ ignoreInboundPorts: ""
 ignoreOutboundPorts: ""
 createdByAnnotation: linkerd.io/created-by
 cniPluginImage:   "gcr.io/linkerd-io/cni-plugin"
-cniPluginVersion: {version}
+cniPluginVersion: linkerdVersionValue
 logLevel:         info
 portsToRedirect:  ""
 proxyUID:         2102

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -8,7 +8,7 @@ probePeriodSeconds: 3
 probePort: 81
 serviceAccountName: linkerd-service-mirror
 serviceAccountNamespace: linkerd-service-mirror
-linkerdVersion: {version}
+linkerdVersion: linkerdVersionValue
 createdByAnnotation: linkerd.io/created-by
 nginxImageVersion: 1.17
 nginxImage: nginx

--- a/charts/linkerd2-service-mirror/values.yaml
+++ b/charts/linkerd2-service-mirror/values.yaml
@@ -3,5 +3,5 @@ serviceMirrorUID: 2103
 logLevel: info
 eventRequeueLimit: 3
 controllerImage: gcr.io/linkerd-io/controller
-controllerImageVersion: {version}
+controllerImageVersion: linkerdVersionValue
 controllerComponentLabel: linkerd.io/control-plane-component

--- a/charts/linkerd2/requirements.lock
+++ b/charts/linkerd2/requirements.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: tracing
   repository: file://../add-ons/tracing
   version: 0.1.0
-digest: sha256:a6d97da282e157fb155677da3509eb96281c2f2acf8a162347b624a5aa345dad
-generated: "2020-05-01T17:23:55.00505776+05:30"
+digest: sha256:f92907b6d243e3b57b4288603ba76eced7c2f4ef913e76505c314971bb4afa21
+generated: "2020-05-11T14:13:54.306010536-05:00"

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -11,7 +11,7 @@ global:
   controlPlaneTracing: false
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version {version}
+  linkerdVersion: &linkerd_version linkerdVersionValue
 
   namespace: linkerd
 

--- a/charts/patch/requirements.lock
+++ b/charts/patch/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: partials
   repository: file://../partials
   version: 0.1.0
-digest: sha256:3a86b96a2966f03ba04518723838b49719a3277dfb9bea0b3f067e83d370e0b3
-generated: "2019-07-29T17:09:48.260154278-05:00"
+digest: sha256:8e42f9c9d4a2dc883f17f94d6044c97518ced19ad0922f47b8760e47135369ba
+generated: "2020-05-11T14:13:55.334621294-05:00"

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -367,14 +367,14 @@ func TestInstallHelm(t *testing.T) {
 	}
 
 	var chartToInstall string
-	args := []string{"--name", TestHelper.GetHelmReleaseName()}
+	var args []string
 
 	if TestHelper.UpgradeHelmFromVersion() != "" {
 		chartToInstall = TestHelper.GetHelmStableChart()
-		args = append(args, helmOverridesStable(helmTLSCerts)...)
+		args = helmOverridesStable(helmTLSCerts)
 	} else {
 		chartToInstall = TestHelper.GetHelmChart()
-		args = append(args, helmOverridesEdge(helmTLSCerts)...)
+		args = helmOverridesEdge(helmTLSCerts)
 	}
 
 	if stdout, stderr, err := TestHelper.HelmInstall(chartToInstall, args...); err != nil {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -38,7 +38,6 @@ type helm struct {
 	chart              string
 	stableChart        string
 	releaseName        string
-	tillerNs           string
 	upgradeFromVersion string
 }
 
@@ -76,7 +75,6 @@ func NewTestHelper() *TestHelper {
 	helmChart := flag.String("helm-chart", "charts/linkerd2", "path to linkerd2's Helm chart")
 	helmStableChart := flag.String("helm-stable-chart", "linkerd/linkerd2", "path to linkerd2's stable Helm chart")
 	helmReleaseName := flag.String("helm-release", "", "install linkerd via Helm using this release name")
-	tillerNs := flag.String("tiller-ns", "kube-system", "namespace under which Tiller will be installed")
 	upgradeFromVersion := flag.String("upgrade-from-version", "", "when specified, the upgrade test uses it as the base version of the upgrade")
 	clusterDomain := flag.String("cluster-domain", "cluster.local", "when specified, the install test uses a custom cluster domain")
 	externalIssuer := flag.Bool("external-issuer", false, "when specified, the install test uses it to install linkerd with --identity-external-issuer=true")
@@ -118,7 +116,6 @@ func NewTestHelper() *TestHelper {
 			chart:              *helmChart,
 			stableChart:        *helmStableChart,
 			releaseName:        *helmReleaseName,
-			tillerNs:           *tillerNs,
 			upgradeFromVersion: *upgradeHelmFromVersion,
 		},
 		clusterDomain:  *clusterDomain,
@@ -266,7 +263,6 @@ func (h *TestHelper) HelmUpgrade(chart string, arg ...string) (string, string, e
 		"upgrade",
 		h.helm.releaseName,
 		"--kube-context", h.k8sContext,
-		"--tiller-namespace", h.helm.tillerNs,
 		"--set", "global.namespace=" + h.namespace,
 		chart,
 	}, arg...)
@@ -277,11 +273,10 @@ func (h *TestHelper) HelmUpgrade(chart string, arg ...string) (string, string, e
 func (h *TestHelper) HelmInstall(chart string, arg ...string) (string, string, error) {
 	withParams := append([]string{
 		"install",
-		"--kube-context", h.k8sContext,
-		"--tiller-namespace", h.helm.tillerNs,
-		"--name", h.helm.releaseName,
-		"--set", "global.namespace=" + h.namespace,
+		h.helm.releaseName,
 		chart,
+		"--kube-context", h.k8sContext,
+		"--set", "global.namespace=" + h.namespace,
 	}, arg...)
 	return combinedOutput("", h.helm.path, withParams...)
 }


### PR DESCRIPTION
Upgraded to Helm v3.2.1 from v2.16.1, getting rid of Tiller and making
other simplifications.

Note that the version placeholder in the `values.yaml` files had to be
changed from `{version}` to `linkerdVersionValue` because the former
confuses Helm v3.