### PR TITLE
[POC] Destination Service EndpointSlice support

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -509,6 +509,9 @@ func (sp *servicePublisher) newPortPublisher(srcPort Port, hostname string) *por
 		}
 		if err == nil {
 			for _, es := range esList {
+				if !isTargetPortInSlice(port.targetPort, es.Ports) {
+					continue
+				}
 				port.updateEndpoints(es)
 			}
 		}

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -37,7 +37,7 @@ func Main(args []string) {
 
 	k8sAPI, err := k8s.InitializeAPI(
 		*kubeConfigPath, true,
-		k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job,
+		k8s.Endpoint, k8s.ES, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job,
 	)
 	if err != nil {
 		log.Fatalf("Failed to initialize K8s API: %s", err)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -34,6 +34,7 @@ import (
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	batchv1beta1informers "k8s.io/client-go/informers/batch/v1beta1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	dv1beta1informers "k8s.io/client-go/informers/discovery/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
@@ -61,6 +62,7 @@ const (
 	TS
 	Node
 	Secret
+	ES // EndpointSlice resource
 )
 
 // API provides shared informers for all Kubernetes objects
@@ -72,6 +74,7 @@ type API struct {
 	deploy   appv1informers.DeploymentInformer
 	ds       appv1informers.DaemonSetInformer
 	endpoint coreinformers.EndpointsInformer
+	es       dv1beta1informers.EndpointSliceInformer
 	job      batchv1informers.JobInformer
 	mwc      arinformers.MutatingWebhookConfigurationInformer
 	ns       coreinformers.NamespaceInformer
@@ -204,6 +207,9 @@ func NewAPI(
 		case Endpoint:
 			api.endpoint = sharedInformers.Core().V1().Endpoints()
 			api.syncChecks = append(api.syncChecks, api.endpoint.Informer().HasSynced)
+		case ES:
+			api.es = sharedInformers.Discovery().V1beta1().EndpointSlices()
+			api.syncChecks = append(api.syncChecks, api.es.Informer().HasSynced)
 		case Job:
 			api.job = sharedInformers.Batch().V1().Jobs()
 			api.syncChecks = append(api.syncChecks, api.job.Informer().HasSynced)
@@ -332,6 +338,14 @@ func (api *API) Endpoint() coreinformers.EndpointsInformer {
 		panic("Endpoint informer not configured")
 	}
 	return api.endpoint
+}
+
+// ES provides access to a shared informer and lister for EndpointSlices
+func (api *API) ES() dv1beta1informers.EndpointSliceInformer {
+	if api.es == nil {
+		panic("EndpointSlices informer not configured")
+	}
+	return api.es
 }
 
 // CM provides access to a shared informer and lister for ConfigMaps.


### PR DESCRIPTION
### Issue: #4501 

After a few attempts at adding support for `EndpointSlice` resources, I came up with this poc to show one way of doing this.


### EndpointSlice access
---

* The first prerequisite to supporting `EndpointSlices` is to make sure that the cluster has access to the resource, since it sits behind a feature gate. To do this, we are using a similar check to `ServiceProfile`. First, we check to see what resources are registered with the api-server under the group-version `discovery/v1beta1`. Second, we check to see if `kind: EndpointSlice` is a registered api resource, if it is, we return from the function with no error.

* When we create a new `EndpointWatcher`, we check if the cluster has any `EndpointSlice`. If we get an error, we start the `Endpoints` shared informer, otherwise, we start an `EndpointSlice` shared informer.


### Difference between EndpointSlice and Endpoints
---

* There are a couple of differences between the two resources, namely around what labels, names and addresses they contain.
* `Endpoints` contain ALL endpoints of a service. An endpoint contains a _subset_ -- a group of addresses with common ports. The set of all endpoints is the union of all subsets.
```
subsets:
- addresses:
  - ip: 172.17.0.10
  - ip: 172.17.0.9
  ports:
   - name: http
      port: 8080
   - name: metrics
      port: 9090

# Both IP addresses have the common set of ports {http, metrics}
# So our endpoints in this case are Addresses x Ports in this subset
```
* `EndpointSlices` ARE a subset. Instead of grouping all subsets into a single resource, the slice contains only a set of addresses with common parts.
```
endpoints:
- addresses:
  - 172.17.0.10
     # extra stuff
     # e.g topology, conditions
- addresses:
  - 172.17.0.9
     # more extra stuff
ports:
   - name: http
      port: 8080
   - name: metrics
      port: 9090

# Here, we have a set of endpoints for the slice, where each endpoint has an address, a targetRef
# topology, etc
# If ports was included in a subset (so each subset has a different port set)
# a slice only has one set of ports corresponding to its endpoint addresses
```
* **Other notable differences**:
  * Slices have a prefix (svc name), the rest of their name is randomly generated
  * Slices have a label with the service name
  * This means 1 service ------ * slices instead of a 1:1 relationship (like with Endpoints)
  * **EndpointSlices are dual-stack, an endpoint can have both IPv4 and IPv6** (which is why addresses is a set, and not a field like it is in `Endpoints` with `ip:`

* Because of these differences, `EndpointSlices` as resources need to be processed a bit differently than `Endpoints`. Will go more in-depth in the next sections.

### Handler functions
---

* When implementing new handler functions for `EndpointSlice`, I tried to reuse as much code as possible. Not everything can be reused because of the type system, where applicable I tried to reuse logic by doing type assertions.

* **Add**:
  * Most type assertions have been done here
  * When adding a new `EndpointSlice` in my mind there was one thing that needs to be addressed and is different from `Endpoints`. Specifically, only update those ports whose addresses are in the slice.
  * For example, if an `Endpoints` resource has 2 subsets, one which includes addresses associated with 8080 and one with addresses associated with 6000, all ports would have to be updated when a change to the `Endpoints` object is made, since E = Subset1 U Subset2. A slice IS a subset, however, so we want to update only the `portPublisher` that has a targetPort of 8080, if our slice contains addresses associated with 8080. I'm not sure if this would be a case often met in a real production cluster, I've personally never seen an `Endpoints` with more than 1 subset, but I thought mathematically this should hold (?)
   * To check, I added a function `isTargetPortInSlice` that checks whether the current `portPublisher`'s targetPort is part of the slice, if it is, update the endpoint.
   * Another key difference is when building `AddressSets` for a port. Because each address has a `conditions` field associated with it, we only want to add an address when it is ready (to avoid duplicate ADDs being sent to the proxy).

* **Delete**:
   * No type assertions here because it was too complicated to get it working (due to the tombstones), so I just decided to create its own functions.
   * The key difference here is similar to `Add` -- when we want the delete the addresses of a `portPublisher`, only delete those addresses which were part of the slice, since other slices can be in existence it does not make sense to delete all endpoints.
  * Again, we make use of `isTargetPortInSlice`. If the addressSet is empty when we delete the slice addresses, we do what `noEndpoints()` does -- set the existence to false and tear down the `portPublisher` (along with its listener).

### Misc
---

I'm thinking that the resource access for `EndpointSlices` should be done before on the server-side and passed as an argument to `NewEndpointsWatcher` to make it easier to write tests. 

I planned on adding new tests for the actual PR where we can check conditions such as ensuring a slice's addresses have been completely updated, a slice that does not correspond to a `portPublisher` does not change anything, etc.

When we create a new portPublisher we make another check for each resource to use when we populate it. If we have slices, we will populate the port with it. Not sure what to do when a port is updated, however.

I have tested this with the destination client script and it seems to be working fine. I have tested if `EndpointSlices` can be deleted, updated, added and that `NoEndpoints` is returned when all pods in a slice have been deleted (to test if the address set is empty the functionality is similar to `noEndpoints`).


Let me know if I've missed anything!