### PR TITLE
[POC] service topologies: add nodeName to context token

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -41,13 +41,13 @@ env:
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
-- name: LINKERD2_PROXY_DESTINATION_CONTEXT
-  value: |
-    {"ns":"$(_pod_ns)","nodeName":"$(_pod_node)"}
-- name: _pod_node
+- name: _pod_nodeName
   valueFrom:
     fieldRef:
-      fieldPath: spec.nodeName
+      fieldPath: spec.nodeName      
+- name: LINKERD2_PROXY_DESTINATION_CONTEXT
+  value: |
+    {"ns":"$(_pod_ns)","nodeName":"$(_pod_nodeName)"}
 {{ if eq .Values.global.proxy.component "linkerd-prometheus" -}}
 - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
   value: "10000"

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -42,7 +42,12 @@ env:
     fieldRef:
       fieldPath: metadata.namespace
 - name: LINKERD2_PROXY_DESTINATION_CONTEXT
-  value: ns:$(_pod_ns)
+  value: |
+    {"ns":"$(_pod_ns)","nodeName":"$(_pod_node)"}
+- name: _pod_node
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
 {{ if eq .Values.global.proxy.component "linkerd-prometheus" -}}
 - name: LINKERD2_PROXY_OUTBOUND_ROUTER_CAPACITY
   value: "10000"

--- a/controller/script/destination-client/main.go
+++ b/controller/script/destination-client/main.go
@@ -26,8 +26,9 @@ func main() {
 	defer conn.Close()
 
 	req := &pb.GetDestination{
-		Scheme: "k8s",
-		Path:   *path,
+		Scheme:       "k8s",
+		Path:         *path,
+		ContextToken: "{\"ns\":\"linkerd\",\"nodeName\":\"minikube\"}",
 	}
 
 	switch *method {


### PR DESCRIPTION
### PoC for [linkerd/linkerd2#4498](https://github.com/linkerd/linkerd2/issues/4498)
**N.B**:  *most of the information in the ticket/issue/card related to implementation details is not as relevant following the [first PR](https://github.com/linkerd/linkerd2/pull/4570)*

### What
---

* Proof of concept to show how to add a pod's nodeName as part of the `LINKERD2_PROXY_DESTINATION_CONTEXT` environmental variable. Following a conversation on this topic (*see first PR*), I tried to structure the context token in json format.
* `LINKERD2_PROXY_DESTINATION_CONTEXT` receives a json string with the field & field values (obtained through downward API, hardcoded, etc.). The proxy should read the json string in and pass it over the wire through gRPC.
* On the server side (i.e destination service), we keep track of the structure of the token and unmarshal the string into the applicable fields.


As part of this PR, I changed the server to log out the fields of the structure when a call of type `GetDestination` is made. I also modified the client script to test it out at first, all log clippings annexed at the end of the PR are from the destination service running in minikube.

Think this is a good way to piggyback contextual information on the already present `DESTINATION_CONTEXT_TOKEN`. I'm not sure what the performance implications are necessarily, but this would allow the token to be extended over time. For the purpose of simplicity, I don't think the `proxy-api` should be extended. I have also looked into it, and splitting it into additional fields on the `proxy-api` side shouldn't have any performance improvements (and can have the complete opposite effect depending on the chosen way of structuring the token).

Finally, I think this approach should preserve the opacity and separation of concerns in the proxy. Since the destination service is aware of all of the contextual bits and bobs associated with a service/pod, having a structure of the token inside makes sense to me. On the other hand, by simply treating the token as a json string from proxy all the way through the wire, it will not have any concept of what's inside the token, other than its type. Hope this makes sense.

Let me know what you think of the approach and if it fits with what you had in mind
@olix0r @adleong @grampelberg 

---


```bash
# Pod exec to check if env variables have been properly set
$ k exec linkerd-destination-88f8bb878-jrqbk -n linkerd -it -c linkerd-proxy -- bin/bash -c "env | grep nodeName"
_pod_nodeName=minikube
LINKERD2_PROXY_DESTINATION_CONTEXT={"ns":"linkerd","nodeName":"minikube"}
```

```bash
# Destination Service logs, no other apps were running in minikube at the time
# so the client in this case is another linkerd component
$ k logs <dest-service>
time="2020-07-01T17:22:36Z" level=debug msg=Context token: [ogToken={\"ns\":\"linkerd\",\"nodeName\":\"minikube\"}\n] [tokenStruct={linkerd minikube}] [ns=linkerd], [nodeName=minikube]