### PR TITLE
Changes for edge-20.6.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ to the multicluster support functionality as well as other fixes.
 
 * Controller
   * Added an option to change the set of networks for which the proxy
-    can should do discovery by IP address
+    should do discovery by IP address
   * Upgraded the version of Grafana to 7.0.3
   * Improved multicluster support to be able to work with gateways that
     expose a hostname rather than a concrete IP address

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ to support multicluster gateways on EKS.
   target clusters when an IP address it not known.
 * Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
   for providing a fix!
-* The CLI will be published for Chocalatey (Windows) on future stable releases.
+* The CLI will be published for Chocolatey (Windows) on future stable releases.
 * Base images have been updated:
   * debian:buster-20200514-slim
   * grafana/grafana:7.0.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,26 @@
 # Changes
 
+## edge-20.6.3
+
+This edge release is our release candidate for 2.8.1. It includes improvements
+to the multicluster support functionality as well as other fixes.
+
+* Controller
+  * Added an option to change the set of networks for which the proxy
+    can should do discovery by IP address
+  * Upgraded the version of Grafana to 7.0.3
+  * Improved multicluster support to be able to work with gateways that
+    expose a hostname rather than a concrete IP address
+* Web UI
+  * Fixed a bug causing the Linkerd checks to fail when ran from the
+    dashboard (thanks @alex-berger!)
+* Internal
+  * Added an integration test for upgrading from edge to the current build
+  * Fixed a problem with the `install-pr` script, causing it to not be
+    able to find expected docker images
+  * Introduced CI steps for producing a Chocolatey package
+  * Changed web and base Docker images to use buster (thanks @joakimr-axis!)
+
 ## stable-2.8.0
 
 This release introduces new a multi-cluster extension to Linkerd, allowing it

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,24 +2,20 @@
 
 ## edge-20.6.3
 
-This edge release is our release candidate for 2.8.1. It includes improvements
-to the multicluster support functionality as well as other fixes.
+This edge release is a release candidate for stable-2.8.1. It includes a fix
+to support multicluster gateways on EKS.
 
-* Controller
-  * Added an option to change the set of networks for which the proxy
-    should do discovery by IP address
-  * Upgraded the version of Grafana to 7.0.3
-  * Improved multicluster support to be able to work with gateways that
-    expose a hostname rather than a concrete IP address
-* Web UI
-  * Fixed a bug causing the Linkerd checks to fail when ran from the
-    dashboard (thanks @alex-berger!)
-* Internal
-  * Added an integration test for upgrading from edge to the current build
-  * Fixed a problem with the `install-pr` script, causing it to not be
-    able to find expected docker images
-  * Introduced CI steps for producing a Chocolatey package
-  * Changed web and base Docker images to use buster (thanks @joakimr-axis!)
+* The `config.linkerd.io/proxy-destination-get-networks` annotation configures
+  the networks for which a proxy can discover metadata. This is an advanced
+  configuration option that has security implications.
+* The multicluster service-mirror has been extended to resolve DNS names for
+  target clusters when an IP address it not known.
+* Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
+  for providing a fix!
+* The CLI will be published for Chocalatey (Windows) on future stable releases.
+* Base images have been updated:
+  * debian:buster-20200514-slim
+  * grafana/grafana:7.0.3
 
 ## stable-2.8.0
 


### PR DESCRIPTION
## edge-20.6.3

This edge release is a release candidate for stable-2.8.1. It includes a fix
to support multicluster gateways on EKS.

* The `config.linkerd.io/proxy-destination-get-networks` annotation configures
  the networks for which a proxy can discover metadata. This is an advanced
  configuration option that has security implications.
* The multicluster service-mirror has been extended to resolve DNS names for
  target clusters when an IP address it not known.
* Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
  for providing a fix!
* The CLI will be published for Chocalatey (Windows) on future stable releases.
* Base images have been updated:
  * debian:buster-20200514-slim
  * grafana/grafana:7.0.3

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
