### PR TITLE
Multicluster Helm templates nits

### DIFF
--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -29,9 +29,9 @@ linkerd2-multicluster chart and their default values.
 |`identityTrustDomain`            | Trust domain used for identity of the existing linkerd installation                         |`cluster.local`                               |
 |`linkerdNamespace`               | The namespace of the existing Linkerd installation                                          |`linkerd`                                     |
 |`linkerdVersion`                 | Control plane version                                                                       | latest version                               |
-|`namespace`                      | Service Mirror component namespace                                                          |`linkerd-multicluster`                      |
+|`namespace`                      | Service Mirror component namespace                                                          |`linkerd-multicluster`                        |
 |`proxyOutboundPort`              | The port on which the proxy accepts outbound traffic                                        |`4140`                                        |
-|`remoteAccessServiceAccountName` | The name of the service account used to allow remote clusters to mirror local services      |`linkerd-service-mirror-remote-access-default`|
+|`remoteMirrorServiceAccountName` | The name of the service account used to allow remote clusters to mirror local services      |`linkerd-service-mirror-remote-access-default`|
 |`remoteMirrorServiceAccount`     | If the remote mirror service account should be installed                                    |`true`                                        |
 |`serviceMirror`                  | If the service mirror component should be installed                                         |`true`                                        |
 |`logLevel`                       | Log level for the Multicluster components                                                   |`info`                                        |

--- a/charts/linkerd2-multicluster/templates/service-mirror.yaml
+++ b/charts/linkerd2-multicluster/templates/service-mirror.yaml
@@ -1,10 +1,5 @@
 {{if .Values.serviceMirror -}}
 ---
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: {{.Values.namespace}}
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Followup to #4466

Fixed var name in multicluster's chart README.md, and removed duped
namespace yaml in `service-mirror.yaml`
