### PR TITLE
Removed trailing spaces from entries in configmaps

### DIFF
--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -11,12 +11,12 @@ data:
   nginx.conf: |-
     events {
     }
-    stream {                                                                                                                                                                                  
-       server {                                                                                                                                                                                
-           listen     4180;                                                                                                                                                 
-           proxy_pass 127.0.0.1:{{.Values.proxyOutboundPort}};                                                                                                                                 
-       }                                                                                                                                                                                       
-    } 
+    stream {
+       server {
+           listen     4180;
+           proxy_pass 127.0.0.1:{{.Values.proxyOutboundPort}};
+       }
+    }
     http {
       server {
           listen     {{.Values.gatewayProbePort}};
@@ -31,9 +31,9 @@ data:
             access_log off;
             return 200 "healthy\n";
           }
-      }    
+      }
     }
----    
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/linkerd2/templates/linkerd-config-addons.yaml
+++ b/charts/linkerd2/templates/linkerd-config-addons.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: {{.Values.global.grafanaUrl}}
+      grafanaUrl:{{.Values.global.grafanaUrl}}
     grafana:
       {{- include "linkerd.addons.sanitize-config" .Values.grafana}}
     tracing:

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -2010,7 +2010,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -2009,7 +2009,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -2953,7 +2953,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -2824,7 +2824,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: somegrafana.xyz
+      grafanaUrl:somegrafana.xyz
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -2747,7 +2747,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2877,7 +2877,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -2878,7 +2878,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -3126,7 +3126,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -2569,7 +2569,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -2828,7 +2828,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -2771,7 +2771,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -2026,7 +2026,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -2838,7 +2838,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_enabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -3101,7 +3101,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
+++ b/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_nothing_addon.yaml
+++ b/cli/cmd/testdata/upgrade_nothing_addon.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -2822,7 +2822,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
+++ b/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl:
     grafana:
       enabled: true
       image:


### PR DESCRIPTION
Fixes #4454

As explained
[here](https://github.com/kubernetes/kubernetes/issues/36222#issuecomment-553966166),
trailing spaces in configmap data makes it to look funky when retrieved
later on. This is currently affecting `linkerd-config-addons` and
`linkerd-gateway-config`:

```
$ k -n linkerd-multicluster get cm linkerd-gateway-config -oyaml
apiVersion: v1
data:
  nginx.conf: "events {\n}\nstream {                                                                                                                                                                                  \n
    \  server {                                                                                                                                                                                \n
    \      listen     4180;                                                                                                                                                 \n
    \      proxy_pass 127.0.0.1:4140;                                                                                                                                 \n
    \  }                                                                                                                                                                                       \n}
    \nhttp {\n  server {\n      listen     4181;\n      location /health {\n        access_log
    off;\n        return 200 \"healthy\\n\";\n      }\n  }\n  server {\n      listen
    \    8888;\n      location /health-local {\n        access_log off;\n        return
    200 \"healthy\\n\";\n      }\n  }    \n}"
kind: ConfigMap
```

AFAIK this is only cosmetic and doesn't affect functionality.
