### PR TITLE
conformance validation: add new helper to `testutil`

### DIFF
--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -61,12 +61,11 @@ var LinkerdDeployReplicas = map[string]deploySpec{
 	"linkerd-proxy-injector": {1, []string{"proxy-injector"}},
 }
 
-// ConformanceTestHelperOptions defines the TestHelper
-// options required for conformance validation - https://github.com/linkerd/linkerd2-conformance
-// This way the default options may be defined in the linkerd2-conformance repo,
-// and an instance can be passed to NewConformanceTestHelper() to obtain a *TestHelper
+// GenericTestHelperOptions defines the TestHelper options
+// that are used along with `NewGenericTestHelper()` method
+// to obtain a *TestHelper
 // See - https://github.com/linkerd/linkerd2/issues/4530
-type ConformanceTestHelperOptions struct {
+type GenericTestHelperOptions struct {
 	Linkerd            string
 	Namespace          string
 	UpgradeFromVersion string
@@ -79,10 +78,11 @@ type ConformanceTestHelperOptions struct {
 	HelmReleaseName    string
 }
 
-// NewConformanceTestHelper creates a new TestHelper from the options provided
-// This helper was created to be able to reuse this package for Conformance validation
+// NewGenericTestHelper returns a new *TestHelper from the options provided.
+// This helper was created to be able to reuse this package without hard restrictions
+// as seen in `NewTestHelper()` which is primarily used with integration tests
 // See - https://github.com/linkerd/linkerd2/issues/4530
-func NewConformanceTestHelper(options *ConformanceTestHelperOptions) *TestHelper {
+func NewGenericTestHelper(options *GenericTestHelperOptions) *TestHelper {
 	return &TestHelper{
 		linkerd:            options.Linkerd,
 		namespace:          options.Namespace,

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -61,42 +61,36 @@ var LinkerdDeployReplicas = map[string]deploySpec{
 	"linkerd-proxy-injector": {1, []string{"proxy-injector"}},
 }
 
-// GenericTestHelperOptions defines the TestHelper options
-// that are used along with `NewGenericTestHelper()` method
-// to obtain a *TestHelper
-// See - https://github.com/linkerd/linkerd2/issues/4530
-type GenericTestHelperOptions struct {
-	Linkerd            string
-	Namespace          string
-	UpgradeFromVersion string
-	ClusterDomain      string
-	ExternalIssuer     bool
-	Uninstall          bool
-	HelmPath           string
-	HelmChart          string
-	HelmStableChart    string
-	HelmReleaseName    string
-}
-
-// NewGenericTestHelper returns a new *TestHelper from the options provided.
+// NewGenericTestHelper returns a new *TestHelper from the options provided as function parameters.
 // This helper was created to be able to reuse this package without hard restrictions
 // as seen in `NewTestHelper()` which is primarily used with integration tests
 // See - https://github.com/linkerd/linkerd2/issues/4530
-func NewGenericTestHelper(options *GenericTestHelperOptions) *TestHelper {
+func NewGenericTestHelper(
+	linkerd,
+	namespace,
+	upgradeFromVersion,
+	clusterDomain,
+	helmPath,
+	helmChart,
+	helmStableChart,
+	helmReleaseName string,
+	externalIssuer,
+	uninstall bool,
+) *TestHelper {
 	return &TestHelper{
-		linkerd:            options.Linkerd,
-		namespace:          options.Namespace,
-		upgradeFromVersion: options.UpgradeFromVersion,
+		linkerd:            linkerd,
+		namespace:          namespace,
+		upgradeFromVersion: upgradeFromVersion,
 		helm: helm{
-			path:               options.HelmPath,
-			chart:              options.HelmChart,
-			stableChart:        options.HelmStableChart,
-			releaseName:        options.HelmReleaseName,
-			upgradeFromVersion: options.UpgradeFromVersion,
+			path:               helmPath,
+			chart:              helmChart,
+			stableChart:        helmStableChart,
+			releaseName:        helmReleaseName,
+			upgradeFromVersion: upgradeFromVersion,
 		},
-		clusterDomain:  options.ClusterDomain,
-		externalIssuer: options.ExternalIssuer,
-		uninstall:      options.Uninstall,
+		clusterDomain:  clusterDomain,
+		externalIssuer: externalIssuer,
+		uninstall:      uninstall,
 	}
 }
 

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -61,6 +61,45 @@ var LinkerdDeployReplicas = map[string]deploySpec{
 	"linkerd-proxy-injector": {1, []string{"proxy-injector"}},
 }
 
+// ConformanceTestHelperOptions defines the TestHelper
+// options required for conformance validation - https://github.com/linkerd/linkerd2-conformance
+// This way the default options may be defined in the linkerd2-conformance repo,
+// and an instance can be passed to NewConformanceTestHelper() to obtain a *TestHelper
+// See - https://github.com/linkerd/linkerd2/issues/4530
+type ConformanceTestHelperOptions struct {
+	Linkerd            string
+	Namespace          string
+	UpgradeFromVersion string
+	ClusterDomain      string
+	ExternalIssuer     bool
+	Uninstall          bool
+	HelmPath           string
+	HelmChart          string
+	HelmStableChart    string
+	HelmReleaseName    string
+}
+
+// NewConformanceTestHelper creates a new TestHelper from the options provided
+// This helper was created to be able to reuse this package for Conformance validation
+// See - https://github.com/linkerd/linkerd2/issues/4530
+func NewConformanceTestHelper(options *ConformanceTestHelperOptions) *TestHelper {
+	return &TestHelper{
+		linkerd:            options.Linkerd,
+		namespace:          options.Namespace,
+		upgradeFromVersion: options.UpgradeFromVersion,
+		helm: helm{
+			path:               options.HelmPath,
+			chart:              options.HelmChart,
+			stableChart:        options.HelmStableChart,
+			releaseName:        options.HelmReleaseName,
+			upgradeFromVersion: options.UpgradeFromVersion,
+		},
+		clusterDomain:  options.ClusterDomain,
+		externalIssuer: options.ExternalIssuer,
+		uninstall:      options.Uninstall,
+	}
+}
+
 // NewTestHelper creates a new instance of TestHelper for the current test run.
 // The new TestHelper can be configured via command line flags.
 func NewTestHelper() *TestHelper {


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/4530

- Add new struct `GenericTestHelperOptions`

`GenericTestHelperOptions` defines the `TestHelper` options
that are used along with `NewGenericTestHelper()` method to obtain a `*TestHelper`

- Add new helper function `NewGenericTestHelper`

`NewGenericTestHelper` accepts a `*GenericTestHelperOptions` and returns a new `*TestHelper` from the options provided. This helper was created to be able to reuse the `testutil` package without any hard restrictions 

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
