### PR TITLE
Fix yaml in linkerd-config-addons when providing grafanaUrl

### DIFF
--- a/charts/linkerd2/templates/linkerd-config-addons.yaml
+++ b/charts/linkerd2/templates/linkerd-config-addons.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: {{.Values.global.grafanaUrl}}
+      grafanaUrl: "{{.Values.global.grafanaUrl}}"
     grafana:
       {{- include "linkerd.addons.sanitize-config" .Values.grafana}}
     tracing:

--- a/charts/linkerd2/templates/linkerd-config-addons.yaml
+++ b/charts/linkerd2/templates/linkerd-config-addons.yaml
@@ -21,7 +21,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:{{.Values.global.grafanaUrl}}
+      grafanaUrl: {{.Values.global.grafanaUrl}}
     grafana:
       {{- include "linkerd.addons.sanitize-config" .Values.grafana}}
     tracing:

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -2010,7 +2010,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -2010,7 +2010,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -2009,7 +2009,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -2009,7 +2009,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -2953,7 +2953,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -2953,7 +2953,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -2824,7 +2824,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: somegrafana.xyz
+      grafanaUrl: "somegrafana.xyz"
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -2824,7 +2824,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:somegrafana.xyz
+      grafanaUrl: somegrafana.xyz
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -3085,7 +3085,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -2747,7 +2747,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -2747,7 +2747,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2877,7 +2877,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2877,7 +2877,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -2878,7 +2878,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -2878,7 +2878,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -3126,7 +3126,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -3126,7 +3126,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -2569,7 +2569,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -2569,7 +2569,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -2828,7 +2828,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -2828,7 +2828,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -2771,7 +2771,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -2771,7 +2771,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -2837,7 +2837,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -2026,7 +2026,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -2026,7 +2026,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -2853,7 +2853,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -2838,7 +2838,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -2838,7 +2838,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_enabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_enabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
@@ -2839,7 +2839,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: false
     tracing:

--- a/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -3101,7 +3101,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -3101,7 +3101,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
+++ b/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
+++ b/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_nothing_addon.yaml
+++ b/cli/cmd/testdata/upgrade_nothing_addon.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_nothing_addon.yaml
+++ b/cli/cmd/testdata/upgrade_nothing_addon.yaml
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -2822,7 +2822,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -2822,7 +2822,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -2836,7 +2836,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
+++ b/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl: 
+      grafanaUrl: ""
     grafana:
       enabled: true
       image:

--- a/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
+++ b/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
@@ -2852,7 +2852,7 @@ metadata:
 data:
   values: |-
     global:
-      grafanaUrl:
+      grafanaUrl: 
     grafana:
       enabled: true
       image:


### PR DESCRIPTION
Put back space after `grafanaUrl` label in `linkerd-config-addons.yaml`
to avoid breaking the yaml parsing.

```
$ linkerd check
...
linkerd-addons
--------------
‼ 'linkerd-config-addons' config map exists
    could not unmarshal linkerd-config-addons config-map: error
    unmarshaling JSON: while decoding JSON: json: cannot unmarshal
    string into Go struct field Values.global of type linkerd2.Global
```
This was added in #4544 to avoid having the configmap being badly formatted.

So this PR fixes the yaml, but then if we don't set `grafanaUrl` the
configmap format gets messed up, but apparently that's just a cosmetic
problem:

```
apiVersion: v1
data:
  values: "global:\n  grafanaUrl: \ngrafana:\n  enabled: true\n
  image:\n    name:
      gcr.io/linkerd-io/grafana\n  name: linkerd-grafana\n  resources:\n
      cpu:\n      limit:
          240m\n    memory:\n      limit: null\ntracing:\n  enabled:
          false"
          kind: ConfigMap
```
