### PR TITLE
Fix release workflow - avoid downloading choco package in edges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,7 @@ jobs:
         echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
         extract_release_notes NOTES.md
     - name: Download choco package
+      if: startsWith(github.ref, 'refs/tags/stable')
       # actions/download-artifact@v1
       uses: actions/download-artifact@18f0f59
       with:


### PR DESCRIPTION
Added guard against trying to download choco package when not doing a
stable release.
