### PR TITLE
Support parsing PKCS8 encoded private keys

### DIFF
--- a/pkg/tls/codec.go
+++ b/pkg/tls/codec.go
@@ -3,10 +3,12 @@ package tls
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 // === ENCODE ===
@@ -67,6 +69,20 @@ func DecodePEMKey(txt string) (GenericPrivateKey, error) {
 			return nil, err
 		}
 		return privateKeyRSA{k}, nil
+	case "PRIVATE KEY":
+		k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		if ec, ok := k.(*ecdsa.PrivateKey); ok {
+			return privateKeyEC{ec}, nil
+		}
+		if rsa, ok := k.(*rsa.PrivateKey); ok {
+			return privateKeyRSA{rsa}, nil
+		}
+		return nil, fmt.Errorf(
+			"unsupported PKCS#8 encoded private key type: '%s', linkerd2 only supports ECDSA and RSA private keys",
+			reflect.TypeOf(k))
 	default:
 		return nil, fmt.Errorf("unsupported block type: '%s'", block.Type)
 	}

--- a/pkg/tls/codec_test.go
+++ b/pkg/tls/codec_test.go
@@ -1,0 +1,28 @@
+package tls
+
+import (
+	"testing"
+)
+
+func TestPrivateKeyParsing(t *testing.T) {
+	if _, err := DecodePEMKey(""); err == nil {
+		t.Fatalf("Empty private key should fail to parse")
+	}
+	if _, err := DecodePEMKey("BEGIN EC PRIVATE KEY\nafjlakjflaksdjf\nEND EC PRIVATE KEY"); err == nil {
+		t.Fatalf("Invalid PKCS#1 ECDSA private key should fail to parse")
+	}
+	if _, err := DecodePEMKey("BEGIN RSA PRIVATE KEY\nafjlakjflaksdjf\nEND RSA PRIVATE KEY"); err == nil {
+		t.Fatalf("Invalid PKCS#1 RSA private key should fail to parse")
+	}
+	if _, err := DecodePEMKey("BEGIN PRIVATE KEY\nafjlakjflaksdjf\nEND PRIVATE KEY"); err == nil {
+		t.Fatalf("Invalid PKCS#8 private key should fail to parse")
+	}
+	ecPkcs8 := "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgDZUgDvKixfLi8cK8\n/TFLY97TDmQV3J2ygPpvuI8jSdihRANCAARRN3xgbPIR83dr27UuDaf2OJezpEJx\nUC3v06+FD8MUNcRAboqt4akehaNNSh7MMZI+HdnsM4RXN2y8NePUQsPL\n-----END PRIVATE KEY-----"
+	if _, err := DecodePEMKey(ecPkcs8); err != nil {
+		t.Fatalf("Failed to parse PKCS#8 encoded ECDSA private key: %s", err)
+	}
+	rsaPkcs8 := "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAq7BFUpkGp3+LQmlQ\nYx2eqzDV+xeG8kx/sQFV18S5JhzGeIJNA72wSeukEPojtqUyX2J0CciPBh7eqclQ\n2zpAswIDAQABAkAgisq4+zRdrzkwH1ITV1vpytnkO/NiHcnePQiOW0VUybPyHoGM\n/jf75C5xET7ZQpBe5kx5VHsPZj0CBb3b+wSRAiEA2mPWCBytosIU/ODRfq6EiV04\nlt6waE7I2uSPqIC20LcCIQDJQYIHQII+3YaPqyhGgqMexuuuGx+lDKD6/Fu/JwPb\n5QIhAKthiYcYKlL9h8bjDsQhZDUACPasjzdsDEdq8inDyLOFAiEAmCr/tZwA3qeA\nZoBzI10DGPIuoKXBd3nk/eBxPkaxlEECIQCNymjsoI7GldtujVnr1qT+3yedLfHK\nsrDVjIT3LsvTqw==\n-----END PRIVATE KEY-----"
+	if _, err := DecodePEMKey(rsaPkcs8); err != nil {
+		t.Fatalf("Failed to parse PKCS#8 encoded RSA private key: %s", err)
+	}
+}


### PR DESCRIPTION
Tools like cert-manager might encode private keys in PKCS8 format instead of PKCS1
in which case linkerd would fail as it cannot parse PKCS8 encoded private keys.

With this commit support for parsing PKCS8 encoded private keys is added to linkerd,
allowing it to read ECDSA and RSA keys encoded in PKCS8.

Unit tests have been added to test the private key parsing.

This commit addresses https://github.com/jetstack/cert-manager/issues/2942.

Signed-off-by: Alexander Berger <alex.berger@nexxiot.com>