### PR TITLE
service topologies: topology-aware service routing

### DIFF
--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_addon_config.golden
+++ b/cli/cmd/testdata/install_addon_config.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -141,7 +141,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -141,7 +141,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -141,7 +141,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_prometheus_overwrite.golden
+++ b/cli/cmd/testdata/install_prometheus_overwrite.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -133,7 +133,7 @@ rules:
   resources: ["jobs"]
   verbs: ["list", "get", "watch"]
 - apiGroups: [""]
-  resources: ["pods", "endpoints", "services"]
+  resources: ["pods", "endpoints", "services", "nodes"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["linkerd.io"]
   resources: ["serviceprofiles"]

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -9,6 +9,9 @@ import (
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const defaultWeight uint32 = 10000
@@ -19,8 +22,12 @@ type endpointTranslator struct {
 	controllerNS        string
 	identityTrustDomain string
 	enableH2Upgrade     bool
-	stream              pb.Destination_GetServer
-	log                 *logging.Entry
+	nodeTopologyLabels  map[string]string
+
+	availableEndpoints watcher.AddressSet
+	filteredSnapshot   watcher.AddressSet
+	stream             pb.Destination_GetServer
+	log                *logging.Entry
 }
 
 func newEndpointTranslator(
@@ -28,6 +35,8 @@ func newEndpointTranslator(
 	identityTrustDomain string,
 	enableH2Upgrade bool,
 	service string,
+	srcNodeName string,
+	k8sClient kubernetes.Interface,
 	stream pb.Destination_GetServer,
 	log *logging.Entry,
 ) *endpointTranslator {
@@ -36,10 +45,161 @@ func newEndpointTranslator(
 		"service":   service,
 	})
 
-	return &endpointTranslator{controllerNS, identityTrustDomain, enableH2Upgrade, stream, log}
+	nodeTopologyLabels, err := getK8sNodeTopology(k8sClient, srcNodeName)
+	if err != nil {
+		log.Errorf("Failed to get node topology for node %s: %s", srcNodeName, err)
+	}
+	availableEndpoints := newEmptyAddressSet()
+
+	filteredSnapshot := newEmptyAddressSet()
+
+	return &endpointTranslator{
+		controllerNS,
+		identityTrustDomain,
+		enableH2Upgrade,
+		nodeTopologyLabels,
+		availableEndpoints,
+		filteredSnapshot,
+		stream,
+		log,
+	}
 }
 
 func (et *endpointTranslator) Add(set watcher.AddressSet) {
+	for id, address := range set.Addresses {
+		et.availableEndpoints.Addresses[id] = address
+	}
+
+	if len(set.TopologicalPref) == 0 {
+		if len(set.Addresses) > 0 {
+			et.sendClientAdd(set)
+		} else {
+			// when the set is empty it means we receive a topology pref update
+			// in this case, the Add set is empty, so send all avail endpoints
+			// that have not yet been sent
+			add, _ := et.diffEndpoints(et.availableEndpoints)
+			et.sendClientAdd(add)
+		}
+		return
+	}
+
+	et.availableEndpoints.TopologicalPref = set.TopologicalPref
+
+	et.sendFilteredUpdate()
+}
+
+func (et *endpointTranslator) Remove(set watcher.AddressSet) {
+	for id := range set.Addresses {
+		delete(et.availableEndpoints.Addresses, id)
+	}
+
+	if len(set.TopologicalPref) == 0 {
+		et.sendClientRemove(set)
+		return
+	}
+
+	et.availableEndpoints.TopologicalPref = set.TopologicalPref
+
+	et.sendFilteredUpdate()
+}
+
+func (et *endpointTranslator) sendFilteredUpdate() {
+	filtered := et.filterAddresses()
+	diffAdd, diffRemove := et.diffEndpoints(filtered)
+
+	if len(diffAdd.Addresses) > 0 {
+		et.sendClientAdd(diffAdd)
+	}
+	if len(diffRemove.Addresses) > 0 {
+		et.sendClientRemove(diffRemove)
+	}
+
+	et.filteredSnapshot = filtered
+}
+
+// filterAddresses is responsible for filtering endpoints based on service topology preference.
+// The client will receive only endpoints with the same topology label value as the source node,
+// the order of labels is based on the topological preference elicited from the K8s service.
+func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
+	et.log.Debugf("Filtering through address set with preference %v", et.availableEndpoints.TopologicalPref)
+	filtered := make(map[watcher.ID]watcher.Address)
+	for _, pref := range et.availableEndpoints.TopologicalPref {
+		// '*' as a topology preference means all endpoints
+		if pref == "*" {
+			return et.availableEndpoints
+		}
+
+		srcLocality, ok := et.nodeTopologyLabels[pref]
+		if !ok {
+			continue
+		}
+
+		for id, address := range et.availableEndpoints.Addresses {
+			addrLocality := address.TopologyLabels[pref]
+			if addrLocality == srcLocality {
+				filtered[id] = address
+			}
+		}
+
+		// if we filtered at least one endpoint, it means that preference has been satisfied
+		if len(filtered) > 0 {
+			et.log.Debugf("Filtered %d from a total of %d", len(filtered), len(et.availableEndpoints.Addresses))
+			return watcher.AddressSet{
+				Addresses: filtered,
+				Labels:    et.availableEndpoints.Labels,
+			}
+		}
+	}
+
+	// if we have no filtered endpoints or the '*' preference then no topology pref is satisfied
+	return newEmptyAddressSet()
+}
+
+// diffEndpoints calculates the difference between the filtered set of endpoints in the current (Add/Remove) operation
+// and the snapshot of previously filtered endpoints. This diff allows the client to receive only the endpoints that
+// satisfy the topological preference, by adding new endpoints and removing stale ones.
+func (et *endpointTranslator) diffEndpoints(filtered watcher.AddressSet) (watcher.AddressSet, watcher.AddressSet) {
+	add := make(map[watcher.ID]watcher.Address)
+	remove := make(map[watcher.ID]watcher.Address)
+
+	for id, address := range filtered.Addresses {
+		if _, ok := et.filteredSnapshot.Addresses[id]; !ok {
+			add[id] = address
+		}
+	}
+
+	for id, address := range et.filteredSnapshot.Addresses {
+		if _, ok := filtered.Addresses[id]; !ok {
+			remove[id] = address
+		}
+	}
+
+	return watcher.AddressSet{
+			Addresses: add,
+		},
+		watcher.AddressSet{
+			Addresses: remove,
+		}
+}
+
+func (et *endpointTranslator) NoEndpoints(exists bool) {
+	et.log.Debugf("NoEndpoints(%+v)", exists)
+
+	u := &pb.Update{
+		Update: &pb.Update_NoEndpoints{
+			NoEndpoints: &pb.NoEndpoints{
+				Exists: exists,
+			},
+		},
+	}
+
+	et.log.Debugf("Sending destination no endpoints: %+v", u)
+	if err := et.stream.Send(u); err != nil {
+		et.log.Errorf("Failed to send address update: %s", err)
+	}
+}
+
+func (et *endpointTranslator) sendClientAdd(set watcher.AddressSet) {
 	addrs := []*pb.WeightedAddr{}
 	for _, address := range set.Addresses {
 		var (
@@ -103,7 +263,7 @@ func (et *endpointTranslator) Add(set watcher.AddressSet) {
 	}
 }
 
-func (et *endpointTranslator) Remove(set watcher.AddressSet) {
+func (et *endpointTranslator) sendClientRemove(set watcher.AddressSet) {
 	addrs := []*net.TcpAddress{}
 	for _, address := range set.Addresses {
 		tcpAddr, err := et.toAddr(address)
@@ -122,23 +282,6 @@ func (et *endpointTranslator) Remove(set watcher.AddressSet) {
 
 	et.log.Debugf("Sending destination remove: %+v", remove)
 	if err := et.stream.Send(remove); err != nil {
-		et.log.Errorf("Failed to send address update: %s", err)
-	}
-}
-
-func (et *endpointTranslator) NoEndpoints(exists bool) {
-	et.log.Debugf("NoEndpoints(%+v)", exists)
-
-	u := &pb.Update{
-		Update: &pb.Update_NoEndpoints{
-			NoEndpoints: &pb.NoEndpoints{
-				Exists: exists,
-			},
-		},
-	}
-
-	et.log.Debugf("Sending destination no endpoints: %+v", u)
-	if err := et.stream.Send(u); err != nil {
 		et.log.Errorf("Failed to send address update: %s", err)
 	}
 }
@@ -202,4 +345,30 @@ func (et *endpointTranslator) toWeightedAddr(address watcher.Address) (*pb.Weigh
 		TlsIdentity:  identity,
 		ProtocolHint: hint,
 	}, nil
+}
+
+func getK8sNodeTopology(k8sClient kubernetes.Interface, srcNode string) (map[string]string, error) {
+	nodeTopology := make(map[string]string)
+	node, err := k8sClient.CoreV1().Nodes().Get(srcNode, metav1.GetOptions{})
+	if err != nil {
+		return nodeTopology, err
+	}
+
+	for k, v := range node.Labels {
+		if k == corev1.LabelHostname ||
+			k == corev1.LabelZoneFailureDomainStable ||
+			k == corev1.LabelZoneRegionStable {
+			nodeTopology[k] = v
+		}
+	}
+
+	return nodeTopology, nil
+}
+
+func newEmptyAddressSet() watcher.AddressSet {
+	return watcher.AddressSet{
+		Addresses:       make(map[watcher.ID]watcher.Address),
+		Labels:          make(map[string]string),
+		TopologicalPref: []string{},
+	}
 }

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -30,6 +30,7 @@ type (
 		identityTrustDomain string
 		clusterDomain       string
 
+		k8sAPI   *k8s.API
 		log      *logging.Entry
 		shutdown <-chan struct{}
 	}
@@ -75,6 +76,7 @@ func NewServer(
 		controllerNS,
 		identityTrustDomain,
 		clusterDomain,
+		k8sAPI,
 		log,
 		shutdown,
 	}
@@ -93,11 +95,19 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 	}
 	log.Debugf("Get %s", dest.GetPath())
 
+	var token contextToken
+	if dest.GetContextToken() != "" {
+		token = s.parseContextToken(dest.GetContextToken())
+		log.Debugf("Dest token: %v", token)
+	}
+
 	translator := newEndpointTranslator(
 		s.controllerNS,
 		s.identityTrustDomain,
 		s.enableH2Upgrade,
 		dest.GetPath(),
+		token.NodeName,
+		s.k8sAPI.Client,
 		stream,
 		log,
 	)

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -115,6 +115,7 @@ spec:
 		"linkerd",
 		"trust.domain",
 		"mycluster.local",
+		k8sAPI,
 		log,
 		make(<-chan struct{}),
 	}

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -47,12 +47,14 @@ type (
 		OwnerKind         string
 		Identity          string
 		AuthorityOverride string
+		TopologyLabels    map[string]string
 	}
 
 	// AddressSet is a set of Address, indexed by ID.
 	AddressSet struct {
-		Addresses map[ID]Address
-		Labels    map[string]string
+		Addresses       map[ID]Address
+		Labels          map[string]string
+		TopologicalPref []string
 	}
 
 	portAndHostname struct {
@@ -88,7 +90,8 @@ type (
 		k8sAPI               *k8s.API
 		enableEndpointSlices bool
 
-		ports map[portAndHostname]*portPublisher
+		TopologyPref []string
+		ports        map[portAndHostname]*portPublisher
 		// All access to the servicePublisher and its portPublishers is explicitly synchronized by
 		// this mutex.
 		sync.Mutex
@@ -107,6 +110,7 @@ type (
 		log                  *logging.Entry
 		k8sAPI               *k8s.API
 		enableEndpointSlices bool
+		TopologyPref         []string
 
 		exists    bool
 		addresses AddressSet
@@ -393,6 +397,7 @@ func (ew *EndpointsWatcher) getOrNewServicePublisher(id ServiceID) *servicePubli
 				"svc":       id.Name,
 			}),
 			k8sAPI:               ew.k8sAPI,
+			TopologyPref:         make([]string, 0),
 			ports:                make(map[portAndHostname]*portPublisher),
 			enableEndpointSlices: ew.enableEndpointSlices,
 		}
@@ -462,12 +467,23 @@ func (sp *servicePublisher) updateService(newService *corev1.Service) {
 	defer sp.Unlock()
 	sp.log.Debugf("Updating service for %s", sp.id)
 
+	if sp.enableEndpointSlices {
+		sp.TopologyPref = make([]string, len(newService.Spec.TopologyKeys))
+		copy(sp.TopologyPref, newService.Spec.TopologyKeys)
+	}
+
 	for key, port := range sp.ports {
+		if sp.enableEndpointSlices {
+			port.TopologyPref = sp.TopologyPref
+			port.updateTopologyPreference()
+		}
+
 		newTargetPort := getTargetPort(newService, key.port)
 		if newTargetPort != port.targetPort {
 			port.updatePort(newTargetPort)
 		}
 	}
+
 }
 
 func (sp *servicePublisher) subscribe(srcPort Port, hostname string, listener EndpointUpdateListener) {
@@ -528,6 +544,7 @@ func (sp *servicePublisher) newPortPublisher(srcPort Port, hostname string) *por
 		log:                  log,
 		metrics:              endpointsVecs.newEndpointsMetrics(sp.metricsLabels(srcPort, hostname)),
 		enableEndpointSlices: sp.enableEndpointSlices,
+		TopologyPref:         sp.TopologyPref,
 	}
 
 	if port.enableEndpointSlices {
@@ -614,8 +631,9 @@ func (pp *portPublisher) addEndpointSlice(slice *discovery.EndpointSlice) {
 
 func (pp *portPublisher) updateEndpointSlice(oldSlice *discovery.EndpointSlice, newSlice *discovery.EndpointSlice) {
 	updatedAddressSet := AddressSet{
-		Addresses: make(map[ID]Address),
-		Labels:    pp.addresses.Labels,
+		Addresses:       make(map[ID]Address),
+		Labels:          pp.addresses.Labels,
+		TopologicalPref: pp.TopologyPref,
 	}
 
 	for id, address := range pp.addresses.Addresses {
@@ -715,6 +733,11 @@ func (pp *portPublisher) endpointSliceToAddresses(es *discovery.EndpointSlice) A
 				identity := es.Annotations[consts.RemoteGatewayIdentity]
 				address, id := pp.newServiceRefAddress(resolvedPort, IPAddr, serviceID.Name, es.Namespace)
 				address.Identity, address.AuthorityOverride = authorityOverride, identity
+
+				for k, v := range endpoint.Topology {
+					address.TopologyLabels[k] = v
+				}
+
 				addresses[id] = address
 			}
 
@@ -728,14 +751,21 @@ func (pp *portPublisher) endpointSliceToAddresses(es *discovery.EndpointSlice) A
 					pp.log.Errorf("Unable to create new address:%v", err)
 					continue
 				}
+
+				for k, v := range endpoint.Topology {
+					address.TopologyLabels[k] = v
+				}
+
 				addresses[id] = address
 			}
 		}
 
 	}
+
 	return AddressSet{
-		Addresses: addresses,
-		Labels:    metricLabels(es),
+		Addresses:       addresses,
+		Labels:          metricLabels(es),
+		TopologicalPref: pp.TopologyPref,
 	}
 }
 
@@ -773,8 +803,9 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) Addre
 		}
 	}
 	return AddressSet{
-		Addresses: addresses,
-		Labels:    metricLabels(endpoints),
+		Addresses:       addresses,
+		Labels:          metricLabels(endpoints),
+		TopologicalPref: []string{},
 	}
 }
 
@@ -788,7 +819,7 @@ func (pp *portPublisher) newServiceRefAddress(endpointPort Port, endpointIP, ser
 		Namespace: serviceNamespace,
 	}
 
-	return Address{IP: endpointIP, Port: endpointPort}, id
+	return Address{IP: endpointIP, Port: endpointPort, TopologyLabels: make(map[string]string)}, id
 }
 
 func (pp *portPublisher) newPodRefAddress(endpointPort Port, endpointIP, podName, podNamespace string) (Address, PodID, error) {
@@ -802,11 +833,12 @@ func (pp *portPublisher) newPodRefAddress(endpointPort Port, endpointIP, podName
 	}
 	ownerKind, ownerName := pp.k8sAPI.GetOwnerKindAndName(pod, false)
 	addr := Address{
-		IP:        endpointIP,
-		Port:      endpointPort,
-		Pod:       pod,
-		OwnerName: ownerName,
-		OwnerKind: ownerKind,
+		IP:             endpointIP,
+		Port:           endpointPort,
+		Pod:            pod,
+		TopologyLabels: make(map[string]string),
+		OwnerName:      ownerName,
+		OwnerKind:      ownerKind,
 	}
 
 	return addr, id, nil
@@ -867,6 +899,22 @@ func (pp *portPublisher) updatePort(targetPort namedPort) {
 		} else {
 			pp.log.Errorf("Unable to get endpoints during port update: %s", err)
 		}
+	}
+}
+
+// updateTopologyPreference is used when a service's topology preference changes. This method
+// propagates the changes to the portPublisher, the portPublisher's AddressSet and triggers
+// an (empty) update for all of its listeners to reflect the new preference changes.
+func (pp *portPublisher) updateTopologyPreference() {
+	pp.addresses.TopologicalPref = pp.TopologyPref
+
+	updatedAddrSet := AddressSet{
+		Addresses:       make(map[ID]Address),
+		Labels:          make(map[string]string),
+		TopologicalPref: pp.TopologyPref,
+	}
+	for _, listener := range pp.listeners {
+		listener.Add(updatedAddrSet)
 	}
 }
 
@@ -993,13 +1041,15 @@ func diffAddresses(oldAddresses, newAddresses AddressSet) (add, remove AddressSe
 		}
 	}
 	add = AddressSet{
-		Addresses: addAddresses,
-		Labels:    newAddresses.Labels,
+		Addresses:       addAddresses,
+		Labels:          newAddresses.Labels,
+		TopologicalPref: newAddresses.TopologicalPref,
 	}
 	remove = AddressSet{
-		Addresses: removeAddresses,
+		Addresses:       removeAddresses,
+		TopologicalPref: newAddresses.TopologicalPref,
 	}
-	return
+	return add, remove
 }
 
 func getEndpointSliceServiceID(es *discovery.EndpointSlice) (ServiceID, error) {


### PR DESCRIPTION
[Link to RFC](https://github.com/linkerd/rfc/pull/23)
**Updated** (_29 Jul_): Initially, this PR was supposed to be only for adding topology preference to `servicePublisher` and for collecting topology information from slices. However, the PR (now marked as a draft) covers the prioritisation of endpoints for topology-aware service routing.

### What
---
* PR that puts together all past pieces of the puzzle to deliver topology-aware service routing, as specified in the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service-topology/) but with a much better load balancing algorithm and all the coolness of linkerd :) 
* The first piece of this PR is focused on adding topology metadata: topology preference for services and topology `<k,v>` pairs for endpoints.
* The second piece of this PR puts together the new context format and fetching the source node topology metadata in order to allow for endpoints filtering.
* The final part is doing the filtering -- passing all of the metadata to the listener and on every `Add` filtering endpoints based on the topology preference of the service, topology `<k,v>` pairs of endpoints and topology of the source (again `<k,v>` pairs).

### How
---

* **Collecting metadata**:
   -  Services do not have values for topology keys -- the topological keys defined in a service's spec are only there to dictate locality preference for routing; as such, I decided to store them in an array, they will be taken exactly as they are found in the service spec, this ensures we respect the preference order.

   - For EndpointSlices, we are using a map -- an EndpointSlice has locality information in the form of `<k,v>` pair, where the key is a topological key (similar to what's listed in the service) and the value is the locality information -- e.g `hostname: minikube`. For each address we now have a map of topology values which gets populated when we translate the endpoints to an address set. Because normal Endpoints do not have any topology information, we create each address with an empty map which is subsequently populated ONLY for slices in the `endpointSliceToAddressSet` function.

* **Filtering endpoints**:
  - This was a tricky part and filled me with doubts. I think there are a few ways to do this, but this is how I "envisioned" it. First, the `endpoint_translator.go` should be the one to do the filtering; this means that on subscription, we need to feed all of the relevant metadata to the listener. To do this, I created a new function `AddTopologyFilter` as part of the listener interface.

  - To complement the `AddTopologyFilter` function, I created a new `TopologyFilter` struct in `endpoints_watcher.go`. I then embedded this structure in all listeners that implement the interface. The structure holds the source topology (source node), a boolean to tell if slices are activated in case we need to double check (or write tests for the function) and the service preference. We create the filter on Subscription -- we have access to the k8s client here as well as the service, so it's the best point to collect all of this data together. Addresses all have their own topology added to them so they do not have to be collected by the filter.

  - When we add a new set of addresses, we check to see if slices are enabled -- chances are if slices are enabled, service topology might be too. This lets us skip this step if the latest version is not adopted. Prior to sending an `Add` we filter the endpoints -- if the preference is registered by the filter we strictly enforce it, otherwise nothing changes.

And that's pretty much it. 

### Points of concern
---

* I have been thinking about this for a while, I think this architectural choice should work fine but is there any cause of concern when it comes to scaling? What would happen when a cluster has 20 services with 5 EndpointSlices each, would adding extra metadata (topology map) degrade performance? I would appreciate some rigid feedback in this area to figure out if this is the right choice.

* Again, related to the architecture, I am not sure what other ways we have to collect all of the data together other than having a dedicated structure or storing the data in the listener structure. There are a couple of pain points here, we could pass everything as an argument to `Add` but there is no point where we will send an `Add` AND we have access to the k8s client and service in question. We could initialise a client and get all of this data but I find that it will slow everything down. Doing everything in `Subscribe` to me seems to be the simpler and more efficient way, but as always I look forward to finding a better and cleaner way to do this.

 * Finally, I left some scattered comments throughout the PR -- this is intentional, there are alternative concerns over performance or behaviour that I have. Will clean them up when the draft is in a good state, feel free to ignore them or debate them, wanted to show what my reasoning is or ask indirect questions of the reviewer.

 * At the moment, if a service changes its topology, in order for it to be enforced all pods have to be re subscribed (so deleted). This isn't good (?).

### Tests
---

* Testing is not very straightforward so, I'll detail how I tested everything. I'm collating more cases, for now I have just tested the preference is enforced.

* To test this, minikube won't help much -- we need at least two nodes with different hostnames, regions and zones. Kind was the best option for me, since it's bootstrapped with `kubeadm` -- you can label each node as you want on creation so you can test multiple scenarios. You can find my [kind config here](https://gist.github.com/Matei207/ba318acf576703cfd151b41af162dc30).

* Next, I decided to use `emojivoto` as my test services. `web-svc` feeds into `emoji-svc`, so to test topology I edited `emoji deployment`: scaled replicas to 2 (I only used 2 nodes, 3+ kind nodes make my laptop take off) -- there is no need for affinity in this case because Kubernetes will automatically spread for resilience. For 3 nodes, scale to 3 replicas etc. You can use anti affinity to space the pods out if you wish. Next is adding the topological preference to the service, in `emoji-svc` add :
```yaml
topologyKeys:
  - "kubernetes.io/hostname"
  - <other keys>
```

Supported labels are `["kubernetes.io/hostname", "topology.kubernetes.io/region", "topology.kubernetes.io/zone","*"]`

**Note**: `*` has to go last. You can re-edit topologies! To change preference you must first delete the topology and then re-write it. This was the case with me; I edited the service using `kubectl edit` though.

* Final step is get the logs for the destination service, to kick everything into gear I deleted the `web` pod to force re subscriptions. I have added quite a few debug statements so you can observe what's going on -- these will not stay in but it helps to figure what the call trace is like. Make sure you start the controllers with debug log level.


For my test, this is what we get for 2 replicas of `emoji` spread across 2 nodes, and 1 of `web`connecting to a topology of node local:

```
time="2020-07-29T16:11:10Z" level=info msg="Establishing endpoint topology filter with preference: [kubernetes.io/hostname]" addr=":8086" component=endpoints-watcher
time="2020-07-29T16:11:10Z" level=debug msg="Adding topology filter with preference [kubernetes.io/hostname] and node topology map[kubernetes.io/hostname:kind-worker2 topology.kubernetes.io/region:east topology.kubernetes.io/zone:east-1c]" addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:11:10Z" level=debug msg="Filtering through address set with preference [kubernetes.io/hostname]" addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:11:10Z" level=debug msg="Locality [kubernetes.io/hostname]" addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:11:10Z" level=debug msg="Address [10.244.2.29:emoji-7dc976587b-qfgfr]: Topology is map[kubernetes.io/hostname:kind-worker topology.kubernetes.io/region:west topology.kubernetes.io/zone:west-1a] " addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:11:10Z" level=debug msg="Address [10.244.1.29:emoji-7dc976587b-nb2rc]: Topology is map[kubernetes.io/hostname:kind-worker2 topology.kubernetes.io/region:east topology.kubernetes.io/zone:east-1c] " addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:11:10Z" level=debug msg="Filtered 1 from a total of 2" addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster
time="2020-07-29T16:11:10Z" level=debug msg="Sending destination add: add:{addrs:{addr:{ip:{ipv4:183763229}  port:8080}  weight:10000  metric_labels:{key:\"control_plane_ns\"  value:\"linkerd\"}  metric_labels:{key:\"deployment\"  value:\"emoji\"}  metric_labels:{key:\"pod\"  value:\"emoji-7dc976587b-nb2rc\"}  metric_labels:{key:\"pod_template_hash\"  value:\"7dc976587b\"}  metric_labels:{key:\"serviceaccount\"  value:\"emoji\"}  tls_identity:{dns_like_identity:{name:\"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local\"}}  protocol_hint:{h2:{}}}  metric_labels:{key:\"namespace\"  value:\"emojivoto\"}  metric_labels:{key:\"service\"  value:\"emoji-svc\"}}" addr=":8086" component=endpoint-translator remote="127.0.0.1:37800" service="emoji-svc.emojivoto.svc.cluster.local:8080"
```

To show it also works as normal with no pref specified, I edited the svc, deleted the pref, re-started web pod:
```
time="2020-07-29T16:16:41Z" level=info msg="Establishing endpoint topology filter with preference: []" addr=":8086" component=endpoints-watcher
time="2020-07-29T16:16:41Z" level=debug msg="Adding topology filter with preference [] and node topology map[kubernetes.io/hostname:kind-worker2 topology.kubernetes.io/region:east topology.kubernetes.io/zone:east-1c]" addr=":8086" component=endpoint-translator remote="127.0.0.1:47182" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:16:41Z" level=debug msg="Filtering through address set with preference []" addr=":8086" component=endpoint-translator remote="127.0.0.1:47182" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:16:41Z" level=debug msg="Did not filter!" addr=":8086" component=endpoint-translator remote="127.0.0.1:47182" service="emoji-svc.emojivoto.svc.cluster.local:8080"
time="2020-07-29T16:16:41Z" level=debug msg="Sending destination add: add:{addrs:{addr:{ip:{ipv4:183763485}  port:8080}  weight:10000  metric_labels:{key:\"control_plane_ns\"  value:\"linkerd\"}  metric_labels:{key:\"deployment\"  value:\"emoji\"}  metric_labels:{key:\"pod\"  value:\"emoji-7dc976587b-qfgfr\"}  metric_labels:{key:\"pod_template_hash\"  value:\"7dc976587b\"}  metric_labels:{key:\"serviceaccount\"  value:\"emoji\"}  tls_identity:{dns_like_identity:{name:\"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local\"}}  protocol_hint:{h2:{}}}  addrs:{addr:{ip:{ipv4:183763229}  port:8080}  weight:10000  metric_labels:{key:\"control_plane_ns\"  value:\"linkerd\"}  metric_labels:{key:\"deployment\"  value:\"emoji\"}  metric_labels:{key:\"pod\"  value:\"emoji-7dc976587b-nb2rc\"}  metric_labels:{key:\"pod_template_hash\"  value:\"7dc976587b\"}  metric_labels:{key:\"serviceaccount\"  value:\"emoji\"}  tls_identity:{dns_like_identity:{name:\"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local\"}}  protocol_hint:{h2:{}}}  metric_labels:{key:\"namespace\"  value:\"emojivoto\"}  metric_labels:{key:\"service\"  value:\"emoji-svc\"}}" addr=":8086" component=endpoint-translator remote="127.0.0.1:47182" service="emoji-svc.emojivoto.svc.cluster.local:8080"
```