### PR TITLE
Use 2 nodes in cloud integration tests

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -108,6 +108,7 @@ jobs:
         preemptible: false
         create: true
         name: testing-${{ steps.install_cli.outputs.tag }}-${{ github.run_id }}
+        num_nodes: 2
     - name: Run integration tests
       env:
         GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}


### PR DESCRIPTION
The deep integration tests started failing on GKE.

Originally, this was thought to be a cleanup issue, but we have not cleaned up
deep integration tests in the past. We install Linkerd once, and then run all
the tests serially.

In thinking it's been a while since we've run a full deep tests on GKE, we may
just need more resources when running them now.

This increases the node count of the GKE cluster that we run on from 1 to 2.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
