### PR TITLE
Bump KinD to 0.8.1

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -130,14 +130,14 @@ jobs:
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
-        version: "v0.7.0"
+        version: "v0.8.1"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
-        version: "v0.7.0"
+        version: "v0.8.1"
     - name: Load image archives into the local KinD cluster
       if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,14 +129,14 @@ jobs:
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
-        version: "v0.7.0"
+        version: "v0.8.1"
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       # engineerd/setup-kind@v0.3.0
       uses: engineerd/setup-kind@d0e9be1
       with:
         config: test/testdata/custom_cluster_domain_config.yaml
-        version: "v0.7.0"
+        version: "v0.8.1"
     - name: Load image archives into the local KinD cluster
       env:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1

--- a/bin/kind
+++ b/bin/kind
@@ -2,7 +2,7 @@
 
 set -eu
 
-kindversion=v0.7.0
+kindversion=v0.8.1
 
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin


### PR DESCRIPTION
This brings us K8s 1.18, which is in theory passing all the integration
tests. Currently the tracing one is failing just because of the quay.io
downtime, that hosts the nginx-ingress image.

Re #4382
