### PR TITLE
Fix install-pr script

### DIFF
--- a/bin/install-pr
+++ b/bin/install-pr
@@ -80,7 +80,7 @@ cd "$dir" || exit
 echo "### Downloading images ###"
 
 curl -L -o archive.zip -H "$auth" "$archive"
-unzip -o archive.zip
+unzip -o archive.zip -d image-archives/
 
 echo "### Loading images into Docker ###"
 

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -84,7 +84,7 @@ unzip -o archive.zip -d image-archives/
 
 echo "### Loading images into Docker ###"
 
-image=$(docker load -i cli-bin.tar | sed 's/Loaded image: //')
+image=$(docker load -i image-archives/cli-bin.tar | sed 's/Loaded image: //')
 tag=$(echo "$image" | cut -f 2 -d ":")
 
 if [ $is_kind ]
@@ -99,7 +99,7 @@ then
 else
   for image in cni-plugin controller debug grafana proxy web
   do
-    image=$(docker load -i "$image.tar" | sed 's/Loaded image: //')
+    image=$(docker load -i "image-archives/$image.tar" | sed 's/Loaded image: //')
     docker push "$image"
   done
 fi

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -655,7 +655,7 @@ func TestInject(t *testing.T) {
 }
 
 func TestServiceProfileDeploy(t *testing.T) {
-	bbProto, err := TestHelper.HTTPGetURL("https://raw.githubusercontent.com/BuoyantIO/bb/55b78f210c98a7eb431c3f555cf0a406f0b12edf/api.proto")
+	bbProto, err := TestHelper.HTTPGetURL("https://raw.githubusercontent.com/BuoyantIO/bb/v0.0.5/api.proto")
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "unexpected error",
 			"unexpected error: %v %s", err, bbProto)


### PR DESCRIPTION
`bin/kind-load --images` expects images to be located in `image-archives/`.

This fixes the `install-pr` script to unzip the images into that directory.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>