### PR TITLE
Diff generated code from proto files

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -30,6 +30,17 @@ jobs:
       uses: actions/checkout@722adc6
     - name: Format
       run: bin/fmt
+  proto_diff:
+    name: Proto diff
+    runs-on: ubuntu-18.04
+    container:
+      image: golang:1.13.4
+    steps:
+      - name: Checkout code
+        # actions/checkout@v2
+        uses: actions/checkout@722adc6
+      - name: Diff proto files
+        run: bin/protoc-diff
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-18.04

--- a/bin/protoc-diff
+++ b/bin/protoc-diff
@@ -4,19 +4,19 @@ set -eu
 
 # Install unzip if not already installed (Linux only)
 system=$(uname -s)
-if [ "$system" = Linux ] && [ $(dpkg-query -W -f='${Status}' unzip 2>/dev/null | grep -c "ok installed") -eq 0 ];
-then
+if [ "$system" = Linux ] && ! [ -x "$(command -v unzip)" ]; then
   apt-get update
   apt-get install unzip
 fi
 
 bin/protoc-go.sh
 
-dir_dirty=$(git status -s)
+dir_dirty=$(git diff HEAD)
 if [ -z "$dir_dirty" ]; then
   echo "Protobuf definitions match generated code"
   exit 0
 else
-  echo "Protobuf definitions diverge from generated code"
+  echo "Protobuf definitions diverge from generated code:"
+  echo "$(git status)"
   exit 64
 fi

--- a/bin/protoc-diff
+++ b/bin/protoc-diff
@@ -1,12 +1,21 @@
 #!/usr/bin/env sh
 
 set -eu
-dir_dirty=$(git status --untracked-files=no --porcelain)
+
+# Install unzip if not already installed
+if [ $(dpkg-query -W -f='${Status}' unzip 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+  apt-get update
+  apt-get install unzip
+fi
 
 bin/protoc-go.sh
 
-if [ -z "$dir_dirty" ]; then 
+dir_dirty=$(git status -s)
+if [ -z "$dir_dirty" ]; then
+  echo "Protobuf definitions match generated code"
   exit 0
-else 
+else
+  echo "Protobuf definitions diverge from generated code"
   exit 64
 fi

--- a/bin/protoc-diff
+++ b/bin/protoc-diff
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -eu
+dir_dirty=$(git status --untracked-files=no --porcelain)
+
+bin/protoc-go.sh
+
+if [ -z "$dir_dirty" ]; then 
+  exit 0
+else 
+  exit 64
+fi

--- a/bin/protoc-diff
+++ b/bin/protoc-diff
@@ -2,8 +2,9 @@
 
 set -eu
 
-# Install unzip if not already installed
-if [ $(dpkg-query -W -f='${Status}' unzip 2>/dev/null | grep -c "ok installed") -eq 0 ];
+# Install unzip if not already installed (Linux only)
+system=$(uname -s)
+if [ "$system" = Linux ] && [ $(dpkg-query -W -f='${Status}' unzip 2>/dev/null | grep -c "ok installed") -eq 0 ];
 then
   apt-get update
   apt-get install unzip


### PR DESCRIPTION
This PR adds a static check that ensures the generated files from the proto definitions have not changed. 

Fix #4669

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>

