### PR TITLE
Uncomment EndpointSliceAccess function

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -129,7 +129,6 @@ var endpointsVecs = newEndpointsMetricsVecs()
 // NewEndpointsWatcher creates an EndpointsWatcher and begins watching the
 // k8sAPI for pod, service, and endpoint changes. An EndpointsWatcher will
 // watch on Endpoints or EndpointSlice resources, depending on cluster configuration.
-//TODO: Allow EndpointSlice resources to be used once opt-in functionality is supported.
 func NewEndpointsWatcher(k8sAPI *k8s.API, log *logging.Entry, enableEndpointSlices bool) *EndpointsWatcher {
 	ew := &EndpointsWatcher{
 		publishers:           make(map[ServiceID]*servicePublisher),
@@ -161,7 +160,6 @@ func NewEndpointsWatcher(k8sAPI *k8s.API, log *logging.Entry, enableEndpointSlic
 			UpdateFunc: ew.updateEndpointSlice,
 		})
 	} else {
-		// ew.log.Debugf("Cluster does not have EndpointSlice access:%v", err)
 		ew.log.Debugf("Watching Endpoints resources")
 		k8sAPI.Endpoint().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    ew.addEndpoints,

--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	authV1 "k8s.io/api/authorization/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 )
@@ -107,40 +109,36 @@ func ServiceProfilesAccess(k8sClient kubernetes.Interface) error {
 
 // EndpointSliceAccess verifies whether the K8s cluster has
 // access to EndpointSlice resources.
-//TODO: Uncomment function and change return type once EndpointSlices
-// are supported and made opt-in through install flag
 func EndpointSliceAccess(k8sClient kubernetes.Interface) error {
-	// gv := discovery.SchemeGroupVersion.String()
-	// res, err := k8sClient.Discovery().ServerResourcesForGroupVersion(gv)
-	// if err != nil {
-	// 	return err
-	// }
+	gv := discovery.SchemeGroupVersion.String()
+	res, err := k8sClient.Discovery().ServerResourcesForGroupVersion(gv)
+	if err != nil {
+		return err
+	}
 
-	// if res.GroupVersion == gv {
-	// 	for _, apiRes := range res.APIResources {
-	// 		if apiRes.Kind == "EndpointSlice" {
-	// 			return checkEndpointSlicesExist(k8sClient)
-	// 		}
-	// 	}
-	// }
+	if res.GroupVersion == gv {
+		for _, apiRes := range res.APIResources {
+			if apiRes.Kind == "EndpointSlice" {
+				return checkEndpointSlicesExist(k8sClient)
+			}
+		}
+	}
 
-	// return errors.New("EndpointSlice resource not found")
-	return errors.New("EndpointSlice not supported")
+	return errors.New("EndpointSlice resource not found")
 }
 
-//TODO: Uncomment function once EndpointSlices are supported and opt-in
-//func checkEndpointSlicesExist(k8sclient kubernetes.Interface) error {
-//	sliceList, err := k8sclient.DiscoveryV1beta1().EndpointSlices("").List(metav1.ListOptions{})
-//	if err != nil {
-//		return err
-//	}
-//
-//	if len(sliceList.Items) > 0 {
-//		return nil
-//	}
-//
-//	return errors.New("no EndpointSlice resources exist in the cluster")
-//}
+func checkEndpointSlicesExist(k8sClient kubernetes.Interface) error {
+	sliceList, err := k8sClient.DiscoveryV1beta1().EndpointSlices("").List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(sliceList.Items) > 0 {
+		return nil
+	}
+
+	return errors.New("no EndpointSlice resources exist in the cluster")
+}
 
 // ClusterAccess verifies whether k8sClient is authorized to access all pods in
 // all namespaces in the cluster.


### PR DESCRIPTION
### What
---

* Small PR that uncomments the `EndpointSliceAcess` method and cleans up left over todos in the destination service.
* Based on the past three PRs related to `EndpointSlices` (#4663 #4696 #4740); they should now be functional (albeit prone to bugs) and ready to use.

### Tests
---

* Although I haven't extensively tested all edge cases in the context of this PR, I did test that everything comes together nicely. To this, may approach has been:
  - Test how the flag behaves when we have (and don't have) support for slices in the cluster;
  - Test how the destination service behaves in combination with the flag and feature gate.

I tested a total of three broad scenarios:

1. When minikube has no `EndpointSlices`:
```sh
# install should fail when flag is enabled
$ target/cli/darwin/linkerd install --enable-endpoint-slices
# output
Error: --enableEndpointSlice=true not supported: no EndpointSlice resources exist in the cluster

# install should succeed when flag disabled
# everything should work as normal
# dest service should watch endpoints
$ k logs <dest-service-pod> -f destination
#output
ime="2020-07-15T19:40:22Z" level=debug msg="Watching Endpoints resources" addr=":8086" component=endpoints-watcher
time="2020-07-15T19:40:22Z" level=info msg="waiting for caches to sync"
I0715 19:40:22.143369       1 reflector.go:150] Starting reflector *v1.Service (10m0s) from pkg/mod/k8s.io/client-go@v0.17.4/tools/cache/reflector.go:105
```
* When the flag is disabled, works as expected, when flag is enabled, works as expected.
* No hanging on syncing cache, not watching wrong resource.

2. When minikube has `EndpointSlice` support, but not Linkerd installed with `EndpointSlice` support:
```sh
# Install should succeed
$ target/cli/darwin/linkerd install
# Output:
<installed successfully>

# Destination service should watch Endpoints
# shouldn't crash, shouldn't hang on informer syncing:
$ k logs <dest-service-pod> -f destination
# Output:
time="2020-07-15T20:09:44Z" level=debug msg="Watching Endpoints resources" addr=":8086" component=endpoints-watcher
time="2020-07-15T20:09:44Z" level=info msg="waiting for caches to sync"
<starting reflector> # forgot to copy line
# more logs in between
time="2020-07-15T20:34:05Z" level=debug msg="Sending destination add: add:{addrs:{addr:{ip:{ipv4:2886795270}  port:9996}  weight:10000}}" addr=":8086" component=endpoint-translator remote="127.0.0.1:49108" service="172.17.0.6:9996"
```
* When installed in a cluster with `EndpointSlice` support but without support in Linkerd, the right resource is watched
* No errors, no hanging on cache syncing

3. When minikube has `EndpointSlice` support, with Linkerd installed with `EndpointSlice` support:
```
# Install should succeed (resource active in cluster)
$ target/cli/darwin/linkerd install --enable-endpoint-slices
# Output:
<installed successfully>

# Destination service should watch slices
# shouldn't error out, should transmit updates to other control plane
# components (i.e finding endpoints in slices)
$ k logs <dest-service-pod> -f destination
# Output:
time="2020-07-15T20:12:09Z" level=debug msg="Watching EndpointSlice resources" addr=":8086" component=endpoints-watcher
time="2020-07-15T20:12:09Z" level=info msg="waiting for caches to sync"
I0715 20:12:09.463803       1 reflector.go:150] Starting reflector *v1.Pod (10m0s) from pkg/mod/k8s.io/client-go@v0.17.4/tools/cache/reflector.go:105

time="2020-07-15T20:12:09Z" level=debug msg="Adding EndpointSlice for linkerd/linkerd-dst" addr=":8086" component=service-publisher ns=linkerd svc=linkerd-dst
time="2020-07-15T20:12:09Z" level=debug msg="Adding EndpointSlice for linkerd/linkerd-sp-validator" addr=":8086" component=service-publisher ns=linkerd svc=linkerd-sp-validator
# ... extra logs in between
time="2020-07-15T20:12:20Z" level=debug msg="Sending destination add: add:{addrs:{addr:{ip:{ipv4:2886795273}  port:4191}  weight:10000  metric_labels:{key}
```
* Everything works as expected, no nasty errors, destination messages are being sent to the proxy

My conclusion is that at first glance everything seems to be working well enough to have them enabled for experimental use. The same messages are being sent as for the Endpoints resource, the flag does a well enough job of preventing installation when the resource does not exist and a well enough job of allowing the installation to proceed when the access criteria is met.

Signed-off-by: Matei David <matei.david.35@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
