### PR TITLE
Remove `--prune` from multi-stage upgrade docs

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -85,7 +85,7 @@ func newCmdUpgradeConfig(options *upgradeOptions) *cobra.Command {
 
 Note that this command should be followed by "linkerd upgrade control-plane".`,
 		Example: `  # Default upgrade.
-  linkerd upgrade config | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -`,
+  linkerd upgrade config | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeRunE(options, configStage, options.recordableFlagSet())
 		},
@@ -110,7 +110,7 @@ Note that the default flag values for this command come from the Linkerd control
 plane. The default values displayed in the Flags section below only apply to the
 install command. It should be run after "linkerd upgrade config".`,
 		Example: `  # Default upgrade.
-  linkerd upgrade control-plane | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -`,
+  linkerd upgrade control-plane | kubectl apply -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeRunE(options, controlPlaneStage, flags)
 		},


### PR DESCRIPTION
Fixes #4606

This has not worked as far back as stable-2.6.0.

## Solution

The recommended upgrade process is to include `--prune` as part of `kubectl
apply ..`:

```bash
$ linkerd upgrade | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
```

This is an issue for multi-stage upgrade because `linkerd upgrade config` does
not include the `linkerd-config` ConfigMap in it's output.

`kubectl apply --prune ..` will then prune this resource because it matches the
label selector *and* is not in the above output.

The issue occurs when `linkerd upgrade control-plane` is run and expects to find
the ConfigMap that was just pruned.

This can be fixed by not suggesting to prune resources as part of the
multi-stage upgrade.

## Considered

Including `templates/config.yaml` in the install output regardless of the stage.
Instead of it being a template only used in `control-plane` stage in
[render](https://github.com/linkerd/linkerd2/blob/4aa3ca7f87f0f17774d4baee9dd87ac702461426/cli/cmd/install.go#L873-L886), it could always be rendered.

This just exposes other things that are pruned in the process:

```bash
❯ bin/linkerd upgrade control-plane |kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
× Failed to build upgrade configuration: secrets "linkerd-identity-issuer" not found
For troubleshooting help, visit: https://linkerd.io/upgrade/#troubleshooting

error: no objects passed to apply
```

Ultimately, resources part of the `control-plane` stage need to remain and that
will not happen if we prune all resources not in the `config` stage output
