### PR TITLE
conformance validation: Refactor install test helpers

### DIFF
--- a/test/install_test.go
+++ b/test/install_test.go
@@ -109,20 +109,6 @@ func TestCheckPreInstall(t *testing.T) {
 	}
 }
 
-func exerciseTestAppEndpoint(endpoint, namespace string) error {
-	testAppURL, err := TestHelper.URLFor(namespace, "web", 8080)
-	if err != nil {
-		return err
-	}
-	for i := 0; i < 30; i++ {
-		_, err := TestHelper.HTTPGetURL(testAppURL + endpoint)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func TestUpgradeTestAppWorksBeforeUpgrade(t *testing.T) {
 	if TestHelper.UpgradeFromVersion() != "" {
 		// make sure app is running
@@ -141,7 +127,7 @@ func TestUpgradeTestAppWorksBeforeUpgrade(t *testing.T) {
 			}
 		}
 
-		if err := exerciseTestAppEndpoint("/api/list", testAppNamespace); err != nil {
+		if err := testutil.ExerciseTestAppEndpoint("/api/list", testAppNamespace, TestHelper); err != nil {
 			testutil.AnnotatedFatalf(t, "error exercising test app endpoint before upgrade",
 				"error exercising test app endpoint before upgrade %s", err)
 		}
@@ -355,39 +341,8 @@ func TestInstallHelm(t *testing.T) {
 	}
 }
 
-func testResourcesPostInstall(namespace string, services []string, deploys map[string]testutil.DeploySpec, t *testing.T) {
-	// Tests Namespace
-	err := TestHelper.CheckIfNamespaceExists(namespace)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "received unexpected output",
-			"received unexpected output\n%s", err)
-	}
-
-	// Tests Services
-	for _, svc := range services {
-		if err := TestHelper.CheckService(namespace, svc); err != nil {
-			testutil.AnnotatedErrorf(t, fmt.Sprintf("error validating service [%s]", svc),
-				"error validating service [%s]:\n%s", svc, err)
-		}
-	}
-
-	// Tests Pods and Deployments
-	for deploy, spec := range deploys {
-		if err := TestHelper.CheckPods(namespace, deploy, spec.Replicas); err != nil {
-			if rce, ok := err.(*testutil.RestartCountError); ok {
-				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
-			} else {
-				testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
-			}
-		}
-		if err := TestHelper.CheckDeployment(namespace, deploy, spec.Replicas); err != nil {
-			testutil.AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-		}
-	}
-}
-
 func TestControlPlaneResourcesPostInstall(t *testing.T) {
-	testResourcesPostInstall(TestHelper.GetLinkerdNamespace(), linkerdSvcs, testutil.LinkerdDeployReplicas, t)
+	testutil.TestResourcesPostInstall(TestHelper.GetLinkerdNamespace(), linkerdSvcs, testutil.LinkerdDeployReplicas, TestHelper, t)
 }
 
 func TestInstallMulticluster(t *testing.T) {
@@ -426,7 +381,7 @@ func TestMulticlusterResourcesPostInstall(t *testing.T) {
 	if !TestHelper.Multicluster() {
 		return
 	}
-	testResourcesPostInstall(TestHelper.GetMulticlusterNamespace(), multiclusterSvcs, testutil.MulticlusterDeployReplicas, t)
+	testutil.TestResourcesPostInstall(TestHelper.GetMulticlusterNamespace(), multiclusterSvcs, testutil.MulticlusterDeployReplicas, TestHelper, t)
 }
 
 func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
@@ -679,7 +634,7 @@ func TestCheckPostInstall(t *testing.T) {
 func TestUpgradeTestAppWorksAfterUpgrade(t *testing.T) {
 	if TestHelper.UpgradeFromVersion() != "" {
 		testAppNamespace := "upgrade-test"
-		if err := exerciseTestAppEndpoint("/api/vote?choice=:policeman:", testAppNamespace); err != nil {
+		if err := testutil.ExerciseTestAppEndpoint("/api/vote?choice=:policeman:", testAppNamespace, TestHelper); err != nil {
 			testutil.AnnotatedFatalf(t, "error exercising test app endpoint after upgrade",
 				"error exercising test app endpoint after upgrade %s", err)
 		}

--- a/testutil/install.go
+++ b/testutil/install.go
@@ -1,0 +1,53 @@
+package testutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestResourcesPostInstall tests resources post control plane installation
+func TestResourcesPostInstall(namespace string, services []string, deploys map[string]DeploySpec, h *TestHelper, t *testing.T) {
+	// Tests Namespace
+	err := h.CheckIfNamespaceExists(namespace)
+	if err != nil {
+		AnnotatedFatalf(t, "received unexpected output",
+			"received unexpected output\n%s", err)
+	}
+
+	// Tests Services
+	for _, svc := range services {
+		if err := h.CheckService(namespace, svc); err != nil {
+			AnnotatedErrorf(t, fmt.Sprintf("error validating service [%s]", svc),
+				"error validating service [%s]:\n%s", svc, err)
+		}
+	}
+
+	// Tests Pods and Deployments
+	for deploy, spec := range deploys {
+		if err := h.CheckPods(namespace, deploy, spec.Replicas); err != nil {
+			if rce, ok := err.(*RestartCountError); ok {
+				AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				AnnotatedFatal(t, "CheckPods timed-out", err)
+			}
+		}
+		if err := h.CheckDeployment(namespace, deploy, spec.Replicas); err != nil {
+			AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
+		}
+	}
+}
+
+// ExerciseTestAppEndpoint tests if the emojivoto service is reachable
+func ExerciseTestAppEndpoint(endpoint, namespace string, h *TestHelper) error {
+	testAppURL, err := h.URLFor(namespace, "web", 8080)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < 30; i++ {
+		_, err := h.HTTPGetURL(testAppURL + endpoint)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The `install_test.go` integration tests currently make use of 2 useful helper funcions - `exerciseTestAppEndpoint` and `testResourcesPostInstall`. In order to be able to reuse these in [conformance validation](https://github.com/linkerd/linkerd2-conformance) for install and upgrade tests, this PR refactors these helpers into the `testutil` package

- Move `testResourcesPostInstall` to `testutil.TestResourcesPostInstall`
- Move `exerciseTestAppEndpoint` to `testutil.ExerciseTestAppEndpoint`

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
