### PR TITLE
Enable service mirroring to work in private networks

### DIFF
--- a/charts/linkerd2-service-mirror/templates/service-mirror.yaml
+++ b/charts/linkerd2-service-mirror/templates/service-mirror.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: ["list", "get", "watch", "create", "delete", "update"]
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["list", "get", "watch"]
+  verbs: ["create","list", "get", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -169,8 +169,8 @@ func newGatewaysCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.clusterName, "cluster-name", "remote", "the name of the remote cluster")
-	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", defaultMulticlusterNamespace, "the namespace in which the gateway resides on the remote cluster")
+	cmd.Flags().StringVar(&opts.clusterName, "cluster-name", "", "the name of the remote cluster")
+	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", "", "the namespace in which the gateway resides on the remote cluster")
 	cmd.Flags().StringVarP(&opts.timeWindow, "time-window", "t", "1m", "Time window (for example: \"15s\", \"1m\", \"10m\", \"1h\"). Needs to be at least 15s.")
 
 	return cmd

--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -719,7 +719,7 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayDeleted(ev *RemoteGa
 		clusterName: rcsw.clusterName,
 	})
 
-	if err := rcsw.localAPIClient.Client.CoreV1().Services("linkerd-multicluster").Delete(ev.gatewayData.Name, &metav1.DeleteOptions{}); err != nil {
+	if err := rcsw.localAPIClient.Client.CoreV1().Services(rcsw.serviceMirrorNamespace).Delete(rcsw.mirroredResourceName(ev.gatewayData.Name), &metav1.DeleteOptions{}); err != nil {
 		rcsw.log.Errorf("Could not delete  gateway proxy %s", err)
 	}
 

--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -27,15 +27,16 @@ type (
 	// it can be requeued up to N times, to ensure that the failure is not due to some temporary network
 	// problems or general glitch in the Matrix.
 	RemoteClusterServiceWatcher struct {
-		clusterName     string
-		clusterDomain   string
-		remoteAPIClient *k8s.API
-		localAPIClient  *k8s.API
-		stopper         chan struct{}
-		log             *logging.Entry
-		eventsQueue     workqueue.RateLimitingInterface
-		requeueLimit    int
-		probeEventsSink ProbeEventSink
+		serviceMirrorNamespace string
+		clusterName            string
+		clusterDomain          string
+		remoteAPIClient        *k8s.API
+		localAPIClient         *k8s.API
+		stopper                chan struct{}
+		log                    *logging.Entry
+		eventsQueue            workqueue.RateLimitingInterface
+		requeueLimit           int
+		probeEventsSink        ProbeEventSink
 	}
 
 	// ProbeConfig describes the configured probe on particular gateway (if presents)
@@ -174,6 +175,7 @@ func (rcsw *RemoteClusterServiceWatcher) resolveGateway(metadata *gatewayMetadat
 
 // NewRemoteClusterServiceWatcher constructs a new cluster watcher
 func NewRemoteClusterServiceWatcher(
+	serviceMirrorNamespace string,
 	localAPI *k8s.API,
 	cfg *rest.Config,
 	clusterName string,
@@ -187,11 +189,12 @@ func NewRemoteClusterServiceWatcher(
 	}
 	stopper := make(chan struct{})
 	return &RemoteClusterServiceWatcher{
-		clusterName:     clusterName,
-		clusterDomain:   clusterDomain,
-		remoteAPIClient: remoteAPI,
-		localAPIClient:  localAPI,
-		stopper:         stopper,
+		serviceMirrorNamespace: serviceMirrorNamespace,
+		clusterName:            clusterName,
+		clusterDomain:          clusterDomain,
+		remoteAPIClient:        remoteAPI,
+		localAPIClient:         localAPI,
+		stopper:                stopper,
 		log: logging.WithFields(logging.Fields{
 			"cluster":    clusterName,
 			"apiAddress": cfg.Host,
@@ -497,6 +500,132 @@ func remapRemoteServicePorts(ports []corev1.ServicePort) []corev1.ServicePort {
 	return newPorts
 }
 
+func (rcsw *RemoteClusterServiceWatcher) updateGatewayProxyService(spec *GatewaySpec) error {
+	localSvcProxyName := rcsw.mirroredResourceName(spec.gatewayName)
+	service, err := rcsw.localAPIClient.Svc().Lister().Services(rcsw.serviceMirrorNamespace).Get(localSvcProxyName)
+	if err != nil {
+		return err
+	}
+
+	if service.Annotations != nil && service.Annotations[consts.RemoteGatewayResourceVersionAnnotation] != spec.resourceVersion {
+		updatedService := service.DeepCopy()
+		if updatedService.Annotations != nil {
+			updatedService.Annotations[consts.RemoteGatewayResourceVersionAnnotation] = spec.resourceVersion
+		}
+
+		endpoints, err := rcsw.localAPIClient.Endpoint().Lister().Endpoints(rcsw.serviceMirrorNamespace).Get(localSvcProxyName)
+		if err != nil {
+			return err
+		}
+
+		updatedEndpoints := endpoints.DeepCopy()
+		updatedEndpoints.Subsets = []corev1.EndpointSubset{
+			{
+				Addresses: spec.addresses,
+				Ports: []corev1.EndpointPort{
+					{
+						Protocol: "TCP",
+						Port:     int32(spec.ProbeConfig.port),
+					},
+				},
+			},
+		}
+
+		_, err = rcsw.localAPIClient.Client.CoreV1().Services(rcsw.serviceMirrorNamespace).Update(updatedService)
+		if err != nil {
+			return err
+		}
+
+		_, err = rcsw.localAPIClient.Client.CoreV1().Endpoints(rcsw.serviceMirrorNamespace).Update(updatedEndpoints)
+		if err != nil {
+			rcsw.localAPIClient.Client.CoreV1().Services(rcsw.serviceMirrorNamespace).Delete(updatedService.Name, &metav1.DeleteOptions{})
+			return err
+		}
+		rcsw.log.Debugf("%s gateway proxy service updated", localSvcProxyName)
+	}
+
+	return nil
+}
+
+func (rcsw *RemoteClusterServiceWatcher) createGatewayProxyService(spec *GatewaySpec) error {
+	localSvcProxyName := rcsw.mirroredResourceName(spec.gatewayName)
+	if spec.ProbeConfig == nil {
+		rcsw.log.Debugf("Skipping creation of gateway proxy service as gateway does not specify probe config")
+		return nil
+	}
+
+	_, err := rcsw.localAPIClient.Svc().Lister().Services(rcsw.serviceMirrorNamespace).Get(localSvcProxyName)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			serviceToCreate := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      localSvcProxyName,
+					Namespace: rcsw.serviceMirrorNamespace,
+					Labels: map[string]string{
+						consts.MirroredResourceLabel:  "true",
+						consts.RemoteClusterNameLabel: rcsw.clusterName,
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol: "TCP",
+							Port:     int32(spec.ProbeConfig.port),
+						},
+					},
+				},
+			}
+
+			endpointsToCreate := &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      localSvcProxyName,
+					Namespace: rcsw.serviceMirrorNamespace,
+					Labels: map[string]string{
+						consts.MirroredResourceLabel:  "true",
+						consts.RemoteClusterNameLabel: rcsw.clusterName,
+					},
+					Annotations: map[string]string{
+						consts.RemoteGatewayIdentity:                  spec.identity,
+						consts.RemoteGatewayResourceVersionAnnotation: spec.resourceVersion,
+					},
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: spec.addresses,
+						Ports: []corev1.EndpointPort{
+							{
+								Protocol: "TCP",
+								Port:     int32(spec.ProbeConfig.port),
+							},
+						},
+					},
+				},
+			}
+
+			rcsw.log.Debugf("Creating a new gateway service proxy mirror %s", localSvcProxyName)
+			if _, err := rcsw.localAPIClient.Client.CoreV1().Services(rcsw.serviceMirrorNamespace).Create(serviceToCreate); err != nil {
+				if !kerrors.IsAlreadyExists(err) {
+					// we might have created it during earlier attempt, if that is not the case, we retry
+					return RetryableError{[]error{err}}
+				}
+			}
+
+			rcsw.log.Debugf("Creating a new gateway service proxy Endpoints for %s", localSvcProxyName)
+			if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(rcsw.serviceMirrorNamespace).Create(endpointsToCreate); err != nil {
+				// we clean up after ourselves
+				rcsw.localAPIClient.Client.CoreV1().Services(rcsw.serviceMirrorNamespace).Delete(spec.gatewayName, &metav1.DeleteOptions{})
+				// and retry
+				return RetryableError{[]error{err}}
+			}
+
+			return nil
+		}
+		return err
+	}
+	rcsw.log.Debugf("Skipping creation of gateway proxy service as it already exists")
+	return nil
+}
+
 func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceCreated(ev *RemoteServiceCreated) error {
 	remoteService := ev.service.DeepCopy()
 	serviceInfo := fmt.Sprintf("%s/%s", remoteService.Namespace, remoteService.Name)
@@ -550,6 +679,10 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceCreated(ev *RemoteSe
 			endpointsToCreate.Annotations[consts.RemoteGatewayIdentity] = gatewaySpec.identity
 		}
 
+		if err := rcsw.createGatewayProxyService(gatewaySpec); err != nil {
+			return err
+		}
+
 		rcsw.probeEventsSink.send(&MirroredServicePaired{
 			serviceName:      serviceToCreate.Name,
 			serviceNamespace: serviceToCreate.Namespace,
@@ -585,6 +718,11 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayDeleted(ev *RemoteGa
 		gatewayNs:   ev.gatewayData.Namespace,
 		clusterName: rcsw.clusterName,
 	})
+
+	if err := rcsw.localAPIClient.Client.CoreV1().Services("linkerd-multicluster").Delete(ev.gatewayData.Name, &metav1.DeleteOptions{}); err != nil {
+		rcsw.log.Errorf("Could not delete  gateway proxy %s", err)
+	}
+
 	affectedEndpoints, err := rcsw.endpointsForGateway(&ev.gatewayData)
 	if err != nil {
 		// if we cannot find the endpoints, we can give up
@@ -661,6 +799,10 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteGatewayUpdated(ev *RemoteGa
 			serviceNamespace: updatedService.Namespace,
 			GatewaySpec:      ev.gatewaySpec,
 		})
+	}
+
+	if err := rcsw.updateGatewayProxyService(&ev.gatewaySpec); err != nil {
+		rcsw.log.Errorf("Could not update %s gateway proxy service: %s", ev.gatewaySpec.gatewayName, err)
 	}
 
 	rcsw.probeEventsSink.send(&GatewayUpdated{

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -80,7 +80,7 @@ func Main(args []string) {
 	probeManager.Start()
 
 	k8sAPI.Sync(nil)
-	watcher := NewRemoteClusterConfigWatcher(secretsInformer, k8sAPI, *requeueLimit, &chanProbeEventSink{probeManager.enqueueEvent})
+	watcher := NewRemoteClusterConfigWatcher(*namespace, secretsInformer, k8sAPI, *requeueLimit, &chanProbeEventSink{probeManager.enqueueEvent})
 	log.Info("Started cluster config watcher")
 
 	go admin.StartServer(*metricsAddr)

--- a/controller/cmd/service-mirror/probe_manager.go
+++ b/controller/cmd/service-mirror/probe_manager.go
@@ -149,7 +149,8 @@ func (m *ProbeManager) handleMirroredServicePaired(event *MirroredServicePaired)
 		} else {
 			probeSpec := gatewayToProbeSpec(event.GatewaySpec)
 			if probeSpec != nil {
-				worker = NewProbeWorker(probeSpec, probeMetrics, probeKey)
+				localGatewayName := fmt.Sprintf("%s-%s", event.gatewayName, event.clusterName)
+				worker = NewProbeWorker(localGatewayName, probeSpec, probeMetrics, probeKey)
 				worker.PairService(event.serviceName, event.serviceNamespace)
 				m.probeWorkers[probeKey] = worker
 				worker.Start()

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -210,7 +210,7 @@ var expectedServiceMirrorClusterRolePolicies = []expectedPolicy{
 	},
 	{
 		resources: []string{"namespaces"},
-		verbs:     []string{"list", "get", "watch"},
+		verbs:     []string{"create", "list", "get", "watch"},
 	},
 }
 


### PR DESCRIPTION
This change creates a gateway proxy for every gateway. This enables the probe worker to leverage the destination service functionality in order to discover the identity of the gateway. 

Fix #4411
