### PR TITLE
update helm render tests to consider child charts values.yaml

### DIFF
--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -230,9 +230,7 @@ func chartControlPlane(t *testing.T, ha bool, addOnConfig string, ignoreOutbound
 }
 
 func buildAddOnChart(t *testing.T, addon l5dcharts.AddOn, chartPartials *pb.Chart) *pb.Chart {
-
 	rawValues := readValuesFile(t, filepath.Join("add-ons", addon.Name()))
-
 	addOnChart := pb.Chart{
 		Metadata: &pb.Metadata{
 			Name: addon.Name(),

--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -231,10 +231,7 @@ func chartControlPlane(t *testing.T, ha bool, addOnConfig string, ignoreOutbound
 
 func buildAddOnChart(t *testing.T, addon l5dcharts.AddOn, chartPartials *pb.Chart) *pb.Chart {
 
-	rawValues, err := readValuesFile(t, filepath.Join("add-ons", addon.Name()))
-	if err != nil {
-		t.Fatal("Unexpected error", err)
-	}
+	rawValues := readValuesFile(t, filepath.Join("add-ons", addon.Name()))
 
 	addOnChart := pb.Chart{
 		Metadata: &pb.Metadata{
@@ -302,15 +299,15 @@ func readTestValues(t *testing.T, ha bool, ignoreOutboundPorts string, ignoreInb
 }
 
 // readValues reads values.yaml file from the given path
-func readValuesFile(t *testing.T, path string) ([]byte, error) {
+func readValuesFile(t *testing.T, path string) []byte {
 
 	valuesFiles := []*chartutil.BufferedFile{
 		{Name: chartutil.ValuesfileName},
 	}
 
-	if err := charts.FilesReader(path + "/", valuesFiles); err != nil {
-		return nil, err
+	if err := charts.FilesReader(path+"/", valuesFiles); err != nil {
+		t.Fatal("Unexpected error", err)
 	}
 
-	return valuesFiles[0].Data, nil
+	return valuesFiles[0].Data
 }


### PR DESCRIPTION
Helm installation by default, considers values.yaml for dependend charts
and uses them in rendering (which are empty as of now). This function is
being used for add-ons to keep the default template values, allowing
further override from the parent chart's i.e linkerd2 values.yaml 
or --addon-config through CLI as per #4682 

This PR updates the Helm tests to reflect the same behaviour i.e consider
values.yaml of chart dependencies if present.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
