### PR TITLE
bin/test-clouds-cleanup: Fix shellcheck issues

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -106,7 +106,6 @@ jobs:
         ! -name root-tag \
         ! -name _tag.sh \
         ! -name test-cleanup \
-        ! -name test-clouds-cleanup \
         ! -name test-clouds \
         ! -name test-run \
         ! -name _test-run.sh \

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -13,7 +13,7 @@
 
 set -e
 
-for CLUSTER in AKS DO EKS GKE; do
+for CLUSTER in 'AKS' 'DO' 'EKS' 'GKE'; do
   if [ -z "${!CLUSTER}" ]; then
     echo "\$$CLUSTER not set" >&2
     exit 64
@@ -23,5 +23,5 @@ done
 for CLUSTER in $AKS $DO $EKS $GKE
 do
   printf '\n%s\n' "$CLUSTER"
-  bin/test-cleanup $CLUSTER
+  bin/test-cleanup "$CLUSTER"
 done


### PR DESCRIPTION
shellcheck will not accept the string DO since it is not sure whether it is a misspelled do command or a string with DO. Explicitly quoting it will mitigate this.