### PR TITLE
Update release workflow kind_integration job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,33 +124,8 @@ jobs:
 
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
-    - name: Setup default KinD cluster
-      if: matrix.integration_test != 'custom_domain'
-      run: bin/kind create cluster --wait 300s
-    - name: Setup custom_domain KinD cluster
-      if: matrix.integration_test == 'custom_domain'
-      run: bin/kind create cluster --wait 300s --config test/testdata/custom_cluster_domain_config.yaml
-    - name: Load image archives into the local KinD cluster
-      env:
-        PROXY_INIT_IMAGE_NAME: gcr.io/linkerd-io/proxy-init:v1.3.1
-        PROMETHEUS_IMAGE_NAME: prom/prometheus:v2.15.2
-      run: |
-        # Fetch images from the Packet host and load them into the local KinD cluster
-        bin/kind-load --images --images-host ssh://linkerd-docker
-
-        # Load proxy-init and prometheus images into KinD while it is
-        # available. Allow these commands to fail since they will be cached
-        # for the next run.
-        kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROXY_INIT_IMAGE_NAME) 2>&1 || true
-        kind load image-archive <(DOCKER_HOST=ssh://linkerd-docker docker save $PROMETHEUS_IMAGE_NAME) 2>&1 || true
     - name: Run integration tests
-      run: |
-        # Export `init_test_run` and `*_integration_tests` into the
-        # environment.
-        . bin/_test-run.sh
-
-        init_test_run $HOME/.linkerd
-        ${{ matrix.integration_test }}_integration_tests
+      run: bin/tests --images --images-host ssh://linkerd-docker --name ${{ matrix.integration_test }} "$HOME/.linkerd"
   # todo: Keep in sync with `cloud_integration.yml`
   cloud_integration_tests:
     name: Cloud integration tests


### PR DESCRIPTION
## Description

As discussed [here](https://github.com/linkerd/linkerd2/pull/4653#discussion_r445543061), the `kind_integration` job of the release workflow was not kept in sync with the changes made in #4593.

Until GitHub actions can reuse yaml for separate workflows, these sections are supposed to be kept in sync.

This would be an issue if we had tried doing a release since #4593 merged, but that has not happened yet.

## Changes

This updates the release workflow `kind_integration` job to use the use new test interface, mainly removing cluster creation and image loading as necessary prerequisites.