### PR TITLE
bin/update-go-deps-shas: Fix shellcheck issues

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -88,7 +88,6 @@ jobs:
         ! -name _tag.sh \
         ! -name test-cleanup \
         ! -name _test-run.sh \
-        ! -name update-go-deps-shas \
         ! -name *.nuspec \
         ! -name *.ps1 \
         | xargs -I {} bin/shellcheck -x -P ./bin {}

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -1,15 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
 # Updates the tag for `linkerd-io/go-deps` across all Dockerfiles in this repository.
 
-bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
-
 # shellcheck source=_tag.sh
-sha=$(. "$bindir"/_tag.sh ; go_deps_sha)
+sha=$(. "${0%/*}"/_tag.sh ; go_deps_sha)
 
-for f in $( grep -lR --include=Dockerfile\* go-deps: $bindir/.. ) ; do
+for f in $( grep -lR --include=Dockerfile\* go-deps: "$(cd "${0%/*}"/.. && pwd)" | xargs ) ; do
     sed -E -i.bak -e "s|linkerd-io/go-deps:[^ ]+|linkerd-io/go-deps:$sha|" "$f"
     rm "$f".bak
 done


### PR DESCRIPTION
Pass grep output through xargs.
Use `${0%/*}` instead of `$bindir `since the variable `bindir` exists in
_tag.sh too and then triggers the shellcheck variable modifed warning.
Script uses no bash features and can thus be a POSIX /bin/sh script.