### PR TITLE
bin/fmt: Use sort -u instead of sort | uniq

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -8,7 +8,7 @@ dirs=$(go list -f \{\{.Dir\}\} ./... | grep -v controller/gen)
 # go list will list all subdirectories and goimports acts recursively.  This
 # results in certain files being reported multiple time.  Therefore, we must
 # dedup them.
-files=$(bin/goimports -l $dirs | sort | uniq)
+files=$(bin/goimports -l $dirs | sort -u)
 
 if [ -n "$files" ]; then
   for file in $files; do


### PR DESCRIPTION
No need to pipe output to another program when the functionality
exists in sort.
