### PR TITLE
Make `service mirror controller is running check` retry

### DIFF
--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -64,9 +64,10 @@ func (hc *HealthChecker) multiClusterCategory() []category {
 			id: LinkerdMulticlusterSourceChecks,
 			checkers: []checker{
 				{
-					description: "service mirror controller is running",
-					hintAnchor:  "l5d-multicluster-service-mirror-running",
-					fatal:       true,
+					description:   "service mirror controller is running",
+					hintAnchor:    "l5d-multicluster-service-mirror-running",
+					retryDeadline: hc.RetryDeadline,
+					fatal:         true,
 					check: func(context.Context) error {
 						return hc.checkServiceMirrorController()
 					},


### PR DESCRIPTION
This PR makes the `service mirror controller is running` retry on failure. This brings the check in line with the rest of the checks that verify that certain Linkerd components are running. It is especially useful in integration tests when we want to wait for the service mirror component to be initialized for a certain amount of time before we simply fail the `linkerd check` command

Fix #4642

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
