### PR TITLE
Fix up multicluster component labels

### DIFF
--- a/charts/linkerd2-multicluster-link/templates/service-mirror.yaml
+++ b/charts/linkerd2-multicluster-link/templates/service-mirror.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+    {{.Values.controllerComponentLabel}}: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
 - apiGroups: [""]
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+    {{.Values.controllerComponentLabel}}: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -36,7 +36,7 @@ metadata:
   name: linkerd-service-mirror-read-remote-creds-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}
   labels:
-      {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+      {{.Values.controllerComponentLabel}}: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
   - apiGroups: [""]
@@ -53,7 +53,7 @@ metadata:
   name: linkerd-service-mirror-read-remote-creds-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}
   labels:
-      {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+      {{.Values.controllerComponentLabel}}: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -70,14 +70,14 @@ metadata:
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+    {{.Values.controllerComponentLabel}}: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{.Values.controllerComponentLabel}}: linkerd-service-mirror
+    {{.Values.controllerComponentLabel}}: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}

--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{.Values.gatewayName}}-config
+  labels:
+    {{.Values.controllerComponentLabel}}: gateway
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
   namespace: {{.Values.namespace}}
@@ -54,6 +56,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
+    {{.Values.controllerComponentLabel}}: gateway
     app: {{.Values.gatewayName}}
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
@@ -117,6 +120,7 @@ metadata:
     mirror.linkerd.io/probe-period: "{{.Values.gatewayProbeSeconds}}"
     mirror.linkerd.io/probe-path: {{.Values.gatewayProbePath}}
     mirror.linkerd.io/multicluster-gateway: "true"
+    {{.Values.controllerComponentLabel}}: gateway
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:
   ports:

--- a/charts/linkerd2-multicluster/values.yaml
+++ b/charts/linkerd2-multicluster/values.yaml
@@ -1,3 +1,4 @@
+controllerComponentLabel: linkerd.io/control-plane-component
 createdByAnnotation: linkerd.io/created-by
 gateway: true
 gatewayLocalProbePath: /health-local


### PR DESCRIPTION
Fixes #4511

Add the `linkerd.io/control-plane-component: gateway` label to the multicluster gateway.  Change the value of `linkerd.io/control-plane-component` from `linkerd-service-mirror` to `service-mirror` for the service mirror controller.

These changes are for consistency and should not result in any change in functionality.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
