### PR TITLE
markdownlint: Use /bin/sh instead of /bin/bash

### DIFF
--- a/bin/markdownlint
+++ b/bin/markdownlint
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/bin/sh -eu
 
-set -eu
-
-bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 markdownlintbin="$rootdir/node_modules/.bin/markdownlint"
 
@@ -10,7 +8,7 @@ markdownlint_version=0.23.1
 
 if [ ! -x "$markdownlintbin" ] || [ "$($markdownlintbin -V)" != $markdownlint_version ]; then
     if ! [ -x "$(command -v npm)" ]; then
-        echo "Error: npm required to install markdownlint command"
+        echo 'Error: npm required to install markdownlint command'
         exit 1
     fi
     npm install markdownlint-cli@$markdownlint_version

--- a/bin/markdownlint-all
+++ b/bin/markdownlint-all
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh -eu
 
-bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+bindir=$( cd "${0%/*}" && pwd )
 
 "$bindir"/markdownlint ./*.md
 "$bindir"/markdownlint ./**/*.md --ignore node_modules/


### PR DESCRIPTION
The nice and clean markdownlint scripts use no bash-specific
functionality. Hence they could be run with /bin/sh instead. On e.g.
Debian-based systems /bin/sh is dash which has 1/10 of bash's footprint.

Signed-off-by: Joakim Roubert <joakimr@axis.com>
