### PR TITLE
test-cleanup: Make populate_array() bash 3-friendly

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -15,7 +15,7 @@ Usage: ${FUNCNAME[0]} TARGET_ARRAY RESOURCE_TYPE LINKERD_LABEL (FRIENDLY_NAME)" 
   # shellcheck disable=SC2034
   local i=0
   unset -v "$1"
-  while IFS= read -r "$1[i++]"; do :; done <<< "$(kubectl --context="$k8s_context" get "$2" -oname -l "linkerd.io/$3")"
+  while IFS= read -r "$1[i++]"; do :; done <<< "$(kubectl --context="$k8s_context" get -A "$2" -oname -l "linkerd.io/$3")"
   # ensure that the last element isn't empty
   eval "[[ \${$1[--i]} ]]" || unset "$1[i]" # ensures last element isn't empty
   # inform user if no results were returned from command

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -11,11 +11,15 @@ Usage: ${FUNCNAME[0]} TARGET_ARRAY RESOURCE_TYPE LINKERD_LABEL (FRIENDLY_NAME)" 
     return
   }
 
-  local -n res=$1
-  while IFS= read -r line; do res+=("$line"); done <<< "$(kubectl --context="$k8s_context" get "$2" -oname -l "linkerd.io/$3")"
-  if [ -z "${res[*]}" ]; then
-    echo "no ${4:-$2} found" >&2
-  fi
+  # We are using the variable i even if shellsheck does not see it
+  # shellcheck disable=SC2034
+  local i=0
+  unset -v "$1"
+  while IFS= read -r "$1[i++]"; do :; done <<< "$(kubectl --context="$k8s_context" get "$2" -oname -l "linkerd.io/$3")"
+  # ensure that the last element isn't empty
+  eval "[[ \${$1[--i]} ]]" || unset "$1[i]" # ensures last element isn't empty
+  # inform user if no results were returned from command
+  [ -z "$(eval "[[ \${$1[0]} ]]")" ] && echo "no ${4:-$2} found" >&2
 }
 
 # Initialize empty arrays


### PR DESCRIPTION
Legacy versions of bash (used in e.g. Mac OS) do not have the [nameref](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameters.html) functionality.
This patch replaces the use of that in the `populate_array` function and uses a bash 3-friendly way of handing this instead.

([Kubernetes](https://github.com/kubernetes/kubernetes) developers will recognize this bash 3-friendly way from [kube::util::read-array](https://github.com/kubernetes/kubernetes/blob/d8febccacfc9d51a017be9531247689e0e36df04/hack/lib/util.sh#L755-L770) in the Kubernetes code base.)

Fixes #4621
