### PR TITLE
Move multicluster API connectivity checks earlier

### DIFF
--- a/controller/cmd/service-mirror/cluster_watcher.go
+++ b/controller/cmd/service-mirror/cluster_watcher.go
@@ -130,6 +130,11 @@ func NewRemoteClusterServiceWatcher(
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize api for target cluster %s: %s", clusterName, err)
 	}
+	_, err = remoteAPI.Client.Discovery().ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to api for target cluster %s: %s", clusterName, err)
+	}
+
 	stopper := make(chan struct{})
 	return &RemoteClusterServiceWatcher{
 		serviceMirrorNamespace: serviceMirrorNamespace,

--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/linkerd/linkerd2/controller/gen/public"
@@ -29,12 +28,6 @@ const (
 	linkerdServiceMirrorClusterRoleName    = "linkerd-service-mirror-access-local-resources-%s"
 	linkerdServiceMirrorRoleName           = "linkerd-service-mirror-read-remote-creds-%s"
 )
-
-var expectedServiceMirrorRemoteClusterPolicyVerbs = []string{
-	"get",
-	"list",
-	"watch",
-}
 
 func (hc *HealthChecker) multiClusterCategory() []category {
 	return []category{
@@ -571,18 +564,4 @@ func joinErrors(errs []error, tabDepth int) error {
 		errStrings = append(errStrings, indent+err.Error())
 	}
 	return errors.New(strings.Join(errStrings, "\n"))
-}
-
-func comparePermissions(expected, actual []string) error {
-	sort.Strings(expected)
-	sort.Strings(actual)
-
-	expectedStr := strings.Join(expected, ",")
-	actualStr := strings.Join(actual, ",")
-
-	if expectedStr != actualStr {
-		return fmt.Errorf("expected %s, got %s", expectedStr, actualStr)
-	}
-
-	return nil
 }

--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -61,6 +61,27 @@ func (hc *HealthChecker) multiClusterCategory() []category {
 						return &SkipError{Reason: "not checking muticluster"}
 					},
 				},
+				/* Target cluster access checks */
+				{
+					description: "remote cluster access credentials are valid",
+					hintAnchor:  "l5d-smc-target-clusters-access",
+					check: func(context.Context) error {
+						if hc.Options.MultiCluster {
+							return hc.checkRemoteClusterConnectivity()
+						}
+						return &SkipError{Reason: "not checking muticluster"}
+					},
+				},
+				{
+					description: "clusters share trust anchors",
+					hintAnchor:  "l5d-multicluster-clusters-share-anchors",
+					check: func(ctx context.Context) error {
+						if hc.Options.MultiCluster {
+							return hc.checkRemoteClusterAnchors()
+						}
+						return &SkipError{Reason: "not checking muticluster"}
+					},
+				},
 				/* Serivce mirror controller checks */
 				{
 					description: "service mirror controller has required permissions",
@@ -80,27 +101,6 @@ func (hc *HealthChecker) multiClusterCategory() []category {
 					check: func(context.Context) error {
 						if hc.Options.MultiCluster {
 							return hc.checkServiceMirrorController()
-						}
-						return &SkipError{Reason: "not checking muticluster"}
-					},
-				},
-				/* Target cluster access checks */
-				{
-					description: "remote cluster access credentials are valid",
-					hintAnchor:  "l5d-smc-target-clusters-access",
-					check: func(context.Context) error {
-						if hc.Options.MultiCluster {
-							return hc.checkRemoteClusterConnectivity()
-						}
-						return &SkipError{Reason: "not checking muticluster"}
-					},
-				},
-				{
-					description: "clusters share trust anchors",
-					hintAnchor:  "l5d-multicluster-clusters-share-anchors",
-					check: func(ctx context.Context) error {
-						if hc.Options.MultiCluster {
-							return hc.checkRemoteClusterAnchors()
 						}
 						return &SkipError{Reason: "not checking muticluster"}
 					},
@@ -314,21 +314,18 @@ func (hc *HealthChecker) checkRemoteClusterConnectivity() error {
 			continue
 		}
 
-		var verbs []string
-		if err := hc.checkCanPerformAction(remoteAPI, "get", corev1.NamespaceAll, "", "v1", "services"); err == nil {
-			verbs = append(verbs, "get")
+		// We use this call just to check connectivity.
+		_, err = remoteAPI.Discovery().ServerVersion()
+		if err != nil {
+			errors = append(errors, fmt.Errorf("* failed to connect to API for cluster: [%s]: %s", link.TargetClusterName, err))
+			continue
 		}
 
-		if err := hc.checkCanPerformAction(remoteAPI, "list", corev1.NamespaceAll, "", "v1", "services"); err == nil {
-			verbs = append(verbs, "list")
-		}
-
-		if err := hc.checkCanPerformAction(remoteAPI, "watch", corev1.NamespaceAll, "", "v1", "services"); err == nil {
-			verbs = append(verbs, "watch")
-		}
-
-		if err := comparePermissions(expectedServiceMirrorRemoteClusterPolicyVerbs, verbs); err != nil {
-			errors = append(errors, fmt.Errorf("* cluster: [%s]: Insufficient Service permissions: %s", link.TargetClusterName, err))
+		verbs := []string{"get", "list", "watch"}
+		for _, verb := range verbs {
+			if err := hc.checkCanPerformAction(remoteAPI, verb, corev1.NamespaceAll, "", "v1", "services"); err != nil {
+				errors = append(errors, fmt.Errorf("* missing service permission [%s] for cluster [%s]: %s", verb, link.TargetClusterName, err))
+			}
 		}
 
 		links = append(links, fmt.Sprintf("\t* %s", link.TargetClusterName))


### PR DESCRIPTION
Fixes #4774

When a service mirror controller is unable to connect to the target cluster's API, the service mirror controller crashes with the error that it has failed to sync caches.  This error lacks the necessary detail to debug the situation.  Unfortunately, client-go does not surface more useful information about why the caches failed to sync.

To make this more debuggable we do a couple things:

1. When creating the target cluster api client, we eagerly issue a server version check to test the connection.  If the connection fails, the service-mirror-controller logs now look like this:

```
time="2020-07-30T23:53:31Z" level=info msg="Got updated link broken: {Name:broken Namespace:linkerd-multicluster TargetClusterName:broken TargetClusterDomain:cluster.local TargetClusterLinkerdNamespace:linkerd ClusterCredentialsSecret:cluster-credentials-broken GatewayAddress:35.230.81.215 GatewayPort:4143 GatewayIdentity:linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local ProbeSpec:ProbeSpec: {path: /health, port: 4181, period: 3s} Selector:{MatchLabels:map[] MatchExpressions:[{Key:mirror.linkerd.io/exported Operator:Exists Values:[]}]}}"
time="2020-07-30T23:54:01Z" level=error msg="Unable to create cluster watcher: cannot connect to api for target cluster remote: Get \"https://36.199.152.138/version?timeout=32s\": dial tcp 36.199.152.138:443: i/o timeout"
```

This error also no longer causes the service mirror controller to crash.  Updating the Link resource will cause the service mirror controller to reload the credentials and try again.

2. We rearrange the checks in `linkerd check --multicluster` to perform the target API connectivity checks before the service mirror controller checks.  This means that we can validate the target cluster API connection even if the service mirror controller is not healthy.  We also add a server version check here to quickly determine if the connection is healthy.  Sample check output:

```
linkerd-multicluster
--------------------
√ Link CRD exists
√ Link resources are valid
	* broken
W0730 16:52:05.620806   36735 transport.go:243] Unable to cancel request for promhttp.RoundTripperFunc
× remote cluster access credentials are valid
            * failed to connect to API for cluster: [broken]: Get "https://36.199.152.138/version?timeout=30s": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
    see https://linkerd.io/checks/#l5d-smc-target-clusters-access for hints

W0730 16:52:35.645499   36735 transport.go:243] Unable to cancel request for promhttp.RoundTripperFunc
× clusters share trust anchors
    Problematic clusters:
    * broken: unable to fetch anchors: Get "https://36.199.152.138/api/v1/namespaces/linkerd/configmaps/linkerd-config?timeout=30s": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
    see https://linkerd.io/checks/#l5d-multicluster-clusters-share-anchors for hints
√ service mirror controller has required permissions
	* broken
√ service mirror controllers are running
	* broken
× all gateway mirrors are healthy
        wrong number of (0) gateway metrics entries for probe-gateway-broken.linkerd-multicluster
    see https://linkerd.io/checks/#l5d-multicluster-gateways-endpoints for hints
√ all mirror services have endpoints
‼ all mirror services are part of a Link
        mirror service voting-svc-gke.emojivoto is not part of any Link
    see https://linkerd.io/checks/#l5d-multicluster-orphaned-services for hints
```

Some logs from the underlying go network libraries sneak into the output which is kinda gross but I don't think it interferes too much with being able to understand what's going on.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
