### PR TITLE
Fix `splitStringListToPorts` port range object rendering

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -30,10 +30,10 @@
     "port": {{.Values.global.proxy.ports.control}}
   },
   "ignoreInboundPorts":[
-    {{- include "partials.splitStringListToPorts" .Values.global.proxyInit.ignoreInboundPorts -}}
+    {{- include "partials.splitStringListToPortRanges" .Values.global.proxyInit.ignoreInboundPorts -}}
   ],
   "ignoreOutboundPorts":[
-    {{- include "partials.splitStringListToPorts" .Values.global.proxyInit.ignoreOutboundPorts -}}
+    {{- include "partials.splitStringListToPortRanges" .Values.global.proxyInit.ignoreOutboundPorts -}}
   ],
   "inboundPort":{
     "port": {{.Values.global.proxy.ports.inbound}}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -11,7 +11,7 @@ global:
   controlPlaneTracing: false
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version dev-f00c17e5-zaharidichev
+  linkerdVersion: &linkerd_version linkerdVersionValue
 
   namespace: linkerd
 

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -11,7 +11,7 @@ global:
   controlPlaneTracing: false
 
   # control plane version. See Proxy section for proxy version
-  linkerdVersion: &linkerd_version linkerdVersionValue
+  linkerdVersion: &linkerd_version dev-f00c17e5-zaharidichev
 
   namespace: linkerd
 

--- a/charts/partials/templates/_helpers.tpl
+++ b/charts/partials/templates/_helpers.tpl
@@ -55,7 +55,7 @@ For example "11,22,55" will become{"port":11},{"port":22},
 {{- $ports := splitList "," . -}}
 {{- $last := sub (len $ports) 1 -}}
 {{- range $i,$port := $ports -}}
-{"port":{{$port}}}{{ternary "," "" (ne $i $last)}}
+{"portRange":"{{$port}}"}{{ternary "," "" (ne $i $last)}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/partials/templates/_helpers.tpl
+++ b/charts/partials/templates/_helpers.tpl
@@ -46,11 +46,11 @@ For example "11,22,55,44" will become "11","22","55","44"
 {{- end -}}
 
 {{/*
-Splits a coma separated list into a list of port objects.
-For example "11,22,55" will become{"port":11},{"port":22},
-{"port":55}
+Splits a coma separated list into a list of PortRange objects.
+For example "11,22,55" will become{"portRange":11},{"portRange":22},
+{"portRange":55}
 */}}
-{{- define "partials.splitStringListToPorts" -}}
+{{- define "partials.splitStringListToPortRanges" -}}
 {{- if gt (len .) 0 -}}
 {{- $ports := splitList "," . -}}
 {{- $last := sub (len $ports) 1 -}}

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -902,8 +902,8 @@ data:
       "controlPort":{
         "port": 4190
       },
-      "ignoreInboundPorts":[{"port":222}],
-      "ignoreOutboundPorts":[{"port":111}],
+      "ignoreInboundPorts":[{"portRange":"222"}],
+      "ignoreOutboundPorts":[{"portRange":"111"}],
       "inboundPort":{
         "port": 4143
       },

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -902,8 +902,8 @@ data:
       "controlPort":{
         "port": 4190
       },
-      "ignoreInboundPorts":[{"port":222}],
-      "ignoreOutboundPorts":[{"port":111}],
+      "ignoreInboundPorts":[{"portRange":"222"}],
+      "ignoreOutboundPorts":[{"portRange":"111"}],
       "inboundPort":{
         "port": 4143
       },

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -902,8 +902,8 @@ data:
       "controlPort":{
         "port": 4190
       },
-      "ignoreInboundPorts":[{"port":222}],
-      "ignoreOutboundPorts":[{"port":111}],
+      "ignoreInboundPorts":[{"portRange":"222"}],
+      "ignoreOutboundPorts":[{"portRange":"111"}],
       "inboundPort":{
         "port": 4143
       },


### PR DESCRIPTION
The `splitStringListToPorts` helm function is currently incorrectly formating a list of ports as an array of Port objects that look ike `{"port" : 555}`.  The config map protobuf representation however expects that the `ignoreOutboundPorts` and `ignoreInboundPorts` fields are are list of `PortRange` objects (`{"portRange" : 555}`). 

This was causing the injector to return an empty string when trying to parse a `PortRange` object resulting in the ports not getting set correctly when injecting workloads. Note that this is happening only with helm installations as this is when we are actually using a helm template for outputting the config map. 

To fix that the `splitStringListToPorts` helm function is changed to format the objects as the json representation of PortRange and is renamed to `splitStringListToPortRanges`

Fix: #4679

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>