### PR TITLE
Add volume and volumeMount for buster-based proxy-init

### DIFF
--- a/charts/add-ons/grafana/templates/grafana.yaml
+++ b/charts/add-ons/grafana/templates/grafana.yaml
@@ -180,4 +180,7 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/add-ons/tracing/templates/tracing.yaml
+++ b/charts/add-ons/tracing/templates/tracing.yaml
@@ -136,6 +136,9 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
 ---
 ###
@@ -223,5 +226,8 @@ spec:
       volumes:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/add-ons/tracing/templates/tracing.yaml
+++ b/charts/add-ons/tracing/templates/tracing.yaml
@@ -121,7 +121,7 @@ spec:
         - mountPath: /conf
           name: {{ printf "%s-config-val" .Values.collector.name}}
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .Values.global.noInitContainer -}}
+      {{ if not .Values.global.cniEnabled -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
@@ -217,7 +217,7 @@ spec:
         {{- include "partials.resources" .Values.jaeger.resources | nindent 8 }}
         {{- end }}
       - {{- include "partials.proxy" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if not .Values.global.noInitContainer -}}
+      {{ if not .Values.global.cniEnabled -}}
       initContainers:
       - {{- include "partials.proxy-init" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -118,4 +118,7 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -118,4 +118,7 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -140,5 +140,8 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
 {{end -}}

--- a/charts/linkerd2/templates/prometheus.yaml
+++ b/charts/linkerd2/templates/prometheus.yaml
@@ -291,6 +291,9 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
 {{- if .Values.prometheusPersistence.enabled }}
 ---

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -102,6 +102,9 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
 ---
 kind: Service

--- a/charts/linkerd2/templates/smi-metrics.yaml
+++ b/charts/linkerd2/templates/smi-metrics.yaml
@@ -98,6 +98,9 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - name: config
         configMap:
           name: linkerd-smi-metrics

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -116,4 +116,7 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -127,6 +127,9 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
       - name: tls
         secret:

--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -125,4 +125,7 @@ spec:
       {{ if .Values.global.controlPlaneTracing -}}
       - {{- include "partials.proxy.volumes.labels" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
+      {{ if not .Values.global.cniEnabled -}}
+      - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -74,7 +74,6 @@ global:
     xtMountPath:
       mountPath: /run
       name: linkerd-proxy-init-xtables-lock
-      subPath: xtables.lock
 
   # control plane annotations - do not edit
   createdByAnnotation: linkerd.io/created-by

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -71,6 +71,10 @@ global:
         limit: 50Mi
         request: 10Mi
     closeWaitTimeoutSecs: 0
+    xtMountPath:
+      mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+      subPath: xtables.lock
 
   # control plane annotations - do not edit
   createdByAnnotation: linkerd.io/created-by

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -50,10 +50,13 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
 terminationMessagePolicy: FallbackToLogsOnError
-{{- if .Values.global.proxyInit.saMountPath }}
 volumeMounts:
+- mountPath: {{.Values.global.proxyInit.xtMountPath.mountPath}}
+  name: {{.Values.global.proxyInit.xtMountPath.name}}
+  subPath: {{.Values.global.proxyInit.xtMountPath.subPath}}
+{{- if .Values.global.proxyInit.saMountPath }}
 - mountPath: {{.Values.global.proxyInit.saMountPath.mountPath}}
   name: {{.Values.global.proxyInit.saMountPath.name}}
   readOnly: {{.Values.global.proxyInit.saMountPath.readOnly}}
-{{- end -}}
+{{- end -}}  
 {{- end -}}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -50,10 +50,14 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
 terminationMessagePolicy: FallbackToLogsOnError
+{{- if or (not .Values.global.cniEnabled) .Values.global.proxyInit.saMountPath }}
 volumeMounts:
+{{- end -}}
+{{- if not .Values.global.cniEnabled }}
 - mountPath: {{.Values.global.proxyInit.xtMountPath.mountPath}}
   name: {{.Values.global.proxyInit.xtMountPath.name}}
   subPath: {{.Values.global.proxyInit.xtMountPath.subPath}}
+{{- end -}}
 {{- if .Values.global.proxyInit.saMountPath }}
 - mountPath: {{.Values.global.proxyInit.saMountPath.mountPath}}
   name: {{.Values.global.proxyInit.saMountPath.name}}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -56,7 +56,6 @@ volumeMounts:
 {{- if not .Values.global.cniEnabled }}
 - mountPath: {{.Values.global.proxyInit.xtMountPath.mountPath}}
   name: {{.Values.global.proxyInit.xtMountPath.name}}
-  subPath: {{.Values.global.proxyInit.xtMountPath.subPath}}
 {{- end -}}
 {{- if .Values.global.proxyInit.saMountPath }}
 - mountPath: {{.Values.global.proxyInit.saMountPath.mountPath}}

--- a/charts/partials/templates/_volumes.tpl
+++ b/charts/partials/templates/_volumes.tpl
@@ -24,3 +24,8 @@ downwardAPI:
     path: "labels"
 name: podinfo
 {{- end -}}
+
+{{ define "partials.proxyInit.volumes.xtables" -}}
+emptyDir: {}
+name: linkerd-proxy-init-xtables-lock
+{{- end -}}

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -35,6 +35,15 @@
     "value": "{{$value}}"
   },
   {{- end }}
+  {{- if or .Values.global.proxyInit .Values.global.proxy }}
+  {{- if .Values.addRootVolumes }}
+  {
+    "op": "add",
+    "path": "{{$prefix}}/spec/volumes",
+    "value": []
+  },
+  {{- end }}
+  {{- end}}
   {{- if .Values.global.proxyInit }}
   {{- if .Values.addRootInitContainers }}
   {
@@ -43,6 +52,14 @@
     "value": []
   },
   {{- end }}
+  {
+    "op": "add",
+    "path": "{{$prefix}}/spec/volumes/-",
+    "value": {
+      "emptyDir": {},
+      "name": "linkerd-proxy-init-xtables-lock"
+    }
+  },  
   {
     "op": "add",
     "path": "{{$prefix}}/spec/initContainers/-",
@@ -59,13 +76,6 @@
   },
   {{- end }}
   {{- if .Values.global.proxy }}
-  {{- if .Values.addRootVolumes }}
-  {
-    "op": "add",
-    "path": "{{$prefix}}/spec/volumes",
-    "value": []
-  },
-  {{- end }}
   {{- if (.Values.global.proxy.trace.collectorSvcAddr) }}
   {
     "op": "add",

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -824,6 +824,11 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*l5d
 	installValues.Global.ProxyInit.Image.Version = options.initImageVersion
 	installValues.Global.ProxyInit.IgnoreInboundPorts = strings.Join(options.ignoreInboundPorts, ",")
 	installValues.Global.ProxyInit.IgnoreOutboundPorts = strings.Join(options.ignoreOutboundPorts, ",")
+	installValues.Global.ProxyInit.XTMountPath = &l5dcharts.VolumeMountPath{
+		MountPath: k8s.MountPathXtablesLock,
+		Name:      k8s.InitXtablesLockVolumeMountName,
+		SubPath:   k8s.MountSubPathXtablesLock,
+	}
 
 	installValues.DebugContainer.Image.Name = registryOverride(options.debugImage, options.dockerRegistry)
 	installValues.DebugContainer.Image.PullPolicy = options.imagePullPolicy

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -827,7 +827,6 @@ func (options *installOptions) buildValuesWithoutIdentity(configs *pb.All) (*l5d
 	installValues.Global.ProxyInit.XTMountPath = &l5dcharts.VolumeMountPath{
 		MountPath: k8s.MountPathXtablesLock,
 		Name:      k8s.InitXtablesLockVolumeMountName,
-		SubPath:   k8s.MountSubPathXtablesLock,
 	}
 
 	installValues.DebugContainer.Image.Name = registryOverride(options.debugImage, options.dockerRegistry)

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -119,7 +119,6 @@ func TestRender(t *testing.T) {
 				},
 				XTMountPath: &charts.VolumeMountPath{
 					MountPath: "/run",
-					SubPath:   "xtables.lock",
 					Name:      "linkerd-proxy-init-xtables-lock",
 				},
 			},

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -117,6 +117,11 @@ func TestRender(t *testing.T) {
 						Request: "10Mi",
 					},
 				},
+				XTMountPath: &charts.VolumeMountPath{
+					MountPath: "/run",
+					SubPath:   "xtables.lock",
+					Name:      "linkerd-proxy-init-xtables-lock",
+				},
 			},
 		},
 		Configs: charts.ConfigJSONs{

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -149,7 +149,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -146,7 +146,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -146,7 +146,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -299,7 +305,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -149,7 +149,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -308,7 +307,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -149,7 +149,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -146,7 +146,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -189,7 +189,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -186,7 +186,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -321,7 +327,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -485,7 +497,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -649,7 +667,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -330,7 +329,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -500,7 +498,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -670,7 +667,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -173,7 +173,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -176,7 +176,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -178,7 +178,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -175,7 +175,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -321,7 +327,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -330,7 +329,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -162,7 +162,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -165,7 +165,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -157,7 +157,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -160,7 +160,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -158,7 +158,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -161,7 +161,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -158,7 +158,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -161,7 +161,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -159,7 +159,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -162,7 +162,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
@@ -170,7 +170,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
@@ -167,7 +167,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - downwardAPI:
           items:
           - fieldRef:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -159,7 +159,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -162,7 +162,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -159,7 +159,13 @@ items:
             runAsNonRoot: false
             runAsUser: 0
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /run
+            name: linkerd-proxy-init-xtables-lock
+            subPath: xtables.lock
         volumes:
+        - emptyDir: {}
+          name: linkerd-proxy-init-xtables-lock
         - emptyDir:
             medium: Memory
           name: linkerd-identity-end-entity
@@ -317,7 +323,13 @@ items:
             runAsNonRoot: false
             runAsUser: 0
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /run
+            name: linkerd-proxy-init-xtables-lock
+            subPath: xtables.lock
         volumes:
+        - emptyDir: {}
+          name: linkerd-proxy-init-xtables-lock
         - emptyDir:
             medium: Memory
           name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -162,7 +162,6 @@ items:
           volumeMounts:
           - mountPath: /run
             name: linkerd-proxy-init-xtables-lock
-            subPath: xtables.lock
         volumes:
         - emptyDir: {}
           name: linkerd-proxy-init-xtables-lock
@@ -326,7 +325,6 @@ items:
           volumeMounts:
           - mountPath: /run
             name: linkerd-proxy-init-xtables-lock
-            subPath: xtables.lock
         volumes:
         - emptyDir: {}
           name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -159,7 +159,13 @@ items:
             runAsNonRoot: false
             runAsUser: 0
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /run
+            name: linkerd-proxy-init-xtables-lock
+            subPath: xtables.lock
         volumes:
+        - emptyDir: {}
+          name: linkerd-proxy-init-xtables-lock
         - emptyDir:
             medium: Memory
           name: linkerd-identity-end-entity
@@ -317,7 +323,13 @@ items:
             runAsNonRoot: false
             runAsUser: 0
           terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+          - mountPath: /run
+            name: linkerd-proxy-init-xtables-lock
+            subPath: xtables.lock
         volumes:
+        - emptyDir: {}
+          name: linkerd-proxy-init-xtables-lock
         - emptyDir:
             medium: Memory
           name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -162,7 +162,6 @@ items:
           volumeMounts:
           - mountPath: /run
             name: linkerd-proxy-init-xtables-lock
-            subPath: xtables.lock
         volumes:
         - emptyDir: {}
           name: linkerd-proxy-init-xtables-lock
@@ -326,7 +325,6 @@ items:
           volumeMounts:
           - mountPath: /run
             name: linkerd-proxy-init-xtables-lock
-            subPath: xtables.lock
         volumes:
         - emptyDir: {}
           name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -142,7 +142,13 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
     terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+      subPath: xtables.lock
   volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
   - emptyDir:
       medium: Memory
     name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -145,7 +145,6 @@ spec:
     volumeMounts:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
-      subPath: xtables.lock
   volumes:
   - emptyDir: {}
     name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -147,7 +147,6 @@ spec:
     volumeMounts:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
-      subPath: xtables.lock
   volumes:
   - emptyDir: {}
     name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -144,7 +144,13 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
     terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+      subPath: xtables.lock
   volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
   - emptyDir:
       medium: Memory
     name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -149,7 +149,13 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
     terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+      subPath: xtables.lock
   volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
   - emptyDir:
       medium: Memory
     name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -152,7 +152,6 @@ spec:
     volumeMounts:
     - mountPath: /run
       name: linkerd-proxy-init-xtables-lock
-      subPath: xtables.lock
   volumes:
   - emptyDir: {}
     name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -158,7 +158,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -161,7 +161,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -162,7 +162,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
@@ -334,7 +333,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -159,7 +159,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -325,7 +331,13 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -213,6 +213,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
@@ -228,6 +232,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: linkerd-tap-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -216,7 +216,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -243,6 +243,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -251,6 +255,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -467,11 +473,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -688,11 +700,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -959,11 +977,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1333,6 +1357,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1340,6 +1368,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1535,6 +1565,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1543,6 +1577,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1774,11 +1810,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2001,11 +2043,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2286,6 +2334,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -2294,6 +2346,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: linkerd-collector-config
         name: linkerd-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2493,9 +2547,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2773,6 +2833,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -2787,6 +2851,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -246,7 +246,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -476,7 +475,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -703,7 +701,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -980,7 +977,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -1360,7 +1356,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1568,7 +1563,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1813,7 +1807,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2046,7 +2039,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -2337,7 +2329,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -2550,7 +2541,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -2836,7 +2826,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -246,7 +246,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -476,7 +475,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -703,7 +701,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -979,7 +976,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -1359,7 +1355,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1567,7 +1562,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1812,7 +1806,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2045,7 +2038,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -2362,7 +2354,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -243,6 +243,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -251,6 +255,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -467,11 +473,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -688,11 +700,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -958,11 +976,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1332,6 +1356,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1339,6 +1367,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1534,6 +1564,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1542,6 +1576,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1773,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2000,11 +2042,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2311,6 +2359,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -2325,6 +2377,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1085,6 +1085,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1099,6 +1103,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1324,6 +1330,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1335,6 +1345,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1560,6 +1572,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1571,6 +1587,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1845,6 +1863,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -1856,6 +1878,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2233,6 +2257,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2246,6 +2274,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2449,6 +2479,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2463,6 +2497,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2702,6 +2738,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2713,6 +2753,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2944,6 +2986,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -2955,6 +3001,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3282,6 +3330,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3302,6 +3354,8 @@ spec:
               fieldPath: metadata.labels
             path: "labels"
         name: podinfo
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1088,7 +1088,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1333,7 +1332,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1575,7 +1573,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1866,7 +1863,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2260,7 +2256,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2482,7 +2477,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2741,7 +2735,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2989,7 +2982,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3333,7 +3325,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -1076,7 +1076,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1306,7 +1305,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1533,7 +1531,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1809,7 +1806,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2180,7 +2176,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2388,7 +2383,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2633,7 +2627,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2866,7 +2859,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -1073,6 +1073,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1081,6 +1085,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1297,11 +1303,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1518,11 +1530,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1788,11 +1806,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2153,6 +2177,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2160,6 +2188,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2355,6 +2385,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2363,6 +2397,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2594,11 +2630,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2821,11 +2863,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1115,7 +1115,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1381,7 +1380,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1644,7 +1642,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1940,7 +1937,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2333,7 +2329,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2577,7 +2572,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2858,7 +2852,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -3127,7 +3120,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3477,7 +3469,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1112,6 +1112,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1120,6 +1124,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1372,11 +1378,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1629,11 +1641,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1919,11 +1937,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2306,6 +2330,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2313,6 +2341,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2544,6 +2574,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2552,6 +2586,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2819,11 +2855,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3082,11 +3124,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3426,6 +3474,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3440,6 +3492,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1115,7 +1115,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1381,7 +1380,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1644,7 +1642,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1940,7 +1937,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2333,7 +2329,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2577,7 +2572,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2858,7 +2852,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -3127,7 +3120,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3477,7 +3469,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1112,6 +1112,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1120,6 +1124,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1372,11 +1378,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1629,11 +1641,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1919,11 +1937,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2306,6 +2330,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2313,6 +2341,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2544,6 +2574,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2552,6 +2586,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2819,11 +2855,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3082,11 +3124,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3426,6 +3474,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3440,6 +3492,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1035,7 +1035,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1265,7 +1264,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1492,7 +1490,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1723,7 +1720,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2103,7 +2099,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2311,7 +2306,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2556,7 +2550,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2789,7 +2782,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3119,7 +3111,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1032,6 +1032,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1040,6 +1044,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1256,11 +1262,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1477,11 +1489,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1702,11 +1720,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2076,6 +2100,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2083,6 +2111,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2278,6 +2308,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2286,6 +2320,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2517,11 +2553,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2744,11 +2786,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3068,6 +3116,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3082,6 +3134,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1162,7 +1162,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1385,7 +1384,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1605,7 +1603,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1876,7 +1873,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2249,7 +2245,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2451,7 +2446,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2690,7 +2684,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2917,7 +2910,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3246,7 +3238,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1159,6 +1159,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1167,6 +1171,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1376,11 +1382,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1590,11 +1602,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1855,11 +1873,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2222,6 +2246,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2229,6 +2257,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2418,6 +2448,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2426,6 +2460,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2651,11 +2687,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2872,11 +2914,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3195,6 +3243,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3209,6 +3261,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -1162,7 +1162,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1385,7 +1384,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1605,7 +1603,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1877,7 +1874,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2250,7 +2246,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2452,7 +2447,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2691,7 +2685,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2918,7 +2911,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3234,7 +3226,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3438,7 +3429,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -3732,7 +3722,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -1159,6 +1159,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1167,6 +1171,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1376,11 +1382,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1590,11 +1602,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1856,11 +1874,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2223,6 +2247,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2230,6 +2258,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2419,6 +2449,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2427,6 +2461,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2652,11 +2688,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2873,11 +2915,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3183,6 +3231,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3191,6 +3243,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: linkerd-collector-config
         name: linkerd-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3381,9 +3435,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3669,6 +3729,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3683,6 +3747,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1195,6 +1195,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1203,6 +1207,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1448,11 +1454,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1698,11 +1710,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1983,11 +2001,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2363,6 +2387,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2370,6 +2398,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2595,6 +2625,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2603,6 +2637,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2864,11 +2900,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3121,11 +3163,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3464,6 +3512,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3478,6 +3530,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1198,7 +1198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1457,7 +1456,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1713,7 +1711,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -2004,7 +2001,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2390,7 +2386,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2628,7 +2623,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2903,7 +2897,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -3166,7 +3159,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3515,7 +3507,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1075,6 +1075,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1083,6 +1087,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1298,11 +1304,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1518,11 +1530,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1787,11 +1805,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2160,6 +2184,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2167,6 +2195,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2361,6 +2391,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2369,6 +2403,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2599,11 +2635,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2825,11 +2867,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3148,6 +3196,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3162,6 +3214,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1078,7 +1078,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1307,7 +1306,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1533,7 +1531,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1808,7 +1805,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2187,7 +2183,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2394,7 +2389,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2638,7 +2632,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2870,7 +2863,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3199,7 +3191,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -1008,6 +1008,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1016,6 +1020,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1232,11 +1238,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1453,11 +1465,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1723,11 +1741,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2097,6 +2121,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2104,6 +2132,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2299,6 +2329,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2307,6 +2341,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2538,11 +2574,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2765,11 +2807,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3089,6 +3137,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3103,6 +3155,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -1011,7 +1011,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1241,7 +1240,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1468,7 +1466,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1744,7 +1741,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2124,7 +2120,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2332,7 +2327,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2577,7 +2571,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2810,7 +2803,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3140,7 +3132,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1792,11 +1810,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2166,6 +2190,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2173,6 +2201,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2368,6 +2398,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2376,6 +2410,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2607,11 +2643,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2834,11 +2876,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3145,6 +3193,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3153,6 +3205,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: linkerd-collector-config
         name: linkerd-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3352,9 +3406,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3645,6 +3705,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3659,6 +3723,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1813,7 +1810,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2193,7 +2189,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2401,7 +2396,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2646,7 +2640,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2879,7 +2872,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3196,7 +3188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3409,7 +3400,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -3708,7 +3698,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1813,7 +1810,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2193,7 +2189,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2401,7 +2396,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2646,7 +2640,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2879,7 +2872,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3194,7 +3186,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: overwrite-collector
       volumes:
       - configMap:
@@ -3407,7 +3398,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -3706,7 +3696,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1792,11 +1810,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2166,6 +2190,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2173,6 +2201,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2368,6 +2398,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2376,6 +2410,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2607,11 +2643,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2834,11 +2876,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3143,6 +3191,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: overwrite-collector
       volumes:
       - configMap:
@@ -3151,6 +3203,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: overwrite-collector-config
         name: overwrite-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3350,9 +3404,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3643,6 +3703,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3657,6 +3721,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -245,6 +245,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -253,6 +257,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -471,11 +477,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -694,11 +706,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -967,11 +985,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1343,6 +1367,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1350,6 +1378,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1547,6 +1577,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1555,6 +1589,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1788,11 +1824,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2017,11 +2059,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2304,6 +2352,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -2312,6 +2364,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: linkerd-collector-config
         name: linkerd-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2513,9 +2567,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2795,6 +2855,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -2809,6 +2873,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_add-on_controlplane.golden
+++ b/cli/cmd/testdata/upgrade_add-on_controlplane.golden
@@ -248,7 +248,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -480,7 +479,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -709,7 +707,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -988,7 +985,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -1370,7 +1366,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -1580,7 +1575,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -1827,7 +1821,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2062,7 +2055,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -2355,7 +2347,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -2570,7 +2561,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -2858,7 +2848,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1800,11 +1818,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2176,6 +2200,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2183,6 +2211,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2380,6 +2410,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2388,6 +2422,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2621,11 +2657,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2850,11 +2892,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3163,6 +3211,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: overwrite-collector
       volumes:
       - configMap:
@@ -3171,6 +3223,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: overwrite-collector-config
         name: overwrite-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3372,9 +3426,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3667,6 +3727,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3681,6 +3745,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_add-on_overwrite.golden
+++ b/cli/cmd/testdata/upgrade_add-on_overwrite.golden
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1821,7 +1818,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2203,7 +2199,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2413,7 +2408,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2660,7 +2654,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2895,7 +2888,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3214,7 +3206,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: overwrite-collector
       volumes:
       - configMap:
@@ -3429,7 +3420,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -3730,7 +3720,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1800,11 +1818,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2176,6 +2200,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2183,6 +2211,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2380,6 +2410,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2388,6 +2422,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2621,11 +2657,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2850,11 +2892,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3163,6 +3211,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3171,6 +3223,8 @@ spec:
             path: linkerd-collector-config.yaml
           name: linkerd-collector-config
         name: linkerd-collector-config-val
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3372,9 +3426,15 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3667,6 +3727,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3681,6 +3745,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_add_add-on.golden
+++ b/cli/cmd/testdata/upgrade_add_add-on.golden
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1821,7 +1818,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2203,7 +2199,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2413,7 +2408,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2660,7 +2654,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2895,7 +2888,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3214,7 +3206,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-collector
       volumes:
       - configMap:
@@ -3429,7 +3420,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       dnsPolicy: ClusterFirst
       serviceAccountName: linkerd-jaeger
       volumes:
@@ -3730,7 +3720,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_default.golden
+++ b/cli/cmd/testdata/upgrade_default.golden
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -1067,7 +1067,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1299,7 +1298,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1528,7 +1526,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1806,7 +1803,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2188,7 +2184,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2398,7 +2393,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2880,7 +2873,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3212,7 +3204,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_external_issuer.golden
+++ b/cli/cmd/testdata/upgrade_external_issuer.golden
@@ -1064,6 +1064,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1072,6 +1076,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1290,11 +1296,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1513,11 +1525,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1785,11 +1803,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2161,6 +2185,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2168,6 +2196,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2365,6 +2395,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2373,6 +2407,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2835,11 +2877,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3161,6 +3209,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3175,6 +3227,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_addon_overwrite.yaml
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_grafana_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_disabled.yaml
@@ -1078,7 +1078,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1310,7 +1309,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1539,7 +1537,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1816,7 +1813,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2189,7 +2185,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2399,7 +2394,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2646,7 +2640,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2881,7 +2874,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:

--- a/cli/cmd/testdata/upgrade_grafana_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_disabled.yaml
@@ -1075,6 +1075,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1083,6 +1087,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1301,11 +1307,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1524,11 +1536,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1795,11 +1813,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2162,6 +2186,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2169,6 +2197,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2366,6 +2396,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2374,6 +2408,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2607,11 +2643,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2836,11 +2878,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_grafana_enabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled.yaml
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_grafana_enabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled.yaml
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
@@ -1078,7 +1078,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1310,7 +1309,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1539,7 +1537,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1816,7 +1813,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2189,7 +2185,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2399,7 +2394,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2646,7 +2640,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2881,7 +2874,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:

--- a/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_enabled_disabled.yaml
@@ -1075,6 +1075,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1083,6 +1087,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1301,11 +1307,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1524,11 +1536,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1795,11 +1813,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2162,6 +2186,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2169,6 +2197,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2366,6 +2396,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2374,6 +2408,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2607,11 +2643,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2836,11 +2878,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana-overwrite
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
+++ b/cli/cmd/testdata/upgrade_grafana_overwrite.yaml
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana-overwrite
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-overwrite-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1117,7 +1117,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1385,7 +1384,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1650,7 +1648,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1948,7 +1945,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2343,7 +2339,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2589,7 +2584,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2872,7 +2866,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -3143,7 +3136,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3495,7 +3487,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_ha.golden
+++ b/cli/cmd/testdata/upgrade_ha.golden
@@ -1114,6 +1114,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1122,6 +1126,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1376,11 +1382,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1635,11 +1647,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1927,11 +1945,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2316,6 +2340,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2323,6 +2351,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2556,6 +2586,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2564,6 +2598,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2869,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3098,11 +3140,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3444,6 +3492,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3458,6 +3510,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
+++ b/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
+++ b/cli/cmd/testdata/upgrade_keep_webhook_cabundle.golden
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_nothing_addon.yaml
+++ b/cli/cmd/testdata/upgrade_nothing_addon.yaml
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_nothing_addon.yaml
+++ b/cli/cmd/testdata/upgrade_nothing_addon.yaml
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_overwrite_issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_issuer.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -1065,7 +1065,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1295,7 +1294,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1522,7 +1520,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1798,7 +1795,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2178,7 +2174,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2386,7 +2381,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2631,7 +2625,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2864,7 +2857,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3194,7 +3186,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors-external-issuer.golden
@@ -1062,6 +1062,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1070,6 +1074,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1286,11 +1292,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1507,11 +1519,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1777,11 +1795,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2151,6 +2175,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2158,6 +2186,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2353,6 +2383,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2361,6 +2395,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2592,11 +2628,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2819,11 +2861,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3143,6 +3191,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3157,6 +3209,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -1076,6 +1076,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1084,6 +1088,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1300,11 +1306,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1521,11 +1533,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1791,11 +1809,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2165,6 +2189,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2172,6 +2200,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2367,6 +2397,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2375,6 +2409,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2606,11 +2642,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2833,11 +2875,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3157,6 +3205,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3171,6 +3223,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
+++ b/cli/cmd/testdata/upgrade_overwrite_trust_anchors.golden
@@ -1079,7 +1079,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1309,7 +1308,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1536,7 +1534,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1812,7 +1809,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2192,7 +2188,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2400,7 +2395,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2645,7 +2639,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2878,7 +2871,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3208,7 +3200,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
+++ b/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
@@ -1078,6 +1078,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1086,6 +1090,8 @@ spec:
       - name: identity-issuer
         secret:
           secretName: linkerd-identity-issuer
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1304,11 +1310,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1527,11 +1539,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -1799,11 +1817,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2175,6 +2199,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2182,6 +2210,8 @@ spec:
       - configMap:
           name: linkerd-prometheus-config
         name: prometheus-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2379,6 +2409,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2387,6 +2421,8 @@ spec:
       - name: tls
         secret:
           secretName: linkerd-proxy-injector-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2620,11 +2656,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
         secret:
           secretName: linkerd-sp-validator-tls
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -2849,11 +2891,17 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
           name: linkerd-config
         name: config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
@@ -3175,6 +3223,10 @@ spec:
           runAsNonRoot: false
           runAsUser: 0
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /run
+          name: linkerd-proxy-init-xtables-lock
+          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}
@@ -3189,6 +3241,8 @@ spec:
             path: provisioning/dashboards/dashboards.yaml
           name: linkerd-grafana-config
         name: grafana-config
+      - emptyDir: {}
+        name: linkerd-proxy-init-xtables-lock
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity

--- a/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
+++ b/cli/cmd/testdata/upgrade_two_level_webhook_cert.golden
@@ -1081,7 +1081,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-identity
       volumes:
       - configMap:
@@ -1313,7 +1312,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-controller
       volumes:
       - configMap:
@@ -1542,7 +1540,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-destination
       volumes:
       - configMap:
@@ -1820,7 +1817,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-web
       volumes:
       - configMap:
@@ -2202,7 +2198,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-prometheus
       volumes:
       - name: data
@@ -2412,7 +2407,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:
@@ -2659,7 +2653,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-sp-validator
       volumes:
       - name: tls
@@ -2894,7 +2887,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-tap
       volumes:
       - configMap:
@@ -3226,7 +3218,6 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
-          subPath: xtables.lock
       serviceAccountName: linkerd-grafana
       volumes:
       - emptyDir: {}

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -23,12 +23,24 @@
     "op": "add",
     "path": "/metadata/labels/linkerd.io~1workload-ns",
     "value": "kube-public"
+  },{
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": []
   },
   {
     "op": "add",
     "path": "/spec/initContainers",
     "value": []
   },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "emptyDir": {},
+      "name": "linkerd-proxy-init-xtables-lock"
+    }
+  }, 
   {
     "op": "add",
     "path": "/spec/initContainers/-",
@@ -69,7 +81,14 @@
         "runAsNonRoot": false,
         "runAsUser": 0
       },
-      "terminationMessagePolicy": "FallbackToLogsOnError"
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/run",
+          "name": "linkerd-proxy-init-xtables-lock",
+          "subPath": "xtables.lock"
+        }
+      ]
     }
   },
   {
@@ -81,11 +100,6 @@
       "name": "linkerd-debug",
       "terminationMessagePolicy": "FallbackToLogsOnError"
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": []
   },
   {
     "op": "add",

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -85,8 +85,7 @@
       "volumeMounts": [
         {
           "mountPath": "/run",
-          "name": "linkerd-proxy-init-xtables-lock",
-          "subPath": "xtables.lock"
+          "name": "linkerd-proxy-init-xtables-lock"
         }
       ]
     }

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -26,8 +26,21 @@
   },
   {
     "op": "add",
+    "path": "/spec/volumes",
+    "value": []
+  },
+  {
+    "op": "add",
     "path": "/spec/initContainers",
     "value": []
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "emptyDir": {},
+      "name": "linkerd-proxy-init-xtables-lock"
+    }
   },
   {
     "op": "add",
@@ -69,13 +82,15 @@
         "runAsNonRoot": false,
         "runAsUser": 0
       },
-      "terminationMessagePolicy": "FallbackToLogsOnError"
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/run",
+          "name": "linkerd-proxy-init-xtables-lock",
+          "subPath": "xtables.lock"
+        }
+      ]
     }
-  },
-  {
-    "op": "add",
-    "path": "/spec/volumes",
-    "value": []
   },
   {
     "op": "add",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -86,8 +86,7 @@
       "volumeMounts": [
         {
           "mountPath": "/run",
-          "name": "linkerd-proxy-init-xtables-lock",
-          "subPath": "xtables.lock"
+          "name": "linkerd-proxy-init-xtables-lock"
         }
       ]
     }

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -111,34 +111,35 @@ type (
 
 	// Proxy contains the fields to set the proxy sidecar container
 	Proxy struct {
-		Capabilities                  *Capabilities `json:"capabilities"`
-		Component                     string        `json:"component"`
-		DisableIdentity               bool          `json:"disableIdentity"`
-		DisableTap                    bool          `json:"disableTap"`
-		EnableExternalProfiles        bool          `json:"enableExternalProfiles"`
-		DestinationGetNetworks        string        `json:"destinationGetNetworks"`
-		Image                         *Image        `json:"image"`
-		LogLevel                      string        `json:"logLevel"`
-		LogFormat                     string        `json:"logFormat"`
-		SAMountPath                   *SAMountPath  `json:"saMountPath"`
-		Ports                         *Ports        `json:"ports"`
-		Resources                     *Resources    `json:"resources"`
-		Trace                         *Trace        `json:"trace"`
-		UID                           int64         `json:"uid"`
-		WaitBeforeExitSeconds         uint64        `json:"waitBeforeExitSeconds"`
-		IsGateway                     bool          `json:"isGateway"`
-		RequireIdentityOnInboundPorts string        `json:"requireIdentityOnInboundPorts"`
+		Capabilities                  *Capabilities    `json:"capabilities"`
+		Component                     string           `json:"component"`
+		DisableIdentity               bool             `json:"disableIdentity"`
+		DisableTap                    bool             `json:"disableTap"`
+		EnableExternalProfiles        bool             `json:"enableExternalProfiles"`
+		DestinationGetNetworks        string           `json:"destinationGetNetworks"`
+		Image                         *Image           `json:"image"`
+		LogLevel                      string           `json:"logLevel"`
+		LogFormat                     string           `json:"logFormat"`
+		SAMountPath                   *VolumeMountPath `json:"saMountPath"`
+		Ports                         *Ports           `json:"ports"`
+		Resources                     *Resources       `json:"resources"`
+		Trace                         *Trace           `json:"trace"`
+		UID                           int64            `json:"uid"`
+		WaitBeforeExitSeconds         uint64           `json:"waitBeforeExitSeconds"`
+		IsGateway                     bool             `json:"isGateway"`
+		RequireIdentityOnInboundPorts string           `json:"requireIdentityOnInboundPorts"`
 	}
 
 	// ProxyInit contains the fields to set the proxy-init container
 	ProxyInit struct {
-		Capabilities         *Capabilities `json:"capabilities"`
-		IgnoreInboundPorts   string        `json:"ignoreInboundPorts"`
-		IgnoreOutboundPorts  string        `json:"ignoreOutboundPorts"`
-		Image                *Image        `json:"image"`
-		SAMountPath          *SAMountPath  `json:"saMountPath"`
-		Resources            *Resources    `json:"resources"`
-		CloseWaitTimeoutSecs int64         `json:"closeWaitTimeoutSecs"`
+		Capabilities         *Capabilities    `json:"capabilities"`
+		IgnoreInboundPorts   string           `json:"ignoreInboundPorts"`
+		IgnoreOutboundPorts  string           `json:"ignoreOutboundPorts"`
+		Image                *Image           `json:"image"`
+		SAMountPath          *VolumeMountPath `json:"saMountPath"`
+		XTMountPath          *VolumeMountPath `json:"xtMountPath"`
+		Resources            *Resources       `json:"resources"`
+		CloseWaitTimeoutSecs int64            `json:"closeWaitTimeoutSecs"`
 	}
 
 	// DebugContainer contains the fields to set the debugging sidecar
@@ -174,11 +175,12 @@ type (
 		Drop []string `json:"drop"`
 	}
 
-	// SAMountPath contains the details for ServiceAccount volume mount
-	SAMountPath struct {
+	// VolumeMountPath contains the details for volume mounts
+	VolumeMountPath struct {
 		Name      string `json:"name"`
 		MountPath string `json:"mountPath"`
 		ReadOnly  bool   `json:"readOnly"`
+		SubPath   string `json:"subPath"`
 	}
 
 	// Resources represents the computational resources setup for a given container

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -180,7 +180,6 @@ type (
 		Name      string `json:"name"`
 		MountPath string `json:"mountPath"`
 		ReadOnly  bool   `json:"readOnly"`
-		SubPath   string `json:"subPath"`
 	}
 
 	// Resources represents the computational resources setup for a given container

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -103,7 +103,6 @@ func TestNewValues(t *testing.T) {
 				},
 				XTMountPath: &VolumeMountPath{
 					Name:      "linkerd-proxy-init-xtables-lock",
-					SubPath:   "xtables.lock",
 					MountPath: "/run",
 				},
 			},

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -101,6 +101,11 @@ func TestNewValues(t *testing.T) {
 						Request: "10Mi",
 					},
 				},
+				XTMountPath: &VolumeMountPath{
+					Name:      "linkerd-proxy-init-xtables-lock",
+					SubPath:   "xtables.lock",
+					MountPath: "/run",
+				},
 			},
 		},
 		Identity: &Identity{

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -607,7 +607,6 @@ func (conf *ResourceConfig) injectProxyInit(values *patch) {
 		XTMountPath: &l5dcharts.VolumeMountPath{
 			MountPath: k8s.MountPathXtablesLock,
 			Name:      k8s.InitXtablesLockVolumeMountName,
-			SubPath:   k8s.MountSubPathXtablesLock,
 		},
 	}
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -553,7 +553,7 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 	}
 
 	if saVolumeMount != nil {
-		values.Global.Proxy.SAMountPath = &l5dcharts.SAMountPath{
+		values.Global.Proxy.SAMountPath = &l5dcharts.VolumeMountPath{
 			Name:      saVolumeMount.Name,
 			MountPath: saVolumeMount.MountPath,
 			ReadOnly:  saVolumeMount.ReadOnly,
@@ -604,6 +604,11 @@ func (conf *ResourceConfig) injectProxyInit(values *patch) {
 		},
 		Capabilities: values.Global.Proxy.Capabilities,
 		SAMountPath:  values.Global.Proxy.SAMountPath,
+		XTMountPath: &l5dcharts.VolumeMountPath{
+			MountPath: k8s.MountPathXtablesLock,
+			Name:      k8s.InitXtablesLockVolumeMountName,
+			SubPath:   k8s.MountSubPathXtablesLock,
+		},
 	}
 
 	if v := conf.pod.meta.Annotations[k8s.CloseWaitTimeoutAnnotation]; v != "" {

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -56,7 +56,7 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 
 	volumes := []v1.Volume{}
 	for _, volume := range t.Volumes {
-		if volume.Name != k8s.IdentityEndEntityVolumeName && volume.Name != k8s.PodInfoVolumeName {
+		if volume.Name != k8s.IdentityEndEntityVolumeName && volume.Name != k8s.PodInfoVolumeName && volume.Name != k8s.InitXtablesLockVolumeMountName {
 			volumes = append(volumes, volume)
 		}
 	}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -358,10 +358,6 @@ const (
 	// This is necessary for xtables-legacy support
 	MountPathXtablesLock = "/run"
 
-	// MountSubPathXtablesLock is the file name which the proxy init container uses for xtables
-	// This is necessary for xtables-legacy support
-	MountSubPathXtablesLock = "xtables.lock"
-
 	// IdentityServiceAccountTokenPath is the path to the kubernetes service
 	// account token used by proxies to provision identity.
 	//

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -261,6 +261,10 @@ const (
 	// InitContainerName is the name assigned to the injected init container.
 	InitContainerName = "linkerd-init"
 
+	// InitXtablesLockVolumeMountName is the name of the volumeMount used by proxy-init
+	// to handle iptables-legacy
+	InitXtablesLockVolumeMountName = "linkerd-proxy-init-xtables-lock"
+
 	// ProxyContainerName is the name assigned to the injected proxy container.
 	ProxyContainerName = "linkerd-proxy"
 
@@ -349,6 +353,14 @@ const (
 
 	// MountPathTLSCrtPEM is the path at which the TLS cert PEM file is mounted.
 	MountPathTLSCrtPEM = MountPathBase + "/tls/crt.pem"
+
+	// MountPathXtablesLock is the path at which the proxy init container mounts xtables
+	// This is necessary for xtables-legacy support
+	MountPathXtablesLock = "/run"
+
+	// MountSubPathXtablesLock is the file name which the proxy init container uses for xtables
+	// This is necessary for xtables-legacy support
+	MountSubPathXtablesLock = "xtables.lock"
 
 	// IdentityServiceAccountTokenPath is the path to the kubernetes service
 	// account token used by proxies to provision identity.


### PR DESCRIPTION
## Subject
Add volume and volumeMount resources for the proxy-init container which uses `buster` as described in [proxy-init PR 3](https://github.com/linkerd/linkerd2-proxy-init/pull/3)

## Problem
The buster image uses iptables 1.8.x which attempts to lock a file named `/run/xtables.lock` in order to safely manage iptables updates to the system. This also requires using `iptables-legacy` to support backwards compatibility.

The securityPolicy of the proxy-init container sets `readOnlyRootFileSytem` to true, and the buster-based proxy-init container fails to start because it can't create `/run/xtables.lock`.

## Solution
This PR adds a `volumeMount` to the proxy-init container with using `subPath` to ensure that `/run/xtables.lock` is writeable by the container. In addition, an `emptyDir` `volume` resource is added to the pod spec to make the `volumeMount` available to the container.

Many of the template files have been updated to ensure that the injected/patched pod spec output correctly reflects the changes required by these additions.

This change touches how the service account volume mount is handled in `values.go`. The `SAMountPath` struct is renamed to a more abstract `VolumeMountPath` and a field named `SubPath` has been added. The ProxyInit struct has a new field named `XTMountPath` which is of type `VolumeMountPath` and instances of this field are instantiated in  `install.go` and `inject.go`.

`uninject.go` includes a check for the volume named `InitXtablesLockVolumeMountName`, as defined in `labels.go`.

## Validation
These changes were validated by running `bin/tests` with `kind` on a laptop. All test ran successfully.

A second validation was done by manually installing linkerd from the binary generated from this branch and adding the `--init-image-version` and `--init-image` flags to make sure that the changes are compatible with the changes in the proxy init [PR](https://github.com/linkerd/linkerd2-proxy-init/pull/3)

During this test:
- the `emojivoto` app was injected and confirmed that it works as expected
- verified that `linkerd dashboard` works
- verified that the grafana dashboard is available
- confirmed that metrics were logged to prometheus
- confirmed that the proxy-init container started without any errors and the iptables were written properly
- verified that `linkerd stat` and `linked tap` work for the emojivoto app and linkerd control plane components
- verified that the changes are backwards compatible with `proxy-init:v1.3.3` (the current release version)

Signed-off-by: Charles Pretzer <charles@buoyant.io>
