### PR TITLE
Turn on multicluster checks when --multicluster flag is used

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -207,6 +207,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 		RetryDeadline:         time.Now().Add(options.wait),
 		CNIEnabled:            options.cniEnabled,
 		InstallManifest:       installManifest,
+		MultiCluster:          options.multicluster,
 	})
 
 	success := runChecks(wout, werr, hc, options.output)


### PR DESCRIPTION
When the Link CRD does not exist, multicluster checks in `linkerd check` will be skipped.  The `--multicluster` flag is intended to force these checks on, but was being ignored.

We update the options to force the multicluster checks on when the `--multicluster` flag is used, as intended.

Now when `linkerd check --multicluster` is run on a cluster without the multicluster support installed, it gives the following output:

```
linkerd-multicluster
--------------------
× Link CRD exists
    multicluster.linkerd.io/Link CRD is missing: the server could not find the requested resource
    see https://linkerd.io/checks/#l5d-multicluster-link-crd-exists for hints

Status check results are ×
```

Signed-off-by: Alex Leong <alex@buoyant.io>

