### PR TITLE
Add missing install flag when disableHeartBeat value is set

### DIFF
--- a/charts/linkerd2/templates/_config.tpl
+++ b/charts/linkerd2/templates/_config.tpl
@@ -73,6 +73,10 @@
 {{- define "linkerd.configs.install" -}}
 {
   "cliVersion":"{{ .Values.global.linkerdVersion }}",
-  "flags":[]
+  "flags":[
+  {{- if .Values.disableHeartBeat -}}
+  {"name": "disable-heartbeat", "value": "true"}
+  {{- end -}}
+  ]
 }
 {{- end -}}


### PR DESCRIPTION
Add missing install flag when DisableHeartBeat value is provided

Problem
I am getting the following errors when using helm with `DisableHeartBeat` set to `true`
```
linkerd endpoints <endpoint>
Cannot find Linkerd: missing ServiceAccounts: linkerd-heartbeat
Validate the install with: linkerd check
```
It is also failing `check`.
```
× heartbeat ServiceAccount exist
    missing ServiceAccounts: linkerd-heartbeat
    see https://linkerd.io/checks/#l5d-existence-sa for hints
```
This issue was introduced here:
https://github.com/linkerd/linkerd2/issues/3386
The command was added to the install command, but not included in the helm chart.

Solution is to include it in the helm chart options.

Once merged, it should no longer return the error and return a successful `check` result.

Fixes #4834 

Signed-off-by: Marcus Vaal <mjvaal@gmail.com>