### PR TITLE
Fix spelling mistakes using codespell

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -186,7 +186,7 @@ available to the cluster
 
 We use [WebdriverIO](https://webdriver.io/) to test how the web dashboard looks
 and operates locally in Chrome. For cross-browser testing, we use
-[SauceLabs](https://saucelabs.com/), which runs simulataneous tests on different
+[SauceLabs](https://saucelabs.com/), which runs simultaneous tests on different
 browsers in the cloud.
 
 If you're new to the repo, make sure you've installed web dependencies via
@@ -292,7 +292,7 @@ godoc github.com/linkerd/linkerd2/testutil | less
 The scale tests deploy a single Linkerd control-plane, and then scale up
 multiple sample apps across multiple replicas across multiple namespaces.
 
-Prequisites:
+Prerequisites:
 
 - a `linkerd` CLI binary
 - Linkerd Docker images associated with the `linkerd` CLI binary

--- a/bin/_release.sh
+++ b/bin/_release.sh
@@ -19,7 +19,7 @@ extract_release_notes() {
 
   # Save commit message into temporary file.
   #
-  # Match each occurence of the regex and increment `n` by 1. While n == 1
+  # Match each occurrence of the regex and increment `n` by 1. While n == 1
   # (which is true only for the first section) print that line of `CHANGES.md`.
   # This ends up being the first section of release changes.
   awk '/^## (edge|stable)-[0-9]+\.[0-9]+\.[0-9]+/{n++} n==1' "$rootdir"/CHANGES.md > "$tmp"

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -39,11 +39,11 @@ Examples:
     ${0##*/} --skip-kind-create /path/to/linkerd
 
     # Load images from tar files located under the 'image-archives' directory
-    # Note: This is primarly for CI
+    # Note: This is primarily for CI
     ${0##*/} --images /path/to/linkerd
 
     # Retrieve images from a remote docker instance and then load them into KinD
-    # Note: This is primarly for CI
+    # Note: This is primarily for CI
     ${0##*/} --images --images-host ssh://linkerd-docker /path/to/linkerd
 
 Available Commands:

--- a/bin/test-scale
+++ b/bin/test-scale
@@ -144,7 +144,7 @@ for ((i=1; i <= NAMESPACES; i++)); do
 done
 
 #
-# Lifecyle / bb
+# Lifecycle / bb
 #
 
 LIFECYCLE=$(curl -s https://raw.githubusercontent.com/linkerd/linkerd-examples/master/lifecycle/lifecycle.yml)

--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -22,7 +22,7 @@ generate these automatically). You can provide your own, or follow [these
 instructions](https://linkerd.io/2/tasks/generate-certificates/) to generate new
 ones.
 
-Note that the provided certificates must be ECDSA certficates.
+Note that the provided certificates must be ECDSA certificates.
 
 ## Adding Linkerd's Helm repository
 

--- a/cli/cmd/get_test.go
+++ b/cli/cmd/get_test.go
@@ -58,7 +58,7 @@ func TestGetPods(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns error if cant find pods in API", func(t *testing.T) {
+	t.Run("Returns error if can't find pods in API", func(t *testing.T) {
 		mockClient := &public.MockAPIClient{}
 		mockClient.ErrorToReturn = errors.New("expected")
 

--- a/controller/api/public/test_helper.go
+++ b/controller/api/public/test_helper.go
@@ -583,7 +583,7 @@ func newMockGrpcServer(exp expectedStatRPC) (*MockProm, *grpcServer, error) {
 }
 
 func (exp expectedStatRPC) verifyPromQueries(mockProm *MockProm) error {
-	// if exp.expectedPrometheusQueries is an empty slice we still wanna check no queries were executed.
+	// if exp.expectedPrometheusQueries is an empty slice we still want to check no queries were executed.
 	if exp.expectedPrometheusQueries != nil {
 		sort.Strings(exp.expectedPrometheusQueries)
 		sort.Strings(mockProm.QueriesExecuted)

--- a/grafana/dashboards/prometheus-benchmark.json
+++ b/grafana/dashboards/prometheus-benchmark.json
@@ -3261,7 +3261,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Rule group evaulation problems/s",
+      "title": "Rule group evaluation problems/s",
       "tooltip": {
         "msResolution": false,
         "shared": true,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1445,7 +1445,7 @@ func (hc *HealthChecker) checkCertificatesConfig() (*tls.Cred, []*x509.Certifica
 		data, err = issuercerts.FetchIssuerData(hc.kubeAPI, idctx.TrustAnchorsPem, hc.ControlPlaneNamespace)
 	} else {
 		data, err = issuercerts.FetchExternalIssuerData(hc.kubeAPI, hc.ControlPlaneNamespace)
-		// ensure trust anchors in config matches whats in the secret
+		// ensure trust anchors in config matches what's in the secret
 		if data != nil && strings.TrimSpace(idctx.TrustAnchorsPem) != strings.TrimSpace(data.TrustAnchors) {
 			errFormat := "IdentityContext.TrustAnchorsPem does not match %s in %s"
 			err = fmt.Errorf(errFormat, k8s.IdentityIssuerTrustAnchorsNameExternal, k8s.IdentityIssuerSecretName)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -620,7 +620,7 @@ func (conf *ResourceConfig) injectProxyInit(values *patch) {
 }
 
 func (conf *ResourceConfig) serviceAccountVolumeMount() *corev1.VolumeMount {
-	// Probably always true, but wanna be super-safe
+	// Probably always true, but want to be super-safe
 	if containers := conf.pod.spec.Containers; len(containers) > 0 {
 		for _, vm := range containers[0].VolumeMounts {
 			if vm.MountPath == k8s.MountPathServiceAccount {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -20,7 +20,7 @@ func TestGetConfig(t *testing.T) {
 	t.Run("Returns error if configuration cannot be found", func(t *testing.T) {
 		_, err := GetConfig("/this/doest./not/exist.config", "")
 		if err == nil {
-			t.Fatalf("Expecting error when config file doesnt exist, got nothing")
+			t.Fatalf("Expecting error when config file does not exist, got nothing")
 		}
 	})
 }

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -132,7 +132,7 @@ const (
 	// config.
 	ProxyInitImageAnnotation = ProxyConfigAnnotationsPrefix + "/init-image"
 
-	// ProxyInitImageVersionAnnotation can be used to overrided the proxy-init image version
+	// ProxyInitImageVersionAnnotation can be used to override the proxy-init image version
 	ProxyInitImageVersionAnnotation = ProxyConfigAnnotationsPrefix + "/init-image-version"
 
 	// DebugImageAnnotation can be used to override the debugImage config.

--- a/pkg/protohttp/protohttp_test.go
+++ b/pkg/protohttp/protohttp_test.go
@@ -409,7 +409,7 @@ func TestNewStreamingWriter(t *testing.T) {
 		}
 	})
 
-	t.Run("Returns an error if writer doesnt support streaming", func(t *testing.T) {
+	t.Run("Returns an error if writer does not support streaming", func(t *testing.T) {
 		_, err := NewStreamingWriter(&nonStreamingResponseWriter{})
 		if err == nil {
 			t.Fatalf("Expecting error, got nothing")

--- a/proto/public.proto
+++ b/proto/public.proto
@@ -335,7 +335,7 @@ message ResourceSelection {
   // A string-formatted Kubernetes label selector as passed to `kubectl get
   // --selector`.
   //
-  // XXX in the future this may be superceded by a data structure that more
+  // XXX in the future this may be superseded by a data structure that more
   // richly describes a parsed label selector.
   string label_selector = 2;
 }
@@ -486,7 +486,7 @@ message RouteTable {
 
 message GatewaysTable {
   repeated Row rows = 1;
-  
+
   message Row {
     string namespace = 1;
     string name = 2;
@@ -520,7 +520,7 @@ service Api {
   rpc StatSummary(StatSummaryRequest) returns (StatSummaryResponse) {}
 
   rpc Edges(EdgesRequest) returns (EdgesResponse) {}
-  
+
   rpc Gateways(GatewaysRequest) returns (GatewaysResponse) {}
 
   rpc TopRoutes(TopRoutesRequest) returns (TopRoutesResponse) {}
@@ -529,10 +529,10 @@ service Api {
 
   rpc ListServices(ListServicesRequest) returns (ListServicesResponse) {}
 
-  // Superceded by `TapByResource`.
+  // Superseded by `TapByResource`.
   rpc Tap(TapRequest) returns (stream TapEvent) { option deprecated = true; }
 
-  // Superceded by tap APIServer.
+  // Superseded by tap APIServer.
   rpc TapByResource(TapByResourceRequest) returns (stream TapEvent) { option deprecated = true; }
 
   rpc Version(Empty) returns (VersionInfo) {}

--- a/test/integration/externalissuer/external_issuer_test.go
+++ b/test/integration/externalissuer/external_issuer_test.go
@@ -21,7 +21,7 @@ const (
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
 	if !TestHelper.ExternalIssuer() {
-		fmt.Fprintln(os.Stdout, "Skiping as --external-issuer=false")
+		fmt.Fprintln(os.Stdout, "Skipping as --external-issuer=false")
 		os.Exit(0)
 	}
 	os.Exit(testutil.Run(m, TestHelper))
@@ -83,7 +83,7 @@ func checkAppWoks(t *testing.T, timeout time.Duration) error {
 
 		stat := rowStats[TestAppBackendDeploymentName]
 		if stat.Success != "100.00%" {
-			t.Fatalf("Expected no errors in test app but got [%s] succes rate", stat.Success)
+			t.Fatalf("Expected no errors in test app but got [%s] success rate", stat.Success)
 		}
 		return nil
 	})

--- a/test/integration/inject/inject_test.go
+++ b/test/integration/inject/inject_test.go
@@ -147,12 +147,12 @@ func TestInjectAutoNamespaceOverrideAnnotations(t *testing.T) {
 
 	// Match the pod configuration with the namespace level overrides
 	if proxyContainer.Resources.Requests["memory"] != resource.MustParse(nsProxyMemReq) {
-		testutil.Fatalf(t, "proxy memory resource request falied to match with namespace level override")
+		testutil.Fatalf(t, "proxy memory resource request failed to match with namespace level override")
 	}
 
 	// Match with proxy level override
 	if proxyContainer.Resources.Requests["cpu"] != resource.MustParse(podProxyCPUReq) {
-		testutil.Fatalf(t, "proxy cpu resource request falied to match with pod level override")
+		testutil.Fatalf(t, "proxy cpu resource request failed to match with pod level override")
 	}
 }
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -69,7 +69,7 @@ export class ResourceDetailBase extends React.Component {
       resourceMetrics: [],
       podMetrics: [], // metrics for all pods whose owner is this resource
       upstreamMetrics: {}, // metrics for resources who send traffic to this resource
-      downstreamMetrics: {}, // metrics for resources who this resouce sends traffic to
+      downstreamMetrics: {}, // metrics for resources who this resource sends traffic to
       unmeshedSources: {},
       resourceIsMeshed: true,
       pendingRequests: false,


### PR DESCRIPTION
Using following command the wrong spelling were found and later on
fixed:

```
codespell --skip CHANGES.md,.git,go.sum,\
    controller/cmd/service-mirror/events_formatting.go,\
    controller/cmd/service-mirror/cluster_watcher_test_util.go,\
    SECURITY_AUDIT.pdf,.gcp.json.enc,web/app/img/favicon.png \
    --ignore-words-list=aks,uint,ans,files\' --check-filenames \
    --check-hidden
```
