### PR TITLE
Add namespace global flag to hold default namespace name (#4469)

### DIFF
--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -23,7 +23,7 @@ type edgesOptions struct {
 
 func newEdgesOptions() *edgesOptions {
 	return &edgesOptions{
-		namespace:     getDefaultNamespace(),
+		namespace:     kubeNamespace,
 		outputFormat:  tableOutput,
 		allNamespaces: false,
 	}

--- a/cli/cmd/edges.go
+++ b/cli/cmd/edges.go
@@ -23,7 +23,7 @@ type edgesOptions struct {
 
 func newEdgesOptions() *edgesOptions {
 	return &edgesOptions{
-		namespace:     kubeNamespace,
+		namespace:     defaultNamespace,
 		outputFormat:  tableOutput,
 		allNamespaces: false,
 	}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -18,7 +18,7 @@ type getOptions struct {
 
 func newGetOptions() *getOptions {
 	return &getOptions{
-		namespace:     kubeNamespace,
+		namespace:     defaultNamespace,
 		allNamespaces: false,
 	}
 }

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -18,7 +18,7 @@ type getOptions struct {
 
 func newGetOptions() *getOptions {
 	return &getOptions{
-		namespace:     getDefaultNamespace(),
+		namespace:     kubeNamespace,
 		allNamespaces: false,
 	}
 }

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -202,7 +202,7 @@ func newCmdLogs() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&options.container, "container", "c", options.container, "Tail logs from the specified container. Options are 'public-api', 'destination', 'tap', 'prometheus', 'grafana' or 'linkerd-proxy'")
 	cmd.PersistentFlags().StringVar(&options.controlPlaneComponent, "control-plane-component", options.controlPlaneComponent, "Tail logs from the specified control plane component. Default value (empty string) causes this command to tail logs from all resources marked with the 'linkerd.io/control-plane-component' label selector")
-	cmd.PersistentFlags().BoolVar(&options.noColor, "no-color", options.noColor, "Disable colorized output") // needed until at least https://github.com/wercker/stern/issues/69 is resolved
+	cmd.PersistentFlags().BoolVarP(&options.noColor, "no-color", "n", options.noColor, "Disable colorized output") // needed until at least https://github.com/wercker/stern/issues/69 is resolved
 	cmd.PersistentFlags().DurationVarP(&options.sinceSeconds, "since", "s", options.sinceSeconds, "Duration of how far back logs should be retrieved")
 	cmd.PersistentFlags().Int64Var(&options.tail, "tail", options.tail, "Last number of log lines to show for a given container. -1 does not show previous log lines")
 	cmd.PersistentFlags().BoolVarP(&options.timestamps, "timestamps", "t", options.timestamps, "Print timestamps for each given log line")

--- a/cli/cmd/logs.go
+++ b/cli/cmd/logs.go
@@ -202,7 +202,7 @@ func newCmdLogs() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&options.container, "container", "c", options.container, "Tail logs from the specified container. Options are 'public-api', 'destination', 'tap', 'prometheus', 'grafana' or 'linkerd-proxy'")
 	cmd.PersistentFlags().StringVar(&options.controlPlaneComponent, "control-plane-component", options.controlPlaneComponent, "Tail logs from the specified control plane component. Default value (empty string) causes this command to tail logs from all resources marked with the 'linkerd.io/control-plane-component' label selector")
-	cmd.PersistentFlags().BoolVarP(&options.noColor, "no-color", "n", options.noColor, "Disable colorized output") // needed until at least https://github.com/wercker/stern/issues/69 is resolved
+	cmd.PersistentFlags().BoolVar(&options.noColor, "no-color", options.noColor, "Disable colorized output") // needed until at least https://github.com/wercker/stern/issues/69 is resolved
 	cmd.PersistentFlags().DurationVarP(&options.sinceSeconds, "since", "s", options.sinceSeconds, "Duration of how far back logs should be retrieved")
 	cmd.PersistentFlags().Int64Var(&options.tail, "tail", options.tail, "Last number of log lines to show for a given container. -1 does not show previous log lines")
 	cmd.PersistentFlags().BoolVarP(&options.timestamps, "timestamps", "t", options.timestamps, "Print timestamps for each given log line")

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -22,7 +22,7 @@ type metricsOptions struct {
 
 func newMetricsOptions() *metricsOptions {
 	return &metricsOptions{
-		namespace: kubeNamespace,
+		namespace: defaultNamespace,
 		pod:       "",
 	}
 }

--- a/cli/cmd/metrics.go
+++ b/cli/cmd/metrics.go
@@ -22,7 +22,7 @@ type metricsOptions struct {
 
 func newMetricsOptions() *metricsOptions {
 	return &metricsOptions{
-		namespace: getDefaultNamespace(),
+		namespace: kubeNamespace,
 		pod:       "",
 	}
 }

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -27,7 +27,7 @@ type profileOptions struct {
 func newProfileOptions() *profileOptions {
 	return &profileOptions{
 		name:          "",
-		namespace:     getDefaultNamespace(),
+		namespace:     kubeNamespace,
 		template:      false,
 		openAPI:       "",
 		proto:         "",

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -27,7 +27,7 @@ type profileOptions struct {
 func newProfileOptions() *profileOptions {
 	return &profileOptions{
 		name:          "",
-		namespace:     kubeNamespace,
+		namespace:     defaultNamespace,
 		template:      false,
 		openAPI:       "",
 		proto:         "",

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -87,7 +87,7 @@ func exitOnError(result *healthcheck.CheckResult) {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, result.Err)
 
 		checkCmd := "linkerd check"
-		if controlPlaneNamespace != defaultNamespace {
+		if controlPlaneNamespace != defaultLinkerdNamespace {
 			checkCmd += fmt.Sprintf(" --linkerd-namespace %s", controlPlaneNamespace)
 		}
 		fmt.Fprintf(os.Stderr, "Validate the install with: %s\n", checkCmd)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -47,6 +47,7 @@ var (
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
 	kubeContext           string
+	kubeNamespace         string
 	impersonate           string
 	impersonateGroup      []string
 	verbose               bool
@@ -98,6 +99,7 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
+	RootCmd.PersistentFlags().StringVarP(&kubeNamespace, "namespace", "n", getDefaultNamespace(), "Namespace for specified resource")
 	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "linkerd-namespace", "L", defaultNamespace, "Namespace in which Linkerd is installed [$LINKERD_NAMESPACE]")
 	RootCmd.PersistentFlags().StringVarP(&cniNamespace, "cni-namespace", "", defaultCNINamespace, "Namespace in which the Linkerd CNI plugin is installed")
 	RootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
@@ -141,7 +143,7 @@ type statOptionsBase struct {
 
 func newStatOptionsBase() *statOptionsBase {
 	return &statOptionsBase{
-		namespace:    getDefaultNamespace(),
+		namespace:    kubeNamespace,
 		timeWindow:   "1m",
 		outputFormat: tableOutput,
 	}
@@ -205,7 +207,7 @@ func getDefaultNamespace() string {
 	ns, _, err := kubeCfg.Namespace()
 
 	if err != nil {
-		log.Errorf("failed to set namespace from config context:%v", err)
+		log.Errorf("could not set namespace from kubectl context: ensure a valid KUBECONFIG path has been set")
 		return corev1.NamespaceDefault
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	defaultNamespace      = "linkerd"
-	defaultCNINamespace   = "linkerd-cni"
-	defaultClusterDomain  = "cluster.local"
-	defaultDockerRegistry = "gcr.io/linkerd-io"
+	defaultLinkerdNamespace = "linkerd"
+	defaultCNINamespace     = "linkerd-cni"
+	defaultClusterDomain    = "cluster.local"
+	defaultDockerRegistry   = "gcr.io/linkerd-io"
 
 	jsonOutput  = "json"
 	tableOutput = "table"
@@ -47,7 +47,7 @@ var (
 	apiAddr               string // An empty value means "use the Kubernetes configuration"
 	kubeconfigPath        string
 	kubeContext           string
-	kubeNamespace         string
+	defaultNamespace      string // Default namespace taken from current kubectl context
 	impersonate           string
 	impersonateGroup      []string
 	verbose               bool
@@ -86,7 +86,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		controlPlaneNamespaceFromEnv := os.Getenv("LINKERD_NAMESPACE")
-		if controlPlaneNamespace == defaultNamespace && controlPlaneNamespaceFromEnv != "" {
+		if controlPlaneNamespace == defaultLinkerdNamespace && controlPlaneNamespaceFromEnv != "" {
 			controlPlaneNamespace = controlPlaneNamespaceFromEnv
 		}
 
@@ -99,8 +99,8 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&kubeNamespace, "namespace", "n", getDefaultNamespace(), "Namespace for specified resource")
-	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "linkerd-namespace", "L", defaultNamespace, "Namespace in which Linkerd is installed [$LINKERD_NAMESPACE]")
+	defaultNamespace = getDefaultNamespace()
+	RootCmd.PersistentFlags().StringVarP(&controlPlaneNamespace, "linkerd-namespace", "L", defaultLinkerdNamespace, "Namespace in which Linkerd is installed [$LINKERD_NAMESPACE]")
 	RootCmd.PersistentFlags().StringVarP(&cniNamespace, "cni-namespace", "", defaultCNINamespace, "Namespace in which the Linkerd CNI plugin is installed")
 	RootCmd.PersistentFlags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")
 	RootCmd.PersistentFlags().StringVar(&kubeContext, "context", "", "Name of the kubeconfig context to use")
@@ -143,7 +143,7 @@ type statOptionsBase struct {
 
 func newStatOptionsBase() *statOptionsBase {
 	return &statOptionsBase{
-		namespace:    kubeNamespace,
+		namespace:    defaultNamespace,
 		timeWindow:   "1m",
 		outputFormat: tableOutput,
 	}

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -103,7 +103,7 @@ type tapEvent struct {
 
 func newTapOptions() *tapOptions {
 	return &tapOptions{
-		namespace:     getDefaultNamespace(),
+		namespace:     kubeNamespace,
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,

--- a/cli/cmd/tap.go
+++ b/cli/cmd/tap.go
@@ -103,7 +103,7 @@ type tapEvent struct {
 
 func newTapOptions() *tapOptions {
 	return &tapOptions{
-		namespace:     kubeNamespace,
+		namespace:     defaultNamespace,
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -259,7 +259,7 @@ const (
 
 func newTopOptions() *topOptions {
 	return &topOptions{
-		namespace:     kubeNamespace,
+		namespace:     defaultNamespace,
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -259,7 +259,7 @@ const (
 
 func newTopOptions() *topOptions {
 	return &topOptions{
-		namespace:     getDefaultNamespace(),
+		namespace:     kubeNamespace,
 		toResource:    "",
 		toNamespace:   "",
 		maxRps:        maxRps,


### PR DESCRIPTION
### What
---

* When [linkerd/linkerd2#4291](https://github.com/linkerd/linkerd2/pull/4291) was merged in, because all `cli` commands were calling the same function, they were repeatedly displaying the same error log -- see [issue #4469 ](https://github.com/linkerd/linkerd2/issues/4469).

* To fix this, I introduced a global variable `kubeNamespace` whose value is given by `getDefaultNamespace()`, the function previously called in all `cli` subcommands.

* The function should be called once, so no more than one error message should now be displayed

* This PR also changes the error message to provide a bit more context around the issue

### How
---

* Added a global `namespace` flag -- the flag binds to `kubeNamespace`, a global variable used by all subcommands

* To set the default namespace in the command options, each subcommand now assigns the value of `kubeNamespace` as a default (instead of calling the function)

* Because I added a short-form `-n` for the command, I had to edit the short-flag for `--no-color`, which is part of the logs flagset (the two can't co-exist, tests are failing around the generation of code completion i.e `cli/completions.go`).

* For the log/error message, I opted NOT to display the actual error message, but instead specify that a valid `KUBECONFIG` was not used. This is because the main point of error when using the client config loader, the error message would only add on verbosity that does not give any additional context/information (as far as I can tell)

* I wanted to also modify the alpha commands which currently use a hardcoded default namespace, I didn't edit them because I do not know what the intended functionality for those two subcommands are, however, I'd be more than happy to add them as part of this PR.


#### Other options I considered:

Instead of setting a global flag, these are the other options I have considered, and why I chose not to use them:

1. Have `kubeNamespace` as a global variable and set it in the `PreRunE` hook -> this to me was the most sensible choice, however, all command options are created before the `cmd` itself is created, meaning the `PreRunE` function actually runs after the options have been created.

2. Have a `--namespace` global flag and remove all subcommand `--namespace` flags -> to be consistent, I thought only one `--namespace` flag should exist, the global one. This approach again, does not work, the behaviour here is similar to (1): the flag is registered after the options are created, so in this case the `-n` flag does not do anything (except set a default value from the context).

3. Set `kubeNamespace` in the `init()` function instead of relying on the flag to do this -> thought this approach is not very sensible.

#### Manual test output:
```
bin/go-run cli stat deployment/web
Error: StatSummary API error: deployment.apps "web" not found

bin/go-run cli stat deployment/web -n emojivoto
web       1/1    91.15%   1.9rps          18ms          35ms          39ms          2


kubectl config set-context --namespace=emojivoto --current
bin/go-run cli stat deployments
web       1/1    93.64%   1.8rps          19ms          31ms          38ms          2

```

I'm interested to see if there is any way to avoid having the root flag and subcommand flags for `--namespace`.
