### PR TITLE
Run shellcheck for all shell scripts in repository

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -68,28 +68,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: shellcheck
-      # TODO: Each file listed here is excluded from shellcheck because it
-      # fails. As we fix files we can remove them from this list.
-      #
-      # Once we have this list paired down signficantly, we can switch to
-      # disabling specific checks across all files, for example:
-      # bin/shellcheck bin/* --exclude=SC1000
-      #
       # For more information on shellcheck failures:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
-        bin/shellcheck -x -P ./bin $(find . -type f \
-        ! -path ./bin/docker-build-proxy \
-        ! -path ./bin/fmt \
-        ! -path ./bin/lint \
-        ! -path ./bin/minikube-start-hyperv.bat \
-        ! -path ./bin/_tag.sh \
-        ! -path ./bin/test-cleanup \
-        ! -path ./bin/_test-run.sh \
-        ! -path ./bin/update-go-deps-shas \
-        ! -path ./cni-plugin/deployment/scripts/install-cni.sh \
-        ! -path ./.git/hooks/\*.sample \
-        | while read -r f; do [ "$(file -b --mime-type "$f")" = 'text/x-shellscript' ] && printf '%s\0' "$f"; done | xargs -0)
+        bin/shellcheck-all
   markdown_lint:
     name: Markdown lint
     runs-on: ubuntu-18.04

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -78,14 +78,18 @@ jobs:
       # For more information on shellcheck failures:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
-        find ./bin -type f \
-        ! -name docker-build-proxy \
-        ! -name minikube-start-hyperv.bat \
-        ! -name test-cleanup \
-        ! -name _test-run.sh \
-        ! -name *.nuspec \
-        ! -name *.ps1 \
-        | xargs -I {} bin/shellcheck -x -P ./bin {}
+        bin/shellcheck -x -P ./bin $(find . -type f \
+        ! -path ./bin/docker-build-proxy \
+        ! -path ./bin/fmt \
+        ! -path ./bin/lint \
+        ! -path ./bin/minikube-start-hyperv.bat \
+        ! -path ./bin/_tag.sh \
+        ! -path ./bin/test-cleanup \
+        ! -path ./bin/_test-run.sh \
+        ! -path ./bin/update-go-deps-shas \
+        ! -path ./cni-plugin/deployment/scripts/install-cni.sh \
+        ! -path ./.git/hooks/\*.sample \
+        | while read -r f; do [ "$(file -b --mime-type "$f")" = 'text/x-shellscript' ] && printf '%s\0' "$f"; done | xargs -0)
   markdown_lint:
     name: Markdown lint
     runs-on: ubuntu-18.04

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -85,7 +85,7 @@ if [ $# -ne 1 ]; then
 fi
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
-# shellcheck source=bin/_release.sh
+# shellcheck source=_release.sh
 tmp=$(. "$bindir"/_release.sh; extract_release_notes)
 
 # Create a signed tag with the commit message.

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -32,7 +32,7 @@ rootdir=$( cd "$bindir"/.. && pwd )
 
 # `bin/helm-build package` assumes the presence of "$rootdir"/target/helm/index-pre.yaml which is downloaded in the chart_deploy CI job
 if [ "$1" = package ]; then
-    # shellcheck source=bin/_tag.sh
+    # shellcheck source=_tag.sh
     . "$bindir"/_tag.sh
     tag=$(named_tag)
     clean_head || { echo 'There are uncommitted changes'; exit 1; }

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -58,9 +58,9 @@ cluster=${1:-"kind"}
 
 bindir=$( cd "${0%/*}" && pwd )
 
-# shellcheck source=bin/_tag.sh
+# shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
-# shellcheck source=bin/_docker.sh
+# shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 
 TAG=${TAG:-$(head_root_tag)}

--- a/bin/shellcheck-all
+++ b/bin/shellcheck-all
@@ -1,0 +1,22 @@
+#!/bin/sh -eu
+
+bindir=$( cd "${0%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+
+# TODO: Each file excluded from the shell script search result below is
+# excluded from shellcheck because it fails. As we fix files we can remove them
+# from this exclusion list. And this comment when all files pass shellcheck.
+
+# For more information on shellcheck failures:
+# https://github.com/koalaman/shellcheck/wiki/Checks
+
+# We want the word splitting for the shellcheck arguments
+# shellcheck disable=SC2046
+"$bindir"/shellcheck -x -P "$bindir" $(find "$rootdir" -type f \
+		! -path "$bindir"/docker-build-proxy \
+		! -path "$bindir"/_log.sh \
+		! -path "$bindir"/test-cleanup \
+		! -path "$bindir"/_test-run.sh \
+		! -path "$rootdir"/cni-plugin/deployment/scripts/install-cni.sh \
+		! -path "$rootdir"/.git/hooks/\*.sample \
+		| while read -r f; do [ "$(file -b --mime-type "$f")" = 'text/x-shellscript' ] && printf '%s\0' "$f"; done | xargs -0)


### PR DESCRIPTION
Currently, only the shell scripts in `./bin` are scanned by shellcheck for linkerd2 pull requests.
But the repository contains more shell scripts in other directories.

This patch aims to update the shellcheck command in static_checks.yml to search for all files with mimetype `text/x-shellscript` and feed them to shellcheck.

Certainly, this is a tad more time consuming than just scanning one directory, but still a quite fast thing to do while it prevents any new scripts to fly under the radar.

(Also, there is no need to exclude `*.nuspec` or `*.ps1` from the find command as they do not have the text/x-shellscript mimetype.)

Signed-off-by: Joakim Roubert <joakimr@axis.com>