### PR TITLE
Fix release workflow dependencies on choco_pack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,24 +203,29 @@ jobs:
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
   choco_pack:
+    # only runs for stable tags. The conditionals are at each step level instead of the job level
+    # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
-    if: startsWith(github.ref, 'refs/tags/stable')
     needs: [kind_integration_tests, cloud_integration_tests]
     runs-on: windows-2019
     steps:
     - name: Checkout code
+      if: startsWith(github.ref, 'refs/tags/stable')
       # actions/checkout@v2
       uses: actions/checkout@722adc6
     - name: Chocolatey - update nuspec
+      if: startsWith(github.ref, 'refs/tags/stable')
       run: |
         $LINKERD_VERSION=$env:GITHUB_REF.Substring(17)
         (Get-Content bin\win\linkerd.nuspec).replace('LINKERD_VERSION', $LINKERD_VERSION) | Set-Content bin\win\linkerd.nuspec
     - name: Chocolatey - pack
+      if: startsWith(github.ref, 'refs/tags/stable')
       # crazy-max/ghaction-chocolatey@v1.2.2
       uses: crazy-max/ghaction-chocolatey@55c9188
       with:
         args: pack bin/win/linkerd.nuspec
     - name: Chocolatey - upload package
+      if: startsWith(github.ref, 'refs/tags/stable')
       # actions/upload-artifact@v2.01
       uses: actions/upload-artifact@97b7dac
       with:


### PR DESCRIPTION
The `choco_pack` job only runs for stable tags. In order for jobs to
depend on it to run on non-stable tags, we need to move this tag check from the
`choco_pack` job level down into its steps.
