### PR TITLE
cli/cmd/inject_test: add os.RemoveAll err verification

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -575,7 +575,12 @@ func TestWalk(t *testing.T) {
 	if err := os.MkdirAll(tmpFolderData, os.ModeDir|os.ModePerm); err != nil {
 		t.Fatal("Unexpected error: ", err)
 	}
-	defer os.RemoveAll(tmpFolderRoot)
+	defer func() {
+		err := os.RemoveAll(tmpFolderRoot)
+		if err != nil {
+			t.Errorf("failed to remove temp dir %q: %v", tmpFolderRoot, err)
+		}
+	}()
 
 	var (
 		data  = []byte(readTestdata(t, "inject_gettest_deployment.bad.input.yml"))


### PR DESCRIPTION
Add error judgment of return value to os.RemoveAll in TestWalk function.


Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
