### PR TITLE
Added documentation for alpha cli command

### DIFF
--- a/cli/cmd/alpha.go
+++ b/cli/cmd/alpha.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newCmdAlpha creates a new cobra command for the `alpha` command which are
-// used by experimental subcommands for Linkerd
+// newCmdAlpha creates a new cobra command `alpha` which is used by experimental subcommands
+// for linkerd
 func newCmdAlpha() *cobra.Command {
 	alphaCmd := &cobra.Command{
 		Use:   "alpha",

--- a/cli/cmd/alpha.go
+++ b/cli/cmd/alpha.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// newCmdAlpha creates a new cobra command for the `alpha` command which are
+// used by experimental subcommands for Linkerd
 func newCmdAlpha() *cobra.Command {
 	alphaCmd := &cobra.Command{
 		Use:   "alpha",

--- a/cli/cmd/alpha.go
+++ b/cli/cmd/alpha.go
@@ -4,8 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newCmdAlpha creates a new cobra command `alpha` which is used by experimental subcommands
-// for linkerd
+// newCmdAlpha creates a new cobra command `alpha` which contains experimental subcommands for linkerd
 func newCmdAlpha() *cobra.Command {
 	alphaCmd := &cobra.Command{
 		Use:   "alpha",

--- a/cli/cmd/alpha_clients.go
+++ b/cli/cmd/alpha_clients.go
@@ -12,10 +12,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// alphaClientsOptions holds values for command line flags that apply to the alpha
+// clients command. All fields in this struct should have corresponding flags added in
+// the newCmdAlphaClients func later in this file.
 type alphaClientsOptions struct {
 	namespace string
 }
 
+// newCmdAlphaClients creates a new cobra command for the `alpha clients` subcommand which
+// display client-side traffic stats to a resource. [Experimental]
 func newCmdAlphaClients() *cobra.Command {
 	options := alphaClientsOptions{
 		namespace: corev1.NamespaceDefault,

--- a/cli/cmd/alpha_stat.go
+++ b/cli/cmd/alpha_stat.go
@@ -167,7 +167,6 @@ func buildToResource(namespace, to string) *public.Resource {
 	return &toResource
 }
 
-
 // renderTrafficMetrics will render a table with a single row to the given Writer.
 // It will render or hide columns according to the outbound restrictions requested via flags.
 func renderTrafficMetrics(metrics *v1alpha1.TrafficMetrics, allNamespaces bool, w io.Writer) {
@@ -266,8 +265,7 @@ func metricsToRow(metrics *v1alpha1.TrafficMetrics, direction string) []string {
 	}
 }
 
-
-// buildTable will build a table.Table according to the outbound restrictions requested.
+// buildTable will build a table.Table according to the outbound restrictions requested .
 func buildTable(outbound, allNamespaces bool) table.Table {
 	columns := []table.Column{
 		table.Column{

--- a/cli/cmd/alpha_stat.go
+++ b/cli/cmd/alpha_stat.go
@@ -154,8 +154,6 @@ Examples:
 	return statCmd
 }
 
-// buildToResource builds a *public.Resource that represents the destination which
-// outbounds will be restricted to.
 func buildToResource(namespace, to string) *public.Resource {
 	toResource, err := util.BuildResource(namespace, to)
 	if err != nil {
@@ -167,16 +165,12 @@ func buildToResource(namespace, to string) *public.Resource {
 	return &toResource
 }
 
-// renderTrafficMetrics will render a table with a single row to the given Writer.
-// It will render or hide columns according to the outbound restrictions requested via flags.
 func renderTrafficMetrics(metrics *v1alpha1.TrafficMetrics, allNamespaces bool, w io.Writer) {
 	t := buildTable(false, allNamespaces)
 	t.Data = []table.Row{metricsToRow(metrics, "")}
 	t.Render(w)
 }
 
-// renderTrafficMetricsList will render a table to the given Writer.
-// It will render or hide columns according to the outbound restrictions requested via flags.
 func renderTrafficMetricsList(metrics *v1alpha1.TrafficMetricsList, allNamespaces bool, w io.Writer) {
 	t := buildTable(false, allNamespaces)
 	t.Data = []table.Row{}
@@ -188,7 +182,7 @@ func renderTrafficMetricsList(metrics *v1alpha1.TrafficMetricsList, allNamespace
 }
 
 // renderTrafficMetricsEdgesList will render a table to the given Writer.
-// Rows will be filtered to make sure that only traffic directed to the resource requested by the `--to` flag
+// Rows will be filtered to make sure that only traffic directed to the resource requested by the `--to` flag is shown
 func renderTrafficMetricsEdgesList(metrics *v1alpha1.TrafficMetricsList, w io.Writer, toResource *public.Resource, direction string) {
 	t := buildTable(true, false)
 	t.Data = []table.Row{}
@@ -208,7 +202,6 @@ func renderTrafficMetricsEdgesList(metrics *v1alpha1.TrafficMetricsList, w io.Wr
 	t.Render(w)
 }
 
-// getNumericMetric will return a numerical representation of a metric as decimal
 func getNumericMetric(metrics *v1alpha1.TrafficMetrics, name string) *resource.Quantity {
 	for _, m := range metrics.Metrics {
 		if m.Name == name {
@@ -218,7 +211,6 @@ func getNumericMetric(metrics *v1alpha1.TrafficMetrics, name string) *resource.Q
 	return resource.NewQuantity(0, resource.DecimalSI)
 }
 
-// getNumericMetricWithUnit will return a numerical representation of a metric concatenated with its unit
 func getNumericMetricWithUnit(metrics *v1alpha1.TrafficMetrics, name string) string {
 	for _, m := range metrics.Metrics {
 		if m.Name == name {
@@ -229,8 +221,6 @@ func getNumericMetricWithUnit(metrics *v1alpha1.TrafficMetrics, name string) str
 	return ""
 }
 
-// metricsToRow will receive traffic metrics and transform them to a slice of strings
-// that represents a human readable row.
 func metricsToRow(metrics *v1alpha1.TrafficMetrics, direction string) []string {
 	success := getNumericMetric(metrics, "success_count").MilliValue()
 	failure := getNumericMetric(metrics, "failure_count").MilliValue()
@@ -265,7 +255,6 @@ func metricsToRow(metrics *v1alpha1.TrafficMetrics, direction string) []string {
 	}
 }
 
-// buildTable will build a table.Table according to the outbound restrictions requested .
 func buildTable(outbound, allNamespaces bool) table.Table {
 	columns := []table.Column{
 		table.Column{

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -80,7 +80,7 @@ func newCmdProfile() *cobra.Command {
 		Short: "Output service profile config for Kubernetes",
 		Long:  "Output service profile config for Kubernetes.",
 		Example: `  # Output a basic template to apply after modification.
-  linkerd profile -n emoijvoto --template web-svc
+  linkerd profile -n emojivoto --template web-svc
 
   # Generate a profile from an OpenAPI specification.
   linkerd profile -n emojivoto --open-api web-svc.swagger web-svc


### PR DESCRIPTION
Added comments to document several methods and structs on cmd package. Based on GoDoc guidelines. Focus on alpha cli command

Signed-off-by: arthursens <arthursens2005@gmail.com>




This is the first of several PRs that I plan on opening to improve code documentation, following [GoDoc guidelines](https://blog.golang.org/godoc-documenting-go-code). As requested on #216 
