### PR TITLE
Update function signature of `testutil.NewGenericTestHelper`

### DIFF
--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -71,6 +71,7 @@ func NewGenericTestHelper(
 	namespace,
 	upgradeFromVersion,
 	clusterDomain,
+	k8sContext,
 	helmPath,
 	helmChart,
 	helmStableChart,
@@ -78,8 +79,8 @@ func NewGenericTestHelper(
 	externalIssuer,
 	uninstall bool,
 	httpClient http.Client,
-) *TestHelper {
-	return &TestHelper{
+) (*TestHelper, error) {
+	h := &TestHelper{
 		linkerd:            linkerd,
 		version:            version,
 		namespace:          namespace,
@@ -96,6 +97,14 @@ func NewGenericTestHelper(
 		uninstall:      uninstall,
 		httpClient:     httpClient,
 	}
+
+	kubernetesHelper, err := NewKubernetesHelper(k8sContext, h.RetryFor)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kubernetes helper: %s", err.Error())
+	}
+
+	h.KubernetesHelper = *kubernetesHelper
+	return h, nil
 }
 
 // NewTestHelper creates a new instance of TestHelper for the current test run.

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -71,7 +71,6 @@ func NewGenericTestHelper(
 	namespace,
 	upgradeFromVersion,
 	clusterDomain,
-	k8sContext,
 	helmPath,
 	helmChart,
 	helmStableChart,
@@ -79,8 +78,9 @@ func NewGenericTestHelper(
 	externalIssuer,
 	uninstall bool,
 	httpClient http.Client,
-) (*TestHelper, error) {
-	h := &TestHelper{
+	kubernetesHelper KubernetesHelper,
+) *TestHelper {
+	return &TestHelper{
 		linkerd:            linkerd,
 		version:            version,
 		namespace:          namespace,
@@ -92,19 +92,12 @@ func NewGenericTestHelper(
 			releaseName:        helmReleaseName,
 			upgradeFromVersion: upgradeFromVersion,
 		},
-		clusterDomain:  clusterDomain,
-		externalIssuer: externalIssuer,
-		uninstall:      uninstall,
-		httpClient:     httpClient,
+		clusterDomain:    clusterDomain,
+		externalIssuer:   externalIssuer,
+		uninstall:        uninstall,
+		httpClient:       httpClient,
+		KubernetesHelper: kubernetesHelper,
 	}
-
-	kubernetesHelper, err := NewKubernetesHelper(k8sContext, h.RetryFor)
-	if err != nil {
-		return nil, fmt.Errorf("error creating kubernetes helper: %s", err.Error())
-	}
-
-	h.KubernetesHelper = *kubernetesHelper
-	return h, nil
 }
 
 // NewTestHelper creates a new instance of TestHelper for the current test run.

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -67,6 +67,7 @@ var LinkerdDeployReplicas = map[string]deploySpec{
 // See - https://github.com/linkerd/linkerd2/issues/4530
 func NewGenericTestHelper(
 	linkerd,
+	version,
 	namespace,
 	upgradeFromVersion,
 	clusterDomain,
@@ -76,9 +77,11 @@ func NewGenericTestHelper(
 	helmReleaseName string,
 	externalIssuer,
 	uninstall bool,
+	httpClient http.Client,
 ) *TestHelper {
 	return &TestHelper{
 		linkerd:            linkerd,
+		version:            version,
 		namespace:          namespace,
 		upgradeFromVersion: upgradeFromVersion,
 		helm: helm{
@@ -91,6 +94,7 @@ func NewGenericTestHelper(
 		clusterDomain:  clusterDomain,
 		externalIssuer: externalIssuer,
 		uninstall:      uninstall,
+		httpClient:     httpClient,
 	}
 }
 


### PR DESCRIPTION
This PR is a follow-up for https://github.com/linkerd/linkerd2/pull/4532

Once merged, `testutil.NewGenericTestHelper` will

- accept `version`, `httpClient` and `k8sContext` as parameters
- initialize the `KubernetesHelper` field in the returned instance of `*TestHelper`

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

Cc: @Pothulapati @alpeb 