### PR TITLE
Fix upgrade integration test

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -242,13 +242,13 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	// test `linkerd upgrade --from-manifests`
 	if TestHelper.UpgradeFromVersion() != "" {
 		resources := []string{"configmaps/" + k8s.ConfigConfigMapName, "configmaps/" + k8s.AddOnsConfigMapName, "secrets/" + k8s.IdentityIssuerSecretName}
-		args := append([]string{"--namespace", TestHelper.GetLinkerdNamespace(), "get"}, resources...)
-		args = append(args, "-oyaml")
+		kubeArgs := append([]string{"--namespace", TestHelper.GetLinkerdNamespace(), "get"}, resources...)
+		kubeArgs = append(kubeArgs, "-oyaml")
 
-		manifests, err := TestHelper.Kubectl("", args...)
+		manifests, err := TestHelper.Kubectl("", kubeArgs...)
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'kubectl get' command failed",
-				"'kubectl get' command failed with %s\n%s\n%s", err, manifests, args)
+				"'kubectl get' command failed with %s\n%s\n%s", err, manifests, kubeArgs)
 		}
 
 		exec = append(exec, "--from-manifests", "-")


### PR DESCRIPTION
An inappropriate variable reuse resulted in the failure of the test for
upgrading using manifests. This only happened when the upgrade was
retried a second time (when there's a discrepancy in the heartbeat cron
schedule, which is benign).

