### PR TITLE
Add HA flags for HA installations using helm (#4568)

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -66,15 +66,12 @@
 {{- end -}}
 
 {{- define "linkerd.configs.install" -}}
-{{- if ge (.Values.controllerReplicas | int) 3 -}}
 {
   "cliVersion":"{{ .Values.global.linkerdVersion }}",
+{{- if ge (.Values.controllerReplicas | int) 3 }}
   "flags":[{"name":"ha","value":"true"}]
-}
-{{- else -}}
-{
-  "cliVersion":"{{ .Values.global.linkerdVersion }}",
+{{- else }}
   "flags":[]
+{{- end }}
 }
-{{- end -}}
 {{- end -}}

--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -66,8 +66,15 @@
 {{- end -}}
 
 {{- define "linkerd.configs.install" -}}
+{{- if ge (.Values.controllerReplicas | int) 3 -}}
+{
+  "cliVersion":"{{ .Values.global.linkerdVersion }}",
+  "flags":[{"name":"ha","value":"true"}]
+}
+{{- else -}}
 {
   "cliVersion":"{{ .Values.global.linkerdVersion }}",
   "flags":[]
 }
+{{- end -}}
 {{- end -}}

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -929,7 +929,7 @@ data:
   install: |
     {
       "cliVersion":"linkerd-version",
-      "flags":[]
+      "flags":[{"name":"ha","value":"true"}]
     }
 ---
 # Source: linkerd2/templates/identity.yaml


### PR DESCRIPTION
Subject:
Add HA flags for HA installations using helm.

Problem:
If install the Linkerd HA using helm, then the indication that the linkerd is deployed as HA is skipped.

Solution:
Added HA flags if `controllerReplicas` is 3 or more.

Fixes #4568