### PR TITLE
Fix proxy-identity log line and print identity in destination client

### DIFF
--- a/controller/script/destination-client/main.go
+++ b/controller/script/destination-client/main.go
@@ -68,6 +68,7 @@ func get(client pb.DestinationClient, req *pb.GetDestination) {
 				default:
 					log.Printf("  - protocol hint: UNKNOWN")
 				}
+				log.Printf("  - identity: %s", addr.GetTlsIdentity())
 			}
 			log.Println()
 		case *pb.Update_Remove:

--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -65,16 +65,16 @@ func loadVerifier(pem string) (verify x509.VerifyOptions, err error) {
 }
 
 // checkEndEntityDir checks that the provided directory path exists and is
-// suitable to write key material to, returning the Key, CSR, and Crt paths.
+// suitable to write key material to, returning the key and CSR paths.
 //
 // If the directory does not exist, we assume that the wrong directory was
-// specified incorrectly, instead of trying to
-// create or repair the directory. In practice, this directory should be tmpfs
-// so that credentials are not written to disk, so we want to be extra sensitive
-// to an incorrectly specified path.
+// specified incorrectly instead of trying to create or repair the directory.
+// In practice this directory should be tmpfs so that credentials are not
+// written to disk, so we want to be extra sensitive to an incorrectly
+// specified path.
 //
-// If the key, CSR, and/or Crt paths refer to existing files, it is assumed that
-// the proxy has been restarted and these credentials are NOT recreated.
+// If the key and/or CSR paths refer to existing files, it will be logged and
+// the credentials will be recreated.
 func checkEndEntityDir(dir string) (string, string, error) {
 	if dir == "" {
 		return "", "", errors.New("no end entity directory specified")
@@ -90,12 +90,12 @@ func checkEndEntityDir(dir string) (string, string, error) {
 
 	keyPath := filepath.Join(dir, "key.p8")
 	if err = checkNotExists(keyPath); err != nil {
-		log.Infof("Using with pre-existing key: %s", keyPath)
+		log.Infof("Found pre-existing key: %s", keyPath)
 	}
 
 	csrPath := filepath.Join(dir, "csr.der")
 	if err = checkNotExists(csrPath); err != nil {
-		log.Infof("Using with pre-existing CSR: %s", keyPath)
+		log.Infof("Found pre-existing CSR: %s", csrPath)
 	}
 
 	return keyPath, csrPath, nil


### PR DESCRIPTION
## Motivation

These changes came up when testing mock identity. I found it useful for the
destination client to print the identity of endpoints.

```
❯ go run controller/script/destination-client/main.go -method get -path h1.test.example.com:8080
INFO[0000] Add:                                         
INFO[0000] labels: map[concrete:h1.test.example.com:8080] 
INFO[0000] - 127.0.0.1:4143                             
INFO[0000]   - labels: map[addr:127.0.0.1:4143 h2:false] 
INFO[0000]   - protocol hint: UNKNOWN                   
INFO[0000]   - identity: dns_like_identity:{name:"foo.ns1.serviceaccount.identity.linkerd.cluster.local"} 
INFO[0000]
```

I also fixed a log line in the proxy-identity where used the wrong value for the
CSR path

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
