### PR TITLE
Fix missing proxy-init v1.3.2 -> v1.3.3

### DIFF
--- a/cli/cmd/testdata/inject_tap_deployment.input.yml
+++ b/cli/cmd/testdata/inject_tap_deployment.input.yml
@@ -205,7 +205,7 @@ spec:
         - 4190,4191
         - --outbound-ports-to-ignore
         - "443"
-        image: gcr.io/linkerd-io/proxy-init:v1.3.2
+        image: gcr.io/linkerd-io/proxy-init:v1.3.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:


### PR DESCRIPTION
Alex verified that this occurrence was supposed to be v1.3.3 and had just only been forgotten.