### PR TITLE
Fix mechanism to fetch logs/events upon test failures

### DIFF
--- a/test/edges/edges_test.go
+++ b/test/edges/edges_test.go
@@ -18,7 +18,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 // TestEdges requires that there has been traffic recently between linkerd-web

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -16,7 +16,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 //////////////////////

--- a/test/endpoints/endpoints_test.go
+++ b/test/endpoints/endpoints_test.go
@@ -16,7 +16,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 func TestGoodEndpoints(t *testing.T) {

--- a/test/externalissuer/external_issuer_test.go
+++ b/test/externalissuer/external_issuer_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stdout, "Skiping as --external-issuer=false")
 		os.Exit(0)
 	}
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 func TestExternalIssuer(t *testing.T) {

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -21,7 +21,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 var (

--- a/test/inject/inject_test.go
+++ b/test/inject/inject_test.go
@@ -24,7 +24,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 //////////////////////

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -19,15 +19,11 @@ import (
 
 var (
 	TestHelper *testutil.TestHelper
-
-	// controlPlaneInstalled becomes true as soon as there's a CP available to
-	// retrieve logs from
-	controlPlaneInstalled = false
 )
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, controlPlaneInstalled))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 var (
@@ -161,7 +157,6 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	if TestHelper.GetHelmReleaseName() != "" {
 		return
 	}
-	controlPlaneInstalled = true
 
 	var (
 		cmd  = "install"
@@ -322,9 +317,6 @@ func helmOverridesEdge(root *tls.CA) []string {
 }
 
 func TestInstallHelm(t *testing.T) {
-	// at this point all the tests assume the control plane is present
-	controlPlaneInstalled = true
-
 	if TestHelper.GetHelmReleaseName() == "" {
 		return
 	}

--- a/test/routes/routes_test.go
+++ b/test/routes/routes_test.go
@@ -17,7 +17,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 //////////////////////

--- a/test/serviceaccounts/serviceaccounts_test.go
+++ b/test/serviceaccounts/serviceaccounts_test.go
@@ -13,7 +13,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 // namesMatch checks if all the expectedServiceAccountNames are present in the given list,

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -27,7 +27,7 @@ type testCase struct {
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 func TestServiceProfiles(t *testing.T) {

--- a/test/stat/stat_test.go
+++ b/test/stat/stat_test.go
@@ -19,7 +19,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 //////////////////////

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -18,7 +18,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 type tapEvent struct {

--- a/test/tracing/tracing_test.go
+++ b/test/tracing/tracing_test.go
@@ -33,7 +33,7 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 //////////////////////

--- a/test/trafficsplit/trafficsplit_test.go
+++ b/test/trafficsplit/trafficsplit_test.go
@@ -16,7 +16,7 @@ const zeroRPS = "0.0rps"
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 type statTsRow struct {

--- a/test/uninstall/uninstall_test.go
+++ b/test/uninstall/uninstall_test.go
@@ -16,7 +16,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "Uninstall test disabled")
 		os.Exit(0)
 	}
-	os.Exit(testutil.Run(m, TestHelper, true))
+	os.Exit(testutil.Run(m, TestHelper))
 }
 
 func TestInstall(t *testing.T) {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -484,11 +484,11 @@ func ParseEvents(out string) ([]*corev1.Event, error) {
 	return events, nil
 }
 
-// Run calls `m.Run()`, shows unexpected logs/events if showLogs is true,
+// Run calls `m.Run()`, shows unexpected logs/events,
 // and returns the exit code for the tests
-func Run(m *testing.M, helper *TestHelper, showLogs bool) int {
+func Run(m *testing.M, helper *TestHelper) int {
 	code := m.Run()
-	if code != 0 && showLogs {
+	if code != 0 {
 		_, errs1 := FetchAndCheckLogs(helper)
 		for _, err := range errs1 {
 			fmt.Println(err)


### PR DESCRIPTION
Followup to #4522

This removes the `controlPlaneInstalled` var in `bin/install_test.go`
that flagged whether the control plane was already present in the series
of tests, whose intention was to avoid fetching the logs/events when the CP wasn't yet
there. That was done under the assumption `TestMain()` would feed that
flag to the runner for each individual test function, but it turns out
`TestMain()` only runs once per test file, and so
`controlPlaneInstalled` remained with its initial value `false`.

So now logs/events are fetched always, even if the control plane is not
there. If the CP is absent and we try fetching, we only see a `didn't
find any client-go entries` message.