### PR TITLE
conformance validation: move `tap_test.go` test helpers to `testutil`

### DIFF
--- a/test/integration/tap/tap_test.go
+++ b/test/integration/tap/tap_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
 )

--- a/testutil/tap.go
+++ b/testutil/tap.go
@@ -1,0 +1,89 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TapEvent represents a tap event
+type TapEvent struct {
+	Method     string
+	Authority  string
+	Path       string
+	HTTPStatus string
+	GrpcStatus string
+	TLS        string
+	LineCount  int
+}
+
+// Tap executes a tap command and converts the command's streaming output into tap
+// events using each line's "id" field
+func Tap(target string, h *TestHelper, arg ...string) ([]*TapEvent, error) {
+	cmd := append([]string{"tap", target}, arg...)
+	outputStream, err := h.LinkerdRunStream(cmd...)
+	if err != nil {
+		return nil, err
+	}
+	defer outputStream.Stop()
+
+	outputLines, err := outputStream.ReadUntil(10, 1*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+
+	tapEventByID := make(map[string]*TapEvent)
+	for _, line := range outputLines {
+		fields := toFieldMap(line)
+		obj, ok := tapEventByID[fields["id"]]
+		if !ok {
+			obj = &TapEvent{}
+			tapEventByID[fields["id"]] = obj
+		}
+		obj.LineCount++
+		obj.TLS = fields["tls"]
+
+		switch fields["type"] {
+		case "req":
+			obj.Method = fields[":method"]
+			obj.Authority = fields[":authority"]
+			obj.Path = fields[":path"]
+		case "rsp":
+			obj.HTTPStatus = fields[":status"]
+		case "end":
+			obj.GrpcStatus = fields["grpc-status"]
+		}
+	}
+
+	output := make([]*TapEvent, 0)
+	for _, obj := range tapEventByID {
+		if obj.LineCount == 3 { // filter out incomplete events
+			output = append(output, obj)
+		}
+	}
+
+	return output, nil
+}
+
+func toFieldMap(line string) map[string]string {
+	fields := strings.Fields(line)
+	fieldMap := map[string]string{"type": fields[0]}
+	for _, field := range fields[1:] {
+		parts := strings.SplitN(field, "=", 2)
+		fieldMap[parts[0]] = parts[1]
+	}
+	return fieldMap
+}
+
+// ValidateExpected compares the recieved tap event with the expected tap event
+func ValidateExpected(events []*TapEvent, expectedEvent TapEvent) error {
+	if len(events) == 0 {
+		return fmt.Errorf("Expected tap events, got nothing")
+	}
+	for _, event := range events {
+		if *event != expectedEvent {
+			return fmt.Errorf("Unexpected tap event [%+v]; expected=[%+v]", *event, expectedEvent)
+		}
+	}
+	return nil
+}

--- a/testutil/tap.go
+++ b/testutil/tap.go
@@ -75,7 +75,7 @@ func toFieldMap(line string) map[string]string {
 	return fieldMap
 }
 
-// ValidateExpected compares the recieved tap event with the expected tap event
+// ValidateExpected compares the received tap event with the expected tap event
 func ValidateExpected(events []*TapEvent, expectedEvent TapEvent) error {
 	if len(events) == 0 {
 		return fmt.Errorf("Expected tap events, got nothing")


### PR DESCRIPTION
The `tap` integration tests currently make use of 2 useful helper functions - `validateExpected` and `tap`, and struct `tapEvent`. This PR moves these into the `testutil` package so that they can be reused for [conformance validation](https://github.com/linkerd/linkerd2-conformance) and to ensure consistency between the 2 repos.

- move `tap` to `testutil.Tap`
- move `validateExpected` to `testutil.ValidateExpected`
- move struct `tapEvent` to `testutil.TapEvent`

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

Cc: @Pothulapati @ihcsim @alpeb 
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
