### PR TITLE
Properly show the meshed count for non-selector services

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -284,7 +284,15 @@ func writeStatsToBuffer(rows []*pb.StatTable_PodGroup_Row, w *tabwriter.Writer, 
 	}
 
 	for _, r := range rows {
-		if isPodOwnerResource(r.Resource.Type) && !options.unmeshed && r.GetMeshedPodCount() == 0 {
+
+		// Skip unmeshed pods if the unmeshed option isn't enabled.
+		if !options.unmeshed && r.GetMeshedPodCount() == 0 &&
+			// Skip only if the resource can own pods
+			isPodOwnerResource(r.Resource.Type) &&
+			// Skip only if --from isn't specified (unmeshed resources can show
+			// stats in --from mode because metrics are collected on the client
+			// side).
+			options.fromResource == "" {
 			continue
 		}
 

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -562,7 +562,11 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 			return []*corev1.Pod{}, nil
 		}
 		namespace = typed.Namespace
-		selector = labels.Set(typed.Spec.Selector).AsSelector()
+		if typed.Spec.Selector == nil {
+			selector = labels.Nothing()
+		} else {
+			selector = labels.Set(typed.Spec.Selector).AsSelector()
+		}
 
 	case *appsv1.StatefulSet:
 		namespace = typed.Namespace


### PR DESCRIPTION
When viewing the output of `linkerd stat` for services which do not have a selector (such as services created by the service-mirror, for example) the meshed count column shows the total number which exist, even though the service actually selects no pods at all.

We update the StatSummary implementation to account for services which have no selector.

Additionally, we update the logic of the `--unmeshed` flag.  When the `--unmeshed` flag is not set, we typically skip rows for unmeshed resources because those resources would have no stats.  This is not appropriate to do when the `--from` flag is also set because in this case, metrics are not collected on the target resource but are instead collected on the client-side.  This means that stats can be present, even for unmeshed resources and these resources should still be displayed, even if the `--unmeshed` flag is not set.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
