### PR TITLE
CNI add support for priorityClassName

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -30,3 +30,5 @@ and their default values.
 |`portsToRedirect`                     | Ports to redirect to proxy                                            ||
 |`proxyUID`                            | User id under which the proxy shall be ran                            |`2102`|
 |`useWaitFlag`                         | Configures the CNI plugin to use the -w flag for the iptables command |`false`|
+|`installNamespace`                    | Whether to create the CNI plugin plane namespace or not               |`true`|
+|`priorityClassName`                   | Kubernetes priorityClassName for the CNI plugin's Pods                ||

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -183,6 +183,9 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: linkerd-cni
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
       # This container installs the linkerd CNI binaries
       # and CNI network config file on each node. The install

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -17,7 +17,7 @@ limitations under the License.
 This file was inspired by
 1) https://github.com/istio/cni/blob/c63a509539b5ed165a6617548c31b686f13c2133/deployments/kubernetes/install/manifests/istio-cni.yaml
 */ -}}
-{{- if .Values.createNamespace -}}
+{{- if .Values.installNamespace -}}
 kind: Namespace
 apiVersion: v1
 metadata:

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -1,4 +1,5 @@
 namespace: linkerd-cni
+createNamespace: true
 cniResourceLabel: linkerd.io/cni-resource
 inboundProxyPort: 4143
 outboundProxyPort: 4140

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -13,6 +13,7 @@ proxyUID:         2102
 destCNINetDir:    "/etc/cni/net.d"
 destCNIBinDir:    "/opt/cni/bin"
 useWaitFlag:      false
+priorityClassName: ""
 
 # namespace annotation and labels - do not edit
 proxyInjectAnnotation: linkerd.io/inject

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -1,5 +1,5 @@
 namespace: linkerd-cni
-createNamespace: true
+installNamespace: true
 cniResourceLabel: linkerd.io/cni-resource
 inboundProxyPort: 4143
 outboundProxyPort: 4140

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -39,7 +39,7 @@ type cniPluginOptions struct {
 	destCNIBinDir       string
 	useWaitFlag         bool
 	priorityClassName   string
-	createNamespace     bool
+	installNamespace    bool
 }
 
 func (options *cniPluginOptions) validate() error {
@@ -105,7 +105,7 @@ assumes that the 'linkerd install' command will be executed with the
 	cmd.PersistentFlags().StringVar(&options.logLevel, "cni-log-level", options.logLevel, "Log level for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.destCNINetDir, "dest-cni-net-dir", options.destCNINetDir, "Directory on the host where the CNI configuration will be placed")
 	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-name", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
-	cmd.PersistentFlags().BoolVar(&options.createNamespace, "create-namespace", options.createNamespace, "Whether to create the CNI namespace or not")
+	cmd.PersistentFlags().BoolVar(&options.installNamespace, "install-namespace", options.installNamespace, "Whether to create the CNI namespace or not")
 	cmd.PersistentFlags().BoolVar(
 		&options.useWaitFlag,
 		"use-wait-flag",
@@ -136,7 +136,7 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 		destCNIBinDir:       defaults.DestCNIBinDir,
 		useWaitFlag:         defaults.UseWaitFlag,
 		priorityClassName:   defaults.PriorityClassName,
-		createNamespace:     defaults.CreateNamespace,
+		installNamespace:    defaults.InstallNamespace,
 	}, nil
 }
 
@@ -172,7 +172,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.UseWaitFlag = options.useWaitFlag
 	installValues.Namespace = cniNamespace
 	installValues.PriorityClassName = options.priorityClassName
-	installValues.CreateNamespace = options.createNamespace
+	installValues.InstallNamespace = options.installNamespace
 	return installValues, nil
 }
 

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -39,6 +39,7 @@ type cniPluginOptions struct {
 	destCNIBinDir       string
 	useWaitFlag         bool
 	priorityClassName   string
+	createNamespace     bool
 }
 
 func (options *cniPluginOptions) validate() error {
@@ -104,7 +105,7 @@ assumes that the 'linkerd install' command will be executed with the
 	cmd.PersistentFlags().StringVar(&options.logLevel, "cni-log-level", options.logLevel, "Log level for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.destCNINetDir, "dest-cni-net-dir", options.destCNINetDir, "Directory on the host where the CNI configuration will be placed")
 	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-mame", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
-
+	cmd.PersistentFlags().BoolVar(&options.createNamespace, "create-namespace", options.createNamespace, "Whether to create the CNI namespace or not")
 	cmd.PersistentFlags().BoolVar(
 		&options.useWaitFlag,
 		"use-wait-flag",
@@ -135,6 +136,7 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 		destCNIBinDir:       defaults.DestCNIBinDir,
 		useWaitFlag:         defaults.UseWaitFlag,
 		priorityClassName:   defaults.PriorityClassName,
+		createNamespace:     defaults.CreateNamespace,
 	}, nil
 }
 
@@ -170,6 +172,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.UseWaitFlag = options.useWaitFlag
 	installValues.Namespace = cniNamespace
 	installValues.PriorityClassName = options.priorityClassName
+	installValues.CreateNamespace = options.createNamespace
 	return installValues, nil
 }
 

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -38,6 +38,7 @@ type cniPluginOptions struct {
 	destCNINetDir       string
 	destCNIBinDir       string
 	useWaitFlag         bool
+	priorityClassName   string
 }
 
 func (options *cniPluginOptions) validate() error {
@@ -102,7 +103,8 @@ assumes that the 'linkerd install' command will be executed with the
 	cmd.PersistentFlags().StringVar(&options.cniPluginImage, "cni-image", options.cniPluginImage, "Image for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.logLevel, "cni-log-level", options.logLevel, "Log level for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.destCNINetDir, "dest-cni-net-dir", options.destCNINetDir, "Directory on the host where the CNI configuration will be placed")
-	cmd.PersistentFlags().StringVar(&options.destCNIBinDir, "dest-cni-bin-dir", options.destCNIBinDir, "Directory on the host where the CNI plugin binaries reside")
+	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-mame", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
+
 	cmd.PersistentFlags().BoolVar(
 		&options.useWaitFlag,
 		"use-wait-flag",
@@ -132,6 +134,7 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 		destCNINetDir:       defaults.DestCNINetDir,
 		destCNIBinDir:       defaults.DestCNIBinDir,
 		useWaitFlag:         defaults.UseWaitFlag,
+		priorityClassName:   defaults.PriorityClassName,
 	}, nil
 }
 
@@ -166,6 +169,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.DestCNIBinDir = options.destCNIBinDir
 	installValues.UseWaitFlag = options.useWaitFlag
 	installValues.Namespace = cniNamespace
+	installValues.PriorityClassName = options.priorityClassName
 	return installValues, nil
 }
 

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -104,7 +104,7 @@ assumes that the 'linkerd install' command will be executed with the
 	cmd.PersistentFlags().StringVar(&options.cniPluginImage, "cni-image", options.cniPluginImage, "Image for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.logLevel, "cni-log-level", options.logLevel, "Log level for the cni-plugin")
 	cmd.PersistentFlags().StringVar(&options.destCNINetDir, "dest-cni-net-dir", options.destCNINetDir, "Directory on the host where the CNI configuration will be placed")
-	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-mame", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
+	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-name", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
 	cmd.PersistentFlags().BoolVar(&options.createNamespace, "create-namespace", options.createNamespace, "Whether to create the CNI namespace or not")
 	cmd.PersistentFlags().BoolVar(
 		&options.useWaitFlag,

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -28,7 +28,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/opt/my-cni/bin",
 		priorityClassName:   "system-node-critical",
-		createNamespace:     true,
+		installNamespace:    true,
 	}
 
 	otherNamespace := "other"
@@ -48,7 +48,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/etc/kubernetes/cni/net.d",
 		priorityClassName:   "system-node-critical",
-		createNamespace:     true,
+		installNamespace:    true,
 	}
 
 	fullyConfiguredOptionsNoNamespace := &cniPluginOptions{
@@ -66,7 +66,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/opt/my-cni/bin",
 		priorityClassName:   "system-node-critical",
-		createNamespace:     false,
+		installNamespace:    false,
 	}
 
 	testCases := []struct {

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -27,6 +27,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		logLevel:            "debug",
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/opt/my-cni/bin",
+		priorityClassName:   "system-node-critical",
 	}
 
 	otherNamespace := "other"
@@ -45,6 +46,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		logLevel:            "debug",
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/etc/kubernetes/cni/net.d",
+		priorityClassName:   "system-node-critical",
 	}
 
 	testCases := []struct {

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -28,6 +28,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/opt/my-cni/bin",
 		priorityClassName:   "system-node-critical",
+		createNamespace:     true,
 	}
 
 	otherNamespace := "other"
@@ -47,6 +48,25 @@ func TestRenderCNIPlugin(t *testing.T) {
 		destCNINetDir:       "/etc/kubernetes/cni/net.d",
 		destCNIBinDir:       "/etc/kubernetes/cni/net.d",
 		priorityClassName:   "system-node-critical",
+		createNamespace:     true,
+	}
+
+	fullyConfiguredOptionsNoNamespace := &cniPluginOptions{
+		linkerdVersion:      "awesome-linkerd-version.1",
+		dockerRegistry:      "gcr.io/linkerd-io",
+		proxyControlPort:    5190,
+		proxyAdminPort:      5191,
+		inboundPort:         5143,
+		outboundPort:        5140,
+		ignoreInboundPorts:  make([]string, 0),
+		ignoreOutboundPorts: make([]string, 0),
+		proxyUID:            12102,
+		cniPluginImage:      "my-docker-registry.io/awesome/cni-plugin-test-image",
+		logLevel:            "debug",
+		destCNINetDir:       "/etc/kubernetes/cni/net.d",
+		destCNIBinDir:       "/opt/my-cni/bin",
+		priorityClassName:   "system-node-critical",
+		createNamespace:     false,
 	}
 
 	testCases := []struct {
@@ -57,6 +77,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		{defaultOptions, defaultCniNamespace, "install-cni-plugin_default.golden"},
 		{fullyConfiguredOptions, otherNamespace, "install-cni-plugin_fully_configured.golden"},
 		{fullyConfiguredOptionsEqualDsts, otherNamespace, "install-cni-plugin_fully_configured_equal_dsts.golden"},
+		{fullyConfiguredOptionsNoNamespace, otherNamespace, "install-cni-plugin_fully_configured_no_namespace.golden"},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -40,7 +40,8 @@ func TestRenderCniHelm(t *testing.T) {
   			"destCNINetDir": "/etc/cni/net.d-test",
   			"destCNIBinDir": "/opt/cni/bin-test",
   			"useWaitFlag": true,
-			"cliVersion": "test-version"
+			"cliVersion": "test-version",
+			"priorityClassName": "system-node-critical"
 		}`
 
 		overrideConfig := &pb.Config{Raw: overrideJSON}

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -159,6 +159,7 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: linkerd-cni
+      priorityClassName: system-node-critical
       containers:
       # This container installs the linkerd CNI binaries
       # and CNI network config file on each node. The install

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -159,6 +159,7 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: linkerd-cni
+      priorityClassName: system-node-critical
       containers:
       # This container installs the linkerd CNI binaries
       # and CNI network config file on each node. The install

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -1,40 +1,9 @@
-{{- /*
-Copyright 2017 CNI authors
-Modifications copyright (c) Linkerd authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This file was inspired by
-1) https://github.com/istio/cni/blob/c63a509539b5ed165a6617548c31b686f13c2133/deployments/kubernetes/install/manifests/istio-cni.yaml
-*/ -}}
-{{- if .Values.createNamespace -}}
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: {{.Values.namespace}}
-  annotations:
-    {{.Values.proxyInjectAnnotation}}: {{.Values.proxyInjectDisabled}}
-  labels:
-    {{.Values.cniResourceLabel}}: "true"
-    config.linkerd.io/admission-webhooks: disabled
----
-{{ end -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-{{.Values.namespace}}-cni
+  name: linkerd-other-cni
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
@@ -54,31 +23,31 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
   resourceNames:
-  - linkerd-{{.Values.namespace}}-cni
+  - linkerd-other-cni
   verbs: ['use']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -86,14 +55,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "namespaces"]
@@ -104,7 +73,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-cni
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -112,25 +81,25 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: {{.Values.namespace}}
+  namespace: other
   labels:
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
 data:
-  dest_cni_net_dir: "{{.Values.destCNINetDir}}"
-  dest_cni_bin_dir: "{{.Values.destCNIBinDir}}"
+  dest_cni_net_dir: "/etc/kubernetes/cni/net.d"
+  dest_cni_bin_dir: "/opt/my-cni/bin"
   # The CNI network configuration to install on each node. The special
   # values in this config will be automatically populated.
   cni_network_config: |-
     {
       "name": "linkerd-cni",
       "type": "linkerd-cni",
-      "log_level": "{{.Values.logLevel}}",
+      "log_level": "debug",
       "policy": {
           "type": "k8s",
           "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
@@ -140,18 +109,14 @@ data:
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },
       "linkerd": {
-        "incoming-proxy-port": {{.Values.inboundProxyPort}},
-        "outgoing-proxy-port": {{.Values.outboundProxyPort}},
-        "proxy-uid": {{.Values.proxyUID}},
-        "ports-to-redirect": [{{.Values.portsToRedirect}}],
-        "inbound-ports-to-ignore": [
-          {{- include "partials.splitStringList" .Values.ignoreInboundPorts -}}
-        ],
-        "outbound-ports-to-ignore": [
-          {{- include "partials.splitStringList" .Values.ignoreOutboundPorts -}}
-        ],
+        "incoming-proxy-port": 5143,
+        "outgoing-proxy-port": 5140,
+        "proxy-uid": 12102,
+        "ports-to-redirect": [],
+        "inbound-ports-to-ignore": ["5190","5191"],
+        "outbound-ports-to-ignore": [],
         "simulate": false,
-        "use-wait-flag": {{.Values.useWaitFlag}}
+        "use-wait-flag": false
       }
     }
 ---
@@ -159,12 +124,12 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: other
   labels:
     k8s-app: linkerd-cni
-    {{.Values.cniResourceLabel}}: "true"
+    linkerd.io/cni-resource: "true"
   annotations:
-    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.cniPluginVersion) .Values.cliVersion}}
+    linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   selector:
     matchLabels:
@@ -178,22 +143,20 @@ spec:
       labels:
         k8s-app: linkerd-cni
       annotations:
-        {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.cniPluginVersion) .Values.cliVersion}}
+        linkerd.io/created-by: linkerd/cli dev-undefined
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: linkerd-cni
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
-      {{- end }}
+      priorityClassName: system-node-critical
       containers:
       # This container installs the linkerd CNI binaries
       # and CNI network config file on each node. The install
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: {{.Values.cniPluginImage}}:{{.Values.cniPluginVersion}}
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:awesome-linkerd-version.1
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:
@@ -217,25 +180,15 @@ spec:
             exec:
               command: ["kill","-15","1"]
         volumeMounts:
-        {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
-        - mountPath: /host{{.Values.destCNIBinDir}}
+        - mountPath: /host/opt/my-cni/bin
           name: cni-bin-dir
-        - mountPath: /host{{.Values.destCNINetDir}}
+        - mountPath: /host/etc/kubernetes/cni/net.d
           name: cni-net-dir
-        {{- else }}
-        - mountPath: /host{{.Values.destCNINetDir}}
-          name: cni-net-dir
-        {{- end }}
       volumes:
-      {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
       - name: cni-bin-dir
         hostPath:
-          path: {{.Values.destCNIBinDir}}
+          path: /opt/my-cni/bin
       - name: cni-net-dir
         hostPath:
-          path: {{.Values.destCNINetDir}}
-      {{- else }}
-      - name: cni-net-dir
-        hostPath:
-          path: {{.Values.destCNINetDir}}
-      {{- end }}
+          path: /etc/kubernetes/cni/net.d
+---

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -161,6 +161,7 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       serviceAccountName: linkerd-cni
+      priorityClassName: system-node-critical
       containers:
       # This container installs the linkerd CNI binaries
       # and CNI network config file on each node. The install

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -34,6 +34,7 @@ type Values struct {
 	ProxyInjectAnnotation string `json:"proxyInjectAnnotation"`
 	ProxyInjectDisabled   string `json:"proxyInjectDisabled"`
 	PriorityClassName     string `json:"priorityClassName"`
+	CreateNamespace       bool   `json:"createNamespace"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -33,6 +33,7 @@ type Values struct {
 	UseWaitFlag           bool   `json:"useWaitFlag"`
 	ProxyInjectAnnotation string `json:"proxyInjectAnnotation"`
 	ProxyInjectDisabled   string `json:"proxyInjectDisabled"`
+	PriorityClassName     string `json:"priorityClassName"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -34,7 +34,7 @@ type Values struct {
 	ProxyInjectAnnotation string `json:"proxyInjectAnnotation"`
 	ProxyInjectDisabled   string `json:"proxyInjectDisabled"`
 	PriorityClassName     string `json:"priorityClassName"`
-	CreateNamespace       bool   `json:"createNamespace"`
+	InstallNamespace      bool   `json:"installNamespace"`
 }
 
 // NewValues returns a new instance of the Values type.


### PR DESCRIPTION
As requested in #2981 one should be able to optionally define a priorityClassName for the linkerd2 pods.

With this PR support for priorityClassName is added to the CNI plugin helm chart as well as to the
cli command for installing the CNI plugin. Furthermore, a `--create-namespace` flag is introduce to
allow to skip the namespace creation for setups where the namespace already exists.

Implements part of #2981. Note, this PR only adds priorityClassName to the CNI plugin and therefore does not 
yet full resolve/fix #2981. 

Signed-off-by: alex.berger@nexiot.ch <alex.berger@nexiot.ch>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
