### PR TITLE
Fixes #4305

### DIFF
--- a/cli/cmd/testdata/install-sp_default.golden
+++ b/cli/cmd/testdata/install-sp_default.golden
@@ -21,14 +21,6 @@ spec:
     condition:
       method: POST
       pathRegex: /api/v1/ListServices
-  - name: POST /api/v1/Tap
-    condition:
-      method: POST
-      pathRegex: /api/v1/Tap
-  - name: POST /api/v1/TapByResource
-    condition:
-      method: POST
-      pathRegex: /api/v1/TapByResource
   - name: POST /api/v1/Version
     condition:
       method: POST
@@ -61,9 +53,9 @@ metadata:
   namespace: linkerd
 spec:
   routes:
-  - name: GET /api/v1/query
+  - name: POST /api/v1/query
     condition:
-      method: GET
+      method: POST
       pathRegex: /api/v1/query
   - name: GET /api/v1/query_range
     condition:
@@ -93,6 +85,10 @@ spec:
     condition:
       method: GET
       pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/dashboard/{dashboard}
+    condition:
+      method: GET
+      pathRegex: /api/dashboard/.*
   - name: GET /api/datasources/proxy/1/api/v1/series
     condition:
       method: GET
@@ -121,16 +117,4 @@ spec:
     condition:
       method: GET
       pathRegex: /public/img/.*
----
-apiVersion: linkerd.io/v1alpha2
-kind: ServiceProfile
-metadata:
-  name: linkerd-tap.linkerd.svc.cluster.local
-  namespace: linkerd
-spec:
-  routes:
-  - name: POST /linkerd2.controller.tap.Tap/TapByResource
-    condition:
-      method: POST
-      pathRegex: /linkerd2\.controller\.tap\.Tap/TapByResource
 ---

--- a/cli/cmd/testdata/install-sp_output.golden
+++ b/cli/cmd/testdata/install-sp_output.golden
@@ -21,14 +21,6 @@ spec:
     condition:
       method: POST
       pathRegex: /api/v1/ListServices
-  - name: POST /api/v1/Tap
-    condition:
-      method: POST
-      pathRegex: /api/v1/Tap
-  - name: POST /api/v1/TapByResource
-    condition:
-      method: POST
-      pathRegex: /api/v1/TapByResource
   - name: POST /api/v1/Version
     condition:
       method: POST
@@ -61,9 +53,9 @@ metadata:
   namespace: NAMESPACE
 spec:
   routes:
-  - name: GET /api/v1/query
+  - name: POST /api/v1/query
     condition:
-      method: GET
+      method: POST
       pathRegex: /api/v1/query
   - name: GET /api/v1/query_range
     condition:
@@ -93,6 +85,10 @@ spec:
     condition:
       method: GET
       pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/dashboard/{dashboard}
+    condition:
+      method: GET
+      pathRegex: /api/dashboard/.*
   - name: GET /api/datasources/proxy/1/api/v1/series
     condition:
       method: GET
@@ -121,16 +117,4 @@ spec:
     condition:
       method: GET
       pathRegex: /public/img/.*
----
-apiVersion: linkerd.io/v1alpha2
-kind: ServiceProfile
-metadata:
-  name: linkerd-tap.NAMESPACE.svc.CLUSTERDOMAIN
-  namespace: NAMESPACE
-spec:
-  routes:
-  - name: POST /linkerd2.controller.tap.Tap/TapByResource
-    condition:
-      method: POST
-      pathRegex: /linkerd2\.controller\.tap\.Tap/TapByResource
 ---

--- a/cli/installsp/template.go
+++ b/cli/installsp/template.go
@@ -24,14 +24,6 @@ spec:
     condition:
       method: POST
       pathRegex: /api/v1/ListServices
-  - name: POST /api/v1/Tap
-    condition:
-      method: POST
-      pathRegex: /api/v1/Tap
-  - name: POST /api/v1/TapByResource
-    condition:
-      method: POST
-      pathRegex: /api/v1/TapByResource
   - name: POST /api/v1/Version
     condition:
       method: POST
@@ -64,9 +56,9 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   routes:
-  - name: GET /api/v1/query
+  - name: POST /api/v1/query
     condition:
-      method: GET
+      method: POST
       pathRegex: /api/v1/query
   - name: GET /api/v1/query_range
     condition:
@@ -96,6 +88,10 @@ spec:
     condition:
       method: GET
       pathRegex: /api/dashboards/uid/.*
+  - name: GET /api/dashboard/{dashboard}
+    condition:
+      method: GET
+      pathRegex: /api/dashboard/.*
   - name: GET /api/datasources/proxy/1/api/v1/series
     condition:
       method: GET
@@ -124,16 +120,4 @@ spec:
     condition:
       method: GET
       pathRegex: /public/img/.*
----
-apiVersion: linkerd.io/v1alpha2
-kind: ServiceProfile
-metadata:
-  name: linkerd-tap.{{.Namespace}}.svc.{{.ClusterDomain}}
-  namespace: {{.Namespace}}
-spec:
-  routes:
-  - name: POST /linkerd2.controller.tap.Tap/TapByResource
-    condition:
-      method: POST
-      pathRegex: /linkerd2\.controller\.tap\.Tap/TapByResource
 `


### PR DESCRIPTION
Fixed SP route for `POST /api/v1/query`:

```
$ bin/linkerd routes -n linkerd deploy/linkerd-prometheus
ROUTE                                SERVICE   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
GET /api/v1/query_range   linkerd-prometheus   100.00%   3.9rps           1ms           2ms           2ms
GET /api/v1/series        linkerd-prometheus   100.00%   1.1rps           1ms           1ms           1ms
POST /api/v1/query        linkerd-prometheus   100.00%   3.1rps           1ms          17ms          19ms
[DEFAULT]                 linkerd-prometheus         -        -             -             -             -
```

Also added one missing route for `linkerd-grafana`, realizing afterwards there are
many other ones missing, but not really worth adding them all.

I also removed the routes in `linkerd-controller` for the tap routes
given that's no longer handled in that service.

And the tap service SP was also removed alltogether since nothing was
getting reported.

From what I understand tap requests are now served by the k8s API,
which itself hits our tap pod through a TLS connection that the proxy doesn't inspect.
Is that correct @adleong?
