### PR TITLE
Add ARM64 Integration Test

### DIFF
--- a/.github/workflows/cloud_integration.yml
+++ b/.github/workflows/cloud_integration.yml
@@ -77,7 +77,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Install linkerd CLI
-      id: install_cli
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,11 +188,56 @@ jobs:
       run: |
         export TAG="$($CMD version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  arm64_integration_tests:
+    name: ARM64 integration tests
+    runs-on: ubuntu-18.04
+    needs: [docker_build]
+    steps:
+    - name: Checkout code
+      # actions/checkout@v2
+      uses: actions/checkout@722adc6
+    - name: Try to load cached Go modules
+      # actions/cache@v1.1.2
+      uses: actions/cache@70655ec
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install linkerd CLI
+      id: install_cli
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
+        bin/docker-pull-binaries $TAG
+        $CMD version --client
+        # validate CLI version matches the repo
+        [[ "$TAG" == "$($CMD version --short --client)" ]]
+        echo "Installed Linkerd CLI version: $TAG"
+        echo "::set-env name=CMD::$CMD"
+        echo "::set-output name=tag::$TAG"
+    - name: Set KUBECONFIG environment variables
+      run: |
+        mkdir -p $HOME/.kube
+        echo "${{ secrets.ARM64_KUBECONFIG }}" > $HOME/.kube/config
+        echo ::set-env name=KUBECONFIG::$HOME/.kube/config
+        kubectl cluster-info
+    - name: Run integration tests
+      env:
+        ARM_TEST: 1
+      run: bin/tests --skip-kind-create "$CMD"
+    - name: CNI tests
+      run: |
+        export TAG="$($CMD version --client --short)"
+        go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+    - name: Test cleanup
+      if: ${{ always() }}
+      run: bin/test-cleanup
   choco_pack:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
-    needs: [kind_integration_tests, cloud_integration_tests]
+    needs: [kind_integration_tests, cloud_integration_tests, arm64_integration_tests]
     runs-on: windows-2019
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Install linkerd CLI
-      id: install_cli
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
@@ -170,7 +169,7 @@ jobs:
         [[ "$TAG" == "$($CMD version --short --client)" ]]
         echo "Installed Linkerd CLI version: $TAG"
         echo "::set-env name=CMD::$CMD"
-        echo "::set-output name=tag::$TAG"
+        echo "::set-env name=TAG::$TAG"
     - name: Create GKE cluster
       # linkerd/linkerd2-action-gcloud@v1.0.1
       uses: linkerd/linkerd2-action-gcloud@308c4df
@@ -180,7 +179,7 @@ jobs:
         gcp_zone: ${{ secrets.GCP_ZONE }}
         preemptible: false
         create: true
-        name: testing-${{ steps.install_cli.outputs.tag }}-${{ github.run_id }}
+        name: testing-${{ env.TAG }}-${{ github.run_id }}
         num_nodes: 2
     - name: Run integration tests
       run: bin/tests --skip-kind-create "$CMD"
@@ -205,7 +204,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Install linkerd CLI
-      id: install_cli
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
@@ -215,7 +213,6 @@ jobs:
         [[ "$TAG" == "$($CMD version --short --client)" ]]
         echo "Installed Linkerd CLI version: $TAG"
         echo "::set-env name=CMD::$CMD"
-        echo "::set-output name=tag::$TAG"
     - name: Set KUBECONFIG environment variables
       run: |
         mkdir -p $HOME/.kube

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
         kubectl cluster-info
     - name: Run integration tests
       env:
-        ARM_TEST: 1
+        RUN_ARM_TEST: 1
       run: bin/tests --skip-kind-create "$CMD"
     - name: CNI tests
       run: |

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -284,6 +284,11 @@ run_upgrade-edge_test() {
 # Run the upgrade-stable test by upgrading the most-recent stable release to the
 # HEAD of this branch.
 run_upgrade-stable_test() {
+  if [ -n "$ARM_TEST" ]; then
+    echo "Skipped. Linkerd stable version does not support ARM yet"
+    exit 0
+  fi
+
   stable_install_url="https://run.linkerd.io/install"
   upgrade_test "stable" "$stable_install_url"
 }
@@ -313,6 +318,11 @@ helm_cleanup() {
 }
 
 run_helm-upgrade_test() {
+  if [ -n "$ARM_TEST" ]; then
+    echo "Skipped. Linkerd stable version does not support ARM yet"
+    exit 0
+  fi
+
   local stable_version
   stable_version=$(latest_release_channel "stable")
 

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -284,7 +284,7 @@ run_upgrade-edge_test() {
 # Run the upgrade-stable test by upgrading the most-recent stable release to the
 # HEAD of this branch.
 run_upgrade-stable_test() {
-  if [ -n "$ARM_TEST" ]; then
+  if [ -n "$RUN_ARM_TEST" ]; then
     echo "Skipped. Linkerd stable version does not support ARM yet"
     exit 0
   fi
@@ -318,7 +318,7 @@ helm_cleanup() {
 }
 
 run_helm-upgrade_test() {
-  if [ -n "$ARM_TEST" ]; then
+  if [ -n "$RUN_ARM_TEST" ]; then
     echo "Skipped. Linkerd stable version does not support ARM yet"
     exit 0
   fi

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -204,7 +204,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -378,7 +378,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -552,7 +552,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.input.yml
@@ -27,7 +27,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -65,7 +65,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -102,7 +102,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -141,7 +141,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.input.yml
@@ -23,7 +23,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.input.yml
@@ -26,7 +26,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -39,7 +39,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.input.yml
@@ -33,7 +33,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -204,7 +204,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.input.yml
@@ -23,7 +23,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -54,7 +54,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -31,7 +31,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_proxy_version_config.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.input.yml
@@ -27,7 +27,7 @@ spec:
               value: voting-svc.emojivoto:8080
             - name: INDEX_BUNDLE
               value: dist/index_bundle.js
-          image: buoyantio/emojivoto-web:v3
+          image: buoyantio/emojivoto-web:v10
           name: web-svc
           ports:
             - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_version_config.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.input.yml
@@ -26,7 +26,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_true.input.yml
@@ -23,7 +23,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.input.yml
@@ -25,7 +25,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -31,7 +31,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden_noinject.golden.yml
@@ -26,7 +26,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_trace.golden.yml
@@ -32,7 +32,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -30,7 +30,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.input.yml
@@ -23,7 +23,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 9100

--- a/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_uninjected.input.yml
@@ -25,7 +25,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_istio.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_istio.input.yml
@@ -23,7 +23,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -32,7 +32,7 @@ items:
             value: voting-svc.emojivoto:8080
           - name: INDEX_BUNDLE
             value: dist/index_bundle.js
-          image: buoyantio/emojivoto-web:v3
+          image: buoyantio/emojivoto-web:v10
           name: web-svc
           ports:
           - containerPort: 80
@@ -199,7 +199,7 @@ items:
         - env:
           - name: GRPC_PORT
             value: "8080"
-          image: buoyantio/emojivoto-emoji-svc:v3
+          image: buoyantio/emojivoto-emoji-svc:v10
           name: emoji-svc
           ports:
           - containerPort: 8080

--- a/cli/cmd/testdata/inject_emojivoto_list.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.input.yml
@@ -25,7 +25,7 @@ items:
             value: voting-svc.emojivoto:8080
           - name: INDEX_BUNDLE
             value: dist/index_bundle.js
-          image: buoyantio/emojivoto-web:v3
+          image: buoyantio/emojivoto-web:v10
           name: web-svc
           ports:
           - containerPort: 80
@@ -49,7 +49,7 @@ items:
         - env:
           - name: GRPC_PORT
             value: "8080"
-          image: buoyantio/emojivoto-emoji-svc:v3
+          image: buoyantio/emojivoto-emoji-svc:v10
           name: emoji-svc
           ports:
           - containerPort: 8080

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -32,7 +32,7 @@ items:
             value: voting-svc.emojivoto:8080
           - name: INDEX_BUNDLE
             value: dist/index_bundle.js
-          image: buoyantio/emojivoto-web:v3
+          image: buoyantio/emojivoto-web:v10
           name: web-svc
           ports:
           - containerPort: 80
@@ -199,7 +199,7 @@ items:
         - env:
           - name: GRPC_PORT
             value: "8080"
-          image: buoyantio/emojivoto-emoji-svc:v3
+          image: buoyantio/emojivoto-emoji-svc:v10
           name: emoji-svc
           ports:
           - containerPort: 8080

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.input.yml
@@ -29,7 +29,7 @@ items:
                   value: voting-svc.emojivoto:8080
                 - name: INDEX_BUNDLE
                   value: dist/index_bundle.js
-              image: buoyantio/emojivoto-web:v3
+              image: buoyantio/emojivoto-web:v10
               name: web-svc
               ports:
                 - containerPort: 80
@@ -58,7 +58,7 @@ items:
             - env:
                 - name: GRPC_PORT
                   value: "8080"
-              image: buoyantio/emojivoto-emoji-svc:v3
+              image: buoyantio/emojivoto-emoji-svc:v10
               name: emoji-svc
               ports:
                 - containerPort: 8080

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -18,7 +18,7 @@ spec:
     env:
     - name: WEB_HOST
       value: web-svc.emojivoto:80
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v10
     name: vote-bot
   - env:
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.input.yml
@@ -12,6 +12,6 @@ spec:
     env:
     - name: WEB_HOST
       value: web-svc.emojivoto:80
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v10
     name: vote-bot
 ---

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -18,7 +18,7 @@ spec:
     env:
     - name: WEB_HOST
       value: web-svc.emojivoto:80
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v10
     name: vote-bot
   - env:
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -18,7 +18,7 @@ spec:
     env:
     - name: WEB_HOST
       value: web-svc.emojivoto:80
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v10
     name: vote-bot
   - env:
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.input.yml
@@ -12,6 +12,6 @@ spec:
     env:
     - name: WEB_HOST
       value: web-svc.emojivoto:80
-    image: buoyantio/emojivoto-web:v3
+    image: buoyantio/emojivoto-web:v10
     name: vote-bot
 ---

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -31,7 +31,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.input.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.input.yml
@@ -24,7 +24,7 @@ spec:
           value: voting-svc.emojivoto:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v3
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80

--- a/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.bad.input.yml
@@ -9,12 +9,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-two-replicas-c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-two-replicas-c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090
@@ -36,12 +36,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-one-replica-c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-one-replica-c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -23,7 +23,7 @@ spec:
         - "9090"
         - --response-text
         - c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: http-to-grpc-two-replicas-c1
         ports:
         - containerPort: 9090
@@ -33,7 +33,7 @@ spec:
         - "8080"
         - --response-text
         - c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: http-to-grpc-two-replicas-c2
         ports:
         - containerPort: 9090
@@ -199,7 +199,7 @@ spec:
         - "9090"
         - --response-text
         - c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: http-to-grpc-one-replica-c1
         ports:
         - containerPort: 9090
@@ -209,7 +209,7 @@ spec:
         - "8080"
         - --response-text
         - c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: http-to-grpc-one-replica-c2
         ports:
         - containerPort: 9090

--- a/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.input.yml
@@ -11,12 +11,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-two-replicas-c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-two-replicas-c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090
@@ -33,12 +33,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc-one-replica-c1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "c1"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-one-replica-c2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "8080", "--response-text", "c2"]
         ports:
         - containerPort: 9090

--- a/controller/api/public/stat_summary_test.go
+++ b/controller/api/public/stat_summary_test.go
@@ -308,7 +308,7 @@ spec:
   template:
     spec:
       containers:
-      - image: buoyantio/emojivoto-emoji-svc:v3
+      - image: buoyantio/emojivoto-emoji-svc:v10
 `, `
 apiVersion: apps/v1
 kind: ReplicaSet
@@ -416,7 +416,7 @@ spec:
   template:
     spec:
       containers:
-      - image: buoyantio/emojivoto-emoji-svc:v3
+      - image: buoyantio/emojivoto-emoji-svc:v10
 `, `
 apiVersion: v1
 kind: Pod
@@ -492,7 +492,7 @@ spec:
   template:
     spec:
       containers:
-      - image: buoyantio/emojivoto-emoji-svc:v3
+      - image: buoyantio/emojivoto-emoji-svc:v10
 `, `
 apiVersion: v1
 kind: Pod
@@ -1137,7 +1137,7 @@ spec:
   template:
     spec:
       containers:
-      - image: buoyantio/emojivoto-emoji-svc:v3
+      - image: buoyantio/emojivoto-emoji-svc:v10
 `, `
 apiVersion: apps/v1
 kind: ReplicaSet
@@ -1609,7 +1609,7 @@ spec:
   template:
     spec:
       containers:
-      - image: buoyantio/emojivoto-emoji-svc:v3
+      - image: buoyantio/emojivoto-emoji-svc:v10
 `, `
 apiVersion: apps/v1
 kind: ReplicaSet

--- a/test/integration/edges/testdata/slow-cooker.yaml
+++ b/test/integration/edges/testdata/slow-cooker.yaml
@@ -15,13 +15,13 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          slow_cooker -metric-addr 0.0.0.0:9999 http://___TERMINUS_POD_IP___:8080
+          /slow_cooker/slow_cooker -metric-addr 0.0.0.0:9999 http://___TERMINUS_POD_IP___:8080
         ports:
         - containerPort: 9999

--- a/test/integration/edges/testdata/terminus.yaml
+++ b/test/integration/edges/testdata/terminus.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: terminus
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"

--- a/test/integration/egress/testdata/proxy.yaml
+++ b/test/integration/egress/testdata/proxy.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
       - name: http-egress
-        image: gcr.io/linkerd-io/debug:stable-2.6.1
+        image: gcr.io/linkerd-io/debug:edge-20.8.1

--- a/test/integration/externalissuer/testdata/external_issuer_application.yaml
+++ b/test/integration/externalissuer/testdata/external_issuer_application.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -51,14 +51,14 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 5 # wait for pods to start
-          slow_cooker http://backend-svc:8080
+          /slow_cooker/slow_cooker http://backend-svc:8080
         ports:
         - containerPort: 9999
 ---

--- a/test/integration/get/testdata/not_to_be_injected_application.yaml
+++ b/test/integration/get/testdata/not_to_be_injected_application.yaml
@@ -15,12 +15,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90

--- a/test/integration/get/testdata/to_be_injected_application.yaml
+++ b/test/integration/get/testdata/to_be_injected_application.yaml
@@ -15,12 +15,12 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
       - name: http-to-grpc-2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "90", "--response-text", "BANANA"]
         ports:
         - containerPort: 90

--- a/test/integration/inject/testdata/inject_test.yaml
+++ b/test/integration/inject/testdata/inject_test.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: bb-terminus
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090

--- a/test/integration/inject/testdata/injected_default.golden
+++ b/test/integration/inject/testdata/injected_default.golden
@@ -29,7 +29,7 @@ spec:
         - "9090"
         - --response-text
         - BANANA
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: bb-terminus
         ports:
         - containerPort: 9090

--- a/test/integration/inject/testdata/injected_params.golden
+++ b/test/integration/inject/testdata/injected_params.golden
@@ -44,7 +44,7 @@ spec:
         - "9090"
         - --response-text
         - BANANA
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         name: bb-terminus
         ports:
         - containerPort: 9090

--- a/test/integration/inject/testdata/pod.yaml
+++ b/test/integration/inject/testdata/pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: bb-terminus
-    image: buoyantio/bb:v0.0.5
+    image: buoyantio/bb:v0.0.6
     args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
     ports:
     - containerPort: 9090

--- a/test/integration/serviceprofiles/testdata/hello_world.yaml
+++ b/test/integration/serviceprofiles/testdata/hello_world.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: hello
-        image: buoyantio/helloworld:0.1.6
+        image: buoyantio/helloworld:0.1.7
         args:
         - "-addr=:8888"
         - "-text=Hello"
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: world
-        image: buoyantio/helloworld:0.1.6
+        image: buoyantio/helloworld:0.1.7
         args:
         - "-addr=:8889"
         - "-text=World"
@@ -84,12 +84,12 @@ spec:
     spec:
       containers:
       - name: hello-slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          slow_cooker -metric-addr 0.0.0.0:9998 http://hello-svc:8888/testpath
+          /slow_cooker/slow_cooker -metric-addr 0.0.0.0:9998 http://hello-svc:8888/testpath
       restartPolicy: OnFailure

--- a/test/integration/serviceprofiles/testdata/tap_application.yaml
+++ b/test/integration/serviceprofiles/testdata/tap_application.yaml
@@ -1,4 +1,4 @@
-# slow_cooker --http-> gateway --grpc-> t1
+# /slow_cooker/slow_cooker --http-> gateway --grpc-> t1
 #                              --grpc-> t2 always-error
 #                              --http-> t3
 #
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: t1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: t2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
       - name: t3
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - broadcast-channel
         - "--h1-server-port=8080"
@@ -173,14 +173,14 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          slow_cooker -metric-addr 0.0.0.0:9999 http://gateway-svc:8080
+          /slow_cooker/slow_cooker -metric-addr 0.0.0.0:9999 http://gateway-svc:8080
         ports:
         - containerPort: 9999
       restartPolicy: OnFailure

--- a/test/integration/tap/testdata/tap_application.yaml
+++ b/test/integration/tap/testdata/tap_application.yaml
@@ -1,4 +1,4 @@
-# slow_cooker --http-> gateway --grpc-> t1
+# /slow_cooker/slow_cooker --http-> gateway --grpc-> t1
 #                              --grpc-> t2 always-error
 #                              --http-> t3
 #                              --http-> t4 tap-disabled
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: t1
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: t2
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--grpc-server-port=9090"
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: t3
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: t4
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -177,7 +177,7 @@ spec:
     spec:
       containers:
       - name: gateway
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - broadcast-channel
         - "--h1-server-port=8080"
@@ -214,14 +214,14 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          slow_cooker -metric-addr 0.0.0.0:9999 http://gateway-svc:8080
+          /slow_cooker/slow_cooker -metric-addr 0.0.0.0:9999 http://gateway-svc:8080
         ports:
         - containerPort: 9999
       restartPolicy: OnFailure

--- a/test/integration/testdata/smoke_test.yaml
+++ b/test/integration/testdata/smoke_test.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
         ports:
         - containerPort: 9090
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
       - name: http-to-grpc
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args: ["point-to-point-channel", "--grpc-downstream-server", "smoke-test-terminus-svc:9090", "--h1-server-port", "8080"]
         ports:
         - containerPort: 8080

--- a/test/integration/testdata/upgrade_test.yaml
+++ b/test/integration/testdata/upgrade_test.yaml
@@ -36,7 +36,7 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-emoji-svc:v8
+        image: buoyantio/emojivoto-emoji-svc:v10
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -81,7 +81,7 @@ spec:
       - env:
         - name: GRPC_PORT
           value: "8080"
-        image: buoyantio/emojivoto-voting-svc:v8
+        image: buoyantio/emojivoto-voting-svc:v10
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -132,7 +132,7 @@ spec:
           value: voting-svc:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v8
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 8080

--- a/test/integration/tracing/testdata/emojivoto.yaml
+++ b/test/integration/tracing/testdata/emojivoto.yaml
@@ -40,7 +40,7 @@ spec:
           value: "8080"
         - name: OC_AGENT_HOST
           value: "oc-collector.___TRACING_NS___:55678"
-        image: buoyantio/emojivoto-emoji-svc:v10
+        image: buoyantio/emojivoto-emoji-svc:v8-tracing
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -89,7 +89,7 @@ spec:
           value: "8080"
         - name: OC_AGENT_HOST
           value: "oc-collector.___TRACING_NS___:55678"
-        image: buoyantio/emojivoto-voting-svc:v10
+        image: buoyantio/emojivoto-voting-svc:v8-tracing
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -144,7 +144,7 @@ spec:
           value: voting-svc:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v10
+        image: buoyantio/emojivoto-web:v8-tracing
         name: web-svc
         ports:
         - containerPort: 80

--- a/test/integration/tracing/testdata/emojivoto.yaml
+++ b/test/integration/tracing/testdata/emojivoto.yaml
@@ -40,7 +40,7 @@ spec:
           value: "8080"
         - name: OC_AGENT_HOST
           value: "oc-collector.___TRACING_NS___:55678"
-        image: buoyantio/emojivoto-emoji-svc:v8-tracing
+        image: buoyantio/emojivoto-emoji-svc:v10
         name: emoji-svc
         ports:
         - containerPort: 8080
@@ -89,7 +89,7 @@ spec:
           value: "8080"
         - name: OC_AGENT_HOST
           value: "oc-collector.___TRACING_NS___:55678"
-        image: buoyantio/emojivoto-voting-svc:v8-tracing
+        image: buoyantio/emojivoto-voting-svc:v10
         name: voting-svc
         ports:
         - containerPort: 8080
@@ -144,7 +144,7 @@ spec:
           value: voting-svc:8080
         - name: INDEX_BUNDLE
           value: dist/index_bundle.js
-        image: buoyantio/emojivoto-web:v8-tracing
+        image: buoyantio/emojivoto-web:v10
         name: web-svc
         ports:
         - containerPort: 80
@@ -192,7 +192,7 @@ spec:
         env:
         - name: WEB_HOST
           value: nginx-ingress:80
-        image: buoyantio/emojivoto-web:v8
+        image: buoyantio/emojivoto-web:v10
         name: vote-bot
         resources:
           requests:

--- a/test/integration/tracing/testdata/ingress.yaml
+++ b/test/integration/tracing/testdata/ingress.yaml
@@ -35,7 +35,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.k8s.io
+  - extensions
   resources:
   - ingresses
   verbs:
@@ -135,7 +135,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.22.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -173,7 +173,7 @@ spec:
             drop:
             - ALL
           procMount: Default
-          runAsUser: 101
+          runAsUser: 33
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 ---

--- a/test/integration/tracing/testdata/ingress.yaml
+++ b/test/integration/tracing/testdata/ingress.yaml
@@ -35,7 +35,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   verbs:

--- a/test/integration/tracing/testdata/ingress.yaml
+++ b/test/integration/tracing/testdata/ingress.yaml
@@ -92,7 +92,7 @@ kind: ConfigMap
 metadata:
   name: nginx-ingress-controller
   labels:
-    app: nginx-ingress  
+    app: nginx-ingress
 data:
   ssl-redirect: "false"
   enable-opentracing: "true"
@@ -135,7 +135,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.22.0
+        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -173,7 +173,7 @@ spec:
             drop:
             - ALL
           procMount: Default
-          runAsUser: 33
+          runAsUser: 101
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 ---

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -41,6 +41,9 @@ func TestMain(m *testing.M) {
 //////////////////////
 
 func TestTracing(t *testing.T) {
+	if os.Getenv("ARM_TEST") != "" {
+		t.Skip("Skipped. Jaeger & Open Census images does not support ARM yet")
+	}
 
 	// Tracing Components
 	out, stderr, err := TestHelper.LinkerdRun("inject", "testdata/tracing.yaml")

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 //////////////////////
 
 func TestTracing(t *testing.T) {
-	if os.Getenv("ARM_TEST") != "" {
+	if os.Getenv("RUN_ARM_TEST") != "" {
 		t.Skip("Skipped. Jaeger & Open Census images does not support ARM yet")
 	}
 

--- a/test/integration/trafficsplit/testdata/traffic_split_application.yaml
+++ b/test/integration/trafficsplit/testdata/traffic_split_application.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: failing
-        image: buoyantio/bb:v0.0.5
+        image: buoyantio/bb:v0.0.6
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -92,14 +92,14 @@ spec:
     spec:
       containers:
       - name: slow-cooker
-        image: buoyantio/slow_cooker:1.1.1
+        image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
         args:
         - "-c"
         - |
           sleep 5 # wait for pods to start
-          slow_cooker http://backend-svc:8080
+          /slow_cooker/slow_cooker http://backend-svc:8080
         ports:
         - containerPort: 9999
 ---


### PR DESCRIPTION
@cpretzer @alpeb 

# Changes
- Add `arm64_integration_tests` job in the release workflow
- Skip tracing test, because the OpenCensus collector and Jaeger images do not support ARM yet
- Skip `helm-upgrade` and `upgrade-stable` test because the Linkerd stable version does not support ARM yet
- Bump the version of the images that used for testing purposes to version that support ARM

# Note
- Before merging this, it is required to provision an ARM64 machine and also setup Kubernetes on it. Then set a new secret in Github called `ARM64_KUBECONFIG` with the kubeconfig credential from the ARM64 machine.


Signed-off-by: Ali Ariff <ali.ariff12@gmail.com>
