### PR TITLE
Release notes for stable-2.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,16 +4,13 @@
 
 This release fixes multicluster gateways support on EKS.
 
-* The `config.linkerd.io/proxy-destination-get-networks` annotation configures
-  the networks for which a proxy can discover metadata. This is an advanced
-  configuration option that has security implications.
 * The multicluster service-mirror has been extended to resolve DNS names for
-  target clusters when an IP address it not known.
+  target clusters when an IP address is not known.
 * Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
   for providing a fix!
 * Have the service mirror controller check in `linkerd check` retry on failures.
 * As of this version we're including a Chocolatey package (Windows) next to the
-  other binaries in the release assets in Github.
+  other binaries in the release assets in GitHub.
 * Base images have been updated:
   * debian:buster-20200514-slim
   * grafana/grafana:7.0.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changes
 
+## stable-2.8.1
+
+This release fixes multicluster gateways support on EKS.
+
+* The `config.linkerd.io/proxy-destination-get-networks` annotation configures
+  the networks for which a proxy can discover metadata. This is an advanced
+  configuration option that has security implications.
+* The multicluster service-mirror has been extended to resolve DNS names for
+  target clusters when an IP address it not known.
+* Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
+  for providing a fix!
+* Have the service mirror controller check in `linkerd check` retry on failures.
+* As of this version we're including a Chocolatey package (Windows) next to the
+  other binaries in the release assets in Github.
+* Base images have been updated:
+  * debian:buster-20200514-slim
+  * grafana/grafana:7.0.3
+* The shell scripts under `bin` continued to be improved, thanks to @joakimr-axis!
+
 ## edge-20.6.3
 
 This edge release is a release candidate for stable-2.8.1. It includes a fix


### PR DESCRIPTION
## stable-2.8.1

This release fixes multicluster gateways support on EKS.

* The `config.linkerd.io/proxy-destination-get-networks` annotation configures
  the networks for which a proxy can discover metadata. This is an advanced
  configuration option that has security implications.
* The multicluster service-mirror has been extended to resolve DNS names for
  target clusters when an IP address it not known.
* Linkerd checks could fail when run from the dashboard. Thanks to @alex-berger
  for providing a fix!
* Have the service mirror controller check in `linkerd check` retry on failures.
* As of this version we're including a Chocolatey package (Windows) next to the
  other binaries in the release assets in Github.
* Base images have been updated:
  * debian:buster-20200514-slim
  * grafana/grafana:7.0.3
* The shell scripts under `bin` continued to be improved, thanks to @joakimr-axis!
