### PR TITLE
Create webhook certs with SANs, along with legacy Comman Name Field

### DIFF
--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -53,7 +53,8 @@ metadata:
     {{.Values.global.controllerComponentLabel}}: proxy-injector
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
 ---
-{{- $ca := genSelfSignedCert (printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace) (list) (list (printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace)) 365 }}
+{{- $host := printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace }}
+{{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.proxyInjector.externalSecret) }}
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -53,7 +53,7 @@ metadata:
     {{.Values.global.controllerComponentLabel}}: proxy-injector
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
 ---
-{{- $ca := genCA (printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace) 365 }}
+{{- $ca := genSelfSignedCert (printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace) (list) (list (printf "linkerd-proxy-injector.%s.svc" .Values.global.namespace)) 365 }}
 {{- if (not .Values.proxyInjector.externalSecret) }}
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/sp-validator-rbac.yaml
+++ b/charts/linkerd2/templates/sp-validator-rbac.yaml
@@ -41,7 +41,7 @@ metadata:
     {{.Values.global.controllerComponentLabel}}: sp-validator
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
 ---
-{{- $ca := genCA (printf "linkerd-sp-validator.%s.svc" .Values.global.namespace) 365 }}
+{{- $ca := genSelfSignedCert (printf "linkerd-sp-validator.%s.svc" .Values.global.namespace) (list) (list (printf "linkerd-sp-validator.%s.svc" .Values.global.namespace)) 365 }}
 {{- if (not .Values.profileValidator.externalSecret) }}
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/sp-validator-rbac.yaml
+++ b/charts/linkerd2/templates/sp-validator-rbac.yaml
@@ -41,7 +41,8 @@ metadata:
     {{.Values.global.controllerComponentLabel}}: sp-validator
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
 ---
-{{- $ca := genSelfSignedCert (printf "linkerd-sp-validator.%s.svc" .Values.global.namespace) (list) (list (printf "linkerd-sp-validator.%s.svc" .Values.global.namespace)) 365 }}
+{{- $host := printf "linkerd-sp-validator.%s.svc" .Values.global.namespace }}
+{{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.profileValidator.externalSecret) }}
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -91,7 +91,8 @@ subjects:
   name: linkerd-tap
   namespace: {{.Values.global.namespace}}
 ---
-{{-  $ca := genSelfSignedCert (printf "linkerd-tap.%s.svc" .Values.global.namespace) (list ) (list (printf "linkerd-tap.%s.svc" .Values.global.namespace)) 365 }}
+{{- $host := printf "linkerd-tap.%s.svc" .Values.global.namespace }}
+{{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.tap.externalSecret) }}
 kind: Secret
 apiVersion: v1

--- a/charts/linkerd2/templates/tap-rbac.yaml
+++ b/charts/linkerd2/templates/tap-rbac.yaml
@@ -91,7 +91,7 @@ subjects:
   name: linkerd-tap
   namespace: {{.Values.global.namespace}}
 ---
-{{-  $ca := genCA (printf "linkerd-tap.%s.svc" .Values.global.namespace) 365 }}
+{{-  $ca := genSelfSignedCert (printf "linkerd-tap.%s.svc" .Values.global.namespace) (list ) (list (printf "linkerd-tap.%s.svc" .Values.global.namespace)) 365 }}
 {{- if (not .Values.tap.externalSecret) }}
 kind: Secret
 apiVersion: v1


### PR DESCRIPTION
Fixes #4918

In Kubernetes 1.18, Go version has been updated to 1.15 which updated
how certificates are verified. They moved away from legacy Common Name
field to SANs.

This PR replaces the internal Helm cert generation functions to
`genSelfSignedCert` as they allow alternate DNS names to be specified.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
