### PR TITLE
Surface scheduling errors on retry

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -641,10 +641,11 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
-					description:   "no unschedulable pods",
-					hintAnchor:    "l5d-existence-unschedulable-pods",
-					retryDeadline: hc.RetryDeadline,
-					warning:       true,
+					description:         "no unschedulable pods",
+					hintAnchor:          "l5d-existence-unschedulable-pods",
+					retryDeadline:       hc.RetryDeadline,
+					surfaceErrorOnRetry: true,
+					warning:             true,
 					check: func(context.Context) error {
 						// do not save this into hc.controlPlanePods, as this check may
 						// succeed prior to all expected control plane pods being up


### PR DESCRIPTION
Currently `linkerd check` appears to hang  on ha installations where there are pods that are unscheduable. In reality it is just wating on a condition that might never become true without showing any useful information (i.e. which pods are not scheduled). This change adds sets the  `surfaceErrorOnRetry: true` so the user gets feedback wrt to what conditions are not met yet instead of simply being shown `waiting for check to complete`.


Fix #4680