### PR TITLE
Fetch logs/events when integration test fails, not only for install tests

### DIFF
--- a/test/edges/edges_test.go
+++ b/test/edges/edges_test.go
@@ -18,7 +18,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 // TestEdges requires that there has been traffic recently between linkerd-web

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -16,7 +16,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 //////////////////////

--- a/test/endpoints/endpoints_test.go
+++ b/test/endpoints/endpoints_test.go
@@ -16,7 +16,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 func TestGoodEndpoints(t *testing.T) {

--- a/test/externalissuer/external_issuer_test.go
+++ b/test/externalissuer/external_issuer_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stdout, "Skiping as --external-issuer=false")
 		os.Exit(0)
 	}
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 func TestExternalIssuer(t *testing.T) {

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -21,7 +21,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 var (

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -24,7 +24,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 //////////////////////

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -1,10 +1,8 @@
 package test
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,7 +11,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/linkerd/linkerd2/testutil"
-	corev1 "k8s.io/api/core/v1"
 )
 
 //////////////////////
@@ -30,22 +27,7 @@ var (
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	code := m.Run()
-	// if the test failed, show logs and events that can potentially explain cause
-	if code != 0 && controlPlaneInstalled {
-		_, errs1 := fetchAndCheckLogs()
-		for _, err := range errs1 {
-			fmt.Println(err)
-		}
-		errs2 := fetchAndCheckEvents()
-		for _, err := range errs2 {
-			fmt.Println(err)
-		}
-		if len(errs1) == 0 && len(errs2) == 0 {
-			fmt.Println("No unexpected log entries or events found")
-		}
-	}
-	os.Exit(code)
+	os.Exit(testutil.Run(m, TestHelper, controlPlaneInstalled))
 }
 
 var (
@@ -62,44 +44,6 @@ var (
 		"linkerd-web",
 		"linkerd-tap",
 	}
-
-	// Linkerd commonly logs these errors during testing, remove these once
-	// they're addressed: https://github.com/linkerd/linkerd2/issues/2453
-	knownControllerErrorsRegex = regexp.MustCompile(strings.Join([]string{
-		`.*linkerd-controller-.*-.* tap time=".*" level=error msg="\[.*\] encountered an error: rpc error: code = Canceled desc = context canceled"`,
-		`.*linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
-		`.*linkerd-proxy-injector-.*-.* proxy-injector time=".*" level=warning msg="failed to retrieve replicaset from indexer .*-smoke-test.*/smoke-test-.*-.*: replicaset\.apps \\"smoke-test-.*-.*\\" not found"`,
-		`.*linkerd-destination-.* destination time=".*" level=warning msg="failed to retrieve replicaset from indexer .* not found"`,
-	}, "|"))
-
-	knownProxyErrorsRegex = regexp.MustCompile(strings.Join([]string{
-		// k8s hitting readiness endpoints before components are ready
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::app::errors unexpected error: an IO error occurred: Connection reset by peer \(os error 104\)`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: 127\.0\.0\.1:.*\)`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: .*\)`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: operation timed out after 1s`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy WARN \[ *\d+.\d+s\] .* linkerd2_proxy::proxy::reconnect connect error to ControlAddr .*`,
-
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] admin={server=metrics listen=0\.0\.0\.0:4191 remote=.*} linkerd2_proxy::control::serve_http error serving metrics: Error { kind: Shutdown, .* }`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] admin={server=admin listen=127\.0\.0\.1:4191 remote=.*} linkerd2_proxy::control::serve_http error serving admin: Error { kind: Shutdown, cause: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" } }`,
-
-		`.* linkerd-web-.*-.* linkerd-proxy WARN trust_dns_proto::xfer::dns_exchange failed to associate send_message response to the sender`,
-		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|web|tap)-.*-.* linkerd-proxy WARN \[.*\] linkerd2_proxy::proxy::canonicalize failed to refine linkerd-.*\..*\.svc\.cluster\.local: deadline has elapsed; using original name`,
-
-		// prometheus scrape failures of control-plane
-		`.* linkerd-prometheus-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: .*`,
-	}, "|"))
-
-	knownEventWarningsRegex = regexp.MustCompile(strings.Join([]string{
-		`MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition`, // pre k8s 1.16
-		`MountVolume.SetUp failed for volume .* : failed to sync .* cache: timed out waiting for the condition`,         // post k8s 1.16
-		`(Liveness|Readiness) probe failed: HTTP probe failed with statuscode: 50(2|3)`,
-		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
-		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
-		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
-		`Failed to update endpoint .*/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
-		`error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: "rpc error: code = Unknown desc`,
-	}, "|"))
 
 	injectionCases = []struct {
 		ns          string
@@ -745,82 +689,8 @@ func TestCheckProxy(t *testing.T) {
 	}
 }
 
-func fetchAndCheckLogs() ([]string, []error) {
-	okMessages := []string{}
-	errs := []error{}
-
-	controllerRegex := regexp.MustCompile("level=(panic|fatal|error|warn)")
-	proxyRegex := regexp.MustCompile(fmt.Sprintf("%s (ERR|WARN)", k8s.ProxyContainerName))
-	clientGoRegex := regexp.MustCompile("client-go@")
-	hasClientGoLogs := false
-
-	for deploy, spec := range testutil.LinkerdDeployReplicas {
-		deploy := strings.TrimPrefix(deploy, "linkerd-")
-		containers := append(spec.Containers, k8s.ProxyContainerName)
-
-		for _, container := range containers {
-			container := container // pin
-			name := fmt.Sprintf("%s/%s", deploy, container)
-
-			proxy := false
-			errRegex := controllerRegex
-			knownErrorsRegex := knownControllerErrorsRegex
-			if container == k8s.ProxyContainerName {
-				proxy = true
-				errRegex = proxyRegex
-				knownErrorsRegex = knownProxyErrorsRegex
-			}
-
-			outputStream, err := TestHelper.LinkerdRunStream(
-				"logs", "--no-color",
-				"--control-plane-component", deploy,
-				"--container", container,
-			)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("error running command:\n%s", err))
-				continue
-			}
-			defer outputStream.Stop()
-			// Ignore the error returned, since ReadUntil will return an error if it
-			// does not return 10,000 after 2 seconds. We don't need 10,000 log lines.
-			outputLines, _ := outputStream.ReadUntil(10000, 2*time.Second)
-			if len(outputLines) == 0 {
-				// Retry one time for 30 more seconds, in case the cluster is slow to
-				// produce log lines.
-				outputLines, _ = outputStream.ReadUntil(10000, 30*time.Second)
-				if len(outputLines) == 0 {
-					errs = append(errs, fmt.Errorf("no logs found for %s", name))
-				}
-			}
-
-			for _, line := range outputLines {
-				if errRegex.MatchString(line) {
-					if knownErrorsRegex.MatchString(line) {
-						// report all known logging errors in the output
-						okMessages = append(okMessages, fmt.Sprintf("found known error in %s log: %s", name, line))
-					} else {
-						if proxy {
-							okMessages = append(okMessages, fmt.Sprintf("found unexpected proxy error in %s log: %s", name, line))
-						} else {
-							errs = append(errs, fmt.Errorf("found unexpected controller error in %s log: %s", name, line))
-						}
-					}
-				}
-				if clientGoRegex.MatchString((line)) {
-					hasClientGoLogs = true
-				}
-			}
-		}
-	}
-	if !hasClientGoLogs {
-		errs = append(errs, errors.New("didn't find any client-go entries"))
-	}
-
-	return okMessages, errs
-}
-
 func TestLogs(t *testing.T) {
-	okMessages, errs := fetchAndCheckLogs()
+	okMessages, errs := testutil.FetchAndCheckLogs(TestHelper)
 	for msg := range okMessages {
 		t.Log(msg)
 	}
@@ -829,37 +699,8 @@ func TestLogs(t *testing.T) {
 	}
 }
 
-func fetchAndCheckEvents() []error {
-	out, err := TestHelper.Kubectl("",
-		"--namespace", TestHelper.GetLinkerdNamespace(),
-		"get", "events", "-ojson",
-	)
-	if err != nil {
-		return []error{fmt.Errorf("'kubectl get events' command failed with %s\n%s", err, out)}
-	}
-
-	events, err := testutil.ParseEvents(out)
-	if err != nil {
-		return []error{err}
-	}
-
-	errs := []error{}
-	for _, e := range events {
-		if e.Type == corev1.EventTypeNormal {
-			continue
-		}
-
-		evtStr := fmt.Errorf("found unexpected warning event: reason: [%s] Object: [%s] Message: [%s]", e.Reason, e.InvolvedObject.Name, e.Message)
-		if !knownEventWarningsRegex.MatchString(e.Message) {
-			errs = append(errs, evtStr)
-		}
-	}
-
-	return errs
-}
-
 func TestEvents(t *testing.T) {
-	for err := range fetchAndCheckEvents() {
+	for err := range testutil.FetchAndCheckEvents(TestHelper) {
 		testutil.AnnotatedError(t, "Error checking events", err)
 	}
 }

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -322,10 +322,12 @@ func helmOverridesEdge(root *tls.CA) []string {
 }
 
 func TestInstallHelm(t *testing.T) {
+	// at this point all the tests assume the control plane is present
+	controlPlaneInstalled = true
+
 	if TestHelper.GetHelmReleaseName() == "" {
 		return
 	}
-	controlPlaneInstalled = true
 
 	cn := fmt.Sprintf("identity.%s.cluster.local", TestHelper.GetLinkerdNamespace())
 	var err error

--- a/test/routes/routes_test.go
+++ b/test/routes/routes_test.go
@@ -17,7 +17,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 //////////////////////

--- a/test/serviceaccounts/serviceaccounts_test.go
+++ b/test/serviceaccounts/serviceaccounts_test.go
@@ -13,7 +13,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 // namesMatch checks if all the expectedServiceAccountNames are present in the given list,

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -27,7 +27,7 @@ type testCase struct {
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 func TestServiceProfiles(t *testing.T) {

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -19,7 +19,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 //////////////////////

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -18,7 +18,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 type tapEvent struct {

--- a/test/tracing/tracing_test.go
+++ b/test/tracing/tracing_test.go
@@ -33,7 +33,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 //////////////////////

--- a/test/trafficsplit/trafficsplit_test.go
+++ b/test/trafficsplit/trafficsplit_test.go
@@ -16,7 +16,7 @@ const zeroRPS = "0.0rps"
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 type statTsRow struct {

--- a/test/uninstall/uninstall_test.go
+++ b/test/uninstall/uninstall_test.go
@@ -16,7 +16,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "Uninstall test disabled")
 		os.Exit(0)
 	}
-	os.Exit(m.Run())
+	os.Exit(testutil.Run(m, TestHelper, true))
 }
 
 func TestInstall(t *testing.T) {

--- a/testutil/logs_events.go
+++ b/testutil/logs_events.go
@@ -1,0 +1,155 @@
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	// Linkerd commonly logs these errors during testing, remove these once
+	// they're addressed: https://github.com/linkerd/linkerd2/issues/2453
+	knownControllerErrorsRegex = regexp.MustCompile(strings.Join([]string{
+		`.*linkerd-controller-.*-.* tap time=".*" level=error msg="\[.*\] encountered an error: rpc error: code = Canceled desc = context canceled"`,
+		`.*linkerd-web-.*-.* web time=".*" level=error msg="Post http://linkerd-controller-api\..*\.svc\.cluster\.local:8085/api/v1/Version: context canceled"`,
+		`.*linkerd-proxy-injector-.*-.* proxy-injector time=".*" level=warning msg="failed to retrieve replicaset from indexer .*-smoke-test.*/smoke-test-.*-.*: replicaset\.apps \\"smoke-test-.*-.*\\" not found"`,
+		`.*linkerd-destination-.* destination time=".*" level=warning msg="failed to retrieve replicaset from indexer .* not found"`,
+	}, "|"))
+
+	knownProxyErrorsRegex = regexp.MustCompile(strings.Join([]string{
+		// k8s hitting readiness endpoints before components are ready
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::app::errors unexpected error: an IO error occurred: Connection reset by peer \(os error 104\)`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=in listen=0\.0\.0\.0:4143 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: 127\.0\.0\.1:.*\)`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: Connection refused \(os error 111\) \(address: .*\)`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::(proxy::http::router service|app::errors unexpected) error: an error occurred trying to connect: operation timed out after 1s`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy WARN \[ *\d+.\d+s\] .* linkerd2_proxy::proxy::reconnect connect error to ControlAddr .*`,
+
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ *\d+.\d+s\] admin={server=metrics listen=0\.0\.0\.0:4191 remote=.*} linkerd2_proxy::control::serve_http error serving metrics: Error { kind: Shutdown, .* }`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|sp-validator|web|tap)-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] admin={server=admin listen=127\.0\.0\.1:4191 remote=.*} linkerd2_proxy::control::serve_http error serving admin: Error { kind: Shutdown, cause: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" } }`,
+
+		`.* linkerd-web-.*-.* linkerd-proxy WARN trust_dns_proto::xfer::dns_exchange failed to associate send_message response to the sender`,
+		`.* linkerd-(controller|identity|grafana|prometheus|proxy-injector|web|tap)-.*-.* linkerd-proxy WARN \[.*\] linkerd2_proxy::proxy::canonicalize failed to refine linkerd-.*\..*\.svc\.cluster\.local: deadline has elapsed; using original name`,
+
+		// prometheus scrape failures of control-plane
+		`.* linkerd-prometheus-.*-.* linkerd-proxy ERR! \[ +\d+.\d+s\] proxy={server=out listen=127\.0\.0\.1:4140 remote=.*} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: .*`,
+	}, "|"))
+
+	knownEventWarningsRegex = regexp.MustCompile(strings.Join([]string{
+		`MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition`, // pre k8s 1.16
+		`MountVolume.SetUp failed for volume .* : failed to sync .* cache: timed out waiting for the condition`,         // post k8s 1.16
+		`(Liveness|Readiness) probe failed: HTTP probe failed with statuscode: 50(2|3)`,
+		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
+		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
+		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
+		`Failed to update endpoint .*/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
+		`error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: "rpc error: code = Unknown desc`,
+	}, "|"))
+)
+
+func FetchAndCheckLogs(helper *TestHelper) ([]string, []error) {
+	okMessages := []string{}
+	errs := []error{}
+
+	controllerRegex := regexp.MustCompile("level=(panic|fatal|error|warn)")
+	proxyRegex := regexp.MustCompile(fmt.Sprintf("%s (ERR|WARN)", k8s.ProxyContainerName))
+	clientGoRegex := regexp.MustCompile("client-go@")
+	hasClientGoLogs := false
+
+	for deploy, spec := range LinkerdDeployReplicas {
+		deploy := strings.TrimPrefix(deploy, "linkerd-")
+		containers := append(spec.Containers, k8s.ProxyContainerName)
+
+		for _, container := range containers {
+			container := container // pin
+			name := fmt.Sprintf("%s/%s", deploy, container)
+
+			proxy := false
+			errRegex := controllerRegex
+			knownErrorsRegex := knownControllerErrorsRegex
+			if container == k8s.ProxyContainerName {
+				proxy = true
+				errRegex = proxyRegex
+				knownErrorsRegex = knownProxyErrorsRegex
+			}
+
+			outputStream, err := helper.LinkerdRunStream(
+				"logs", "--no-color",
+				"--control-plane-component", deploy,
+				"--container", container,
+			)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("error running command:\n%s", err))
+				continue
+			}
+			defer outputStream.Stop()
+			// Ignore the error returned, since ReadUntil will return an error if it
+			// does not return 10,000 after 2 seconds. We don't need 10,000 log lines.
+			outputLines, _ := outputStream.ReadUntil(10000, 2*time.Second)
+			if len(outputLines) == 0 {
+				// Retry one time for 30 more seconds, in case the cluster is slow to
+				// produce log lines.
+				outputLines, _ = outputStream.ReadUntil(10000, 30*time.Second)
+				if len(outputLines) == 0 {
+					errs = append(errs, fmt.Errorf("no logs found for %s", name))
+				}
+			}
+
+			for _, line := range outputLines {
+				if errRegex.MatchString(line) {
+					if knownErrorsRegex.MatchString(line) {
+						// report all known logging errors in the output
+						okMessages = append(okMessages, fmt.Sprintf("found known error in %s log: %s", name, line))
+					} else {
+						if proxy {
+							okMessages = append(okMessages, fmt.Sprintf("found unexpected proxy error in %s log: %s", name, line))
+						} else {
+							errs = append(errs, fmt.Errorf("found unexpected controller error in %s log: %s", name, line))
+						}
+					}
+				}
+				if clientGoRegex.MatchString((line)) {
+					hasClientGoLogs = true
+				}
+			}
+		}
+	}
+	if !hasClientGoLogs {
+		errs = append(errs, errors.New("didn't find any client-go entries"))
+	}
+
+	return okMessages, errs
+}
+
+func FetchAndCheckEvents(helper *TestHelper) []error {
+	out, err := helper.Kubectl("",
+		"--namespace", helper.GetLinkerdNamespace(),
+		"get", "events", "-ojson",
+	)
+	if err != nil {
+		return []error{fmt.Errorf("'kubectl get events' command failed with %s\n%s", err, out)}
+	}
+
+	events, err := ParseEvents(out)
+	if err != nil {
+		return []error{err}
+	}
+
+	errs := []error{}
+	for _, e := range events {
+		if e.Type == corev1.EventTypeNormal {
+			continue
+		}
+
+		evtStr := fmt.Errorf("found unexpected warning event: reason: [%s] Object: [%s] Message: [%s]", e.Reason, e.InvolvedObject.Name, e.Message)
+		if !knownEventWarningsRegex.MatchString(e.Message) {
+			errs = append(errs, evtStr)
+		}
+	}
+
+	return errs
+}

--- a/testutil/logs_events.go
+++ b/testutil/logs_events.go
@@ -51,6 +51,9 @@ var (
 	}, "|"))
 )
 
+// FetchAndCheckLogs retrieves the logs from the control plane containers and matches them
+// to the list in knownControllerErrorsRegex and knownProxyErrorsRegex.
+// It returns the list of matched entries and the list of unmatched entries (as errors).
 func FetchAndCheckLogs(helper *TestHelper) ([]string, []error) {
 	okMessages := []string{}
 	errs := []error{}
@@ -125,6 +128,9 @@ func FetchAndCheckLogs(helper *TestHelper) ([]string, []error) {
 	return okMessages, errs
 }
 
+// FetchAndCheckEvents retrieves the events from k8s for the current namespace, matches
+// them against knownEventWarningsRegex and returns the list of unmatched entries
+// (as errors).
 func FetchAndCheckEvents(helper *TestHelper) []error {
 	out, err := helper.Kubectl("",
 		"--namespace", helper.GetLinkerdNamespace(),

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -481,4 +482,24 @@ func ParseEvents(out string) ([]*corev1.Event, error) {
 	}
 
 	return events, nil
+}
+
+// Run calls `m.Run()`, shows unexpected logs/events if showLogs is true,
+// and returns the exit code for the tests
+func Run(m *testing.M, helper *TestHelper, showLogs bool) int {
+	code := m.Run()
+	if code != 0 && showLogs {
+		_, errs1 := FetchAndCheckLogs(helper)
+		for _, err := range errs1 {
+			fmt.Println(err)
+		}
+		errs2 := FetchAndCheckEvents(helper)
+		for _, err := range errs2 {
+			fmt.Println(err)
+		}
+		if len(errs1) == 0 && len(errs2) == 0 {
+			fmt.Println("No unexpected log entries or events found")
+		}
+	}
+	return code
 }


### PR DESCRIPTION
## Motivation

Mainly to know what caused containers to not start (or to restart), like in #4285

## Implementation

Followup to #4410, where we fetched unexpected logs/events when a test failed in `test/install_test.go`; now we're expanding that behavior to every integration test.

For that, we replace in each `TestMain()`:

```go
os.Exit(m.Run())
```

with

```go
os.Exit(testutil.Run(m, TestHelper, true))

```

where `testutil.Run()` executes the tests and fetches the logs/events if the tests failed.

Also extracted the log/event fetching and matching into its own separate file.