### PR TITLE
prometheus: add add-on checks

### DIFF
--- a/pkg/charts/linkerd2/prometheus.go
+++ b/pkg/charts/linkerd2/prometheus.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	prometheusAddOn = "prometheus"
+	PrometheusAddOn = "prometheus"
 )
 
 // Prometheus is an add-on that installs the prometheus component
@@ -14,7 +14,7 @@ type Prometheus map[string]interface{}
 
 // Name returns the name of the Tracing add-on
 func (p Prometheus) Name() string {
-	return prometheusAddOn
+	return PrometheusAddOn
 }
 
 // Values returns the configuration values that were assigned for this add-on

--- a/pkg/charts/linkerd2/prometheus.go
+++ b/pkg/charts/linkerd2/prometheus.go
@@ -6,13 +6,14 @@ import (
 )
 
 var (
+	// PrometheusAddOn is the name of the prometheus add-on
 	PrometheusAddOn = "prometheus"
 )
 
 // Prometheus is an add-on that installs the prometheus component
 type Prometheus map[string]interface{}
 
-// Name returns the name of the Tracing add-on
+// Name returns the name of the Prometheus add-on
 func (p Prometheus) Name() string {
 	return PrometheusAddOn
 }

--- a/pkg/healthcheck/healthcheck_addons.go
+++ b/pkg/healthcheck/healthcheck_addons.go
@@ -18,13 +18,16 @@ const (
 	// LinkerdGrafanaAddOnChecks adds checks related to grafana add-on components
 	LinkerdGrafanaAddOnChecks CategoryID = "linkerd-grafana"
 
+	// LinkerdPrometheusAddOnChecks adds checks related to Prometheus add-on components
+	LinkerdPrometheusAddOnChecks CategoryID = "linkerd-prometheus"
+
 	// LinkerdTracingAddOnChecks adds checks related to tracing add-on components
 	LinkerdTracingAddOnChecks CategoryID = "linkerd-tracing"
 )
 
 var (
 	// AddOnCategories is the list of add-on category checks
-	AddOnCategories = []CategoryID{LinkerdAddOnChecks, LinkerdGrafanaAddOnChecks, LinkerdTracingAddOnChecks}
+	AddOnCategories = []CategoryID{LinkerdAddOnChecks, LinkerdPrometheusAddOnChecks, LinkerdGrafanaAddOnChecks, LinkerdTracingAddOnChecks}
 )
 
 // addOnCategories contain all the checks w.r.t add-ons. It is strongly advised to
@@ -40,6 +43,54 @@ func (hc *HealthChecker) addOnCategories() []category {
 					warning:     true,
 					check: func(context.Context) error {
 						return hc.checkIfAddOnsConfigMapExists()
+					},
+				},
+			},
+		},
+		{
+			id: LinkerdPrometheusAddOnChecks,
+			checkers: []checker{
+				{
+					description: "prometheus add-on service account exists",
+					warning:     true,
+					check: func(context.Context) error {
+						if _, ok := hc.addOns[l5dcharts.PrometheusAddOn]; ok {
+							return hc.checkServiceAccounts([]string{"linkerd-prometheus"}, hc.ControlPlaneNamespace, "")
+						}
+						return &SkipError{Reason: "prometheus add-on not enabled"}
+					},
+				},
+				{
+					description: "prometheus add-on config map exists",
+					warning:     true,
+					check: func(context.Context) error {
+						if _, ok := hc.addOns[l5dcharts.PrometheusAddOn]; ok {
+							_, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get("linkerd-prometheus-config", metav1.GetOptions{})
+							if err != nil {
+								return err
+							}
+							return nil
+						}
+						return &SkipError{Reason: "prometheus add-on not enabled"}
+					},
+				},
+				{
+					description:         "prometheus pod is running",
+					warning:             true,
+					retryDeadline:       hc.RetryDeadline,
+					surfaceErrorOnRetry: true,
+					check: func(context.Context) error {
+						if _, ok := hc.addOns[l5dcharts.PrometheusAddOn]; ok {
+							// populate controlPlanePods to get the latest status, during retries
+							var err error
+							hc.controlPlanePods, err = hc.kubeAPI.GetPodsByNamespace(hc.ControlPlaneNamespace)
+							if err != nil {
+								return err
+							}
+
+							return checkContainerRunning(hc.controlPlanePods, "prometheus")
+						}
+						return &SkipError{Reason: "prometheus add-on not enabled"}
 					},
 				},
 			},

--- a/pkg/healthcheck/healthcheck_addons.go
+++ b/pkg/healthcheck/healthcheck_addons.go
@@ -66,10 +66,7 @@ func (hc *HealthChecker) addOnCategories() []category {
 					check: func(context.Context) error {
 						if _, ok := hc.addOns[l5dcharts.PrometheusAddOn]; ok {
 							_, err := hc.kubeAPI.CoreV1().ConfigMaps(hc.ControlPlaneNamespace).Get("linkerd-prometheus-config", metav1.GetOptions{})
-							if err != nil {
-								return err
-							}
-							return nil
+							return err
 						}
 						return &SkipError{Reason: "prometheus add-on not enabled"}
 					},

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -397,6 +397,7 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
 
+	// TODO: make checkOutput as true once 2.9 releases
 	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), false)
 }
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -607,10 +607,6 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 		}
 	}
 
-	if !compareOutput {
-		return
-	}
-
 	timeout := time.Minute
 	err := TestHelper.RetryFor(timeout, func() error {
 		if cliVersionOverride != "" {
@@ -621,6 +617,10 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 
 		if err != nil {
 			return fmt.Errorf("'linkerd check' command failed\n%s\n%s", stderr, out)
+		}
+
+		if !compareOutput {
+			return nil
 		}
 
 		err = TestHelper.ValidateOutput(out, golden)

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -397,7 +397,7 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
 
-	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion())
+	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), false)
 }
 
 func TestUpgradeHelm(t *testing.T) {
@@ -584,7 +584,7 @@ func TestVersionPostInstall(t *testing.T) {
 	}
 }
 
-func testCheckCommand(t *testing.T, stage string, expectedVersion string, namespace string, cliVersionOverride string) {
+func testCheckCommand(t *testing.T, stage string, expectedVersion string, namespace string, cliVersionOverride string, compareOutput bool) {
 	var cmd []string
 	var golden string
 	if stage == "proxy" {
@@ -604,6 +604,10 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 		} else {
 			golden = "check.golden"
 		}
+	}
+
+	if !compareOutput {
+		return
 	}
 
 	timeout := time.Minute
@@ -632,11 +636,11 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 
 // TODO: run this after a `linkerd install config`
 func TestCheckConfigPostInstall(t *testing.T) {
-	testCheckCommand(t, "config", TestHelper.GetVersion(), "", "")
+	testCheckCommand(t, "config", TestHelper.GetVersion(), "", "", true)
 }
 
 func TestCheckPostInstall(t *testing.T) {
-	testCheckCommand(t, "", TestHelper.GetVersion(), "", "")
+	testCheckCommand(t, "", TestHelper.GetVersion(), "", "", true)
 }
 
 func TestUpgradeTestAppWorksAfterUpgrade(t *testing.T) {
@@ -816,7 +820,7 @@ func TestCheckProxy(t *testing.T) {
 		tc := tc // pin
 		t.Run(tc.ns, func(t *testing.T) {
 			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
-			testCheckCommand(t, "proxy", TestHelper.GetVersion(), prefixedNs, "")
+			testCheckCommand(t, "proxy", TestHelper.GetVersion(), prefixedNs, "", true)
 		})
 	}
 }

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -62,6 +62,12 @@ linkerd-addons
 --------------
 √ 'linkerd-config-addons' config map exists
 
+linkerd-prometheus
+------------------
+√ prometheus add-on service account exists
+√ prometheus add-on config map exists
+√ prometheus pod is running
+
 linkerd-grafana
 ---------------
 √ grafana add-on service account exists

--- a/test/integration/testdata/check.multicluster.golden
+++ b/test/integration/testdata/check.multicluster.golden
@@ -62,6 +62,12 @@ linkerd-addons
 --------------
 √ 'linkerd-config-addons' config map exists
 
+linkerd-prometheus
+------------------
+√ prometheus add-on service account exists
+√ prometheus add-on config map exists
+√ prometheus pod is running
+
 linkerd-grafana
 ---------------
 √ grafana add-on service account exists

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -69,6 +69,12 @@ linkerd-addons
 --------------
 √ 'linkerd-config-addons' config map exists
 
+linkerd-prometheus
+------------------
+√ prometheus add-on service account exists
+√ prometheus add-on config map exists
+√ prometheus pod is running
+
 linkerd-grafana
 ---------------
 √ grafana add-on service account exists

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -69,6 +69,12 @@ linkerd-addons
 --------------
 √ 'linkerd-config-addons' config map exists
 
+linkerd-prometheus
+------------------
+√ prometheus add-on service account exists
+√ prometheus add-on config map exists
+√ prometheus pod is running
+
 linkerd-grafana
 ---------------
 √ grafana add-on service account exists


### PR DESCRIPTION
Implements third part of https://github.com/linkerd/rfc/pull/16, https://github.com/linkerd/linkerd2/issues/4375
As linkerd-prometheus is optional now, the checks can also be separated
and should be only work when the prometheus add-on is installed.

PR #4724 already removes the existing checks, and here we separate
the checks.

This is done by re-using the add-on check code.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
