### PR TITLE
Prevent kind-load from resolving TAG when images are provided

### DIFF
--- a/bin/kind-load
+++ b/bin/kind-load
@@ -58,12 +58,13 @@ cluster=${1:-"kind"}
 
 bindir=$( cd "${0%/*}" && pwd )
 
-# shellcheck source=_tag.sh
-. "$bindir"/_tag.sh
-# shellcheck source=_docker.sh
-. "$bindir"/_docker.sh
-
-TAG=${TAG:-$(head_root_tag)}
+if [ -z "$images" ]; then
+  # shellcheck source=_tag.sh
+  . "$bindir"/_tag.sh
+  # shellcheck source=_docker.sh
+  . "$bindir"/_docker.sh
+  TAG=${TAG:-$(head_root_tag)}
+fi
 
 # This is really to load the kind binary synchronously, before
 # the parallel executions below attempt doing so
@@ -74,7 +75,7 @@ for img in proxy controller web grafana cli-bin debug cni-plugin ; do
   if [ $images ]; then
     if [ "$images_host" ]; then
       mkdir -p image-archives
-      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > image-archives/$img.tar
+      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img" > image-archives/$img.tar
     fi
     cmd=(image-archive "image-archives/$img.tar")
   else

--- a/bin/kind-load
+++ b/bin/kind-load
@@ -58,7 +58,7 @@ cluster=${1:-"kind"}
 
 bindir=$( cd "${0%/*}" && pwd )
 
-if [ -z "$images" ]; then
+if [ -z "$images" ] || [ -n "$images_host" ]; then
   # shellcheck source=_tag.sh
   . "$bindir"/_tag.sh
   # shellcheck source=_docker.sh
@@ -75,7 +75,7 @@ for img in proxy controller web grafana cli-bin debug cni-plugin ; do
   if [ $images ]; then
     if [ "$images_host" ]; then
       mkdir -p image-archives
-      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img" > image-archives/$img.tar
+      DOCKER_HOST=$images_host docker save "$DOCKER_REGISTRY/$img:$TAG" > image-archives/$img.tar
     fi
     cmd=(image-archive "image-archives/$img.tar")
   else


### PR DESCRIPTION
## What
This is a follow-on fix to #4610 which prevents the `head_root_tag` function from being called unnecessarily.

## Why
The tag only needs to be resolved when the `--images` parameter is _not_ used when `kind-load` is executed. When the images are provided in an `image-archives` directory, the `TAG` is implied by the archived image.

## How
Add a conditional check to import the `_docker.sh` and `_tag.sh` scripts and call the `head_root_tag` function, per the [comment](https://github.com/linkerd/linkerd2/pull/4610#issuecomment-646105302) made by @kleimkuhler 

## Validation
Ran `install-pr` with and without the `-k` parameter to ensure that the specified PR was installed on both kind and non-kind clusters.

This change affects the call to `kind-load` that is in the `kind_integration.yml` and `release.yml` github actions, and those tests will be run after the PR is created.
Signed-off-by: Charles Pretzer <charles@buoyant.io>
