### PR TITLE
Fix gateway update problems

### DIFF
--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -456,7 +456,6 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ev *RemoteSe
 			})
 		}
 
-		ev.localService.Annotations[consts.RemoteGatewayResourceVersionAnnotation] = gatewaySpec.resourceVersion
 	} else {
 		rcsw.log.Warnf("Could not resolve gateway for %s: %s, nulling endpoints", serviceInfo, err)
 		copiedEndpoints.Subsets = nil
@@ -472,6 +471,10 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ev *RemoteSe
 	ev.localService.Labels = rcsw.getMirroredServiceLabels(&ev.gatewayData)
 	ev.localService.Annotations = rcsw.getMirroredServiceAnnotations(ev.remoteUpdate)
 	ev.localService.Spec.Ports = remapRemoteServicePorts(ev.remoteUpdate.Spec.Ports)
+
+	if gatewaySpec != nil {
+		ev.localService.Annotations[consts.RemoteGatewayResourceVersionAnnotation] = gatewaySpec.resourceVersion
+	}
 
 	if _, err := rcsw.localAPIClient.Client.CoreV1().Services(ev.localService.Namespace).Update(ev.localService); err != nil {
 		return RetryableError{[]error{err}}

--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -289,7 +289,7 @@ func (rcsw *RemoteClusterServiceWatcher) cleanupOrphanedServices() error {
 
 	var errors []error
 	for _, srv := range servicesOnLocalCluster {
-		_, err := rcsw.remoteAPIClient.Svc().Lister().Services(srv.Namespace).Get(rcsw.originalResourceName(srv.Name))
+		remoteSvc, err := rcsw.remoteAPIClient.Svc().Lister().Services(srv.Namespace).Get(rcsw.originalResourceName(srv.Name))
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				// service does not exist anymore. Need to delete
@@ -304,7 +304,7 @@ func (rcsw *RemoteClusterServiceWatcher) cleanupOrphanedServices() error {
 				errors = append(errors, err)
 			}
 		} else {
-			if gtwData := getGatewayMetadata(srv.Annotations); gtwData != nil {
+			if gtwData := getGatewayMetadata(remoteSvc.Annotations); gtwData != nil {
 				gatewaySpec, err := rcsw.resolveGateway(gtwData)
 				if gatewaySpec != nil && err == nil {
 					rcsw.probeEventsSink.send(&MirroredServicePaired{
@@ -442,9 +442,6 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ev *RemoteSe
 			},
 		}
 
-		copiedEndpoints.Labels[consts.RemoteGatewayNameLabel] = ev.gatewayData.Name
-		copiedEndpoints.Labels[consts.RemoteGatewayNsLabel] = ev.gatewayData.Namespace
-
 		if gatewaySpec.identity != "" {
 			copiedEndpoints.Annotations[consts.RemoteGatewayIdentity] = gatewaySpec.identity
 		} else {
@@ -459,10 +456,14 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ev *RemoteSe
 			})
 		}
 
+		ev.localService.Annotations[consts.RemoteGatewayResourceVersionAnnotation] = gatewaySpec.resourceVersion
 	} else {
 		rcsw.log.Warnf("Could not resolve gateway for %s: %s, nulling endpoints", serviceInfo, err)
-		ev.localEndpoints.Subsets = nil
+		copiedEndpoints.Subsets = nil
 	}
+	// we need to set the new name and ns data no matter whether they are valid or not
+	copiedEndpoints.Labels[consts.RemoteGatewayNameLabel] = ev.gatewayData.Name
+	copiedEndpoints.Labels[consts.RemoteGatewayNsLabel] = ev.gatewayData.Namespace
 
 	if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(copiedEndpoints.Namespace).Update(copiedEndpoints); err != nil {
 		return RetryableError{[]error{err}}
@@ -470,7 +471,6 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ev *RemoteSe
 
 	ev.localService.Labels = rcsw.getMirroredServiceLabels(&ev.gatewayData)
 	ev.localService.Annotations = rcsw.getMirroredServiceAnnotations(ev.remoteUpdate)
-	ev.localService.Annotations[consts.RemoteGatewayResourceVersionAnnotation] = gatewaySpec.resourceVersion
 	ev.localService.Spec.Ports = remapRemoteServicePorts(ev.remoteUpdate.Spec.Ports)
 
 	if _, err := rcsw.localAPIClient.Client.CoreV1().Services(ev.localService.Namespace).Update(ev.localService); err != nil {
@@ -613,10 +613,6 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayDeleted(ev *RemoteGa
 func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayUpdated(ev *RemoteGatewayUpdated) error {
 	rcsw.log.Debugf("Updating %d services due to remote gateway [%s/%s] update", len(ev.affectedServices), ev.gatewaySpec.gatewayNamespace, ev.gatewaySpec.gatewayName)
 
-	rcsw.probeEventsSink.send(&GatewayUpdated{
-		GatewaySpec: ev.gatewaySpec,
-	})
-
 	var errors []error
 	for _, svc := range ev.affectedServices {
 		updatedService := svc.DeepCopy()
@@ -654,7 +650,19 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayUpdated(ev *RemoteGa
 			rcsw.localAPIClient.Client.CoreV1().Services(updatedService.Namespace).Delete(updatedService.Name, &metav1.DeleteOptions{})
 			errors = append(errors, err)
 		}
+
+		// we need to repair as this gateway might have been deleted
+		// due to being updated to a state that is not valid anymore
+		rcsw.probeEventsSink.send(&MirroredServicePaired{
+			serviceName:      updatedService.Name,
+			serviceNamespace: updatedService.Namespace,
+			GatewaySpec:      ev.gatewaySpec,
+		})
 	}
+
+	rcsw.probeEventsSink.send(&GatewayUpdated{
+		GatewaySpec: ev.gatewaySpec,
+	})
 
 	if len(errors) > 0 {
 		return RetryableError{errors}
@@ -777,9 +785,17 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateService(service *corev1.S
 			// service we can dispatch a RemoteServiceDeleted event
 			// because at some point in time we mirrored this service,
 			// however it is not mirrorable anymore
+
+			// try to extract the gateway metadata, so we have a well
+			// formed event that we can use to dispatch a service unpaired
+			// event to the probe manager
 			rcsw.eventsQueue.Add(&RemoteServiceDeleted{
 				Name:      service.Name,
 				Namespace: service.Namespace,
+				GatewayData: gatewayMetadata{
+					Name:      localService.Labels[consts.RemoteGatewayNameLabel],
+					Namespace: localService.Labels[consts.RemoteGatewayNsLabel],
+				},
 			})
 		}
 	}
@@ -894,7 +910,6 @@ func (rcsw *RemoteClusterServiceWatcher) processNextEvent() (bool, interface{}, 
 // and deal with retries
 func (rcsw *RemoteClusterServiceWatcher) processEvents() {
 	for {
-
 		done, event, err := rcsw.processNextEvent()
 		// the logic here is that there might have been an API
 		// connectivity glitch or something. So its not a bad idea to requeue

--- a/controller/cmd/service-mirror/cluster_watcher_mirroring_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_mirroring_test.go
@@ -512,6 +512,10 @@ func onAddOrUpdateTestCases(isAdd bool) []mirroringTestCase {
 			expectedEventsInQueue: []interface{}{&RemoteServiceDeleted{
 				Name:      "test-service",
 				Namespace: "test-namespace",
+				GatewayData: gatewayMetadata{
+					Name:      "gateway",
+					Namespace: "gateway-ns",
+				},
 			}},
 
 			expectedLocalServices: []*corev1.Service{

--- a/controller/cmd/service-mirror/cluster_watcher_probe_events_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_probe_events_test.go
@@ -155,6 +155,16 @@ func TestRemoteGatewayUpdatedProbeEvents(t *testing.T) {
 			description: "sends gateway updated when endpoints ports",
 			environment: remoteGatewayUpdated,
 			expectedEventsSentToProbeManager: []interface{}{
+				&MirroredServicePaired{
+					serviceName:      "test-service-1-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "", 999, defaultProbePort, defaultProbePath, defaultProbePeriod),
+				},
+				&MirroredServicePaired{
+					serviceName:      "test-service-2-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "", 999, defaultProbePort, defaultProbePath, defaultProbePeriod),
+				},
 				&GatewayUpdated{
 					GatewaySpec: gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "", 999, defaultProbePort, defaultProbePath, defaultProbePeriod),
 				},
@@ -165,6 +175,16 @@ func TestRemoteGatewayUpdatedProbeEvents(t *testing.T) {
 			description: "sends gateway updated when address changes",
 			environment: gatewayAddressChanged,
 			expectedEventsSentToProbeManager: []interface{}{
+				&MirroredServicePaired{
+					serviceName:      "test-service-1-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", "some-cluster", "0.0.0.1", "currentGatewayResVersion", "", 888, 1, "/p", 222),
+				},
+				&MirroredServicePaired{
+					serviceName:      "test-service-2-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", "some-cluster", "0.0.0.1", "currentGatewayResVersion", "", 888, 1, "/p", 222),
+				},
 				&GatewayUpdated{
 					GatewaySpec: gatewaySpec("gateway", "gateway-ns", "some-cluster", "0.0.0.1", "currentGatewayResVersion", "", 888, 1, "/p", 222),
 				},
@@ -174,6 +194,16 @@ func TestRemoteGatewayUpdatedProbeEvents(t *testing.T) {
 			description: "sends gateway updated when identity changes",
 			environment: gatewayIdentityChanged,
 			expectedEventsSentToProbeManager: []interface{}{
+				&MirroredServicePaired{
+					serviceName:      "test-service-1-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "new-identity", 888, defaultProbePort, defaultProbePath, defaultProbePeriod),
+				},
+				&MirroredServicePaired{
+					serviceName:      "test-service-2-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "new-identity", 888, defaultProbePort, defaultProbePath, defaultProbePeriod),
+				},
 				&GatewayUpdated{
 					GatewaySpec: gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "new-identity", 888, defaultProbePort, defaultProbePath, defaultProbePeriod),
 				},
@@ -183,6 +213,11 @@ func TestRemoteGatewayUpdatedProbeEvents(t *testing.T) {
 			description: "sends gateway updated when probe changes",
 			environment: gatewayProbeConfigChanged,
 			expectedEventsSentToProbeManager: []interface{}{
+				&MirroredServicePaired{
+					serviceName:      "test-service-1-remote",
+					serviceNamespace: "test-namespace",
+					GatewaySpec:      gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "identity", 888, defaultProbePort, "/new-path", defaultProbePeriod),
+				},
 				&GatewayUpdated{
 					GatewaySpec: gatewaySpec("gateway", "gateway-ns", clusterName, "0.0.0.0", "currentGatewayResVersion", "identity", 888, defaultProbePort, "/new-path", defaultProbePeriod),
 				},

--- a/controller/cmd/service-mirror/events_formatting.go
+++ b/controller/cmd/service-mirror/events_formatting.go
@@ -84,7 +84,7 @@ func (rgu RemoteGatewayUpdated) String() string {
 	var services []string
 
 	for _, s := range rgu.affectedServices {
-		services = append(services, fmt.Sprint(s))
+		services = append(services, formatService(s))
 	}
 	return fmt.Sprintf("RemoteGatewayUpdated: {gatewaySpec: %s, affectedServices: [%s]}", rgu.gatewaySpec, strings.Join(services, ","))
 }


### PR DESCRIPTION
This change fixes a a couple of problems where invalid data would be sent to the gateway probe manager and corrupt its state. These were discovered during testing: 

- we now try to repair services each time a gateway update happens (because they might have been unpaired due to a gateway deleted event)
- we avoid sending empty data for gateway name and gateway namespace to the prober even when this data is not present on the remote service anymore.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
