### PR TITLE
set the xtables mountPath name from a variable

### DIFF
--- a/charts/partials/templates/_volumes.tpl
+++ b/charts/partials/templates/_volumes.tpl
@@ -27,5 +27,5 @@ name: podinfo
 
 {{ define "partials.proxyInit.volumes.xtables" -}}
 emptyDir: {}
-name: linkerd-proxy-init-xtables-lock
+name: {{ .Values.global.proxyInit.xtMountPath.name }}
 {{- end -}}


### PR DESCRIPTION
This is a quick fix that dynamically sets the mountPath name as [suggested](https://github.com/linkerd/linkerd2/pull/4692#discussion_r452024831) by @Pothulapati 

Signed-off-by: Charles Pretzer <charles@buoyant.io>