### PR TITLE
Simplify CODEOWNERS constraints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,18 @@
-CHANGES.md @wmorgan @klingerf @olix0r @admc
-GOVERNANCE.md @klingerf @olix0r
-MAINTAINERS.md @klingerf @olix0r
+# By default, the maintainers group is responsible for everything.
+*			@linkerd/maintainers
 
-/.github/workflows/ @alpeb @kleimkuhler
-/charts @alpeb @zaharidichev
+# These documents have special review requirements:
+CHANGES.md		@adleong @olix0r
+CODE_OF_CONDUCT.md	@olix0r
+CONTRIBUTING.md		@olix0r
+DCO			@olix0r
+GOVERNANCE.md		@olix0r
+LICENSE			@olix0r
+MAINTAINERS.md		@olix0r
+README.md		@olix0r
+SECURITY.md		@olix0r
+SECURITY_AUDIT.pdf	@olix0r
 
-/charts/linkerd2-cni @hemakl @zaharidichev
-/charts/linkerd-service-mirror @zaharidichev
-
-/cli @alpeb @adleong @zaharidichev
-
-/cni-plugin @hemakl @zaharidichev
-
-/controller @adleong @alpeb @kleimkuhler
-
-/pkg @adleong @alpeb
-
-Dockerfile* @adleong @alpeb @klingerf @olix0r @siggy
-
-# These do not have clear owners today
-# /grafana
-# /proto
-# /proxy-identity
-# /test
-# /testutil
-# /web
+# Hema & Zahari understand the CNI best:
+/charts/linkerd2-cni	@hemakl @zaharidichev
+/cni-plugin		@hemakl @zaharidichev


### PR DESCRIPTION
My experience of our CODEOWNERS setup is that it frequently causes us to
require additional pro-forma reviews, but I think we can do a decent job
of getting the proper reviews informally without enforcing ownership.

I'd like to simplify this by relaxing the CODEOWNERS to add
@linkerd/maintainers by default. The project infrastructure docs should
remain locked-down, requiring a review from me; and I've updated the
CHANGES review requirement to be @adleong and I (practically, I'll
review most of the CHANGES, but Alex is a suitable fallback in most
cases).

Then, we leave the CNI ownership as-is (unless others want to volunteer
for those reviews ;).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/master/CONTRIBUTING.md#committing
-->
