### PR TITLE
Fix quotes in shellscripts

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -26,7 +26,10 @@ init_test_run() {
   test_directory=$bindir/../test
   linkerd_version=$($linkerd_path version --client --short)
   linkerd_namespace=${2:-l5d-integration}
-  k8s_context=${3:-""}
+  k8s_context=${3:-''}
+  export linkerd_version
+  export linkerd_namespace
+  export k8s_context
 
   check_linkerd_binary
   check_if_k8s_reachable
@@ -76,24 +79,25 @@ helm_integration_tests() {
 }
 
 uninstall_integration_tests() {
-    run_test "$test_directory/uninstall/uninstall_test.go" --linkerd-namespace=$linkerd_namespace --uninstall=true
+    run_test "$test_directory/uninstall/uninstall_test.go" --linkerd-namespace="$linkerd_namespace" --uninstall=true
     cleanup
 }
 
 deep_integration_tests() {
-    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace
-    run_test "$(go list $test_directory/.../...)" --linkerd-namespace=$linkerd_namespace
+    run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace"
+    while IFS= read -r line; do tests+=("$line"); done <<< "$(go list "$test_directory"/.../...)"
+    run_test "${tests[@]}" --linkerd-namespace="$linkerd_namespace"
     cleanup
 }
 
 custom_domain_integration_tests() {
-    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace --cluster-domain="custom.domain"
+    run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace" --cluster-domain='custom.domain'
     cleanup
 }
 
 external_issuer_integration_tests() {
-    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-external-issuer --external-issuer=true
-    run_test "$test_directory/externalissuer/external_issuer_test.go" --linkerd-namespace=$linkerd_namespace-external-issuer --external-issuer=true
+    run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace-external-issuer" --external-issuer=true
+    run_test "$test_directory/externalissuer/external_issuer_test.go" --linkerd-namespace="$linkerd_namespace-external-issuer" --external-issuer=true
     cleanup
 }
 
@@ -120,14 +124,14 @@ check_linkerd_binary(){
 check_if_k8s_reachable(){
     printf 'Checking if there is a Kubernetes cluster available...'
     exit_code=0
-    kubectl --context=$k8s_context --request-timeout=5s get ns > /dev/null 2>&1
+    kubectl --context="$k8s_context" --request-timeout=5s get ns > /dev/null 2>&1
     exit_on_err 'error connecting to Kubernetes cluster'
     printf '[ok]\n'
 }
 
 check_if_l5d_exists() {
     printf 'Checking if Linkerd resources exist on cluster...'
-    resources=$(kubectl --context=$k8s_context get all,clusterrole,clusterrolebinding,mutatingwebhookconfigurations,validatingwebhookconfigurations,psp,crd -l linkerd.io/control-plane-ns --all-namespaces -oname)
+    resources=$(kubectl --context="$k8s_context" get all,clusterrole,clusterrolebinding,mutatingwebhookconfigurations,validatingwebhookconfigurations,psp,crd -l linkerd.io/control-plane-ns --all-namespaces -oname)
     if [ -n "$resources" ]; then
         printf '
 Linkerd resources exist on cluster:
@@ -141,7 +145,7 @@ Help:
 }
 
 cleanup() {
-    "$bindir"/test-cleanup $k8s_context > /dev/null 2>&1
+    "$bindir"/test-cleanup "$k8s_context" > /dev/null 2>&1
     exit_on_err 'error removing existing Linkerd resources'
 }
 
@@ -149,9 +153,9 @@ run_test(){
     filename=$1
     shift
 
-    printf 'Test script: [%s] Params: [%s]\n' "$(basename $filename 2>/dev/null || echo $filename )" "$*"
-    GO111MODULE=on go test --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
-    [ $? -ne 0 ] && exit 1
+    printf 'Test script: [%s] Params: [%s]\n' "${filename##*/}" "$*"
+    # Exit on failure here
+    GO111MODULE=on go test --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@" || exit 1
 }
 
 # Install the latest stable release.
@@ -178,8 +182,8 @@ install_stable() {
     exit_on_err 'install_stable() - linkerd check failed'
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
-    kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1
-    kubectl --context=$k8s_context label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
+    kubectl --context="$k8s_context" create namespace "$test_app_namespace" > /dev/null 2>&1
+    kubectl --context="$k8s_context" label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
     (
         set -x
         "$linkerd_path" inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context="$k8s_context" apply --namespace="$test_app_namespace" -f - 2>&1
@@ -191,45 +195,48 @@ install_stable() {
 # this branch.
 # $1 - namespace to use for the stable release
 run_upgrade_test() {
-    local stable_namespace=$1
-    local stable_version=$(latest_stable)
+    local stable_namespace
+    local stable_version
+    stable_namespace=$1
+    stable_version=$(latest_stable)
 
-    install_stable $stable_namespace
-    run_test "$test_directory/install_test.go" --upgrade-from-version=$stable_version --linkerd-namespace=$stable_namespace
+    install_stable "$stable_namespace"
+    run_test "$test_directory/install_test.go" --upgrade-from-version="$stable_version" --linkerd-namespace="$stable_namespace"
 }
 
 setup_helm() {
     (
         set -e
         "$bindir"/helm-build
-        "$helm_path" --kube-context=$k8s_context repo add linkerd https://helm.linkerd.io/stable
+        "$helm_path" --kube-context="$k8s_context" repo add linkerd https://helm.linkerd.io/stable
     )
     exit_on_err 'error setting up Helm'
 }
 
 run_helm_upgrade_test() {
     setup_helm
-    local stable_version=$(latest_stable)
-    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-helm \
-        --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart="linkerd/linkerd2" --helm-release=$helm_release_name --upgrade-helm-from-version="$stable_version"
+    local stable_version
+    stable_version=$(latest_stable)
+    run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace-helm" \
+        --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart='linkerd/linkerd2' --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
 }
 
 run_helm_test() {
     setup_helm
-    run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-helm \
-        --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-release=$helm_release_name
+    run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace-helm" \
+        --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-release="$helm_release_name"
 }
 
 helm_cleanup() {
     (
         set -e
         # `helm delete` deletes $linkerd_namespace-helm
-        "$helm_path" --kube-context=$k8s_context delete $helm_release_name
+        "$helm_path" --kube-context="$k8s_context" delete "$helm_release_name"
         # `helm delete` doesn't wait for resources to be deleted, so we wait explicitly.
         # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
         # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
         # We don't have that problem with global resources, so no need to wait for them to be gone.
-        kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=120s
+        kubectl wait --for=delete ns/"$linkerd_namespace-helm" --timeout=120s
     )
     exit_on_err 'error cleaning up Helm'
 }

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -28,10 +28,12 @@ get_extra_options() {
     for var in http_proxy https_proxy no_proxy; do
         [ -z "${!var:-}" ] || options="$options --build-arg '$var=${!var}'"
     done
-    echo $options
+    echo "$options"
 }
 
 tag=$(head_root_tag)
+# We want wordsplit for the extra options here:
+# shellcheck disable=SC2046
 docker_build proxy "$tag" "$dockerfile" \
   --build-arg "LINKERD_VERSION=$tag" \
   $(get_extra_options)

--- a/bin/shellcheck-all
+++ b/bin/shellcheck-all
@@ -13,10 +13,6 @@ rootdir=$( cd "$bindir"/.. && pwd )
 # We want the word splitting for the shellcheck arguments
 # shellcheck disable=SC2046
 "$bindir"/shellcheck -x -P "$bindir" $(find "$rootdir" -type f \
-		! -path "$bindir"/docker-build-proxy \
-		! -path "$bindir"/_log.sh \
 		! -path "$bindir"/test-cleanup \
-		! -path "$bindir"/_test-run.sh \
-		! -path "$rootdir"/cni-plugin/deployment/scripts/install-cni.sh \
 		! -path "$rootdir"/.git/hooks/\*.sample \
 		| while read -r f; do [ "$(file -b --mime-type "$f")" = 'text/x-shellscript' ] && printf '%s\0' "$f"; done | xargs -0)

--- a/bin/update-codegen.sh
+++ b/bin/update-codegen.sh
@@ -21,11 +21,11 @@ rm -rf "${GOPATH}/src/${ROOT_PACKAGE}/controller/gen"
 chmod +x "${codegen_pkg}/generate-groups.sh"
 
 # run the code-generator entrypoint script
-GO111MODULE="on" "${codegen_pkg}/generate-groups.sh" \
-  "deepcopy,client,informer,lister" \
+GO111MODULE='on' "${codegen_pkg}/generate-groups.sh" \
+  'deepcopy,client,informer,lister' \
   "${ROOT_PACKAGE}/controller/gen/client" \
   "${ROOT_PACKAGE}/controller/gen/apis" \
   "${CUSTOM_RESOURCE_NAME}:${CUSTOM_RESOURCE_VERSION}"
 
 # copy generated code out of GOPATH
-cp -R "${GOPATH}/src/${ROOT_PACKAGE}/controller/gen" "controller/"
+cp -R "${GOPATH}/src/${ROOT_PACKAGE}/controller/gen" 'controller/'

--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -130,7 +130,7 @@ if [ -f "${SERVICE_ACCOUNT_PATH}/token" ]; then
     echo 'KUBERNETES_SERVICE_PORT not set'; exit 1;
   fi
 
-  if [ "${SKIP_TLS_VERIFY}" = "true" ]; then
+  if [ "${SKIP_TLS_VERIFY}" = 'true' ]; then
     TLS_CFG='insecure-skip-tls-verify: true'
   elif [ -f "${KUBE_CA_FILE}" ]; then
     TLS_CFG="certificate-authority-data: $(base64 "${KUBE_CA_FILE}" | tr -d '\n')"
@@ -166,8 +166,8 @@ EOF
 fi
 
 # Insert any of the supported "auto" parameters.
-grep "__KUBERNETES_SERVICE_HOST__" ${TMP_CONF} && sed -i s/__KUBERNETES_SERVICE_HOST__/"${KUBERNETES_SERVICE_HOST}"/g ${TMP_CONF}
-grep "__KUBERNETES_SERVICE_PORT__" ${TMP_CONF} && sed -i s/__KUBERNETES_SERVICE_PORT__/"${KUBERNETES_SERVICE_PORT}"/g ${TMP_CONF}
+grep '__KUBERNETES_SERVICE_HOST__' ${TMP_CONF} && sed -i s/__KUBERNETES_SERVICE_HOST__/"${KUBERNETES_SERVICE_HOST}"/g ${TMP_CONF}
+grep '__KUBERNETES_SERVICE_PORT__' ${TMP_CONF} && sed -i s/__KUBERNETES_SERVICE_PORT__/"${KUBERNETES_SERVICE_PORT}"/g ${TMP_CONF}
 sed -i s/__KUBERNETES_NODE_NAME__/"${KUBERNETES_NODE_NAME:-$(hostname)}"/g ${TMP_CONF}
 sed -i s/__KUBECONFIG_FILENAME__/"${KUBECONFIG_FILE_NAME}"/g ${TMP_CONF}
 sed -i s/__CNI_MTU__/"${CNI_MTU:-1500}"/g ${TMP_CONF}
@@ -192,9 +192,9 @@ if [ -e "${CNI_CONF_FILE}" ]; then
 fi
 
 # If the old config filename ends with .conf, rename it to .conflist, because it has changed to be a list
-filename=$(basename -- "${CNI_CONF_PATH}")
+filename=${CNI_CONF_PATH##*/}
 extension="${filename##*.}"
-if [ "${filename}" != "01-linkerd-cni.conf" ] && [ "${extension}" = "conf" ]; then
+if [ "${filename}" != '01-linkerd-cni.conf' ] && [ "${extension}" = 'conf' ]; then
   echo "Renaming ${CNI_CONF_PATH} extension to .conflist"
   CNI_CONF_PATH="${CNI_CONF_PATH}list"
 fi
@@ -214,7 +214,7 @@ echo "Created CNI config ${CNI_CONF_PATH}"
 # This prevents Kubernetes from restarting the pod repeatedly.
 should_sleep=${SLEEP:-"true"}
 echo "Done configuring CNI. Sleep=$should_sleep"
-while [ "${should_sleep}" = "true"  ]; do
+while [ "${should_sleep}" = 'true'  ]; do
   sleep infinity &
   wait $!
 done


### PR DESCRIPTION
- Add quotes where missing, to handle whitespace & c:o.
- Use single quotes for non-expansion strings.
- Fix quotes were the current would cause errors.

Signed-off-by: Joakim Roubert <joakim.roubert@axis.com>
