### PR TITLE
Helm chart - linkerd2-collector : enable jaeger receiver

### DIFF
--- a/charts/add-ons/tracing/templates/tracing.yaml
+++ b/charts/add-ons/tracing/templates/tracing.yaml
@@ -20,6 +20,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -51,6 +53,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     {{.Values.global.controllerComponentLabel}}: {{.Values.collector.name}}
 ---
@@ -110,6 +116,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         readinessProbe:
           httpGet:
             path: /

--- a/charts/linkerd2/requirements.lock
+++ b/charts/linkerd2/requirements.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: file://../add-ons/tracing
   version: 0.1.0
 digest: sha256:d2428770ae7d5134c5af6521c78a4c5f95da4c75f21bdea0f74fad6ab6e2e044
-generated: "2020-06-24T11:07:53.924602129Z"
+generated: "2020-07-23T14:47:05.936935407+02:00"

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -2482,6 +2482,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -2513,6 +2515,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     linkerd.io/control-plane-component: linkerd-collector
 ---
@@ -2570,6 +2576,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         readinessProbe:
           httpGet:
             path: /

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -3402,6 +3402,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -3433,6 +3435,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     linkerd.io/control-plane-component: linkerd-collector
 ---
@@ -3490,6 +3496,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         readinessProbe:
           httpGet:
             path: /

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -3350,6 +3350,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -3381,6 +3383,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     linkerd.io/control-plane-component: linkerd-collector
 ---
@@ -3438,6 +3444,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         readinessProbe:
           httpGet:
             path: /

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -3350,6 +3350,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -3381,6 +3383,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     linkerd.io/control-plane-component: overwrite-collector
 ---
@@ -3438,6 +3444,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         readinessProbe:
           httpGet:
             path: /

--- a/test/integration/tracing/testdata/tracing.yaml
+++ b/test/integration/tracing/testdata/tracing.yaml
@@ -54,6 +54,8 @@ data:
         port: 55678
       zipkin:
         port: 9411
+      jaeger:
+        jaeger-thrift-http-port: 14268
     queued-exporters:
       jaeger-all-in-one:
         num-workers: 4
@@ -81,6 +83,10 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
+  - name: jaeger
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
   selector:
     component: oc-collector
 ---
@@ -127,6 +133,7 @@ spec:
         ports:
         - containerPort: 55678
         - containerPort: 9411
+        - containerPort: 14268
         volumeMounts:
         - name: oc-collector-config-vol
           mountPath: /conf


### PR DESCRIPTION
This PR just enable the jaeger receiver in the configmap of linkerd2-collector.

Questions : 
- As the zipkin and opencensus receiver are always enabled, I just enabled also the jaeger receiver. Perhaps this must be an opt-in ?
- I changed the chart version of partials and tracing add-ons, is it the correct way or the version is set by CI as it is for linkerd chart version ?


Fixes #4778

Signed-off-by: Olivier Boudet <o.boudet@gmail.com>
