### PR TITLE
Always return destination overrides for services

### DIFF
--- a/controller/api/destination/traffic_split_adaptor.go
+++ b/controller/api/destination/traffic_split_adaptor.go
@@ -2,10 +2,12 @@ package destination
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
 	ts "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // trafficSplitAdaptor merges traffic splits into service profiles, encoding
@@ -64,11 +66,19 @@ func (tsa *trafficSplitAdaptor) publish() {
 			overrides = append(overrides, dst)
 		}
 		merged.Spec.DstOverrides = overrides
+	} else {
+		// If there is no traffic split, always return a destination override
+		// so that it's known the host is a service.
+		overrides := []*sp.WeightedDst{}
+		id := strings.Split(tsa.id.String(), "/")
+		dst := &sp.WeightedDst{
+			Authority: fmt.Sprintf("%s.%s.svc.%s.:%d", id[1], tsa.id.Namespace, tsa.clusterDomain, tsa.port),
+			// Weights are expressed in decimillis: 10_000 represents 100%
+			Weight: resource.MustParse("10000m"),
+		}
+		overrides = append(overrides, dst)
+		merged.Spec.DstOverrides = overrides
 	}
 
-	if tsa.profile == nil && tsa.split == nil {
-		tsa.listener.Update(nil)
-	} else {
-		tsa.listener.Update(&merged)
-	}
+	tsa.listener.Update(&merged)
 }

--- a/controller/api/destination/traffic_split_adaptor.go
+++ b/controller/api/destination/traffic_split_adaptor.go
@@ -2,7 +2,6 @@ package destination
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
@@ -69,15 +68,11 @@ func (tsa *trafficSplitAdaptor) publish() {
 	} else {
 		// If there is no traffic split, always return a destination override
 		// so that it's known the host is a service.
-		overrides := []*sp.WeightedDst{}
-		id := strings.Split(tsa.id.String(), "/")
 		dst := &sp.WeightedDst{
-			Authority: fmt.Sprintf("%s.%s.svc.%s.:%d", id[1], tsa.id.Namespace, tsa.clusterDomain, tsa.port),
-			// Weights are expressed in decimillis: 10_000 represents 100%
-			Weight: resource.MustParse("10000m"),
+			Authority: fmt.Sprintf("%s.%s.svc.%s.:%d", tsa.id.Name, tsa.id.Namespace, tsa.clusterDomain, tsa.port),
+			Weight:    resource.MustParse("1"),
 		}
-		overrides = append(overrides, dst)
-		merged.Spec.DstOverrides = overrides
+		merged.Spec.DstOverrides = []*sp.WeightedDst{dst}
 	}
 
 	tsa.listener.Update(&merged)

--- a/controller/api/destination/traffic_split_adaptor_test.go
+++ b/controller/api/destination/traffic_split_adaptor_test.go
@@ -23,7 +23,7 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 			DstOverrides: []*sp.WeightedDst{
 				{
 					Authority: "foo.ns.svc.cluster.local.:80",
-					Weight:    resource.MustParse("10000m"),
+					Weight:    resource.MustParse("1"),
 				},
 			},
 		},

--- a/controller/api/destination/traffic_split_adaptor_test.go
+++ b/controller/api/destination/traffic_split_adaptor_test.go
@@ -22,8 +22,8 @@ func TestTrafficSplitAdaptor(t *testing.T) {
 			},
 			DstOverrides: []*sp.WeightedDst{
 				{
-					Authority: "foo",
-					Weight:    resource.MustParse("500m"),
+					Authority: "foo.ns.svc.cluster.local.:80",
+					Weight:    resource.MustParse("10000m"),
 				},
 			},
 		},


### PR DESCRIPTION
## Motivation

#4879

## Solution

When no traffic split exists for services, return a single destination override
with a weight of 100%.

Using the destination client on a new linkerd installation, this results in the
following output for `linkerd-identity` service:

```
❯ go run controller/script/destination-client/main.go -method getProfile -path linkerd-identity.linkerd.svc.cluster.local:8080
INFO[0000] retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} dst_overrides:{authority:"linkerd-identity.linkerd.svc.cluster.local.:8080" weight:100000} 
INFO[0000]
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
