### PR TITLE
Flaky tests: when installation test fails, fetch logs and events

### DIFF
--- a/bin/test-run
+++ b/bin/test-run
@@ -4,8 +4,9 @@
 # 1. upgrade_integration_tests
 # 2. helm_integration_tests
 # 3. helm_upgrade_integration_tests
-# 4. deep_integration_tests
-# 5. external_issuer_integration_tests
+# 4. uninstall_integration_tests
+# 5. deep_integration_tests
+# 6. external_issuer_integration_tests
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -33,15 +33,15 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	// if the test failed, show logs and events that can potentially explain cause
 	if code != 0 && controlPlaneInstalled {
-		_, logs := fetchAndCheckLogs()
-		for _, err := range logs {
+		_, errs1 := fetchAndCheckLogs()
+		for _, err := range errs1 {
 			fmt.Println(err)
 		}
-		evts := fetchAndCheckEvents()
-		for _, err := range evts {
+		errs2 := fetchAndCheckEvents()
+		for _, err := range errs2 {
 			fmt.Println(err)
 		}
-		if len(logs) == 0 && len(evts) == 0 {
+		if len(errs1) == 0 && len(errs2) == 0 {
 			fmt.Println("No unexpected or events found")
 		}
 	}

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -22,17 +23,27 @@ import (
 var (
 	TestHelper *testutil.TestHelper
 
-	// fetchLogsEvents is a switch to enable calling Testlogs and TestEvents
-	// when a test fails
-	fetchLogsEvents = false
+	// controlPlaneInstalled becomes true as soon as there's a CP available to
+	// retrieve logs from
+	controlPlaneInstalled = false
 )
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
 	code := m.Run()
 	// if the test failed, show logs and events that can potentially explain cause
-	if code != 0 && fetchLogsEvents {
-		TestHelper.RunLogsAndEventTests()
+	if code != 0 && controlPlaneInstalled {
+		_, logs := fetchAndCheckLogs()
+		for _, err := range logs {
+			fmt.Println(err)
+		}
+		evts := fetchAndCheckEvents()
+		for _, err := range evts {
+			fmt.Println(err)
+		}
+		if len(logs) == 0 && len(evts) == 0 {
+			fmt.Println("No unexpected or events found")
+		}
 	}
 	os.Exit(code)
 }
@@ -206,8 +217,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	if TestHelper.GetHelmReleaseName() != "" {
 		return
 	}
-	// as of this point, fetch logs and events if any test fails
-	fetchLogsEvents = true
+	controlPlaneInstalled = true
 
 	var (
 		cmd  = "install"
@@ -370,8 +380,7 @@ func TestInstallHelm(t *testing.T) {
 	if TestHelper.GetHelmReleaseName() == "" {
 		return
 	}
-	// as of this point, fetch logs and events if any test fails
-	fetchLogsEvents = true
+	controlPlaneInstalled = true
 
 	cn := fmt.Sprintf("identity.%s.cluster.local", TestHelper.GetLinkerdNamespace())
 	var err error
@@ -410,7 +419,7 @@ func TestResourcesPostInstall(t *testing.T) {
 	for _, svc := range linkerdSvcs {
 		if err := TestHelper.CheckService(TestHelper.GetLinkerdNamespace(), svc); err != nil {
 			testutil.AnnotatedErrorf(t, fmt.Sprintf("error validating service [%s]", svc),
-				"rrror validating service [%s]:\n%s", svc, err)
+				"error validating service [%s]:\n%s", svc, err)
 		}
 	}
 
@@ -735,9 +744,9 @@ func TestCheckProxy(t *testing.T) {
 	}
 }
 
-func TestLogs(t *testing.T) {
-	// as of this point, don't fetch logs nor events if any test fails
-	fetchLogsEvents = false
+func fetchAndCheckLogs() ([]string, []error) {
+	okMessages := []string{}
+	errs := []error{}
 
 	controllerRegex := regexp.MustCompile("level=(panic|fatal|error|warn)")
 	proxyRegex := regexp.MustCompile(fmt.Sprintf("%s (ERR|WARN)", k8s.ProxyContainerName))
@@ -761,85 +770,96 @@ func TestLogs(t *testing.T) {
 				knownErrorsRegex = knownProxyErrorsRegex
 			}
 
-			t.Run(name, func(t *testing.T) {
-				outputStream, err := TestHelper.LinkerdRunStream(
-					"logs", "--no-color",
-					"--control-plane-component", deploy,
-					"--container", container,
-				)
-				if err != nil {
-					testutil.AnnotatedErrorf(t, "error running command",
-						"error running command:\n%s", err)
-				}
-				defer outputStream.Stop()
-				// Ignore the error returned, since ReadUntil will return an error if it
-				// does not return 10,000 after 2 seconds. We don't need 10,000 log lines.
-				outputLines, _ := outputStream.ReadUntil(10000, 2*time.Second)
+			outputStream, err := TestHelper.LinkerdRunStream(
+				"logs", "--no-color",
+				"--control-plane-component", deploy,
+				"--container", container,
+			)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error running command:\n%s", err))
+				continue
+			}
+			defer outputStream.Stop()
+			// Ignore the error returned, since ReadUntil will return an error if it
+			// does not return 10,000 after 2 seconds. We don't need 10,000 log lines.
+			outputLines, _ := outputStream.ReadUntil(10000, 2*time.Second)
+			if len(outputLines) == 0 {
+				// Retry one time for 30 more seconds, in case the cluster is slow to
+				// produce log lines.
+				outputLines, _ = outputStream.ReadUntil(10000, 30*time.Second)
 				if len(outputLines) == 0 {
-					// Retry one time for 30 more seconds, in case the cluster is slow to
-					// produce log lines.
-					outputLines, _ = outputStream.ReadUntil(10000, 30*time.Second)
-					if len(outputLines) == 0 {
-						testutil.AnnotatedErrorf(t, "no logs found for %s", name)
-					}
+					errs = append(errs, fmt.Errorf("no logs found for %s", name))
 				}
+			}
 
-				for _, line := range outputLines {
-					if errRegex.MatchString(line) {
-						if knownErrorsRegex.MatchString(line) {
-							// report all known logging errors in the output
-							t.Logf("Found known error in %s log: %s", name, line)
+			for _, line := range outputLines {
+				if errRegex.MatchString(line) {
+					if knownErrorsRegex.MatchString(line) {
+						// report all known logging errors in the output
+						okMessages = append(okMessages, fmt.Sprintf("found known error in %s log: %s", name, line))
+					} else {
+						if proxy {
+							okMessages = append(okMessages, fmt.Sprintf("found unexpected proxy error in %s log: %s", name, line))
 						} else {
-							if proxy {
-								t.Logf("Found unexpected proxy error in %s log: %s", name, line)
-							} else {
-								testutil.AnnotatedErrorf(t,
-									"Found unexpected controller error in %s log: %s", name, line)
-							}
+							errs = append(errs, fmt.Errorf("found unexpected controller error in %s log: %s", name, line))
 						}
 					}
-					if clientGoRegex.MatchString((line)) {
-						hasClientGoLogs = true
-					}
 				}
-			})
+				if clientGoRegex.MatchString((line)) {
+					hasClientGoLogs = true
+				}
+			}
 		}
 	}
 	if !hasClientGoLogs {
-		testutil.AnnotatedError(t, "didn't find any client-go entries")
+		errs = append(errs, errors.New("didn't find any client-go entries"))
+	}
+
+	return okMessages, errs
+}
+
+func TestLogs(t *testing.T) {
+	okMessages, errs := fetchAndCheckLogs()
+	for msg := range okMessages {
+		t.Log(msg)
+	}
+	for err := range errs {
+		testutil.AnnotatedError(t, "Error checking logs", err)
 	}
 }
 
-func TestEvents(t *testing.T) {
+func fetchAndCheckEvents() []error {
 	out, err := TestHelper.Kubectl("",
 		"--namespace", TestHelper.GetLinkerdNamespace(),
 		"get", "events", "-ojson",
 	)
 	if err != nil {
-		testutil.AnnotatedErrorf(t, "'kubectl get events' command failed",
-			"'kubectl get events' command failed with %s\n%s", err, out)
+		return []error{fmt.Errorf("'kubectl get events' command failed with %s\n%s", err, out)}
 	}
 
 	events, err := testutil.ParseEvents(out)
 	if err != nil {
-		testutil.AnnotatedError(t, "error parsing events", err)
+		return []error{err}
 	}
 
-	var unknownEvents []string
+	errs := []error{}
 	for _, e := range events {
 		if e.Type == corev1.EventTypeNormal {
 			continue
 		}
 
-		evtStr := fmt.Sprintf("Reason: [%s] Object: [%s] Message: [%s]", e.Reason, e.InvolvedObject.Name, e.Message)
+		evtStr := fmt.Errorf("found unexpected warning event: reason: [%s] Object: [%s] Message: [%s]", e.Reason, e.InvolvedObject.Name, e.Message)
 		if !knownEventWarningsRegex.MatchString(e.Message) {
-			unknownEvents = append(unknownEvents, evtStr)
+			errs = append(errs, evtStr)
 		}
 	}
 
-	if len(unknownEvents) > 0 {
-		testutil.AnnotatedErrorf(t, "found unexpected warning events",
-			"found unexpected warning events:\n%s", strings.Join(unknownEvents, "\n"))
+	return errs
+}
+
+func TestEvents(t *testing.T) {
+	for err := range fetchAndCheckEvents() {
+		testutil.AnnotatedError(t, "Error checking events", err)
 	}
 }
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -22,8 +22,8 @@ import (
 var (
 	TestHelper *testutil.TestHelper
 
-	// fetchLogsEvents delimits the tests for which a failure triggers running
-	// the Testlogs and TestEvents tests
+	// fetchLogsEvents is a switch to enable calling Testlogs and TestEvents
+	// when a test fails
 	fetchLogsEvents = false
 )
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 			fmt.Println(err)
 		}
 		if len(errs1) == 0 && len(errs2) == 0 {
-			fmt.Println("No unexpected or events found")
+			fmt.Println("No unexpected log entries or events found")
 		}
 	}
 	os.Exit(code)

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -366,29 +366,6 @@ func (h *TestHelper) HTTPGetURL(url string) (string, error) {
 	return body, err
 }
 
-// RunLogsAndEventTests runs the TestLogs and TestEvents tests in a separate
-// process
-func (h *TestHelper) RunLogsAndEventTests() {
-	args := []string{"test", "-v", ".",
-		"-integration-tests",
-		"-linkerd", h.linkerd,
-		"-run",
-	}
-	out, err := exec.Command("go", append(args, "TestLogs")...).Output()
-	if err != nil {
-		fmt.Println(string(out))
-	} else {
-		fmt.Println("No unexpected log entries were found")
-	}
-
-	out, err = exec.Command("go", append(args, "TestEvents")...).Output()
-	if err != nil {
-		fmt.Println(string(out))
-	} else {
-		fmt.Println("No unexpected warning events were found")
-	}
-}
-
 // ReadFile reads a file from disk and returns the contents as a string.
 func ReadFile(file string) (string, error) {
 	b, err := ioutil.ReadFile(file)

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -26,7 +26,6 @@ type TestHelper struct {
 	namespace          string
 	upgradeFromVersion string
 	clusterDomain      string
-	run                string
 	externalIssuer     bool
 	uninstall          bool
 	httpClient         http.Client
@@ -83,7 +82,6 @@ func NewTestHelper() *TestHelper {
 	verbose := flag.Bool("verbose", false, "turn on debug logging")
 	upgradeHelmFromVersion := flag.String("upgrade-helm-from-version", "", "Indicate a version of the Linkerd helm chart from which the helm installation is being upgraded")
 	uninstall := flag.Bool("uninstall", false, "whether to run the 'linkerd uninstall' integration test")
-	run := flag.String("run", "", "specific test to run")
 	flag.Parse()
 
 	if !*runTests {
@@ -121,7 +119,6 @@ func NewTestHelper() *TestHelper {
 			upgradeFromVersion: *upgradeHelmFromVersion,
 		},
 		clusterDomain:  *clusterDomain,
-		run:            *run,
 		externalIssuer: *externalIssuer,
 		uninstall:      *uninstall,
 	}
@@ -372,10 +369,6 @@ func (h *TestHelper) HTTPGetURL(url string) (string, error) {
 // RunLogsAndEventTests runs the TestLogs and TestEvents tests in a separate
 // process
 func (h *TestHelper) RunLogsAndEventTests() {
-	// don't run for tests that were singled out
-	if h.run != "" {
-		return
-	}
 	args := []string{"test", "-v", ".",
 		"-integration-tests",
 		"-linkerd", h.linkerd,


### PR DESCRIPTION
Re #4371

When a test fails in `./test/install_test.go`, trigger the `TestLogs`
and `TestEvents` tests in a separate process in order to output any
unexpected logs/events that might have caused the initial test failure.

For instance, currently we're sporadically experiencing pod restarts.
Instead of ignoring them, this might help provide us with the real
underlying cause.