### PR TITLE
adding tmp volume for restrictive pod secuity policies

### DIFF
--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -76,6 +76,8 @@ spec:
         - name: config
           configMap:
             name: {{.Values.gatewayName}}-config
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: nginx
           readinessProbe:
@@ -101,6 +103,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/nginx
+            - name: tmp
+              mountPath: /tmp
       serviceAccountName: {{.Values.gatewayName}}
 ---
 apiVersion: v1


### PR DESCRIPTION
This adds an `emptyDir` volume for the `tmp` directory, because during my testing, I was using a PodSecurityPolicy that includes `readOnlyRootFileSystem: true`, which prevented nginx from `chmod'ing` the /tmp directory, and the container failed to start.

This commit ensures that similar restrictive policies allow the pod to run in similar environments.

The container can still run as on-root, and I can remove all the `/tmp` related nginx directives and the volume while still using `runAsUser: 1001` on the deployment.

If the preference is to not use the `emptyDir` volume, then I'll update this PR with a commit that removes all the directives related to the `/tmp` dir in the nginx config so that the configuration assumes that the filesystem is writeable.


Signed-off-by: Charles Pretzer <charles@buoyant.io>
