### PR TITLE
Introduce support for authenticated docker registries using imagePull…

### DIFF
--- a/charts/add-ons/grafana/templates/grafana-rbac.yaml
+++ b/charts/add-ons/grafana/templates/grafana-rbac.yaml
@@ -11,3 +11,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: grafana
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/add-ons/tracing/templates/tracing-rbac.yaml
+++ b/charts/add-ons/tracing/templates/tracing-rbac.yaml
@@ -11,6 +11,8 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: {{.Values.collector.name}}
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent:2 }}
 ---
 ###
 ### linkerd-jaeger RBAC
@@ -24,3 +26,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: {{.Values.jaeger.name}}
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/linkerd2/templates/controller-rbac.yaml
+++ b/charts/linkerd2/templates/controller-rbac.yaml
@@ -51,3 +51,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: controller
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -51,3 +51,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: destination
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/linkerd2/templates/heartbeat-rbac.yaml
+++ b/charts/linkerd2/templates/heartbeat-rbac.yaml
@@ -41,4 +41,6 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: heartbeat
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 {{- end }}

--- a/charts/linkerd2/templates/identity-rbac.yaml
+++ b/charts/linkerd2/templates/identity-rbac.yaml
@@ -46,4 +46,6 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: identity
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 {{ end -}}

--- a/charts/linkerd2/templates/prometheus-rbac.yaml
+++ b/charts/linkerd2/templates/prometheus-rbac.yaml
@@ -39,3 +39,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: prometheus
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -52,6 +52,8 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: proxy-injector
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/smi-metrics-rbac.yaml
+++ b/charts/linkerd2/templates/smi-metrics-rbac.yaml
@@ -12,6 +12,8 @@ metadata:
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
   name: linkerd-smi-metrics
   namespace: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/linkerd2/templates/sp-validator-rbac.yaml
+++ b/charts/linkerd2/templates/sp-validator-rbac.yaml
@@ -40,6 +40,8 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: sp-validator
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 ---
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -73,6 +73,8 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: tap
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/linkerd2/templates/web-rbac.yaml
+++ b/charts/linkerd2/templates/web-rbac.yaml
@@ -101,8 +101,8 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-web
   namespace: {{.Values.global.namespace}}
----
 {{- end}}
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -111,3 +111,5 @@ metadata:
   labels:
     {{.Values.global.controllerComponentLabel}}: web
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
+imagePullSecrets:
+{{toYaml .Values.global.imagePullSecrets | indent 2 }}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -6,6 +6,7 @@
 global:
   clusterDomain: &cluster_domain cluster.local
   imagePullPolicy: &image_pull_policy IfNotPresent
+  imagePullSecrets: []
 
   # control plane trace configuration
   controlPlaneTracing: false


### PR DESCRIPTION
…Secrets

Problem: Private Docker Registries are not supported for the moment as detailed in issue #4413

Solution: Every Service Account of linkerd subcomponents are Attached with imagePullSecrets,
which in turn can then pulls the docker images from authenticated private registries using them.
The imagePullSecret is configured in global.imagePullSecret parameter of values.yaml like

imagePullSecret:
  - name: <name-of-private-registry-secret-resource>

Fixes #4413

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
