### PR TITLE
Perform TLS checks on injector, sp validator and tap

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -179,8 +179,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
 			checks = append(checks, healthcheck.LinkerdAPIChecks)
 			checks = append(checks, healthcheck.LinkerdIdentity)
-			checks = append(checks, healthcheck.LinkerdWebhooksTLS)
-			checks = append(checks, healthcheck.LinkerdTapTLS)
+			checks = append(checks, healthcheck.LinkerdWebhooksAndAPISvcTLS)
 
 			if options.dataPlaneOnly {
 				checks = append(checks, healthcheck.LinkerdDataPlaneChecks)

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -179,6 +179,8 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, stage string, options
 			checks = append(checks, healthcheck.LinkerdControlPlaneExistenceChecks)
 			checks = append(checks, healthcheck.LinkerdAPIChecks)
 			checks = append(checks, healthcheck.LinkerdIdentity)
+			checks = append(checks, healthcheck.LinkerdWebhooksTLS)
+			checks = append(checks, healthcheck.LinkerdTapTLS)
 
 			if options.dataPlaneOnly {
 				checks = append(checks, healthcheck.LinkerdDataPlaneChecks)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -92,6 +92,14 @@ const (
 	// that the control plane is configured with
 	LinkerdIdentity CategoryID = "linkerd-identity"
 
+	// LinkerdWebhooksTLS the integrity of the mTLS certificates
+	// that of the for the injector and sp webhooks
+	LinkerdWebhooksTLS CategoryID = "linkerd-webhooks-tls"
+
+	// LinkerdTapTLS the integrity of the mTLS certificates
+	// of the tap service
+	LinkerdTapTLS CategoryID = "linkerd-tap-tls"
+
 	// LinkerdIdentityDataPlane checks that integrity of the mTLS
 	// certificates that the proxies are configured with and tries to
 	// report useful information with respect to whether the configuration
@@ -152,6 +160,12 @@ const (
 	// This key is passed to checkApiService method to check whether
 	// the api service is available or not
 	linkerdTapAPIServiceName = "v1alpha1.tap.linkerd.io"
+
+	tapTLSSecretName           = "linkerd-tap-tls"
+	proxyInjectorTLSSecretName = "linkerd-proxy-injector-tls"
+	spValidatorTLSSecretName   = "linkerd-sp-validator-tls"
+	certKeyName                = "crt.pem"
+	keyKeyName                 = "key.pem"
 )
 
 // HintBaseURL is the base URL on the linkerd.io website that all check hints
@@ -1008,6 +1022,67 @@ func (hc *HealthChecker) allCategories() []category {
 			},
 		},
 		{
+			id: LinkerdWebhooksTLS,
+			checkers: []checker{
+				{
+					description: "proxy-injector webhook has valid cert",
+					hintAnchor:  "l5d-proxy-injector-webhook-cert-valid",
+					fatal:       true,
+					check: func(context.Context) (err error) {
+						anchors, err := hc.fetchProxyInjectorCaBundle()
+						if err != nil {
+							return err
+						}
+						cert, err := hc.fetchCredsFromSecret(proxyInjectorTLSSecretName)
+						if err != nil {
+							return err
+						}
+						identityName := fmt.Sprintf("linkerd-proxy-injector.%s.svc", hc.ControlPlaneNamespace)
+						return hc.checkCertAndAnchors(cert, anchors, identityName)
+					},
+				},
+				{
+					description: "sp-validator webhook has valid cert",
+					hintAnchor:  "l5d-sp-validator-webhook-cert-valid",
+					fatal:       true,
+					check: func(context.Context) (err error) {
+						anchors, err := hc.fetchSpValidatorCaBundle()
+						if err != nil {
+							return err
+						}
+						cert, err := hc.fetchCredsFromSecret(spValidatorTLSSecretName)
+						if err != nil {
+							return err
+						}
+						identityName := fmt.Sprintf("linkerd-sp-validator.%s.svc", hc.ControlPlaneNamespace)
+						return hc.checkCertAndAnchors(cert, anchors, identityName)
+					},
+				},
+			},
+		},
+		{
+			id: LinkerdTapTLS,
+			checkers: []checker{
+				{
+					description: "tap has valid cert",
+					hintAnchor:  "l5d-tap-cert-valid",
+					fatal:       true,
+					check: func(context.Context) (err error) {
+						anchors, err := hc.fetchTapCaBundle()
+						if err != nil {
+							return err
+						}
+						cert, err := hc.fetchCredsFromSecret(tapTLSSecretName)
+						if err != nil {
+							return err
+						}
+						identityName := fmt.Sprintf("linkerd-tap.%s.svc", hc.ControlPlaneNamespace)
+						return hc.checkCertAndAnchors(cert, anchors, identityName)
+					},
+				},
+			},
+		},
+		{
 			id: LinkerdIdentityDataPlane,
 			checkers: []checker{
 				{
@@ -1234,6 +1309,48 @@ func (hc *HealthChecker) allCategories() []category {
 			},
 		},
 	}
+}
+
+func (hc *HealthChecker) checkCertAndAnchors(cert *tls.Cred, trustAnchors []*x509.Certificate, identityName string) error {
+
+	// check anchors time validity
+	var expiredAnchors []string
+	for _, anchor := range trustAnchors {
+		if err := issuercerts.CheckCertValidityPeriod(anchor); err != nil {
+			expiredAnchors = append(expiredAnchors, fmt.Sprintf("* %v %s %s", anchor.SerialNumber, anchor.Subject.CommonName, err))
+		}
+	}
+	if len(expiredAnchors) > 0 {
+		return fmt.Errorf("Anchors not within their validity period:\n\t%s", strings.Join(expiredAnchors, "\n\t"))
+	}
+
+	// check anchors not expiring soon
+	var expiringAnchors []string
+	for _, anchor := range trustAnchors {
+		anchor := anchor
+		if err := issuercerts.CheckExpiringSoon(anchor); err != nil {
+			expiringAnchors = append(expiringAnchors, fmt.Sprintf("* %v %s %s", anchor.SerialNumber, anchor.Subject.CommonName, err))
+		}
+	}
+	if len(expiringAnchors) > 0 {
+		return fmt.Errorf("Anchors expiring soon:\n\t%s", strings.Join(expiringAnchors, "\n\t"))
+	}
+
+	// check cert validity
+	if err := issuercerts.CheckCertValidityPeriod(cert.Certificate); err != nil {
+		return fmt.Errorf("certificate is %s", err)
+	}
+
+	// check cert not expiring soon
+	if err := issuercerts.CheckExpiringSoon(cert.Certificate); err != nil {
+		return fmt.Errorf("certificate %s", err)
+	}
+
+	if err := cert.Verify(tls.CertificatesToPool(trustAnchors), identityName, time.Time{}); err != nil {
+		return fmt.Errorf("cert is not issued by the trust anchor: %s", err)
+	}
+
+	return nil
 }
 
 func (hc *HealthChecker) checkMinReplicasAvailable() error {
@@ -1495,6 +1612,79 @@ func (hc *HealthChecker) checkCertificatesConfig() (*tls.Cred, []*x509.Certifica
 	return issuerCreds, anchors, nil
 }
 
+func (hc *HealthChecker) fetchProxyInjectorCaBundle() ([]*x509.Certificate, error) {
+	mwh, err := hc.getProxyInjectorMutatingWebhook()
+	if err != nil {
+		return nil, err
+	}
+
+	caBundle, err := tls.DecodePEMCertificates(string(mwh.ClientConfig.CABundle))
+	if err != nil {
+		return nil, err
+	}
+	return caBundle, nil
+}
+
+func (hc *HealthChecker) fetchSpValidatorCaBundle() ([]*x509.Certificate, error) {
+
+	vwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(k8s.SPValidatorWebhookConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vwc.Webhooks) != 1 {
+		return nil, fmt.Errorf("expected 1 webhooks, found %d", len(vwc.Webhooks))
+	}
+
+	caBundle, err := tls.DecodePEMCertificates(string(vwc.Webhooks[0].ClientConfig.CABundle))
+	if err != nil {
+		return nil, err
+	}
+	return caBundle, nil
+}
+
+func (hc *HealthChecker) fetchTapCaBundle() ([]*x509.Certificate, error) {
+	apiServiceClient, err := apiregistrationv1client.NewForConfig(hc.kubeAPI.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	apiService, err := apiServiceClient.APIServices().Get(linkerdTapAPIServiceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	caBundle, err := tls.DecodePEMCertificates(string(apiService.Spec.CABundle))
+	if err != nil {
+		return nil, err
+	}
+	return caBundle, nil
+}
+
+func (hc *HealthChecker) fetchCredsFromSecret(secretName string) (*tls.Cred, error) {
+	secret, err := hc.kubeAPI.CoreV1().Secrets(hc.ControlPlaneNamespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	crt, ok := secret.Data[certKeyName]
+	if !ok {
+		return nil, fmt.Errorf("key %s needs to exist in secret %s", certKeyName, secretName)
+	}
+
+	key, ok := secret.Data[keyKeyName]
+	if !ok {
+		return nil, fmt.Errorf("key %s needs to exist in secret %s", keyKeyName, secretName)
+	}
+
+	cred, err := tls.ValidateAndCreateCreds(string(crt), string(key))
+	if err != nil {
+		return nil, err
+	}
+
+	return cred, nil
+}
+
 // FetchLinkerdConfigMap retrieves the `linkerd-config` ConfigMap from
 // Kubernetes and parses it into `linkerd2.config` protobuf.
 // TODO: Consider a different package for this function. This lives in the
@@ -1672,7 +1862,7 @@ func (hc *HealthChecker) checkCustomResourceDefinitions(shouldExist bool) error 
 	return checkResources("CustomResourceDefinitions", objects, []string{"serviceprofiles.linkerd.io"}, shouldExist)
 }
 
-func (hc *HealthChecker) getMutatingWebhookFailurePolicy() (*admissionRegistration.FailurePolicyType, error) {
+func (hc *HealthChecker) getProxyInjectorMutatingWebhook() (*admissionRegistration.MutatingWebhook, error) {
 	mwc, err := hc.kubeAPI.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(k8s.ProxyInjectorWebhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -1680,7 +1870,15 @@ func (hc *HealthChecker) getMutatingWebhookFailurePolicy() (*admissionRegistrati
 	if len(mwc.Webhooks) != 1 {
 		return nil, fmt.Errorf("expected 1 webhooks, found %d", len(mwc.Webhooks))
 	}
-	return mwc.Webhooks[0].FailurePolicy, nil
+	return &mwc.Webhooks[0], nil
+}
+
+func (hc *HealthChecker) getMutatingWebhookFailurePolicy() (*admissionRegistration.FailurePolicyType, error) {
+	mwh, err := hc.getProxyInjectorMutatingWebhook()
+	if err != nil {
+		return nil, err
+	}
+	return mwh.FailurePolicy, nil
 }
 
 func (hc *HealthChecker) checkMutatingWebhookConfigurations(shouldExist bool) error {

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -40,6 +40,15 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
+linkerd-webhooks-tls
+--------------------
+√ proxy-injector webhook has valid cert
+√ sp-validator webhook has valid cert
+
+linkerd-tap-tls
+---------------
+√ tap has valid cert
+
 linkerd-api
 -----------
 √ control plane pods are ready

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -40,14 +40,11 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
-linkerd-webhooks-tls
---------------------
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ tap API server has valid cert
 √ proxy-injector webhook has valid cert
 √ sp-validator webhook has valid cert
-
-linkerd-tap-tls
----------------
-√ tap has valid cert
 
 linkerd-api
 -----------

--- a/test/integration/testdata/check.multicluster.golden
+++ b/test/integration/testdata/check.multicluster.golden
@@ -40,6 +40,15 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
+linkerd-webhooks-tls
+--------------------
+√ proxy-injector webhook has valid cert
+√ sp-validator webhook has valid cert
+
+linkerd-tap-tls
+---------------
+√ tap has valid cert
+
 linkerd-api
 -----------
 √ control plane pods are ready

--- a/test/integration/testdata/check.multicluster.golden
+++ b/test/integration/testdata/check.multicluster.golden
@@ -40,14 +40,11 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
-linkerd-webhooks-tls
---------------------
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ tap API server has valid cert
 √ proxy-injector webhook has valid cert
 √ sp-validator webhook has valid cert
-
-linkerd-tap-tls
----------------
-√ tap has valid cert
 
 linkerd-api
 -----------

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -40,14 +40,11 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
-linkerd-webhooks-tls
---------------------
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ tap API server has valid cert
 √ proxy-injector webhook has valid cert
 √ sp-validator webhook has valid cert
-
-linkerd-tap-tls
----------------
-√ tap has valid cert
 
 linkerd-identity-data-plane
 ---------------------------

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -40,6 +40,15 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
+linkerd-webhooks-tls
+--------------------
+√ proxy-injector webhook has valid cert
+√ sp-validator webhook has valid cert
+
+linkerd-tap-tls
+---------------
+√ tap has valid cert
+
 linkerd-identity-data-plane
 ---------------------------
 √ data plane proxies certificate match CA

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -40,14 +40,11 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
-linkerd-webhooks-tls
---------------------
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ tap API server has valid cert
 √ proxy-injector webhook has valid cert
 √ sp-validator webhook has valid cert
-
-linkerd-tap-tls
----------------
-√ tap has valid cert
 
 linkerd-identity-data-plane
 ---------------------------

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -40,6 +40,15 @@ linkerd-identity
 √ issuer cert is valid for at least 60 days
 √ issuer cert is issued by the trust anchor
 
+linkerd-webhooks-tls
+--------------------
+√ proxy-injector webhook has valid cert
+√ sp-validator webhook has valid cert
+
+linkerd-tap-tls
+---------------
+√ tap has valid cert
+
 linkerd-identity-data-plane
 ---------------------------
 √ data plane proxies certificate match CA


### PR DESCRIPTION
This PR adds checks for the certificats of Tap, Sp Validator and Proxy injector. Still need to make tests pass and figure out some details around tha naming of things. Good news is we reuse a lot of the code here

UPDATE: 

Simplified the checks and now the output looks like: 

```
linkerd-identity
----------------
√ certificate config is valid
√ trust anchors are using supported crypto algorithm
√ trust anchors are within their validity period
√ trust anchors are valid for at least 60 days
√ issuer cert is using supported crypto algorithm
√ issuer cert is within its validity period
√ issuer cert is valid for at least 60 days
√ issuer cert is issued by the trust anchor

linkerd-webhooks-and-apisvc-tls
-------------------------------
√ tap API server has valid cert
√ proxy-injector webhook has valid cert
√ sp-validator webhook has valid cert
```


Fix #4889

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>