### PR TITLE
Improve shellscript portability by using /bin/env

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/_log.sh
+++ b/bin/_log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -eu
 
 # build debug logging is disabled by default; enable with BUILD_DEBUG=1

--- a/bin/_release.sh
+++ b/bin/_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2120
 # (disabling SC2120 so that we can use functions with optional args
 # see https://github.com/koalaman/shellcheck/wiki/SC2120#exceptions )

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/_test-run.sh
+++ b/bin/_test-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file is a collection of helper functions for running integration tests.
 # It is used primarily by `bin/test-run` and ci.

--- a/bin/build-cli-bin
+++ b/bin/build-cli-bin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset

--- a/bin/docker
+++ b/bin/docker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/docker-build-base
+++ b/bin/docker-build-base
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Builds (or pulls) our base runtime docker image.
 

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-cni-plugin
+++ b/bin/docker-build-cni-plugin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-controller
+++ b/bin/docker-build-controller
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-debug
+++ b/bin/docker-build-debug
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-go-deps
+++ b/bin/docker-build-go-deps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Builds (or pulls) our go-deps docker image.
 

--- a/bin/docker-build-grafana
+++ b/bin/docker-build-grafana
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-build-web
+++ b/bin/docker-build-web
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-images
+++ b/bin/docker-images
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-pull
+++ b/bin/docker-pull
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-pull-deps
+++ b/bin/docker-pull-deps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-push-deps
+++ b/bin/docker-push-deps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-retag-all
+++ b/bin/docker-retag-all
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/docker-test-proxy
+++ b/bin/docker-test-proxy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # If the first argument to this script is "latest" or unset, it fetches the
 # latest proxy binary from the linkerd2-proxy github releases. If it's set to

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/git-commit-proxy-version
+++ b/bin/git-commit-proxy-version
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/go-run
+++ b/bin/go-run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 cd "$(pwd -P)"

--- a/bin/goimports
+++ b/bin/goimports
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/helm
+++ b/bin/helm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Install PR ###
 #

--- a/bin/kind
+++ b/bin/kind
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/bin/kubectl
+++ b/bin/kubectl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/linkerd
+++ b/bin/linkerd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/markdownlint
+++ b/bin/markdownlint
@@ -1,4 +1,6 @@
-#!/bin/sh -eu
+#!/usr/bin/env sh
+
+set -eu
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )

--- a/bin/markdownlint-all
+++ b/bin/markdownlint-all
@@ -1,4 +1,6 @@
-#!/bin/sh -eu
+#!/usr/bin/env sh
+
+set -eu
 
 bindir=$( cd "${0%/*}" && pwd )
 

--- a/bin/mkube
+++ b/bin/mkube
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # A wrapper for interacting with minikube.
 #

--- a/bin/protoc
+++ b/bin/protoc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/protoc-go.sh
+++ b/bin/protoc-go.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/root-tag
+++ b/bin/root-tag
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bindir=$( cd "${0%/*}" && pwd )
 

--- a/bin/shellcheck
+++ b/bin/shellcheck
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/shellcheck-all
+++ b/bin/shellcheck-all
@@ -1,4 +1,6 @@
-#!/bin/sh -eu
+#!/usr/bin/env sh
+
+set -eu
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/test-clouds
+++ b/bin/test-clouds
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Run integration tests on 4 cloud providers:

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Cleans up integration tests from 4 cloud providers:

--- a/bin/test-run
+++ b/bin/test-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script executes the full suite of integration tests, in series:
 # 1. upgrade_stable_integration_tests

--- a/bin/test-scale
+++ b/bin/test-scale
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This test script deploys the following:
 # - 1 Linkerd control-plane

--- a/bin/update-codegen.sh
+++ b/bin/update-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 

--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/bin/web
+++ b/bin/web
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit -o nounset -o pipefail
 

--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Copyright (c) 2018 Tigera, Inc. All rights reserved.
 # Copyright 2018 Istio Authors
 # Modifications copyright (c) Linkerd authors

--- a/proxy-identity/run-proxy.sh
+++ b/proxy-identity/run-proxy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -eu
 
 if [ -z "${LINKERD2_PROXY_IDENTITY_DISABLED:-}" ]; then


### PR DESCRIPTION
Using `/bin/env` increases portability for the shell scripts (and often using `/bin/env` is requested by e.g. Mac users). This would also facilitate testing scripts with different Bash versions via the Bash containers, as they have bash in `/usr/local` and not `/bin`. Using `/bin/env`, there is no need to change the script when testing. (I assume the latter was behind https://github.com/linkerd/linkerd2/pull/4593/files/c301ea214b7ccf8d74d7c41cbf8c4cc05fea7d4a#diff-ecec5e3a811f60bc2739019004fa35b0, which would not happen using `/bin/env`.)

Signed-off-by: Joakim Roubert <joakimr@axis.com>
