### PR TITLE
conformance validation: refactor serviceprofiles test helpers

### DIFF
--- a/testutil/serviceprofiles.go
+++ b/testutil/serviceprofiles.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	cmd2 "github.com/linkerd/linkerd2/cli/cmd"
+	"sigs.k8s.io/yaml"
+)
+
+// GetRoutes runs the `routes` cmd and returns a `JSONRouteStats` object
+func GetRoutes(deployName, namespace string, additionalArgs []string, h *TestHelper) ([]*cmd2.JSONRouteStats, error) {
+	cmd := []string{"routes", "--namespace", namespace, deployName}
+
+	if len(additionalArgs) > 0 {
+		cmd = append(cmd, additionalArgs...)
+	}
+
+	cmd = append(cmd, "--output", "json")
+	var out, stderr string
+	err := h.RetryFor(2*time.Minute, func() error {
+		var err error
+		out, stderr, err = h.LinkerdRun(cmd...)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var list map[string][]*cmd2.JSONRouteStats
+	err = yaml.Unmarshal([]byte(out), &list)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("Error: %s stderr: %s", err, stderr))
+	}
+
+	if deployment, ok := list[deployName]; ok {
+		return deployment, nil
+	}
+	return nil, fmt.Errorf("could not retrieve route info for %s", deployName)
+}
+
+// AssertExpectedRoutes matches expected routes by matching them against given routes
+func AssertExpectedRoutes(expected []string, actual []*cmd2.JSONRouteStats) error {
+
+	if len(expected) != len(actual) {
+		return fmt.Errorf("mismatch routes count. Expected %d, Actual %d", len(expected), len(actual))
+	}
+
+	for _, expectedRoute := range expected {
+		containsRoute := false
+		for _, actualRoute := range actual {
+			if actualRoute.Route == expectedRoute {
+				containsRoute = true
+				break
+			}
+		}
+		if !containsRoute {
+			sb := strings.Builder{}
+			for _, route := range actual {
+				sb.WriteString(fmt.Sprintf("%s ", route.Route))
+			}
+			return fmt.Errorf("expected route %s not found in %+v", expectedRoute, sb.String())
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR makes some of the helper functions in `test/integration/serviceprofiles` public (through the `testutil` package) so that conformance validation may be able to reuse them:

- Move function `assertExpectedRoutes` to `testutil.AssertExpectedRoutes
- Move function `getRoutes` to `testutil.GetRoutes``

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
