### PR TITLE
Fix `bin/update-go-deps-shas` in Ubuntu

### DIFF
--- a/bin/update-go-deps-shas
+++ b/bin/update-go-deps-shas
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 


### PR DESCRIPTION
Explicitly shebang `bin/update-go-deps-shas` with `#!/bin/bash` instead
of `#!/bin/sh` because the latter points to `dash` in most Ubuntu-based
distros, and the script's `bin/_tag.sh` dependency requires bash.