### PR TITLE
Post-2.8.0 integration test cleanup

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -251,7 +251,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 	// test `linkerd upgrade --from-manifests`
 	if TestHelper.UpgradeFromVersion() != "" {
-		resources := []string{"configmaps/" + k8s.ConfigConfigMapName, "configmaps" / +k8s.AddOnsConfigMapName, "secrets/" + k8s.IdentityIssuerSecretName}
+		resources := []string{"configmaps/" + k8s.ConfigConfigMapName, "configmaps/" + k8s.AddOnsConfigMapName, "secrets/" + k8s.IdentityIssuerSecretName}
 		args := append([]string{"--namespace", TestHelper.GetLinkerdNamespace(), "get"}, resources...)
 		args = append(args, "-oyaml")
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -370,7 +370,11 @@ func TestResourcesPostInstall(t *testing.T) {
 	// Tests Pods and Deployments
 	for deploy, spec := range testutil.LinkerdDeployReplicas {
 		if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, spec.Replicas); err != nil {
-			testutil.AnnotatedFatalf(t, "CheckPods timed-out", "Error validating pods for deploy [%s]:\n%s", deploy, err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
+			}
 		}
 		if err := TestHelper.CheckDeployment(TestHelper.GetLinkerdNamespace(), deploy, spec.Replicas); err != nil {
 			testutil.AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
@@ -587,9 +591,12 @@ func TestInject(t *testing.T) {
 			}
 
 			for _, deploy := range []string{"smoke-test-terminus", "smoke-test-gateway"} {
-				err = TestHelper.CheckPods(prefixedNs, deploy, 1)
-				if err != nil {
-					testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
+				if err := TestHelper.CheckPods(prefixedNs, deploy, 1); err != nil {
+					if rce, ok := err.(*testutil.RestartCountError); ok {
+						testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+					} else {
+						testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
+					}
 				}
 			}
 
@@ -672,8 +679,11 @@ func TestEvents(t *testing.T) {
 func TestRestarts(t *testing.T) {
 	for deploy, spec := range testutil.LinkerdDeployReplicas {
 		if err := TestHelper.CheckPods(TestHelper.GetLinkerdNamespace(), deploy, spec.Replicas); err != nil {
-			testutil.AnnotatedFatalf(t, fmt.Sprintf("error validating pods [%s]", deploy),
-				"error validating pods [%s]:\n%s", deploy, err)
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
+			}
 		}
 	}
 }

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -251,15 +251,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 	// test `linkerd upgrade --from-manifests`
 	if TestHelper.UpgradeFromVersion() != "" {
-		resources := []string{}
-		resources = append(resources, "configmaps/"+k8s.ConfigConfigMapName, "secrets/"+k8s.IdentityIssuerSecretName)
-
-		// If `linkerd-config-addons` exists, add it to the resources to get
-		_, err := TestHelper.Kubectl("", "--namespace", TestHelper.GetLinkerdNamespace(), "get", "configmaps/"+k8s.AddOnsConfigMapName)
-		if err == nil {
-			resources = append(resources, "configmaps/"+k8s.AddOnsConfigMapName)
-		}
-
+		resources := []string{"configmaps/" + k8s.ConfigConfigMapName, "configmaps" / +k8s.AddOnsConfigMapName, "secrets/" + k8s.IdentityIssuerSecretName}
 		args := append([]string{"--namespace", TestHelper.GetLinkerdNamespace(), "get"}, resources...)
 		args = append(args, "-oyaml")
 

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -391,7 +391,7 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
 
-	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), true)
+	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion())
 }
 
 func TestUpgradeHelm(t *testing.T) {
@@ -435,7 +435,7 @@ func TestVersionPostInstall(t *testing.T) {
 	}
 }
 
-func testCheckCommand(t *testing.T, stage string, expectedVersion string, namespace string, cliVersionOverride string, compareOutput bool) {
+func testCheckCommand(t *testing.T, stage string, expectedVersion string, namespace string, cliVersionOverride string) {
 	var cmd []string
 	var golden string
 	if stage == "proxy" {
@@ -461,10 +461,6 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 			return fmt.Errorf("'linkerd check' command failed\n%s\n%s", stderr, out)
 		}
 
-		if !compareOutput {
-			return nil
-		}
-
 		err = TestHelper.ValidateOutput(out, golden)
 		if err != nil {
 			return fmt.Errorf("received unexpected output\n%s", err.Error())
@@ -479,11 +475,11 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 
 // TODO: run this after a `linkerd install config`
 func TestCheckConfigPostInstall(t *testing.T) {
-	testCheckCommand(t, "config", TestHelper.GetVersion(), "", "", true)
+	testCheckCommand(t, "config", TestHelper.GetVersion(), "", "")
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	testCheckCommand(t, "", TestHelper.GetVersion(), "", "", true)
+	testCheckCommand(t, "", TestHelper.GetVersion(), "", "")
 }
 
 func TestUpgradeTestAppWorksAfterUpgrade(t *testing.T) {
@@ -660,7 +656,7 @@ func TestCheckProxy(t *testing.T) {
 		tc := tc // pin
 		t.Run(tc.ns, func(t *testing.T) {
 			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
-			testCheckCommand(t, "proxy", TestHelper.GetVersion(), prefixedNs, "", true)
+			testCheckCommand(t, "proxy", TestHelper.GetVersion(), prefixedNs, "")
 		})
 	}
 }

--- a/test/install_test.go
+++ b/test/install_test.go
@@ -391,44 +391,13 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
 
-	// TODO: remove when 2.8.0 is released
-	_, err := TestHelper.Kubectl("",
-		"--namespace", TestHelper.GetLinkerdNamespace(),
-		"create", "serviceaccount", "linkerd-smi-metrics",
-	)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "linkerd-smi-metrics SA creation failed",
-			"linkerd-smi-metrics SA creation failed: %s", err)
-	}
-	_, err = TestHelper.Kubectl("",
-		"--namespace", TestHelper.GetLinkerdNamespace(),
-		"label", "serviceaccount", "linkerd-smi-metrics",
-		"linkerd.io/control-plane-ns="+TestHelper.GetLinkerdNamespace(),
-	)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "linkerd-smi-metrics SA labeling failed",
-			"linkerd-smi-metrics SA labeling failed: %s", err)
-	}
-
-	// TODO: once 2.8 comes out, Replace compareOutput with true to make sure check outputs are correct
-	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), false)
+	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), true)
 }
 
 func TestUpgradeHelm(t *testing.T) {
 	if TestHelper.UpgradeHelmFromVersion() == "" {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
-
-	// TODO: remove when 2.8.0 is released
-	_, err := TestHelper.Kubectl("",
-		"--namespace", TestHelper.GetLinkerdNamespace(),
-		"delete", "serviceaccount", "linkerd-smi-metrics",
-	)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "linkerd-smi-metrics SA deletion failed",
-			"linkerd-smi-metrics SA deletion failed: %s", err)
-	}
-	time.Sleep(3 * time.Second)
 
 	args := []string{
 		"--reset-values",


### PR DESCRIPTION
We had some code for testing upgrades from pre-2.8.0 stables that took
care of creating the non-existent `linkerd-smi-metrics` SA, which is no
longer necessary.
