### PR TITLE
Fix build status badge in README

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -96,7 +96,15 @@ jobs:
   kind_integration_tests:
     strategy:
       matrix:
-        integration_test: [cluster-domain, deep, external-issuer, helm-deep, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
+        integration_test:
+        - cluster-domain
+        - deep
+        - external-issuer
+        - helm-deep
+        - helm-upgrade
+        - uninstall
+        - upgrade-edge
+        - upgrade-stable
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,15 @@ jobs:
   kind_integration_tests:
     strategy:
       matrix:
-        integration_test: [cluster-domain, deep, external-issuer, helm-deep, helm-upgrade, uninstall, upgrade-edge, upgrade-stable]
+        integration_test:
+        - cluster-domain
+        - deep
+        - external-issuer
+        - helm-deep
+        - helm-upgrade
+        - uninstall
+        - upgrade-edge
+        - upgrade-stable
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ specific language governing permissions and limitations under the License.
 
 <!-- refs -->
 [github-actions]: https://github.com/linkerd/linkerd2/actions
-[github-actions-badge]: https://github.com/linkerd/linkerd2/workflows/Release/badge.svg
+[github-actions-badge]: https://github.com/linkerd/linkerd2/workflows/Cloud%20integration/badge.svg
 [cncf]: https://www.cncf.io/
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [getting-started]: https://linkerd.io/2/getting-started/

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ specific language governing permissions and limitations under the License.
 
 <!-- refs -->
 [github-actions]: https://github.com/linkerd/linkerd2/actions
-[github-actions-badge]: https://github.com/linkerd/linkerd2/workflows/CI/badge.svg
+[github-actions-badge]: https://github.com/linkerd/linkerd2/workflows/Release/badge.svg
 [cncf]: https://www.cncf.io/
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [getting-started]: https://linkerd.io/2/getting-started/


### PR DESCRIPTION
The GitHub Actions build status badge was referencing an old workflow
named `CI`, which always shows red, and is no longer used.

Fix the build status badge to reference the `Release` workload.

Also slightly reformat the matrix build yaml, as the list has grown a
bit.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
