### PR TITLE
Change log output for failed namespace lookup

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -207,7 +207,8 @@ func getDefaultNamespace() string {
 	ns, _, err := kubeCfg.Namespace()
 
 	if err != nil {
-		log.Errorf("could not set namespace from kubectl context: ensure a valid KUBECONFIG path has been set")
+		log.Warnf("could not set namespace from kubectl context, using 'default' namespace: %s", err)
+		log.Warnf("ensure the KUBECONFIG path %s is valid", kubeconfigPath)
 		return corev1.NamespaceDefault
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -207,8 +207,7 @@ func getDefaultNamespace() string {
 	ns, _, err := kubeCfg.Namespace()
 
 	if err != nil {
-		log.Warnf("could not set namespace from kubectl context, using 'default' namespace: %s", err)
-		log.Warnf("ensure the KUBECONFIG path %s is valid", kubeconfigPath)
+		log.Warnf("could not set namespace from kubectl context, using 'default' namespace: %s\n ensure the KUBECONFIG path %s is valid", err, kubeconfigPath)
 		return corev1.NamespaceDefault
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -207,7 +207,8 @@ func getDefaultNamespace() string {
 	ns, _, err := kubeCfg.Namespace()
 
 	if err != nil {
-		log.Warnf("could not set namespace from kubectl context, using 'default' namespace: %s\n ensure the KUBECONFIG path %s is valid", err, kubeconfigPath)
+		log.Warnf(`could not set namespace from kubectl context, using 'default' namespace: %s
+		 ensure the KUBECONFIG path %s is valid`, err, kubeconfigPath)
 		return corev1.NamespaceDefault
 	}
 


### PR DESCRIPTION
## What
This PR changes the log output when retrieving the namespace from the `kubeconfig` during install and upgrade operations

## Why
As reported in #4818, if an error occurs while retrieving the namespace set for the current context, the error log message that is written doesn't print the underlying error nor does the message indicate that the `default` namespace will be used instead.

## How
Change the log message to `warn` level, print the underlying error from `client-go`, and report that the `default` namespace will be used

Signed-off-by: Charles Pretzer <charles@buoyant.io>