### PR TITLE
Reenable `upgrade-edge` integration test

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -102,8 +102,7 @@ jobs:
         - helm-deep
         - helm-upgrade
         - uninstall
-        #TO-DO: re-enable upgrade-edge after edge-20-7-5 comes out
-        #- upgrade-edge
+        - upgrade-edge
         - upgrade-stable
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,7 @@ jobs:
         - helm-deep
         - helm-upgrade
         - uninstall
-        #TO-DO: re-enable upgrade-edge after edge-20-7-5 comes out
-        #- upgrade-edge
+        - upgrade-edge
         - upgrade-stable
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -6,9 +6,7 @@ set +e
 
 ##### Test setup helpers #####
 
-# TO-DO: re-enable upgrade-edge after edge-20-7-5 comes out
-#export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
-export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-stable)
+export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
 export all_test_names=(cluster-domain "${default_test_names[*]}")
 
 handle_input() {


### PR DESCRIPTION
Followup to #4797

That test was temporarily disabled until the prometheus check in
`linkerd check` got fixed in #4797 and made it into edge-20.7.5