### PR TITLE
Re-enable custom domain integration test

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -96,7 +96,7 @@ jobs:
   kind_integration_tests:
     strategy:
       matrix:
-        integration_test: [custom-domain, deep, external-issuer, helm, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
+        integration_test: [cluster-domain, deep, external-issuer, helm, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
   kind_integration_tests:
     strategy:
       matrix:
-        integration_test: [custom-domain, deep, external-issuer, helm, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
+        integration_test: [cluster-domain, deep, external-issuer, helm, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -140,6 +140,7 @@ check_cluster() {
 delete_cluster() {
   local name=$1
   "$bindir"/kind delete cluster --name "$name" 2>&1
+  exit_on_err 'error deleting cluster'
 }
 
 cleanup_cluster() {
@@ -183,6 +184,8 @@ start_test() {
   fi
   check_cluster
   run_"$name"_test
+  exit_on_err "error calling 'run_${name}_test'"
+
   if [ -z "$skip_kind_create" ]; then
     delete_cluster "$name"
   else
@@ -194,7 +197,7 @@ get_test_config() {
   local name=$1
   config=''
   case $name in
-    cluster-domain)
+    custom-domain)
       config='cluster-domain'
       ;;
     *)
@@ -349,7 +352,7 @@ run_external-issuer_test() {
   run_test "$test_directory/externalissuer/external_issuer_test.go" --external-issuer=true
 }
 
-run_cluster-domain_test() {
+run_custom-domain_test() {
   run_test "$test_directory/install_test.go" --cluster-domain='custom.domain' --multicluster
 }
 

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -7,7 +7,7 @@ set +e
 ##### Test setup helpers #####
 
 export default_test_names=(deep external-issuer helm helm-upgrade uninstall upgrade-edge upgrade-stable)
-export all_test_names=(custom-domain "${default_test_names[*]}")
+export all_test_names=(cluster-domain "${default_test_names[*]}")
 
 handle_input() {
   export images=''
@@ -23,7 +23,7 @@ handle_input() {
 
 Optionally specify a test with the --name flag: [${all_test_names[*]}]
 
-Note: The custom-domain test requires a cluster configuration with a custom cluster domain (see test/configs/cluster-domain.yaml)
+Note: The cluster-domain test requires a cluster configuration with a custom cluster domain (see test/configs/cluster-domain.yaml)
 
 Usage:
     ${0##*/} [--images] [--images-host ssh://linkerd-docker] [--name test-name] [--skip-kind-create] /path/to/linkerd
@@ -197,7 +197,7 @@ get_test_config() {
   local name=$1
   config=''
   case $name in
-    custom-domain)
+    cluster-domain)
       config='cluster-domain'
       ;;
     *)
@@ -352,7 +352,7 @@ run_external-issuer_test() {
   run_test "$test_directory/externalissuer/external_issuer_test.go" --external-issuer=true
 }
 
-run_custom-domain_test() {
+run_cluster-domain_test() {
   run_test "$test_directory/install_test.go" --cluster-domain='custom.domain' --multicluster
 }
 

--- a/bin/tests
+++ b/bin/tests
@@ -11,7 +11,7 @@ if [ -n "$test_name" ]; then
   start_test "$test_name" "$config"
 else
   printf '==================RUNNING ALL TESTS==================
-Note: custom-domain requires a specific cluster configuration and is skipped by default\n\n'
+Note: cluster-domain requires a specific cluster configuration and is skipped by default\n\n'
 
   for test_name in "${default_test_names[@]}"; do
     config=$(get_test_config "$test_name")

--- a/bin/tests
+++ b/bin/tests
@@ -11,7 +11,7 @@ if [ -n "$test_name" ]; then
   start_test "$test_name" "$config"
 else
   printf '==================RUNNING ALL TESTS==================
-Note: cluster-domain requires a specific cluster configuration and is skipped by default\n\n'
+Note: custom-domain requires a specific cluster configuration and is skipped by default\n\n'
 
   for test_name in "${default_test_names[@]}"; do
     config=$(get_test_config "$test_name")


### PR DESCRIPTION
The function triggering the test for k8s custom cluster domain was
misnamed, and thus the test wasn't being run.

This also adds some extra error handling to catch this and other
potential issues.