### PR TITLE
Fix resync bug + service selection annotations

### DIFF
--- a/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster-remote-setup/templates/gateway.yaml
@@ -98,6 +98,7 @@ metadata:
     mirror.linkerd.io/probe-port: "{{.Values.probePort}}"
     mirror.linkerd.io/probe-period: "{{.Values.probePeriodSeconds}}"
     mirror.linkerd.io/probe-path: {{.Values.probePath}}
+    mirror.linkerd.io/multicluster-gateway: "true"
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:
   ports:

--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -996,6 +996,7 @@ func (rcsw *RemoteClusterServiceWatcher) mirroredServicesForGateway(gatewayData 
 		consts.MirroredResourceLabel:  "true",
 		consts.RemoteGatewayNameLabel: gatewayData.Name,
 		consts.RemoteGatewayNsLabel:   gatewayData.Namespace,
+		consts.RemoteClusterNameLabel: rcsw.clusterName,
 	}
 
 	services, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
@@ -1010,6 +1011,7 @@ func (rcsw *RemoteClusterServiceWatcher) endpointsForGateway(gatewayData *gatewa
 		consts.MirroredResourceLabel:  "true",
 		consts.RemoteGatewayNameLabel: gatewayData.Name,
 		consts.RemoteGatewayNsLabel:   gatewayData.Namespace,
+		consts.RemoteClusterNameLabel: rcsw.clusterName,
 	}
 
 	endpoints, err := rcsw.localAPIClient.Endpoint().Lister().List(labels.Set(matchLabels).AsSelector())

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -368,6 +368,10 @@ const (
 	// of a mirroring operation (can be a namespace or a service)
 	MirroredResourceLabel = SvcMirrorPrefix + "/mirrored-service"
 
+	// MulticlusterGatewayAnnotation indicates that this service is a
+	// gateway
+	MulticlusterGatewayAnnotation = SvcMirrorPrefix + "/multicluster-gateway"
+
 	// RemoteClusterNameLabel put on a local mirrored service, it
 	// allows us to associate a mirrored service with a remote cluster
 	RemoteClusterNameLabel = SvcMirrorPrefix + "/cluster-name"


### PR DESCRIPTION
THis PR addresses two problems: 

- when a resync happens (or the mirror controller is restarted) we incorrectly classify the remote gateway as a mirrored service that is not mirrored anymore and we delete it
- when updating services due to a gateway update, we need to select only the services for the particular cluster

The latter fixes #4451