### PR TITLE
Add support for service-mirror selectors

### DIFF
--- a/cli/cmd/multicluster.go
+++ b/cli/cmd/multicluster.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -25,8 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/helm/pkg/chartutil"
@@ -72,11 +68,7 @@ type (
 		logLevel                string
 		controlPlaneVersion     string
 		dockerRegistry          string
-	}
-
-	exportServiceOptions struct {
-		gatewayNamespace string
-		gatewayName      string
+		selector                string
 	}
 
 	gatewaysOptions struct {
@@ -117,6 +109,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 		dockerRegistry:          defaultDockerRegistry,
 		serviceMirrorRetryLimit: defaults.ServiceMirrorRetryLimit,
 		logLevel:                defaults.LogLevel,
+		selector:                k8s.DefaultExportedServiceSelector,
 	}, nil
 }
 
@@ -561,6 +554,11 @@ func newLinkCommand() *cobra.Command {
 				return err
 			}
 
+			selector, err := metav1.ParseToLabelSelector(opts.selector)
+			if err != nil {
+				return err
+			}
+
 			link := mc.Link{
 				Name:                          opts.clusterName,
 				Namespace:                     opts.namespace,
@@ -572,9 +570,14 @@ func newLinkCommand() *cobra.Command {
 				GatewayPort:                   gatewayPort,
 				GatewayIdentity:               gatewayIdentity,
 				ProbeSpec:                     probeSpec,
+				Selector:                      *selector,
 			}
 
-			linkOut, err := yaml.Marshal(link.ToUnstructured().Object)
+			obj, err := link.ToUnstructured()
+			if err != nil {
+				return err
+			}
+			linkOut, err := yaml.Marshal(obj.Object)
 			if err != nil {
 				return err
 			}
@@ -630,229 +633,7 @@ func newLinkCommand() *cobra.Command {
 	cmd.Flags().Uint32Var(&opts.serviceMirrorRetryLimit, "service-mirror-retry-limit", opts.serviceMirrorRetryLimit, "The number of times a failed update from the target cluster is allowed to be retried")
 	cmd.Flags().StringVar(&opts.logLevel, "log-level", opts.logLevel, "Log level for the Multicluster components")
 	cmd.Flags().StringVar(&opts.dockerRegistry, "registry", opts.dockerRegistry, "Docker registry to pull service mirror controller image from")
-
-	return cmd
-}
-
-type exportReport struct {
-	resourceKind string
-	resourceName string
-	exported     bool
-}
-
-func transform(bytes []byte, gatewayName, gatewayNamespace string) ([]byte, []*exportReport, error) {
-	var metaType metav1.TypeMeta
-
-	if err := yaml.Unmarshal(bytes, &metaType); err != nil {
-		return nil, nil, err
-	}
-
-	if metaType.Kind == "Service" {
-		var service corev1.Service
-		if err := yaml.Unmarshal(bytes, &service); err != nil {
-			return nil, nil, err
-		}
-
-		if service.Annotations == nil {
-			service.Annotations = map[string]string{}
-		}
-		report := &exportReport{
-			resourceKind: strings.ToLower(metaType.Kind),
-			resourceName: service.Name,
-		}
-
-		if service.Labels != nil {
-			if _, isMirroredResource := service.Labels[k8s.MirroredResourceLabel]; isMirroredResource {
-				report.exported = false
-				return bytes, []*exportReport{report}, nil
-			}
-		}
-
-		service.Annotations[k8s.GatewayNameAnnotation] = gatewayName
-		service.Annotations[k8s.GatewayNsAnnotation] = gatewayNamespace
-
-		transformed, err := yaml.Marshal(service)
-
-		if err != nil {
-			return nil, nil, err
-		}
-		report.exported = true
-		return transformed, []*exportReport{report}, nil
-	}
-
-	report := &exportReport{
-		resourceKind: strings.ToLower(metaType.Kind),
-		exported:     false,
-	}
-
-	return bytes, []*exportReport{report}, nil
-}
-
-func generateReport(reports []*exportReport, reportsOut io.Writer) error {
-	unexportedResources := map[string]int{}
-
-	for _, r := range reports {
-		if r.exported {
-			if _, err := reportsOut.Write([]byte(fmt.Sprintf("%s \"%s\" exported\n", r.resourceKind, r.resourceName))); err != nil {
-				return err
-			}
-		} else {
-			if val, ok := unexportedResources[r.resourceKind]; ok {
-				unexportedResources[r.resourceKind] = val + 1
-			} else {
-				unexportedResources[r.resourceKind] = 1
-			}
-		}
-	}
-
-	if len(unexportedResources) > 0 {
-		reportsOut.Write([]byte("\n"))
-		reportsOut.Write([]byte("Number of skipped resources:\n"))
-	}
-
-	for res, num := range unexportedResources {
-		reportsOut.Write([]byte(fmt.Sprintf("%ss: %d\n", res, num)))
-	}
-
-	return nil
-}
-
-func transformList(bytes []byte, gatewayName, gatewayNamespace string) ([]byte, []*exportReport, error) {
-	var sourceList corev1.List
-	if err := yaml.Unmarshal(bytes, &sourceList); err != nil {
-		return nil, nil, err
-	}
-
-	reports := []*exportReport{}
-	items := []runtime.RawExtension{}
-
-	for _, item := range sourceList.Items {
-		result, report, err := transform(item.Raw, gatewayName, gatewayNamespace)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		exported, err := yaml.YAMLToJSON(result)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		items = append(items, runtime.RawExtension{Raw: exported})
-		reports = append(reports, report...)
-	}
-
-	sourceList.Items = items
-	result, err := yaml.Marshal(sourceList)
-	if err != nil {
-		return nil, nil, err
-	}
-	return result, reports, nil
-}
-
-func processExportYaml(in io.Reader, out io.Writer, gatewayName, gatewayNamespace string) ([]*exportReport, error) {
-	reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(in, 4096))
-	var reports []*exportReport
-	// Iterate over all YAML objects in the input
-	for {
-		// Read a single YAML object
-		bytes, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		isList, err := kindIsList(bytes)
-		if err != nil {
-			return nil, err
-		}
-
-		var result []byte
-		var currentReports []*exportReport
-
-		if isList {
-			result, currentReports, err = transformList(bytes, gatewayName, gatewayNamespace)
-
-		} else {
-			result, currentReports, err = transform(bytes, gatewayName, gatewayNamespace)
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		reports = append(reports, currentReports...)
-		out.Write(result)
-		out.Write([]byte("---\n"))
-	}
-
-	return reports, nil
-}
-
-func transformExportInput(inputs []io.Reader, errWriter, outWriter io.Writer, gatewayName, gatewayNamespace string) int {
-	postTransformBuf := &bytes.Buffer{}
-	reportBuf := &bytes.Buffer{}
-	var finalReports []*exportReport
-	for _, input := range inputs {
-		reports, err := processExportYaml(input, postTransformBuf, gatewayName, gatewayNamespace)
-		if err != nil {
-			fmt.Fprintf(errWriter, "Error transforming resources: %v\n", err)
-			return 1
-		}
-		_, err = io.Copy(outWriter, postTransformBuf)
-
-		if err != nil {
-			fmt.Fprintf(errWriter, "Error printing YAML: %v\n", err)
-			return 1
-		}
-
-		finalReports = append(finalReports, reports...)
-	}
-
-	// print error report after yaml output, for better visibility
-	if err := generateReport(finalReports, reportBuf); err != nil {
-		fmt.Fprintf(errWriter, "Error generating reports: %v\n", err)
-		return 1
-	}
-	errWriter.Write([]byte("\n"))
-	io.Copy(errWriter, reportBuf)
-	errWriter.Write([]byte("\n"))
-	return 0
-}
-
-func newExportServiceCommand() *cobra.Command {
-	opts := exportServiceOptions{}
-
-	cmd := &cobra.Command{
-		Use:   "export-service",
-		Short: "Exposes a service to be mirrored",
-		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if len(args) < 1 {
-				return fmt.Errorf("please specify a kubernetes resource file")
-			}
-
-			if opts.gatewayName == "" {
-				return errors.New("The --gateway-name flag needs to be set")
-			}
-
-			if opts.gatewayNamespace == "" {
-				return errors.New("The --gateway-namespace flag needs to be set")
-			}
-
-			in, err := read(args[0])
-			if err != nil {
-				return err
-			}
-			exitCode := transformExportInput(in, stderr, stdout, opts.gatewayName, opts.gatewayNamespace)
-			os.Exit(exitCode)
-			return nil
-		},
-	}
-
-	cmd.Flags().StringVar(&opts.gatewayName, "gateway-name", "linkerd-gateway", "the name of the gateway")
-	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", defaultMulticlusterNamespace, "the namespace of the gateway")
+	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
 
 	return cmd
 }
@@ -870,24 +651,14 @@ This command provides subcommands to manage the multicluster support
 functionality of Linkerd. You can use it to install the service mirror
 components on a cluster, manage credentials and link clusters together.`,
 		Example: `  # Install multicluster addons.
-  linkerd --context=cluster-a cluster install | kubectl --context=cluster-a apply -f -
+  linkerd --context=cluster-a multicluster install | kubectl --context=cluster-a apply -f -
 
   # Extract mirroring cluster credentials from cluster A and install them on cluster B
-  linkerd --context=cluster-a cluster link --cluster-name=target | kubectl apply --context=cluster-b -f -
-
-  # Export services from cluster to be available to other clusters
-  kubectl get svc -o yaml | linkerd export-service - | kubectl apply -f -
-
-  # Exporting a file from a remote URL
-  linkerd export-service http://url.to/yml | kubectl apply -f -
-
-  # Exporting all the resources inside a folder and its sub-folders.
-  linkerd export-service  <folder> | kubectl apply -f -`,
+  linkerd --context=cluster-a multicluster link --cluster-name=target | kubectl apply --context=cluster-b -f -`,
 	}
 
 	multiclusterCmd.AddCommand(newLinkCommand())
 	multiclusterCmd.AddCommand(newMulticlusterInstallCommand())
-	multiclusterCmd.AddCommand(newExportServiceCommand())
 	multiclusterCmd.AddCommand(newGatewaysCommand())
 	multiclusterCmd.AddCommand(newAllowCommand())
 	return multiclusterCmd

--- a/cli/cmd/multicluster.go
+++ b/cli/cmd/multicluster.go
@@ -510,11 +510,6 @@ func newLinkCommand() *cobra.Command {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("cluster-credentials-%s", opts.clusterName),
 					Namespace: opts.namespace,
-					Annotations: map[string]string{
-						k8s.RemoteClusterNameLabel:                  opts.clusterName,
-						k8s.RemoteClusterDomainAnnotation:           configMap.Global.ClusterDomain,
-						k8s.RemoteClusterLinkerdNamespaceAnnotation: controlPlaneNamespace,
-					},
 				},
 				Data: map[string][]byte{
 					k8s.ConfigKeyName: kubeconfig,

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -25,8 +25,6 @@ const (
 	// metrics labels
 	service                = "service"
 	namespace              = "namespace"
-	targetGatewayNamespace = "target_gateway_namespace"
-	targetGateway          = "target_gateway"
 	targetCluster          = "target_cluster"
 	targetService          = "target_service"
 	targetServiceNamespace = "target_service_namespace"
@@ -669,16 +667,12 @@ func metricLabels(resource interface{}) map[string]string {
 
 	labels := map[string]string{service: serviceName, namespace: ns}
 
-	gateway, hasRemoteGateway := resLabels[consts.RemoteGatewayNameLabel]
-	gatewayNs, hasRemoteGatwayNs := resLabels[consts.RemoteGatewayNsLabel]
 	remoteClusterName, hasRemoteClusterName := resLabels[consts.RemoteClusterNameLabel]
 	serviceFqn, hasServiceFqn := resAnnotations[consts.RemoteServiceFqName]
 
-	if hasRemoteGateway && hasRemoteGatwayNs && hasRemoteClusterName && hasServiceFqn {
+	if hasRemoteClusterName && hasServiceFqn {
 		// this means we are looking at Endpoints created for the purpose of mirroring
 		// an out of cluster service.
-		labels[targetGatewayNamespace] = gatewayNs
-		labels[targetGateway] = gateway
 		labels[targetCluster] = remoteClusterName
 
 		fqParts := strings.Split(serviceFqn, ".")

--- a/controller/cmd/service-mirror/cluster_watcher_test_util.go
+++ b/controller/cmd/service-mirror/cluster_watcher_test_util.go
@@ -511,10 +511,9 @@ func gateway(name, namespace, resourceVersion, ip, hostname, portName string, po
 			Namespace:       namespace,
 			ResourceVersion: resourceVersion,
 			Annotations: map[string]string{
-				consts.GatewayIdentity:               identity,
-				consts.GatewayProbePath:              probePath,
-				consts.GatewayProbePeriod:            fmt.Sprint(probePeriod),
-				consts.MulticlusterGatewayAnnotation: "true",
+				consts.GatewayIdentity:    identity,
+				consts.GatewayProbePath:   probePath,
+				consts.GatewayProbePeriod: fmt.Sprint(probePeriod),
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/controller/cmd/service-mirror/main.go
+++ b/controller/cmd/service-mirror/main.go
@@ -114,7 +114,7 @@ func Main(args []string) {
 	}
 }
 
-func loadCredentials(link multicluster.Link, namespace string, k8sAPI *k8s.KubernetesAPI) (*servicemirror.WatchedClusterConfig, error) {
+func loadCredentials(link multicluster.Link, namespace string, k8sAPI *k8s.KubernetesAPI) ([]byte, error) {
 	// Load the credentials secret
 	secret, err := k8sAPI.Interface.CoreV1().Secrets(namespace).Get(link.ClusterCredentialsSecret, metav1.GetOptions{})
 	if err != nil {
@@ -126,7 +126,7 @@ func loadCredentials(link multicluster.Link, namespace string, k8sAPI *k8s.Kuber
 func restartClusterWatcher(
 	link multicluster.Link,
 	namespace string,
-	creds *servicemirror.WatchedClusterConfig,
+	creds []byte,
 	controllerK8sAPI *controllerK8s.API,
 	requeueLimit int,
 	repairPeriod time.Duration,
@@ -139,7 +139,7 @@ func restartClusterWatcher(
 		probeWorker.Stop()
 	}
 
-	cfg, err := clientcmd.RESTConfigFromKubeConfig(creds.APIConfig)
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(creds)
 	if err != nil {
 		log.Errorf("Unable to parse kube config: %s", err)
 		return

--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -302,15 +302,15 @@ func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
 			continue
 		}
 
-		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config.APIConfig)
+		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
 
 		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, requestTimeout)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
 
@@ -328,7 +328,7 @@ func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
 		}
 
 		if err := comparePermissions(expectedServiceMirrorRemoteClusterPolicyVerbs, verbs); err != nil {
-			errors = append(errors, fmt.Errorf("* cluster: [%s]: Insufficient Service permissions: %s", config.ClusterName, err))
+			errors = append(errors, fmt.Errorf("* cluster: [%s]: Insufficient Service permissions: %s", link.TargetClusterName, err))
 		}
 
 		links = append(links, fmt.Sprintf("\t* %s", link.TargetClusterName))
@@ -366,15 +366,15 @@ func (hc *HealthChecker) checkRemoteClusterAnchors() error {
 			continue
 		}
 
-		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config.APIConfig)
+		clientConfig, err := clientcmd.RESTConfigFromKubeConfig(config)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
 
 		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, requestTimeout)
 		if err != nil {
-			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, config.ClusterName, err))
+			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
 
@@ -506,7 +506,7 @@ func (hc *HealthChecker) checkIfMirrorServicesHaveEndpoints() error {
 		// Check if there is a relevant end-point
 		endpoint, err := hc.kubeAPI.CoreV1().Endpoints(svc.Namespace).Get(svc.Name, metav1.GetOptions{})
 		if err != nil || len(endpoint.Subsets) == 0 {
-			servicesWithNoEndpoints = append(servicesWithNoEndpoints, fmt.Sprintf("%s.%s mirrored from cluster [%s] (gateway: [%s/%s])", svc.Name, svc.Namespace, svc.Labels[k8s.RemoteClusterNameLabel], svc.Labels[k8s.RemoteGatewayNsLabel], svc.Labels[k8s.RemoteGatewayNameLabel]))
+			servicesWithNoEndpoints = append(servicesWithNoEndpoints, fmt.Sprintf("%s.%s mirrored from cluster [%s]", svc.Name, svc.Namespace, svc.Labels[k8s.RemoteClusterNameLabel]))
 		}
 	}
 

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -376,15 +376,9 @@ const (
 	// the access information for remote clusters.
 	MirrorSecretType = SvcMirrorPrefix + "/remote-kubeconfig"
 
+	// DefaultExportedServiceSelector is the default label selector for exported
+	// services.
 	DefaultExportedServiceSelector = SvcMirrorPrefix + "/exported"
-
-	// RemoteGatewayNameLabel is same as GatewayNameAnnotation but on the local,
-	// mirrored service. It's used for quick querying when we want to figure out
-	// the services that are being associated with a certain gateway
-	RemoteGatewayNameLabel = SvcMirrorPrefix + "/remote-gateway-name"
-
-	// RemoteGatewayNsLabel follows the same kind of logic as RemoteGatewayNameLabel
-	RemoteGatewayNsLabel = SvcMirrorPrefix + "/remote-gateway-ns"
 
 	// MirroredResourceLabel indicates that this resource is the result
 	// of a mirroring operation (can be a namespace or a service)
@@ -393,34 +387,9 @@ const (
 	// MirroredGatewayLabel indicates that this is a mirrored gateway
 	MirroredGatewayLabel = SvcMirrorPrefix + "/mirrored-gateway"
 
-	// MirroredGatewayProbePeriod specifies the probe period for the gateway mirror
-	MirroredGatewayProbePeriod = SvcMirrorPrefix + "/mirrored-gateway-probe-period"
-
-	// MirroredGatewayProbePath specifies the probe path for the gateway mirror
-	MirroredGatewayProbePath = SvcMirrorPrefix + "/mirrored-gateway-probe-path"
-
-	// MirroredGatewayRemoteName specifies the name of the remote gateway that has been mirrored
-	MirroredGatewayRemoteName = SvcMirrorPrefix + "/mirrored-gateway-remote-name"
-
-	// MirroredGatewayRemoteNameSpace specifies the namespace of the remote gateway that has been mirrored
-	MirroredGatewayRemoteNameSpace = SvcMirrorPrefix + "/mirrored-gateway-remote-namespace"
-
-	// MulticlusterGatewayAnnotation indicates that this service is a
-	// gateway
-	MulticlusterGatewayAnnotation = SvcMirrorPrefix + "/multicluster-gateway"
-
 	// RemoteClusterNameLabel put on a local mirrored service, it
 	// allows us to associate a mirrored service with a remote cluster
 	RemoteClusterNameLabel = SvcMirrorPrefix + "/cluster-name"
-
-	// RemoteClusterDomainAnnotation is present on the secret
-	// carrying the config of the remote cluster, to allow for
-	// using custom cluster domains
-	RemoteClusterDomainAnnotation = SvcMirrorPrefix + "/remote-cluster-domain"
-
-	// RemoteClusterLinkerdNamespaceAnnotation is present on the secret
-	// carrying the config of the remote cluster
-	RemoteClusterLinkerdNamespaceAnnotation = SvcMirrorPrefix + "/remote-cluster-l5d-ns"
 
 	// RemoteResourceVersionAnnotation is the last observed remote resource
 	// version of a mirrored resource. Useful when doing updates

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -376,18 +376,12 @@ const (
 	// the access information for remote clusters.
 	MirrorSecretType = SvcMirrorPrefix + "/remote-kubeconfig"
 
-	// GatewayNameAnnotation is the annotation that is present on the remote
-	// service, indicating which gateway is supposed to route traffic to it
-	GatewayNameAnnotation = SvcMirrorPrefix + "/gateway-name"
+	DefaultExportedServiceSelector = SvcMirrorPrefix + "/exported"
 
 	// RemoteGatewayNameLabel is same as GatewayNameAnnotation but on the local,
 	// mirrored service. It's used for quick querying when we want to figure out
 	// the services that are being associated with a certain gateway
 	RemoteGatewayNameLabel = SvcMirrorPrefix + "/remote-gateway-name"
-
-	// GatewayNsAnnotation is present on the remote service, indicating the ns
-	// in which we can find the gateway
-	GatewayNsAnnotation = SvcMirrorPrefix + "/gateway-ns"
 
 	// RemoteGatewayNsLabel follows the same kind of logic as RemoteGatewayNameLabel
 	RemoteGatewayNsLabel = SvcMirrorPrefix + "/remote-gateway-ns"

--- a/pkg/servicemirror/util.go
+++ b/pkg/servicemirror/util.go
@@ -7,39 +7,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// WatchedClusterConfig contains the needed data to identify a remote cluster
-type WatchedClusterConfig struct {
-	APIConfig        []byte
-	ClusterName      string
-	ClusterDomain    string
-	LinkerdNamespace string
-}
-
 // ParseRemoteClusterSecret extracts the credentials used to access the remote cluster
-func ParseRemoteClusterSecret(secret *corev1.Secret) (*WatchedClusterConfig, error) {
-	clusterName, hasClusterName := secret.Annotations[consts.RemoteClusterNameLabel]
+func ParseRemoteClusterSecret(secret *corev1.Secret) ([]byte, error) {
 	config, hasConfig := secret.Data[consts.ConfigKeyName]
-	domain, hasDomain := secret.Annotations[consts.RemoteClusterDomainAnnotation]
-	l5dNamespace, hasL5dNamespace := secret.Annotations[consts.RemoteClusterLinkerdNamespaceAnnotation]
 
-	if !hasClusterName {
-		return nil, fmt.Errorf("secret of type %s should contain key %s", consts.MirrorSecretType, consts.ConfigKeyName)
-	}
 	if !hasConfig {
 		return nil, fmt.Errorf("secret should contain target cluster name as annotation %s", consts.RemoteClusterNameLabel)
 	}
-	if !hasDomain {
-		return nil, fmt.Errorf("secret should contain target cluster domain as annotation %s", consts.RemoteClusterDomainAnnotation)
-	}
 
-	if !hasL5dNamespace {
-		return nil, fmt.Errorf("secret should contain target cluster linkerd installation namespace as annotation %s", consts.RemoteClusterLinkerdNamespaceAnnotation)
-	}
-
-	return &WatchedClusterConfig{
-		APIConfig:        config,
-		ClusterName:      clusterName,
-		ClusterDomain:    domain,
-		LinkerdNamespace: l5dNamespace,
-	}, nil
+	return config, nil
 }


### PR DESCRIPTION
Fixes #4481 

We add support for the source cluster to now specify which services from the target cluster should be exported by using a 
label selector rather than looking for the `mirror.linkerd.io/gateway` and `mirror.linkerd.io/gateway-ns` annotations.  Further context for this change is described in https://github.com/linkerd/rfc/pull/31

The `Link` resource spec now has a `selector` field which contains a [label selector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta).  All services in the target cluster which match this selector will be mirrored.  This selector can be set by using the `--selector` flag to the `multicluster link` command and follows the same format as the `--selector` flag does in kubectl.  The selector can alternatively be set by editing the Link resource directly.  If the selector flag to `multicluster link` is left unspecified, it defaults to the selector: `mirror.linkerd.io/exported`.

Some example usage:

1. Using the default selector:

```
linkerd --context=target multicluster link --cluster-name=foo | kubectl --context=source apply -f -
kubectl --context=target -n emojivoto label svc/web-svc mirror.linkerd.io/exported=true
# the web-svc service is now mirrored to the source cluster
```

2. Using a custom selector

```
linkerd --context=target multicluster link --cluster-name=foo -l exportme=please | kubectl --context=source apply -f -
kubectl --context=target -n emojivoto label svc/web-svc exportme=please
# the web-svc service is now mirrored to the source cluster
```