### PR TITLE
Release ARM CLI artifacts

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -80,7 +80,7 @@ jobs:
       id: install_cli
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
-        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux"
+        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
         bin/docker-pull-binaries $TAG
         $CMD version --client
         # validate CLI version matches the repo

--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -137,7 +137,7 @@ jobs:
       run: |
         # Copy the CLI out of the local cli-bin container.
         container_id=$(docker create "$DOCKER_REGISTRY/cli-bin:$TAG")
-        docker cp $container_id:/out/linkerd-linux "$HOME/.linkerd"
+        docker cp $container_id:/out/linkerd-linux-amd64 "$HOME/.linkerd"
 
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
-        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux"
+        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
         echo "::set-env name=CMD::$CMD"
         echo "::set-env name=TAG::$TAG"
     - name: Run integration tests
@@ -163,7 +163,7 @@ jobs:
       id: install_cli
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
-        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux"
+        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
         bin/docker-pull-binaries $TAG
         $CMD version --client
         # validate CLI version matches the repo
@@ -243,6 +243,8 @@ jobs:
       with:
         name: choco
     - name: Pull CLI binaries
+      env:
+        DOCKER_MULTIARCH: 1
       run : |
         bin/docker-pull-binaries $TAG
         VERSION=${TAG#"stable-"}
@@ -260,8 +262,8 @@ jobs:
         files: |
           ./target/release/linkerd2-cli-*-darwin
           ./target/release/linkerd2-cli-*-darwin.sha256
-          ./target/release/linkerd2-cli-*-linux
-          ./target/release/linkerd2-cli-*-linux.sha256
+          ./target/release/linkerd2-cli-*-linux-*
+          ./target/release/linkerd2-cli-*-linux-*.sha256
           ./target/release/linkerd2-cli-*-windows.exe
           ./target/release/linkerd2-cli-*-windows.exe.sha256
           ./target/release/linkerd2-cli-*.nupkg

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -27,7 +27,7 @@ export DOCKER_MULTIARCH=${DOCKER_MULTIARCH:-}
 export DOCKER_PUSH=${DOCKER_PUSH:-}
 
 # Default supported docker image architectures
-export SUPPORTED_ARCHS=linux/amd64,linux/arm64,linux/arm/v7
+export SUPPORTED_ARCHS=${SUPPORTED_ARCHS:-linux/amd64,linux/arm64,linux/arm/v7}
 
 docker_repo() {
     repo=$1

--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -15,14 +15,29 @@ rootdir=$( cd "$bindir"/.. && pwd )
 # shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
 
+get_multiarch_argument() {
+    if [ -n "$DOCKER_MULTIARCH" ]; then
+        echo "--build-arg BUILD_STAGE=multi-arch"
+    fi
+}
+
 dockerfile=$rootdir/cli/Dockerfile-bin
 tag=$(head_root_tag)
-docker_build cli-bin "$tag" "$dockerfile" --build-arg LINKERD_VERSION="$tag"
+
+# shellcheck disable=SC2046
+SUPPORTED_ARCHS=linux/amd64 docker_build cli-bin "$tag" "$dockerfile" \
+    --build-arg LINKERD_VERSION="$tag" \
+    $(get_multiarch_argument)
+
 IMG=$(docker_repo cli-bin):$tag
 ID=$(docker create "$IMG")
+OS="darwin windows linux-amd64"
+if [ -n "$DOCKER_MULTIARCH" ]; then
+    OS+=" linux-arm64 linux-arm"
+fi
 
 # copy the newly built linkerd cli binaries to the local system
-for OS in darwin linux windows ; do
+for OS in $OS; do
     DIR=$rootdir/target/cli/$OS
     mkdir -p "$DIR"
 

--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -23,8 +23,12 @@ shorttag=${tag#v}
 
 # create the cli-bin container in order to extract the binaries
 id=$(docker create "$(docker_repo cli-bin):$tag")
+OS="darwin windows linux-amd64"
+if [ -n "$DOCKER_MULTIARCH" ]; then
+    OS+=" linux-arm64 linux-arm"
+fi
 
-for os in darwin linux windows ; do
+for os in $OS; do
   ext=$os
   if [ "$os" = windows ]; then
     ext=windows.exe

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -7,8 +7,7 @@ WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
 RUN go mod download
-ARG TARGETARCH
-RUN ./bin/install-deps $TARGETARCH
+RUN ./bin/install-deps
 
 ## compile binaries
 FROM go-deps as golang-single-arch

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -1,4 +1,5 @@
 ARG BUILDPLATFORM=linux/amd64
+ARG BUILD_STAGE=single-arch
 
 # Precompile key slow-to-build dependencies
 FROM --platform=$BUILDPLATFORM golang:1.14.2-alpine as go-deps
@@ -10,7 +11,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## compile binaries
-FROM go-deps as golang
+FROM go-deps as golang-single-arch
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts
@@ -26,16 +27,27 @@ RUN mkdir -p /out
 RUN go generate -mod=readonly ./pkg/charts/static
 
 # Cache builds without version info
-ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd-darwin -tags prod -mod=readonly -ldflags "-s -w" ./cli
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd-linux -tags prod -mod=readonly -ldflags "-s -w" ./cli
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd-linux-amd64 -tags prod -mod=readonly -ldflags "-s -w" ./cli
 RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd-windows -tags prod -mod=readonly -ldflags "-s -w" ./cli
 
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd-darwin -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/linkerd-linux -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd-linux-amd64 -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd-windows -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+
+FROM golang-single-arch as golang-multi-arch
+RUN ./bin/install-deps arm64
+RUN ./bin/install-deps arm
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /out/linkerd-linux-arm64 -tags prod -mod=readonly -ldflags "-s -w" ./cli
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o /out/linkerd-linux-arm -tags prod -mod=readonly -ldflags "-s -w" ./cli
+ARG LINKERD_VERSION
+ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /out/linkerd-linux-arm64 -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o /out/linkerd-linux-arm -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+
+FROM golang-${BUILD_STAGE} as golang
 
 ## export without sources & dependencies
 FROM scratch
@@ -43,4 +55,4 @@ COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out /out
 # `ENTRYPOINT` prevents `docker build` from otherwise failing with "Error
 # response from daemon: No command specified."
-ENTRYPOINT ["/out/linkerd-linux"]
+ENTRYPOINT ["/out/linkerd-linux-amd64"]


### PR DESCRIPTION
@cpretzer @alpeb @kleimkuhler 

# Changes
- Only push single docker image arch `amd64` for `cli-bin`. Inside that image, it will consist of multiple architecture binary files. It used the multi-stage build pattern to produce those binaries. [Ref](https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae)
- Add the arch name on the binary filename.

# TODO
- [x] Adjust the installer script in https://github.com/linkerd/website

# Note
- Installer script for brew formula does not need a change, because it builds the binary directly instead of download the existing binary. [Brew Formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/linkerd.rb)

Manual tested in a local fork. https://github.com/aliariff/linkerd2/releases/tag/stable-test