### PR TITLE
CI: properly report errors from commands

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -3,6 +3,10 @@
 # This file is a collection of helper functions for running integration tests.
 # It is used primarily by `bin/test-run` and ci.
 
+# Override CI's `set -e` default, so we can catch errors manually and display
+# proper messages
+set +e
+
 # Returns the latest stable verson
 latest_stable() {
   curl -s https://versioncheck.linkerd.io/version.json | grep -o "stable-[0-9]*.[0-9]*.[0-9]*"
@@ -46,7 +50,6 @@ upgrade_integration_tests() {
     # fail subsequent tests. `cleanup` is not called if this test failed so that
     # there is a chance to debug the problem
     run_upgrade_test "$linkerd_namespace"-upgrade
-    exit_on_err "can't upgrade to version $linkerd_version"
     cleanup
 }
 
@@ -56,9 +59,7 @@ helm_upgrade_integration_tests() {
     helm_release_name=$linkerd_namespace-test
 
     run_helm_upgrade_test
-    exit_on_err 'error testing Helm upgrade'
     helm_cleanup
-    exit_on_err 'error cleaning up Helm upgrade'
     # clean the data plane test resources
     cleanup
 }
@@ -69,40 +70,30 @@ helm_integration_tests() {
     helm_release_name=$linkerd_namespace-test
 
     run_helm_test
-    exit_on_err 'error testing Helm'
     helm_cleanup
-    exit_on_err 'error cleaning up Helm'
     # clean the data plane test resources
     cleanup
 }
 
 uninstall_integration_tests() {
     run_test "$test_directory/uninstall/uninstall_test.go" --linkerd-namespace=$linkerd_namespace --uninstall=true
-    exit_on_err 'error during uninstall tests'
     cleanup
 }
 
 deep_integration_tests() {
     run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace
-    exit_on_err 'error during install'
-
     run_test "$(go list $test_directory/.../...)" --linkerd-namespace=$linkerd_namespace
-    exit_on_err 'error during deep tests'
     cleanup
 }
 
 custom_domain_integration_tests() {
     run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace --cluster-domain="custom.domain"
-    exit_on_err 'error during install'
     cleanup
 }
 
 external_issuer_integration_tests() {
     run_test "$test_directory/install_test.go" --linkerd-namespace=$linkerd_namespace-external-issuer --external-issuer=true
-    exit_on_err 'error during install with --external-issuer=true'
-
     run_test "$test_directory/externalissuer/external_issuer_test.go" --linkerd-namespace=$linkerd_namespace-external-issuer --external-issuer=true
-    exit_on_err 'error during external issuer tests'
     cleanup
 }
 
@@ -160,24 +151,31 @@ run_test(){
 
     printf 'Test script: [%s] Params: [%s]\n' "$(basename $filename 2>/dev/null || echo $filename )" "$*"
     GO111MODULE=on go test --failfast --mod=readonly $filename --linkerd="$linkerd_path" --k8s-context="$k8s_context" --integration-tests "$@"
+    [ $? -ne 0 ] && exit 1
 }
 
 # Install the latest stable release.
 # $1 - namespace to use for the stable release
 install_stable() {
     tmp=$(mktemp -d -t l5dbin.XXX)
-    trap "rm -rf $tmp" RETURN
 
     curl -s https://run.linkerd.io/install | HOME=$tmp sh > /dev/null 2>&1
 
     local linkerd_path=$tmp/.linkerd2/bin/linkerd
     local stable_namespace=$1
     local test_app_namespace=$stable_namespace-upgrade-test
+
     (
         set -x
         "$linkerd_path" install --linkerd-namespace="$stable_namespace" | kubectl --context="$k8s_context" apply -f - 2>&1
+    )
+    exit_on_err 'install_stable() - installing stable failed'
+
+    (
+        set -x
         "$linkerd_path" check --linkerd-namespace="$stable_namespace" 2>&1
     )
+    exit_on_err 'install_stable() - linkerd check failed'
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
     kubectl --context=$k8s_context create namespace "$test_app_namespace" > /dev/null 2>&1
@@ -186,6 +184,7 @@ install_stable() {
         set -x
         "$linkerd_path" inject --linkerd-namespace="$stable_namespace" "$test_directory/testdata/upgrade_test.yaml" | kubectl --context="$k8s_context" apply --namespace="$test_app_namespace" -f - 2>&1
     )
+    exit_on_err 'install_stable() - linkerd inject failed'
 }
 
 # Run the upgrade test by upgrading the most-recent stable release to the HEAD of
@@ -200,7 +199,7 @@ run_upgrade_test() {
 }
 
 setup_helm() {
-      (
+    (
         set -e
         "$bindir"/helm-build
         "$helm_path" --kube-context=$k8s_context repo add linkerd https://helm.linkerd.io/stable
@@ -232,12 +231,21 @@ helm_cleanup() {
         # We don't have that problem with global resources, so no need to wait for them to be gone.
         kubectl wait --for=delete ns/$linkerd_namespace-helm --timeout=120s
     )
+    exit_on_err 'error cleaning up Helm'
 }
 
+# exit_on_err should be called right after a command to check the result status and eventually generate a Github error
+# annotation. Do not use after calls to `go test` as that generates its own annotations.
+# Note this should be called outside subshells in order for the script to terminate.
 exit_on_err() {
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
-        printf '\n=== FAIL: %s\n' "$@"
+        export GH_ANNOTATION=${GH_ANNOTATION:-}
+        if [ -n "$GH_ANNOTATION" ]; then
+          printf '::error::%s\n' "$1"
+        else
+          printf '\n=== FAIL: %s\n' "$1"
+        fi
         exit $exit_code
     fi
 }

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -213,7 +213,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 	success := runChecks(wout, werr, hc, options.output)
 
 	if !success {
-		os.Exit(2)
+		os.Exit(1)
 	}
 
 	return nil


### PR DESCRIPTION
Failures in `bin/_test-run` from commands different than `go test`
aren't currently properly reported, in part because CI's bash default is
to have `set -e` which terminates the script and just outputs
`##[error]Process completed with exit code 2.` like
[here](https://github.com/linkerd/linkerd2/pull/4496/checks?check_run_id=720720352#step:14:116)

```
linkerd-existence
-----------------
√ 'linkerd-config' config map exists
√ heartbeat ServiceAccount exist
√ control plane replica sets are ready
× no unschedulable pods
    linkerd-controller-6c77c7ffb8-w8wh5: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-destination-6767d88f7f-rcnbq: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-grafana-76c76fcfb9-pdhfb: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-identity-5bcf97d6c8-q6rll: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-prometheus-6b95c56b44-hd9m6: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-proxy-injector-58d794ff9-jf7cj: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-sp-validator-6c5f999bfb-qg252: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-tap-6fdf84fc65-6txvr: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    linkerd-web-8484fbd867-nm8z2: 0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
    see https://linkerd.io/checks/#l5d-existence-unschedulable-pods for hints

Status check results are ×
[error]Process completed with exit code 2.
```

I've made the following changes to `bin/_test-run` to generate better
messages and Github annotations when an error occurs:

- Unset `set -e` so that errors don't immediately exit the script and
don't allow us to properly format the errors.
- Removed many of the `exit_on_err` calls after go test calls because
those output enough information already. That function wasn't being called
anyways because of `set -e`. Instead have `run_test` exit
upon a `go test` error.
- Added `exit_on_err` calls right after non-`go-test` commands to
properly report their failure.
- Refactored the `exit_on_err` function so that it generates a Github
error annotation upon failure.
- Removed `trap` in `install_stable`, since the OS should be able to
handle GC for stuff under `/tmp`.

Also, I've changed the exit 2 code from `linkerd check` when it fails,
to exit code 1.