### PR TITLE
Fix SC1090 shellcheck issues in shell script files

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -79,37 +79,19 @@ jobs:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
         find ./bin -type f \
-        ! -name build-cli-bin \
-        ! -name docker-build-base \
-        ! -name docker-build-cli-bin \
-        ! -name docker-build-cni-plugin \
-        ! -name docker-build-controller \
-        ! -name docker-build-debug \
-        ! -name docker-build-go-deps \
-        ! -name docker-build-grafana \
         ! -name docker-build-proxy \
-        ! -name docker-build-web \
-        ! -name docker-images \
-        ! -name docker-pull \
-        ! -name docker-pull-binaries \
-        ! -name docker-pull-deps \
-        ! -name docker-push \
-        ! -name docker-push-deps \
-        ! -name docker-retag-all \
         ! -name _docker.sh \
         ! -name fmt \
         ! -name lint \
         ! -name _log.sh \
         ! -name minikube-start-hyperv.bat \
         ! -name protoc-go.sh \
-        ! -name root-tag \
         ! -name _tag.sh \
         ! -name test-cleanup \
         ! -name test-clouds-cleanup \
         ! -name test-clouds \
-        ! -name test-run \
         ! -name _test-run.sh \
         ! -name update-go-deps-shas \
         ! -name *.nuspec \
         ! -name *.ps1 \
-        | xargs -I {} bin/shellcheck -x {}
+        | xargs -I {} bin/shellcheck -x -P ./bin {}

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -2,6 +2,7 @@ set -eu
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_log.sh
 . "$bindir"/_log.sh
 
 # TODO this should be set to the canonical public docker registry; we can override this

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -8,6 +8,7 @@ set -eu
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 case $(uname) in

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -12,6 +12,7 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 tag=2019-09-04.01

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/cli/Dockerfile-bin

--- a/bin/docker-build-cni-plugin
+++ b/bin/docker-build-cni-plugin
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/cni-plugin/Dockerfile

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/controller/Dockerfile

--- a/bin/docker-build-debug
+++ b/bin/docker-build-debug
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/Dockerfile-debug

--- a/bin/docker-build-go-deps
+++ b/bin/docker-build-go-deps
@@ -11,7 +11,9 @@ fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 tag=$(go_deps_sha)

--- a/bin/docker-build-grafana
+++ b/bin/docker-build-grafana
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/grafana/Dockerfile

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/Dockerfile-proxy

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -10,7 +10,9 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 dockerfile=$rootdir/web/Dockerfile

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -4,7 +4,9 @@ set -eu
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 docker_image() {

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -11,6 +11,7 @@ fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 for img in cli-bin cni-plugin controller debug grafana proxy web ; do

--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -12,6 +12,7 @@ fi
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 workdir=$rootdir/target/release

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -4,7 +4,9 @@ set -eu
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 docker_pull base       2019-09-04.01       || true

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -11,6 +11,7 @@ fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 for img in cli-bin cni-plugin controller debug grafana proxy web ; do

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -4,7 +4,9 @@ set -eu
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 docker_push base         2019-09-04.01

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -11,6 +11,7 @@ to=$2
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 for img in cli-bin cni-plugin controller debug grafana proxy web ; do

--- a/bin/root-tag
+++ b/bin/root-tag
@@ -2,6 +2,7 @@
 
 bindir=$( cd "${0%/*}" && pwd )
 
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
 head_root_tag

--- a/bin/test-run
+++ b/bin/test-run
@@ -9,6 +9,7 @@
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_test-run.sh
 . "$bindir"/_test-run.sh
 
 init_test_run "$@"

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -6,6 +6,7 @@ set -eu
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
+# shellcheck source=_tag.sh
 sha=$(. "$bindir"/_tag.sh ; go_deps_sha)
 
 for f in $( grep -lR --include=Dockerfile\* go-deps: $bindir/.. ) ; do


### PR DESCRIPTION
The SC1090 "Can't follow non-constant source" issue is addressed in the way suggested in shellcheck's documentation; the source paths are pointed out in shellcheck comments. By adding the bin dir to the -P shellcheck CLI parameter, we avoid having to state the bin directory in each and every script file.