### PR TITLE
multicluster: Do not use 80 for gateway port

### DIFF
--- a/charts/linkerd2-multicluster-remote-setup/README.md
+++ b/charts/linkerd2-multicluster-remote-setup/README.md
@@ -4,7 +4,7 @@
 Linkerd is a *service mesh*, designed to give platform-wide observability,
 reliability, and security without requiring configuration or code changes.
 This chart provides a reference cluster gateway implementation, which coupled
-with Linkerd and the Service Mirror component can enable multicluster 
+with Linkerd and the Service Mirror component can enable multicluster
 communication and service discovery
 
 ## Configuration
@@ -16,12 +16,12 @@ The following table lists the configurable parameters of the linkerd2-multiclust
 |`gatewayName`             | The name of the gateway that will be installed                                                                  | `linkerd-gateway`      |
 |`gatewayNamespace`        | The namespace in which the gateway will be created                                                              |`linkerd-gateway`       |
 |`identityTrustDomain`     | Trust domain used for identity of the existing linkerd installation                                             |`cluster.local`         |
-|`incomingPort`            | The port on which all the gateway will accept incoming traffic                                                  |`80`                    |
+|`incomingPort`            | The port on which all the gateway will accept incoming traffic                                                  |`4180`                    |
 |`linkerdNamespace`        | The namespace of the existing Linkerd installation                                                              |`linkerd`               |
 |`nginxImage`              | The Nginx image                                                                                                 |`nginx`                 |
 |`nginxImageVersion`       | The version of the Nginx image                                                                                  |`1.17`                  |
 |`probePath`               | The path that will be used by remote clusters for determining whether the gateway is alive                  |`/health`               |
 |`probePeriodSeconds`      | The interval (in seconds) between liveness probes                                                               |`3`                     |
-|`probePort`               | The port used for liveliness probing                                                                            |`81`                    |
+|`probePort`               | The port used for liveliness probing                                                                            |`4181`                    |
 |`serviceAccountName`      | The name of the service account that will be created and used by remote clusters, attempting to mirror services |`linkerd-service-mirror`|
 |`serviceAccountNamespace` | The namespace in which the service account will be created                                                      |`linkerd-service-mirror`|

--- a/charts/linkerd2-multicluster-remote-setup/values.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/values.yaml
@@ -1,11 +1,11 @@
 gatewayName: linkerd-gateway
 gatewayNamespace: linkerd-gateway
 identityTrustDomain: cluster.local
-incomingPort: 80
+incomingPort: 4180
 linkerdNamespace: linkerd
 probePath: /health
 probePeriodSeconds: 3
-probePort: 81
+probePort: 4181
 serviceAccountName: linkerd-service-mirror
 serviceAccountNamespace: linkerd-service-mirror
 linkerdVersion: linkerdVersionValue


### PR DESCRIPTION
Using port `80` opens up services to all sorts of unwanted internet
traffic and, furthermore, we don't even want serve HTTP on this port
since we are always employing Linkerd's mTLS.

This changes the gateway's `incomingPort` to 4180 and the `probePort` to
4181 to fit into Linkerd's other port range being in 41XX.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
