### PR TITLE
Use correct component name in multicluster checks

### DIFF
--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -23,7 +23,7 @@ const (
 	// multicluster setup.
 	LinkerdMulticlusterChecks CategoryID = "linkerd-multicluster"
 
-	linkerdServiceMirrorComponentName      = "linkerd-service-mirror"
+	linkerdServiceMirrorComponentName      = "service-mirror"
 	linkerdServiceMirrorServiceAccountName = "linkerd-service-mirror-%s"
 	linkerdServiceMirrorClusterRoleName    = "linkerd-service-mirror-access-local-resources-%s"
 	linkerdServiceMirrorRoleName           = "linkerd-service-mirror-read-remote-creds-%s"


### PR DESCRIPTION
The multicluster checks make sure that the correct resources exist for each service mirror controller.  When looking up these resources, it uses the `linkerd.io/control-plane-component=linkerd-service-mirror` label selector.  However, these resources have the label `linkerd.io/control-plane-component=service-mirror`.  This causes the resource lookup to fail to find the resource and the check spuriously fails.

```
× service mirror controller has required permissions
    missing ServiceAccounts: linkerd-service-mirror-self
missing ClusterRoles: linkerd-service-mirror-access-local-resources-self
missing ClusterRoleBindings: linkerd-service-mirror-access-local-resources-self
missing Roles: linkerd-service-mirror-read-remote-creds-self
missing RoleBindings: linkerd-service-mirror-read-remote-creds-self
    see https://linkerd.io/checks/#l5d-multicluster-source-rbac-correct for hints
|         * no service mirror controller deployment for Link self
```

Instead, use the correct label selector when looking up these resources.

Signed-off-by: Alex Leong <alex@buoyant.io>

