### PR TITLE
Fix js unit test dependency on ci

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,5 +37,5 @@ jobs:
       run: |
         export PATH="$HOME/.yarn/bin:$PATH"
         export NODE_ENV=test
-        bin/web
+        bin/web --frozen-lockfile
         bin/web test --reporters="jest-dot-reporter" --reporters="./gh_ann_reporter.js"


### PR DESCRIPTION
unit tests in ci are runned using yarn install.
So, there will be some update to the dependencies.
This is fixed by passing --frozen-lockfile in ci workflow
Fixes #3838

Signed-off-by: Tharun <rajendrantharun@live.com>
