### PR TITLE
Use buster-20200514-slim for proxy base image

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,6 +1,6 @@
-ARG RUNTIME_IMAGE=debian:stretch-20190812-slim
+ARG RUNTIME_IMAGE=debian:buster-20200514-slim
 
-FROM debian:stretch-20190812-slim as fetch
+FROM debian:buster-20200514-slim as fetch
 RUN apt-get update && apt-get install -y ca-certificates curl
 WORKDIR /build
 COPY bin/fetch-proxy bin/fetch-proxy


### PR DESCRIPTION
Our stretch images contain some libraries/utilities with CVEs. While we
can't yet upgrade all containers (see #3486), we can upgrade the proxy
image (which is the most widely deployed).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
