### PR TITLE
Choose the right architecture in bin/linkerd script

### DIFF
--- a/bin/linkerd
+++ b/bin/linkerd
@@ -10,7 +10,29 @@ system=$(uname -s)
 if [ "$system" = Darwin ]; then
   bin=$rootdir/target/cli/darwin/linkerd
 elif [ "$system" = Linux ]; then
-  bin=$rootdir/target/cli/linux/linkerd
+  arch=$(uname -m)
+  case $arch in
+    x86_64)
+      arch=amd64
+      ;;
+    armv8*)
+      arch=arm64
+      ;;
+    aarch64*)
+      arch=arm64
+      ;;
+    armv*)
+      arch=arm
+      ;;
+    amd64|arm64)
+      arch=$arch
+      ;;
+    *)
+      echo "unsupported architecture: $arch" >&2
+      exit 1
+      ;;
+  esac
+  bin=$rootdir/target/cli/linux-$arch/linkerd
 else
   echo "unknown system: $system" >&2
   exit 1


### PR DESCRIPTION
## Motivation

I noticed after a local build of linkerd, `bin/linkerd version` was printing a
different git version than I expected.

I realized `bin/linkerd` (on Linux) was still pointing to
`./target/cli/linux/linkerd` even though we now build and put images into
`./target/cli/linux-amd64/linkerd`.

## Solution

We now select the correct architecture directory based off `uname -m`.

## Continued issues

If a binary does not exist in the path returned by `bin/linkerd`, we attempt to
build it with `bin/build-cli-bin`. I don't think this script is up to date with
multi-arch builds.

For example if I was on `arm64`, I don't think `build-cli-bin` would properly
build a put a binary in `./target/cli/linux-amd64/`.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
