### PR TITLE
Check that ActualSuccess is greater than 0 in ServiceProfiles test

### DIFF
--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -175,7 +175,7 @@ func TestServiceProfileMetrics(t *testing.T) {
 	}
 
 	assertRouteStat(testUpstreamDeploy, testNamespace, testDownstreamDeploy, t, func(stat *cmd2.JSONRouteStats) error {
-		if *stat.ActualSuccess == 0.00 || *stat.ActualSuccess == 100.00 {
+		if !(*stat.ActualSuccess > 0.00 && *stat.ActualSuccess < 100.00) {
 			return fmt.Errorf("expected Actual Success to be greater than 0%% and less than 100%% due to pre-seeded failure rate. But got %0.2f", *stat.ActualSuccess)
 		}
 		return nil

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -175,8 +175,8 @@ func TestServiceProfileMetrics(t *testing.T) {
 	}
 
 	assertRouteStat(testUpstreamDeploy, testNamespace, testDownstreamDeploy, t, func(stat *cmd2.JSONRouteStats) error {
-		if *stat.ActualSuccess == 100.00 {
-			return fmt.Errorf("expected Actual Success to be less than 100%% due to pre-seeded failure rate. But got %0.2f", *stat.ActualSuccess)
+		if *stat.ActualSuccess == 0.00 || *stat.ActualSuccess == 100.00 {
+			return fmt.Errorf("expected Actual Success to be greater than 0%% and less than 100%% due to pre-seeded failure rate. But got %0.2f", *stat.ActualSuccess)
 		}
 		return nil
 	})
@@ -212,7 +212,7 @@ func TestServiceProfileMetrics(t *testing.T) {
 
 	assertRouteStat(testUpstreamDeploy, testNamespace, testDownstreamDeploy, t, func(stat *cmd2.JSONRouteStats) error {
 		if *stat.EffectiveSuccess < 0.95 {
-			return fmt.Errorf("expected Effective Success to be at least 95%% with retries enabled. But got %.2f", *stat.ActualSuccess)
+			return fmt.Errorf("expected Effective Success to be at least 95%% with retries enabled. But got %.2f", *stat.EffectiveSuccess)
 		}
 		return nil
 	})


### PR DESCRIPTION
#4217 suggests a retries integration test, but this is already tested as part
of the ServiceProfiles test.

In order to fix this issue, an extra check has been added to the assertion of
the `ActualSuccess` value. It now asserts the value is both greater than 0 and
less than 100.

Closes #4217

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>