### PR TITLE
Resolve gateway hostnames into IP addresses

### DIFF
--- a/controller/cmd/service-mirror/cluster_watcher_mirroring_test.go
+++ b/controller/cmd/service-mirror/cluster_watcher_mirroring_test.go
@@ -265,7 +265,7 @@ func TestRemoteServiceUpdatedMirroring(t *testing.T) {
 
 func TestRemoteGatewayUpdatedMirroring(t *testing.T) {
 
-	linkerdIP, err := net.ResolveIPAddr("ip", "linkerd.io")
+	localhostIP, err := net.ResolveIPAddr("ip", "localhost")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestRemoteGatewayUpdatedMirroring(t *testing.T) {
 						gatewayName:      "gateway",
 						gatewayNamespace: "gateway-ns",
 						clusterName:      "remote",
-						addresses:        []corev1.EndpointAddress{{IP: linkerdIP.String()}},
+						addresses:        []corev1.EndpointAddress{{IP: localhostIP.String()}},
 						incomingPort:     999,
 						resourceVersion:  "currentGatewayResVersion",
 						ProbeConfig: &ProbeConfig{

--- a/controller/cmd/service-mirror/cluster_watcher_test_util.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test_util.go
@@ -383,7 +383,7 @@ var remoteGatewayUpdatedWithHostnameAddress = &testEnvironment{
 		&RepairEndpoints{},
 	},
 	remoteResources: []string{
-		gatewayAsYaml("gateway", "gateway-ns", "currentGatewayResVersion", "", "linkerd.io", "mc-gateway", 999, "", defaultProbePort, defaultProbePath, defaultProbePeriod),
+		gatewayAsYaml("gateway", "gateway-ns", "currentGatewayResVersion", "", "localhost", "mc-gateway", 999, "", defaultProbePort, defaultProbePath, defaultProbePeriod),
 	},
 }
 

--- a/controller/cmd/service-mirror/events_formatting.go
+++ b/controller/cmd/service-mirror/events_formatting.go
@@ -113,6 +113,10 @@ func (od OnDeleteCalled) String() string {
 	return fmt.Sprintf("OnDeleteCalled: {svc: %s}", formatService(od.svc))
 }
 
+func (re RepairEndpoints) String() string {
+	return "RepairEndpoints"
+}
+
 //Events for probe manager
 
 func (ps probeSpec) String() string {

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -55,6 +55,7 @@ func Main(args []string) {
 	requeueLimit := cmd.Int("event-requeue-limit", 3, "requeue limit for events")
 	metricsAddr := cmd.String("metrics-addr", ":9999", "address to serve scrapable metrics on")
 	namespace := cmd.String("namespace", "", "address to serve scrapable metrics on")
+	repairPeriod := cmd.Duration("endpoint-refresh-period", 1*time.Minute, "frequency to refresh endpoint resolution")
 
 	flags.ConfigureAndParse(cmd, args)
 
@@ -88,7 +89,7 @@ func Main(args []string) {
 	probeManager.Start()
 
 	k8sAPI.Sync(nil)
-	watcher := NewRemoteClusterConfigWatcher(*namespace, secretsInformer, k8sAPI, *requeueLimit)
+	watcher := NewRemoteClusterConfigWatcher(*namespace, secretsInformer, k8sAPI, *requeueLimit, *repairPeriod)
 	log.Info("Started cluster config watcher")
 
 	go admin.StartServer(*metricsAddr)

--- a/controller/cmd/service-mirror/metrics.go
+++ b/controller/cmd/service-mirror/metrics.go
@@ -29,6 +29,18 @@ type probeMetrics struct {
 	unregister func()
 }
 
+var endpointRepairCounter *prometheus.CounterVec
+
+func init() {
+	endpointRepairCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "service_mirror_endpoint_repairs",
+			Help: "Increments when the service mirror controller attempts to repair mirror endpoints",
+		},
+		[]string{gatewayNameLabel, gatewayNamespaceLabel, gatewayClusterName},
+	)
+}
+
 func newProbeMetricVecs() probeMetricVecs {
 	labelNames := []string{gatewayNameLabel, gatewayNamespaceLabel, gatewayClusterName}
 


### PR DESCRIPTION
Fixes #4582 

When a target cluster gateway is exposed as a hostname rather than with a fixed IP address, the service mirror controller fails to create mirror services and gateway mirrors for that gateway.  This is because we only look at the IP field of the gateway service.

We make two changes to address this problem:
 
First, when extracting the gateway spec from a gateway that has a hostname instead of an IP address, we do a DNS lookup to resolve that hostname into an IP address to use in the mirror service endpoints and gateway mirror endpoints.

Second, we schedule a repair job on a regular (1 minute) to update these endpoint objects.  This has the effect of re-resolving the DNS names every minute to pick up any changes in DNS resolution.

Signed-off-by: Alex Leong <alex@buoyant.io>
