### PR TITLE
go-run: Move temporary binary into `target` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ web/web
 **/node_modules
 web/app/dist
 web/app/yarn-error.log
-.gorun
 **/*.gogen*
 **/*.swp
 charts/**/charts

--- a/bin/go-run
+++ b/bin/go-run
@@ -12,6 +12,7 @@ fi
 
 version=$("$bindir"/root-tag)
 ldflags="-X github.com/linkerd/linkerd2/pkg/version.Version=$version"
-GO111MODULE=on go build -v -mod=readonly -race -o .gorun -ldflags "$ldflags" "./$1"
+mkdir -p target
+GO111MODULE=on go build -v -mod=readonly -race -o ./target/go-run -ldflags "$ldflags" "./$1"
 shift
-exec ./.gorun "$@"
+exec ./target/go-run "$@"


### PR DESCRIPTION
The `bin/go-run` script generates a temporary binary, stored in the root
of the repository.

This change moves it into `target/` so that is included in the
.dockerignore, and so that the repo can be cleaned easily by removing
the `target/` directory.