### PR TITLE
Do not treat evicted pods as failed in healthchecks

### DIFF
--- a/controller/api/util/api_utils.go
+++ b/controller/api/util/api_utils.go
@@ -594,6 +594,11 @@ func K8sPodToPublicPod(pod corev1.Pod, ownerKind string, ownerName string) *pb.P
 	if pod.DeletionTimestamp != nil {
 		status = "Terminating"
 	}
+
+	if pod.Status.Reason == "Evicted" {
+		status = "Evicted"
+	}
+
 	controllerComponent := pod.Labels[k8s.ControllerComponentLabel]
 	controllerNS := pod.Labels[k8s.ControllerNSLabel]
 

--- a/controller/api/util/api_utils_test.go
+++ b/controller/api/util/api_utils_test.go
@@ -460,6 +460,26 @@ func TestK8sPodToPublicPod(t *testing.T) {
 					PodIP:               "pod-ip",
 				},
 			},
+			{
+				k8sPod: corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase:  "Failed",
+						Reason: "Evicted",
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name:  k8s.ProxyContainerName,
+								Ready: true,
+							},
+						},
+					},
+				},
+				ownerName: "owner-name",
+				publicPod: &pb.Pod{
+					Name:       "/",
+					Status:     "Evicted",
+					ProxyReady: true,
+				},
+			},
 		}
 
 		for _, exp := range expectations {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2132,7 +2132,7 @@ func validateDataPlanePods(pods []*pb.Pod, targetNamespace string) error {
 	}
 
 	for _, pod := range pods {
-		if pod.Status != "Running" {
+		if pod.Status != "Running" && pod.Status != "Evicted" {
 			return fmt.Errorf("The \"%s\" pod is not running",
 				pod.Name)
 		}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2160,6 +2160,17 @@ func TestValidateDataPlanePods(t *testing.T) {
 		}
 	})
 
+	t.Run("Does not return an error if the pod is Evicted", func(t *testing.T) {
+		pods := []*pb.Pod{
+			{Name: "emoji-d9c7866bb-7v74n", Status: "Evicted", ProxyReady: true},
+		}
+
+		err := validateDataPlanePods(pods, "emojivoto")
+		if err != nil {
+			t.Fatalf("Expected no error, got %s", err)
+		}
+	})
+
 	t.Run("Returns an error if the proxy container is not ready", func(t *testing.T) {
 		pods := []*pb.Pod{
 			{Name: "emoji-d9c7866bb-7v74n", Status: "Running", ProxyReady: true},


### PR DESCRIPTION
When a k8s pod is evicted its `Phase` is set to `Failed` and the reason is set to `Evicted`. Because in the `ListPods` method of the public APi we only transmit the phase and treat it as Status, the healthchecks assume such evicted data plane pods to be failed. Since this check is retryable, the results is that `linkerd check --proxy` appears to hang when there are evicted pods. As @adleong correctly pointed out [here](https://github.com/linkerd/linkerd2/issues/4690#issuecomment-655016477), the presence of evicted pod is not something that we should make the checks fail. 

This change modifies the publci api to set the Pod.Status to "Evicted" for evicted pods. The healtcheks are also modified to not treat evicted pods as error cases. 

Fix #4690