### PR TITLE
bin/lint: Fix shellcheck issue

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -80,7 +80,6 @@ jobs:
       run: |
         find ./bin -type f \
         ! -name docker-build-proxy \
-        ! -name lint \
         ! -name _log.sh \
         ! -name minikube-start-hyperv.bat \
         ! -name test-cleanup \

--- a/bin/lint
+++ b/bin/lint
@@ -12,12 +12,8 @@ targetbin=$rootdir/target/bin
 
 cd "$rootdir"
 
-os=linux
 exe=
-if [ "$(uname -s)" = Darwin ]; then
-  os=darwin
-elif [ "$(uname -o)" = Msys ]; then
-  os=windows
+if [ "$(uname -o)" = Msys ]; then
   exe=.exe
 fi
 


### PR DESCRIPTION
Delete variable `os` that is not used. The golangci-lint downloader script does its own extensive platform lookup before downloading the selected binary.