### PR TITLE
edge-20.7.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## edge-20.7.4
+
+This edge release brings support for EndpointSlices.
+
+* Added fish shell completions to the `linkerd` command (thanks @WLun001!)
+* Enabled the support for EndpointSlices (thanks @Matei207!)
+* Separated prometheus checks and made them runnable only when there the add-on
+  is enabled
+
 ## edge-20.7.3
 
 * Add preliminary support for EndpointSlices which will be usable in future

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 ## edge-20.7.4
 
-This edge release brings support for EndpointSlices.
+This edge release adds support for the new Kubernetes [EndpointSlice] resource
+to the Destination controller. Using the EndpointSlice API is more efficient
+for the Kubernetes control plane than using the Endpoints API. If the cluster
+supports EndpointSlices (a beta feature in Kubernetes 1.17), Linkerd can be
+installed with `--enable-endpoint-slices` flag to use this resource rather
+than the Endpoints API.
 
 * Added fish shell completions to the `linkerd` command (thanks @WLun001!)
 * Enabled the support for EndpointSlices (thanks @Matei207!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,16 +2,17 @@
 
 ## edge-20.7.4
 
-This edge release adds support for the new Kubernetes [EndpointSlice] resource
-to the Destination controller. Using the EndpointSlice API is more efficient
-for the Kubernetes control plane than using the Endpoints API. If the cluster
-supports EndpointSlices (a beta feature in Kubernetes 1.17), Linkerd can be
-installed with `--enable-endpoint-slices` flag to use this resource rather
-than the Endpoints API.
+This edge release adds support for the new Kubernetes
+[EndpointSlice](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)
+resource to the Destination controller. Using the EndpointSlice API is more
+efficient for the Kubernetes control plane than using the Endpoints API. If
+the cluster supports EndpointSlices (a beta feature in Kubernetes 1.17),
+Linkerd can be installed with `--enable-endpoint-slices` flag to use this
+resource rather than the Endpoints API.
 
 * Added fish shell completions to the `linkerd` command (thanks @WLun001!)
 * Enabled the support for EndpointSlices (thanks @Matei207!)
-* Separated prometheus checks and made them runnable only when the add-on
+* Separated Prometheus checks and made them runnable only when the add-on
   is enabled
 
 ## edge-20.7.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ This edge release brings support for EndpointSlices.
 
 * Added fish shell completions to the `linkerd` command (thanks @WLun001!)
 * Enabled the support for EndpointSlices (thanks @Matei207!)
-* Separated prometheus checks and made them runnable only when there the add-on
+* Separated prometheus checks and made them runnable only when the add-on
   is enabled
 
 ## edge-20.7.3


### PR DESCRIPTION
## edge-20.7.4

This edge release adds support for the new Kubernetes [EndpointSlice] resource
to the Destination controller. Using the EndpointSlice API is more efficient
for the Kubernetes control plane than using the Endpoints API. If the cluster
supports EndpointSlices (a beta feature in Kubernetes 1.17), Linkerd can be
installed with `--enable-endpoint-slices` flag to use this resource rather
than the Endpoints API.

* Added fish shell completions to the `linkerd` command (thanks @WLun001!)
* Enabled the support for EndpointSlices (thanks @Matei207!)
* Separated prometheus checks and made them runnable only when the add-on
  is enabled

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>