### PR TITLE
Use bash shebang instead of sh in bin/root-tag

### DIFF
--- a/bin/root-tag
+++ b/bin/root-tag
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 bindir=$( cd "${0%/*}" && pwd )
 


### PR DESCRIPTION
In #4436 `head_root_tag()` was changed to replace `sed` with a
bash-native substitution. This assumes bash is our shell, which is the
case in `bin/_tag.sh` but not in `bin/root-tag` which calls it, and
which has a `sh` shebang that in Ubuntu points to dash instead of bash,
which breaks with the new bash-native substitution. Ergo, I'm
expliciting the bash shebang in this file.

@joakimr-axis I would appreciate if you have any comments about this
change ;-)
