### PR TITLE
Fix helm upgrade test

### DIFF
--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -77,7 +77,7 @@ helm_upgrade_integration_tests() {
     helm_chart="$( cd "$bindir"/.. && pwd )"/charts/linkerd2
     helm_release_name=$linkerd_namespace-test
 
-    run_helm_upgrade_test
+    run_helm_upgrade_test "stable"
     helm_cleanup
     # clean the data plane test resources
     cleanup
@@ -237,8 +237,11 @@ setup_helm() {
 
 run_helm_upgrade_test() {
     setup_helm
+
+    local release_channel=$1
     local stable_version
-    stable_version=$(latest_stable)
+    stable_version=$(latest_release_channel "$release_channel")
+
     run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace-helm" \
         --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart='linkerd/linkerd2' --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
 }

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -77,7 +77,7 @@ helm_upgrade_integration_tests() {
     helm_chart="$( cd "$bindir"/.. && pwd )"/charts/linkerd2
     helm_release_name=$linkerd_namespace-test
 
-    run_helm_upgrade_test "stable"
+    run_helm_upgrade_test
     helm_cleanup
     # clean the data plane test resources
     cleanup
@@ -243,7 +243,6 @@ setup_helm() {
 run_helm_upgrade_test() {
     setup_helm
 
-    local release_channel=$1
     local stable_version
     stable_version=$(latest_release_channel "stable")
 

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -222,6 +222,11 @@ run_upgrade_test() {
     upgrade_version=$(latest_release_channel "$release_channel")
     upgrade_namespace="$linkerd_namespace"-upgrade-"$release_channel"
 
+    if [ -z "$upgrade_version" ]; then
+      echo 'error getting upgrade_version'
+      exit 1
+    fi
+
     install_version "$2" "$upgrade_namespace" "$upgrade_version"
     run_test "$test_directory/install_test.go" --upgrade-from-version="$upgrade_version" --linkerd-namespace="$upgrade_namespace"
 }
@@ -240,7 +245,14 @@ run_helm_upgrade_test() {
 
     local release_channel=$1
     local stable_version
-    stable_version=$(latest_release_channel "$release_channel")
+    stable_version=$(latest_release_channel "foo")
+
+    echo "stable_version: $stable_version"
+
+    if [ -z "$stable_version" ]; then
+      echo 'error getting stable_version'
+      exit 1
+    fi
 
     run_test "$test_directory/install_test.go" --linkerd-namespace="$linkerd_namespace-helm" \
         --helm-path="$helm_path" --helm-chart="$helm_chart" --helm-stable-chart='linkerd/linkerd2' --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -245,9 +245,7 @@ run_helm_upgrade_test() {
 
     local release_channel=$1
     local stable_version
-    stable_version=$(latest_release_channel "foo")
-
-    echo "stable_version: $stable_version"
+    stable_version=$(latest_release_channel "stable")
 
     if [ -z "$stable_version" ]; then
       echo 'error getting stable_version'


### PR DESCRIPTION
## Problem

#4557 changed the name of the function that `helm_upgrade_integration_tests`
uses.

`install_stable()` was renamed to `latest_release_channel()` and now takes an
argument for specifying either `edge` or `stable`.

`run_helm_upgrade_test` is a function used by the helm upgrade integration test
and was not properly updated to use `latest_release_channel()`.

This silently passed integration tests because `run_helm_upgrade_test` started
passing an empty string for the version to upgrade from, which results in the
default behavior of `install_test.go`--and therefore still passes.

## Solution

`run_helm_upgrade_test` now uses `latest_release_channel()` and passes the
proper argument.

Additionally, it checks that the version returned from
`latest_release_channel()` is not empty. If it is empty, it exits the test. This
ensures something like this does happen in the future.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
