### PR TITLE
CI steps for Chocolatey package - take 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,13 +241,16 @@ jobs:
         . bin/_release.sh
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
         extract_release_notes NOTES.md
-    - name: Pull CLI binaries
-      run : bin/docker-pull-binaries $TAG
     - name: Download choco package
       # actions/download-artifact@v1
       uses: actions/download-artifact@18f0f59
       with:
         name: choco
+    - name: Pull CLI binaries
+      run : |
+        bin/docker-pull-binaries $TAG
+        VERSION=${TAG#"stable-"}
+        mv choco/linkerd.*.nupkg target/release/linkerd2-cli-stable-$VERSION.nupkg || true
     - name: Create release
       id: create_release
       # softprops/action-gh-release@v1
@@ -265,7 +268,7 @@ jobs:
           ./target/release/linkerd2-cli-*-linux.sha256
           ./target/release/linkerd2-cli-*-windows.exe
           ./target/release/linkerd2-cli-*-windows.exe.sha256
-          ./choco/linkerd.*.nupkg
+          ./target/release/linkerd2-cli-*.nupkg
   website_publish:
     name: Linkerd website publish
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,11 +202,35 @@ jobs:
       run: |
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  choco_pack:
+    name: Pack Chocolatey release
+    if: startsWith(github.ref, 'refs/tags/stable')
+    needs: [kind_integration_tests, cloud_integration_tests]
+    runs-on: windows-2019
+    steps:
+    - name: Checkout code
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
+    - name: Chocolatey - update nuspec
+      run: |
+        $LINKERD_VERSION=$env:GITHUB_REF.Substring(17)
+        (Get-Content bin\win\linkerd.nuspec).replace('LINKERD_VERSION', $LINKERD_VERSION) | Set-Content bin\win\linkerd.nuspec
+    - name: Chocolatey - pack
+      # crazy-max/ghaction-chocolatey@v1.2.2
+      uses: crazy-max/ghaction-chocolatey@55c9188
+      with:
+        args: pack bin/win/linkerd.nuspec
+    - name: Chocolatey - upload package
+      # actions/upload-artifact@v2.01
+      uses: actions/upload-artifact@97b7dac
+      with:
+        name: choco
+        path: ./linkerd.*.nupkg
   gh_release:
     name: Create GH release
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
-    needs: [kind_integration_tests, cloud_integration_tests]
+    needs: [choco_pack]
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -219,6 +243,11 @@ jobs:
         extract_release_notes NOTES.md
     - name: Pull CLI binaries
       run : bin/docker-pull-binaries $TAG
+    - name: Download choco package
+      # actions/download-artifact@v1
+      uses: actions/download-artifact@18f0f59
+      with:
+        name: choco
     - name: Create release
       id: create_release
       # softprops/action-gh-release@v1
@@ -236,6 +265,7 @@ jobs:
           ./target/release/linkerd2-cli-*-linux.sha256
           ./target/release/linkerd2-cli-*-windows.exe
           ./target/release/linkerd2-cli-*-windows.exe.sha256
+          ./choco/linkerd.*.nupkg
   website_publish:
     name: Linkerd website publish
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -72,6 +72,22 @@ jobs:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
         bin/shellcheck-all
+  psscript-analyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
+    - name: Chocolatey - lint
+      # devblackops/github-action-psscriptanalyzer@v2.0.0
+      uses: devblackops/github-action-psscriptanalyzer@889a059
+      env:
+        # https://github.com/devblackops/github-action-psscriptanalyzer/pull/3/files
+        INPUT_FAILONWARNING: 1
+      with:
+        rootPath: bin/win/tools
+        failOnInfos: true
   markdown_lint:
     name: Markdown lint
     runs-on: ubuntu-18.04

--- a/bin/win/linkerd.nuspec
+++ b/bin/win/linkerd.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>linkerd</id>
-    <version>${LINKERD_VERSION}</version>
+    <version>LINKERD_VERSION</version>
     
     <title>Linkerd</title>
     <authors>Linkerd</authors>
@@ -27,6 +27,6 @@
   </metadata>
 
   <files>
-    <file src="bin\win\tools\**" target="tools" />
+    <file src="tools\**" target="tools" />
     </files>
 </package>


### PR DESCRIPTION
Followup to #4205, supersedes #4400

This adds:

- A new job psscript-analyzer into the `statics_checks.yml`
workflow for linting the Chocolatey Powershell script.
- A new `choco_pack` job in the `release.yml` workflow for
updating the Chocolatey spec file and generating the
package. This is only triggered for stable releases. It requires
a windows runner in order to run the choco tooling (in theory
it should have worked on a linux runner but in practice it
didn't).
- The `Create release` step was updated to upload the generated package,
if present.
- The source file path in `bin/win/linkerd.nuspec` was updated
to make this work.
