### PR TITLE
Temporarily disable job `psscript-analyzer` in static checks

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -49,22 +49,22 @@ jobs:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
         bin/shellcheck-all
-  psscript-analyzer:
-    name: PSScriptAnalyzer
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Checkout code
+  #psscript-analyzer:
+    #name: PSScriptAnalyzer
+    #runs-on: ubuntu-18.04
+    #steps:
+    #- name: Checkout code
       # actions/checkout@v2
-      uses: actions/checkout@722adc6
-    - name: Chocolatey - lint
+    #  uses: actions/checkout@722adc6
+    #- name: Chocolatey - lint
       # devblackops/github-action-psscriptanalyzer@v2.0.0
-      uses: devblackops/github-action-psscriptanalyzer@889a059
-      env:
+    #  uses: devblackops/github-action-psscriptanalyzer@889a059
+    #  env:
         # https://github.com/devblackops/github-action-psscriptanalyzer/pull/3/files
-        INPUT_FAILONWARNING: 1
-      with:
-        rootPath: bin/win/tools
-        failOnInfos: true
+    #    INPUT_FAILONWARNING: 1
+    #  with:
+    #    rootPath: bin/win/tools
+    #    failOnInfos: true
   markdown_lint:
     name: Markdown lint
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The job started failing consistently today with:
```
##[error]devblackops/github-action-psscriptanalyzer/v2/action.yml (Line:
30, Col: 9): Unexpected value ''
##[error]devblackops/github-action-psscriptanalyzer/v2/action.yml (Line:
30, Col: 9): Unexpected value ''
##[error]System.ArgumentException: Unexpected type 'NullToken'
encountered while reading 'outputs'. The type 'MappingToken' was
expected.
```

It seems it's something in Github that changed today that is clashing
with the `devblackops/github-action-psscriptanalyzer` action.

I've raised devblackops/github-action-psscriptanalyzer#12
