### PR TITLE
Use add-on level values.yaml for chart generation

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -853,9 +853,14 @@ func render(w io.Writer, values *l5dcharts.Values) error {
 			Dir:       addOnChartsPath + "/" + addOn.Name(),
 			Namespace: controlPlaneNamespace,
 			RawValues: append(addOn.Values(), rawValues...),
-			Files: []*chartutil.BufferedFile{&chartutil.BufferedFile{
-				Name: chartutil.ChartfileName,
-			}},
+			Files: []*chartutil.BufferedFile{
+				{
+					Name: chartutil.ChartfileName,
+				},
+				{
+					Name: chartutil.ValuesfileName,
+				},
+			},
 		}
 	}
 


### PR DESCRIPTION
Part of #4572 

We have been planning to move defaults into add-on specific `values.yaml`.

This change adds add-on level `values.yaml` to be part of the helm template to be used for
rendering.

As there are values specified in `add-on` level `values.yaml`, there are no changes needed for golden test files. 

This PR will have follow up PR's which move defaults into `values.yaml` for `grafana` and `tracing` charts.

 Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
