### PR TITLE
Revert "Temporarily disable job `psscript-analyzer` in static checks"

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -52,22 +52,22 @@ jobs:
       # https://github.com/koalaman/shellcheck/wiki/Checks
       run: |
         bin/shellcheck-all
-  #psscript-analyzer:
-    #name: PSScriptAnalyzer
-    #runs-on: ubuntu-18.04
-    #steps:
-    #- name: Checkout code
+  psscript-analyzer:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout code
       # actions/checkout@v2
-    #  uses: actions/checkout@722adc6
-    #- name: Chocolatey - lint
-      # devblackops/github-action-psscriptanalyzer@v2.0.0
-    #  uses: devblackops/github-action-psscriptanalyzer@889a059
-    #  env:
+      uses: actions/checkout@722adc6
+    - name: Chocolatey - lint
+      # devblackops/github-action-psscriptanalyzer@v2.3.0
+      uses: devblackops/github-action-psscriptanalyzer@819c15c
+      env:
         # https://github.com/devblackops/github-action-psscriptanalyzer/pull/3/files
-    #    INPUT_FAILONWARNING: 1
-    #  with:
-    #    rootPath: bin/win/tools
-    #    failOnInfos: true
+        INPUT_FAILONWARNING: 1
+      with:
+        rootPath: bin/win/tools
+        failOnInfos: true
   markdown_lint:
     name: Markdown lint
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This reverts #4837 which disabled the psscript-analyzer job that had an
issue. This upgrades it to version 2.3.0, which fixes the issue.