### PR TITLE
multicluster: normalize nginx configmap naming

### DIFF
--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-configuration
+  name: linkerd-gateway
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
   namespace: {{.Values.namespace}}
@@ -63,7 +63,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: nginx-configuration   
+            name: linkerd-gateway   
       containers:
         - name: nginx
           readinessProbe:


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/4505

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>