### PR TITLE
Release edge-20.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## edge-20.6.4
+## edge-20.7.1
 
 This edge release improves messaging for retries when pods are unschedulable,
 adds a feature to persist prometheus data as an option to storing the data in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,23 +2,29 @@
 
 ## edge-20.7.1
 
-This edge release improves messaging for retries when pods are unschedulable,
-adds new functionality to persist prometheus data and configure the proxy log
-format using annotations and helm charts, fixes a bug in the helm chart for
-the Linkerd CNI Plugin, and enables the use of URLs with the `--addon-config`
-installation flag
+This edge release introduces the option to persist prometheus data to a volume,
+instead of memory, so that historical metrics are available when prometheus is
+restarted. Also in this release are improvements to control plane check
+conditions for CLI commands, a fix to correctly resolve the CNI image version
+when using helm, support for using URLs with add-ons, proxy improvements under
+concurrency, and functionality to configure the proxy log format by annotation
+or in the helm chart.
 
-* Controller
-  * Adds better messaging during scheduling errors on retry for HA installations
-* CLI
-  * Adds option to persist prometheus data (thanks @naseemkullah!)
-  * Adds support for passing a URL to the `--addon-config` flag, so you can now
-  use a file or an URL for installing add ons
-* Helm
-  * Fixes a bug in the CNI helm chart by correcting a helm value field name
-* Proxy
-  * Improves tail latencies by increasing the default buffer size to reduce
-    contention in high-concurrency situations
+* Some commands like `linkerd stat` would fail if any control plane components
+  were unhealthy, even when other replicas are healthy. The check conditions
+  for these commands have been improved
+* The helm chart can now configure persistent storage for Prometheus
+  (thanks @naseemkullah!)
+* The proxy log output format can now be configured to `plain` or `json` using
+  the `config.linkerd.io/proxy-log-format` annotation or the
+  `global.proxy.logFormat` value in the helm chart
+  (thanks again @naseemkullah!)
+* `linkerd install --addon-config=` now supports URLs in addition to local
+  files
+* The CNI Helm chart used the incorrect variable name to determine the image
+  tag. This is now controlled by `cniPluginVersion` in the helm chart
+* The proxy's default buffer size has been increased, which reduces latency when
+  the proxy has many concurrent clients
 
 ## edge-20.6.4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,9 @@
 
 ## edge-20.7.1
 
-This edge release introduces the option to persist prometheus data to a volume,
+This edge release features the option to persist prometheus data to a volume
 instead of memory, so that historical metrics are available when prometheus is
-restarted. Also in this release are improvements to control plane check
-conditions for CLI commands, a fix to correctly resolve the CNI image version
-when using helm, support for using URLs with add-ons, proxy improvements under
-concurrency, and functionality to configure the proxy log format by annotation
-or in the helm chart.
+restarted. Additional changes are outlined in the bullet points below.
 
 * Some commands like `linkerd stat` would fail if any control plane components
   were unhealthy, even when other replicas are healthy. The check conditions

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,8 @@ restarted. Additional changes are outlined in the bullet points below.
   (thanks again @naseemkullah!)
 * `linkerd install --addon-config=` now supports URLs in addition to local
   files
-* The CNI Helm chart used the incorrect variable name to determine the image
-  tag. This is now controlled by `cniPluginVersion` in the helm chart
+* The CNI Helm chart used the incorrect variable name to determine the `createdBy`
+  version tag. This is now controlled by `cniPluginVersion` in the helm chart
 * The proxy's default buffer size has been increased, which reduces latency when
   the proxy has many concurrent clients
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,16 @@
 
 ## edge-20.6.4
 
+This edge release improves messaging for retries when pods are unschedulable,
+adds a feature to persist prometheus data as an option to storing the data in
+memory, and upgrades the protobuf version to v1.4.2
+
+* Add better messaging during scheduling errors on retry for HA installations
+* Add option to persist prometheus data (thanks @naseemkullah!)
+* Upgrades generated protobuf files to v1.4.2
+
+## edge-20.6.4
+
 This edge release moves the proxy onto a new version of the Tokio runtime. This
 allows us to more easily integrate with the ecosystem and may yield performance
 benefits as well.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,22 @@
 ## edge-20.7.1
 
 This edge release improves messaging for retries when pods are unschedulable,
-adds a feature to persist prometheus data as an option to storing the data in
-memory, and upgrades the protobuf version to v1.4.2
+adds new functionality to persist prometheus data and configure the proxy log
+format using annotations and helm charts, fixes a bug in the helm chart for
+the Linkerd CNI Plugin, and enables the use of URLs with the `--addon-config`
+installation flag
 
-* Add better messaging during scheduling errors on retry for HA installations
-* Add option to persist prometheus data (thanks @naseemkullah!)
-* Upgrades generated protobuf files to v1.4.2
+* Controller
+  * Adds better messaging during scheduling errors on retry for HA installations
+* CLI
+  * Adds option to persist prometheus data (thanks @naseemkullah!)
+  * Adds support for passing a URL to the `--addon-config` flag, so you can now
+  use a file or an URL for installing add ons
+* Helm
+  * Fixes a bug in the CNI helm chart by correcting a helm value field name
+* Proxy
+  * Improves tail latencies by increasing the default buffer size to reduce
+    contention in high-concurrency situations
 
 ## edge-20.6.4
 


### PR DESCRIPTION
Update `CHANGES.md` with release notes for `edge-20.7.1`

Signed-off-by: Charles Pretzer <charles@buoyant.io>