### PR TITLE
Integration tests: Warn (instead of erroring) upon pod restarts

### DIFF
--- a/test/edges/edges_test.go
+++ b/test/edges/edges_test.go
@@ -83,7 +83,11 @@ func TestDirectEdges(t *testing.T) {
 	}
 
 	if err := TestHelper.CheckPods(testNamespace, "terminus", 1); err != nil {
-		testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		if rce, ok := err.(*testutil.RestartCountError); ok {
+			testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+		} else {
+			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		}
 	}
 
 	if err := TestHelper.CheckDeployment(testNamespace, "terminus", 1); err != nil {
@@ -121,7 +125,11 @@ func TestDirectEdges(t *testing.T) {
 	}
 
 	if err := TestHelper.CheckPods(testNamespace, "slow-cooker", 1); err != nil {
-		testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		if rce, ok := err.(*testutil.RestartCountError); ok {
+			testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+		} else {
+			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		}
 	}
 
 	if err := TestHelper.CheckDeployment(testNamespace, "slow-cooker", 1); err != nil {

--- a/test/egress/egress_test.go
+++ b/test/egress/egress_test.go
@@ -41,7 +41,11 @@ func TestEgressHttp(t *testing.T) {
 
 	err = TestHelper.CheckPods(prefixedNs, "egress-test", 1)
 	if err != nil {
-		testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
+		if rce, ok := err.(*testutil.RestartCountError); ok {
+			testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+		} else {
+			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		}
 	}
 
 	testCase := func(url, methodToUse string) {

--- a/test/externalissuer/external_issuer_test.go
+++ b/test/externalissuer/external_issuer_test.go
@@ -53,11 +53,19 @@ func verifyInstallApp(t *testing.T) {
 	}
 
 	if err := TestHelper.CheckPods(prefixedNs, TestAppBackendDeploymentName, 1); err != nil {
-		testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		if rce, ok := err.(*testutil.RestartCountError); ok {
+			testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+		} else {
+			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		}
 	}
 
 	if err := TestHelper.CheckPods(prefixedNs, "slow-cooker", 1); err != nil {
-		testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		if rce, ok := err.(*testutil.RestartCountError); ok {
+			testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+		} else {
+			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+		}
 	}
 }
 

--- a/test/get/get_test.go
+++ b/test/get/get_test.go
@@ -78,8 +78,11 @@ func TestCliGet(t *testing.T) {
 	// wait for pods to start
 	for deploy, replicas := range deployReplicas {
 		if err := TestHelper.CheckPods(prefixedNs, deploy, replicas); err != nil {
-			testutil.AnnotatedError(t, "CheckPods timed-out",
-				fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 	}
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -125,7 +125,11 @@ func TestUpgradeTestAppWorksBeforeUpgrade(t *testing.T) {
 		testAppNamespace := TestHelper.GetTestNamespace("upgrade-test")
 		for _, deploy := range []string{"emoji", "voting", "web"} {
 			if err := TestHelper.CheckPods(testAppNamespace, deploy, 1); err != nil {
-				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+				if rce, ok := err.(*testutil.RestartCountError); ok {
+					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+				} else {
+					testutil.AnnotatedError(t, "CheckPods timed-out", err)
+				}
 			}
 
 			if err := TestHelper.CheckDeployment(testAppNamespace, deploy, 1); err != nil {

--- a/test/serviceprofiles/serviceprofiles_test.go
+++ b/test/serviceprofiles/serviceprofiles_test.go
@@ -52,7 +52,11 @@ func TestServiceProfiles(t *testing.T) {
 	// wait for deployments to start
 	for _, deploy := range []string{"t1", "t2", "t3", "gateway"} {
 		if err := TestHelper.CheckPods(testNamespace, deploy, 1); err != nil {
-			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 
 		if err := TestHelper.CheckDeployment(testNamespace, deploy, 1); err != nil {

--- a/test/tap/tap_test.go
+++ b/test/tap/tap_test.go
@@ -99,7 +99,11 @@ func TestCliTap(t *testing.T) {
 	// wait for deployments to start
 	for _, deploy := range []string{"t1", "t2", "t3", "gateway"} {
 		if err := TestHelper.CheckPods(prefixedNs, deploy, 1); err != nil {
-			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 
 		if err := TestHelper.CheckDeployment(prefixedNs, deploy, 1); err != nil {

--- a/test/tracing/tracing_test.go
+++ b/test/tracing/tracing_test.go
@@ -126,7 +126,11 @@ func TestTracing(t *testing.T) {
 		tracingNs:   "jaeger",
 	} {
 		if err := TestHelper.CheckPods(ns, deploy, 1); err != nil {
-			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 
 		if err := TestHelper.CheckDeployment(ns, deploy, 1); err != nil {

--- a/test/trafficsplit/trafficsplit_test.go
+++ b/test/trafficsplit/trafficsplit_test.go
@@ -168,7 +168,11 @@ func TestTrafficSplitCli(t *testing.T) {
 	// wait for deployments to start
 	for _, deploy := range []string{"backend", "failing", "slow-cooker"} {
 		if err := TestHelper.CheckPods(prefixedNs, deploy, 1); err != nil {
-			testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 
 		if err := TestHelper.CheckDeployment(prefixedNs, deploy, 1); err != nil {

--- a/test/uninstall/uninstall_test.go
+++ b/test/uninstall/uninstall_test.go
@@ -51,8 +51,11 @@ func TestResourcesPostInstall(t *testing.T) {
 	// Tests Pods and Deployments
 	for deploy, spec := range testutil.LinkerdDeployReplicas {
 		if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, spec.Replicas); err != nil {
-			testutil.AnnotatedFatal(t, "CheckPods timed-out",
-				fmt.Errorf("Error validating pods for deploy [%s]:\n%s", deploy, err))
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
 		}
 		if err := TestHelper.CheckDeployment(TestHelper.GetLinkerdNamespace(), deploy, spec.Replicas); err != nil {
 			testutil.AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -24,6 +25,19 @@ type KubernetesHelper struct {
 	k8sContext string
 	clientset  *kubernetes.Clientset
 	retryFor   func(time.Duration, func() error) error
+}
+
+// RestartCountError is returned by CheckPods() whenever a pod has restarted exactly one time.
+// Consumers should log this type of error instead of failing the test.
+// This is to alleviate CI flakiness stemming from a containerd bug.
+// See https://github.com/kubernetes/kubernetes/issues/89064
+// See https://github.com/containerd/containerd/issues/4068
+type RestartCountError struct {
+	s string
+}
+
+func (e *RestartCountError) Error() string {
+	return e.s
 }
 
 // NewKubernetesHelper creates a new instance of KubernetesHelper.
@@ -208,9 +222,13 @@ func (h *KubernetesHelper) CheckPods(namespace string, deploymentName string, re
 
 	for _, pod := range checkedPods {
 		for _, status := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
-			if status.RestartCount != 0 {
-				return fmt.Errorf("Container [%s] in pod [%s] in namespace [%s] has restart count [%d]",
-					status.Name, pod.Name, pod.Namespace, status.RestartCount)
+			errStr := fmt.Sprintf("Container [%s] in pod [%s] in namespace [%s] has restart count [%d]",
+				status.Name, pod.Name, pod.Namespace, status.RestartCount)
+			if status.RestartCount == 1 {
+				return &RestartCountError{errStr}
+			}
+			if status.RestartCount > 1 {
+				return errors.New(errStr)
 			}
 		}
 	}

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -33,11 +33,11 @@ type KubernetesHelper struct {
 // See https://github.com/kubernetes/kubernetes/issues/89064
 // See https://github.com/containerd/containerd/issues/4068
 type RestartCountError struct {
-	s string
+	msg string
 }
 
 func (e *RestartCountError) Error() string {
-	return e.s
+	return e.msg
 }
 
 // NewKubernetesHelper creates a new instance of KubernetesHelper.


### PR DESCRIPTION
Fixes #4595

Don't have integration tests fail whenever a pod is detected to have
restarted just once. For now we'll be just logging this out and creating
a warning annotation for it.