### PR TITLE
Fixes unit tests when default kubeconfig namespace is not "default"

### DIFF
--- a/cli/cmd/stat.go
+++ b/cli/cmd/stat.go
@@ -742,7 +742,7 @@ func (o *statOptions) validateConflictingFlags() error {
 		return fmt.Errorf("--to-namespace and --from-namespace flags are mutually exclusive")
 	}
 
-	if o.allNamespaces && o.namespace != "default" {
+	if o.allNamespaces && o.namespace != defaultNamespace {
 		return fmt.Errorf("--all-namespaces and --namespace flags are mutually exclusive")
 	}
 
@@ -760,9 +760,9 @@ func (o *statOptions) validateNamespaceFlags() error {
 		return fmt.Errorf("--from-namespace flag is incompatible with namespace resource type")
 	}
 
-	// Note: technically, this allows you to say `stat ns --namespace default`, but that
+	// Note: technically, this allows you to say `stat ns --namespace <default-namespace-from-kubectl-context>`, but that
 	// seems like an edge case.
-	if o.namespace != "default" {
+	if o.namespace != defaultNamespace {
 		return fmt.Errorf("--namespace flag is incompatible with namespace resource type")
 	}
 


### PR DESCRIPTION
Unit tests were failing if kubeconfig context namespace was not "default"

Use defaultNamespace from kubeconfig context

Fixes #4779

Signed-off-by: Rajat Jindal <rajatjindal83@gmail.com>