### PR TITLE
Wait for KinD nodes to be ready in CI

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -131,6 +131,8 @@ jobs:
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       run: bin/kind create cluster --config test/testdata/custom_cluster_domain_config.yaml
+    - name: Wait for all nodes to be ready
+      run: kubectl wait --for=condition=Ready --all nodes
     - name: Load image archives into the local KinD cluster
       if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -127,10 +127,10 @@ jobs:
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Setup default KinD cluster
       if: matrix.integration_test != 'custom_domain'
-      run: bin/kind create cluster
+      run: bin/kind create cluster --wait 300s
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
-      run: bin/kind create cluster --config test/testdata/custom_cluster_domain_config.yaml
+      run: bin/kind create cluster --wait 300s --config test/testdata/custom_cluster_domain_config.yaml
     - name: Load image archives into the local KinD cluster
       if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:
@@ -149,8 +149,6 @@ jobs:
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
       run: |
         bin/kind-load --images
-    - name: Wait for all nodes to be ready
-      run: kubectl wait --for=condition=Ready --all nodes
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -131,8 +131,6 @@ jobs:
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
       run: bin/kind create cluster --config test/testdata/custom_cluster_domain_config.yaml
-    - name: Wait for all nodes to be ready
-      run: kubectl wait --for=condition=Ready --all nodes
     - name: Load image archives into the local KinD cluster
       if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       env:
@@ -151,6 +149,8 @@ jobs:
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
       run: |
         bin/kind-load --images
+    - name: Wait for all nodes to be ready
+      run: kubectl wait --for=condition=Ready --all nodes
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,8 @@ jobs:
         # for the next run.
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROXY_INIT_IMAGE_NAME) 2>&1 || true
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROMETHEUS_IMAGE_NAME) 2>&1 || true
+    - name: Wait for all nodes to be ready
+      run: kubectl wait --for=condition=Ready --all nodes
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,10 @@ jobs:
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Setup default KinD cluster
       if: matrix.integration_test != 'custom_domain'
-      run: bin/kind create cluster
+      run: bin/kind create cluster --wait 300s
     - name: Setup custom_domain KinD cluster
       if: matrix.integration_test == 'custom_domain'
-      run: bin/kind create cluster --config test/testdata/custom_cluster_domain_config.yaml
+      run: bin/kind create cluster --wait 300s --config test/testdata/custom_cluster_domain_config.yaml
     - name: Load image archives into the local KinD cluster
       env:
         PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1
@@ -143,8 +143,6 @@ jobs:
         # for the next run.
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROXY_INIT_IMAGE_NAME) 2>&1 || true
         kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROMETHEUS_IMAGE_NAME) 2>&1 || true
-    - name: Wait for all nodes to be ready
-      run: kubectl wait --for=condition=Ready --all nodes
     - name: Run integration tests
       run: |
         # Export `init_test_run` and `*_integration_tests` into the

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -121,7 +121,7 @@ check_linkerd_binary(){
         exit 1
     fi
     exit_code=0
-    "$linkerd_path" version --client > /dev/null 2>&1
+    "$linkerd_path" version --client 2>&1
     exit_on_err 'error running linkerd version command'
     printf '[ok]\n'
 }
@@ -173,13 +173,13 @@ install_stable() {
     local linkerd_path=$tmp/.linkerd2/bin/linkerd
     local stable_namespace=$1
     local test_app_namespace=$stable_namespace-upgrade-test
-    $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - > /dev/null 2>&1
-    $linkerd_path check --linkerd-namespace="$stable_namespace" > /dev/null 2>&1
+    $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - 2>&1
+    $linkerd_path check --linkerd-namespace="$stable_namespace" 2>&1
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
     kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1
     kubectl --context=$k8s_context label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
-    $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - > /dev/null 2>&1
+    $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - 2>&1
 }
 
 # Run the upgrade test by upgrading the most-recent stable release to the HEAD of

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -175,8 +175,8 @@ install_stable() {
     local test_app_namespace=$stable_namespace-upgrade-test
     (
         set -x
-        $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - 2>&1
-        $linkerd_path check --linkerd-namespace="$stable_namespace" 2>&1
+        "$linkerd_path" install --linkerd-namespace="$stable_namespace" | kubectl --context="$k8s_context" apply -f - 2>&1
+        "$linkerd_path" check --linkerd-namespace="$stable_namespace" 2>&1
     )
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
@@ -184,7 +184,7 @@ install_stable() {
     kubectl --context=$k8s_context label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
     (
         set -x
-        $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - 2>&1
+        "$linkerd_path" inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context="$k8s_context" apply --namespace="$test_app_namespace" -f - 2>&1
     )
 }
 

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -185,7 +185,10 @@ install_stable() {
     #Now we need to install the app that will be used to verify that upgrade does not break anything
     kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1
     kubectl --context=$k8s_context label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
-    $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - 2>&1
+    (
+        set -x
+        $linkerd_path inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context=$k8s_context apply --namespace="$test_app_namespace" -f - 2>&1
+    )
 }
 
 # Run the upgrade test by upgrading the most-recent stable release to the HEAD of

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -121,7 +121,10 @@ check_linkerd_binary(){
         exit 1
     fi
     exit_code=0
-    "$linkerd_path" version --client 2>&1
+    (
+        set -x
+        "$linkerd_path" version --client 2>&1
+    )
     exit_on_err 'error running linkerd version command'
     printf '[ok]\n'
 }
@@ -173,8 +176,11 @@ install_stable() {
     local linkerd_path=$tmp/.linkerd2/bin/linkerd
     local stable_namespace=$1
     local test_app_namespace=$stable_namespace-upgrade-test
-    $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - 2>&1
-    $linkerd_path check --linkerd-namespace="$stable_namespace" 2>&1
+    (
+        set -x
+        $linkerd_path install --linkerd-namespace="$stable_namespace" | kubectl --context=$k8s_context apply -f - 2>&1
+        $linkerd_path check --linkerd-namespace="$stable_namespace" 2>&1
+    )
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
     kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -121,10 +121,7 @@ check_linkerd_binary(){
         exit 1
     fi
     exit_code=0
-    (
-        set -x
-        "$linkerd_path" version --client 2>&1
-    )
+    "$linkerd_path" version --client > /dev/null 2>&1
     exit_on_err 'error running linkerd version command'
     printf '[ok]\n'
 }


### PR DESCRIPTION
Recently we have been seeing the following error in `Run integration tests` job
of the `KinD integration` workflow:

```
...
##[error]Process completed with exit code 2.
```

After some testing in a fork and changing the `linkerd check` to output to
`stout` instead of `/dev/null`, these errors show up periodically:

```
× no unschedulable pods
    linkerd-controller-7b65fdf847-rqqhn: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-destination-77b66ff5b-zg9ht: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-grafana-7c87b95798-h4qbf: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-identity-7c7f4694bf-d2wwb: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-prometheus-d479547f-j2b2l: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-proxy-injector-885845b8-xk974: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-sp-validator-7d6f48c48c-ctjkt: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-tap-74c6649ffd-x245h: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-web-6cdf6db9f6-2bbcg: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    see https://linkerd.io/checks/#l5d-existence-unschedulable-pods for hints
```

This is fairly simple to reproduce locally; the kind control plane node is not
immediately ready after `bin/kind create cluster`.

The solution is to wait for all nodes to be ready. Currently, there is only ever
one node, but as this will likely change in the future this covers all cases.

So far this has only happened on forks--so while this may not be the only
issue--it is at least one.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
