### PR TITLE
Make uncheduble pods check warning only

### DIFF
--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -50,13 +50,13 @@ func checkPublicAPIClientOrRetryOrExit(retryDeadline time.Time, apiChecks bool) 
 		checks = append(checks, healthcheck.LinkerdAPIChecks)
 	}
 
-	hc := newHealthChecker(checks, retryDeadline)
+	hc := newHealthChecker(checks, retryDeadline, true)
 
 	hc.RunChecks(exitOnError)
 	return hc.PublicAPIClient()
 }
 
-func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time) *healthcheck.HealthChecker {
+func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time, publicAPIClientChecks bool) *healthcheck.HealthChecker {
 	return healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
@@ -65,6 +65,7 @@ func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time) 
 		ImpersonateGroup:      impersonateGroup,
 		APIAddr:               apiAddr,
 		RetryDeadline:         retryDeadline,
+		PublicAPIClientChecks: publicAPIClientChecks,
 	})
 }
 

--- a/cli/cmd/public_api.go
+++ b/cli/cmd/public_api.go
@@ -50,13 +50,13 @@ func checkPublicAPIClientOrRetryOrExit(retryDeadline time.Time, apiChecks bool) 
 		checks = append(checks, healthcheck.LinkerdAPIChecks)
 	}
 
-	hc := newHealthChecker(checks, retryDeadline, true)
+	hc := newHealthChecker(checks, retryDeadline)
 
 	hc.RunChecks(exitOnError)
 	return hc.PublicAPIClient()
 }
 
-func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time, publicAPIClientChecks bool) *healthcheck.HealthChecker {
+func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time) *healthcheck.HealthChecker {
 	return healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
@@ -65,7 +65,6 @@ func newHealthChecker(checks []healthcheck.CategoryID, retryDeadline time.Time, 
 		ImpersonateGroup:      impersonateGroup,
 		APIAddr:               apiAddr,
 		RetryDeadline:         retryDeadline,
-		PublicAPIClientChecks: publicAPIClientChecks,
 	})
 }
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -348,6 +348,7 @@ type Options struct {
 	SourceCluster         bool
 	TargetCluster         bool
 	MultiCluster          bool
+	PublicAPIClientChecks bool
 }
 
 // HealthChecker encapsulates all health check checkers, and clients required to
@@ -646,6 +647,9 @@ func (hc *HealthChecker) allCategories() []category {
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(context.Context) error {
+						if hc.PublicAPIClientChecks {
+							return &SkipError{Reason: "skipping for public api instantiation triggered checks"}
+						}
 						// do not save this into hc.controlPlanePods, as this check may
 						// succeed prior to all expected control plane pods being up
 						controlPlanePods, err := hc.kubeAPI.GetPodsByNamespace(hc.ControlPlaneNamespace)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -644,7 +644,7 @@ func (hc *HealthChecker) allCategories() []category {
 					description:   "no unschedulable pods",
 					hintAnchor:    "l5d-existence-unschedulable-pods",
 					retryDeadline: hc.RetryDeadline,
-					fatal:         true,
+					warning:       true,
 					check: func(context.Context) error {
 						// do not save this into hc.controlPlanePods, as this check may
 						// succeed prior to all expected control plane pods being up

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -348,7 +348,6 @@ type Options struct {
 	SourceCluster         bool
 	TargetCluster         bool
 	MultiCluster          bool
-	PublicAPIClientChecks bool
 }
 
 // HealthChecker encapsulates all health check checkers, and clients required to
@@ -647,9 +646,6 @@ func (hc *HealthChecker) allCategories() []category {
 					retryDeadline: hc.RetryDeadline,
 					fatal:         true,
 					check: func(context.Context) error {
-						if hc.PublicAPIClientChecks {
-							return &SkipError{Reason: "skipping for public api instantiation triggered checks"}
-						}
 						// do not save this into hc.controlPlanePods, as this check may
 						// succeed prior to all expected control plane pods being up
 						controlPlanePods, err := hc.kubeAPI.GetPodsByNamespace(hc.ControlPlaneNamespace)


### PR DESCRIPTION
Currently commands that need access to the public api are executing the `LinkerdControlPlaneExistenceChecks` This set of checks includes one that specifically checks that there is no unscheduable pods. In fact in order to run commands like `stat` and `edge` we do not need to meet that requirement. 

This change relaxes all this by makind the `no unschedulable pods` a warning only check.  Fixes #3940

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
