### PR TITLE
CNI: Use skip ports configuration in CNI

### DIFF
--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -120,7 +120,7 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &cniPluginOptions{
+	cniOptions := cniPluginOptions{
 		linkerdVersion:      version.Version,
 		dockerRegistry:      defaultDockerRegistry,
 		proxyControlPort:    4190,
@@ -137,7 +137,17 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 		useWaitFlag:         defaults.UseWaitFlag,
 		priorityClassName:   defaults.PriorityClassName,
 		installNamespace:    defaults.InstallNamespace,
-	}, nil
+	}
+
+	if defaults.IgnoreInboundPorts != "" {
+		cniOptions.ignoreInboundPorts = strings.Split(defaults.IgnoreInboundPorts, ",")
+
+	}
+	if defaults.IgnoreOutboundPorts != "" {
+		cniOptions.ignoreOutboundPorts = strings.Split(defaults.IgnoreOutboundPorts, ",")
+	}
+
+	return &cniOptions, nil
 }
 
 func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -69,6 +69,15 @@ func TestRenderCNIPlugin(t *testing.T) {
 		installNamespace:    false,
 	}
 
+	defaultOptionsWithSkipPorts, err := newCNIInstallOptionsWithDefaults()
+	if err != nil {
+		t.Fatalf("Unexpected error from newCNIInstallOptionsWithDefaults(): %v", err)
+	}
+
+	defaultOptionsWithSkipPorts.ignoreInboundPorts = append(defaultOptionsWithSkipPorts.ignoreInboundPorts, []string{"80", "8080"}...)
+	defaultOptionsWithSkipPorts.ignoreOutboundPorts = append(defaultOptionsWithSkipPorts.ignoreOutboundPorts, []string{"443", "1000"}...)
+
+
 	testCases := []struct {
 		*cniPluginOptions
 		namespace      string
@@ -78,6 +87,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 		{fullyConfiguredOptions, otherNamespace, "install-cni-plugin_fully_configured.golden"},
 		{fullyConfiguredOptionsEqualDsts, otherNamespace, "install-cni-plugin_fully_configured_equal_dsts.golden"},
 		{fullyConfiguredOptionsNoNamespace, otherNamespace, "install-cni-plugin_fully_configured_no_namespace.golden"},
+		{defaultOptionsWithSkipPorts, defaultCniNamespace, "install-cni-plugin_skip_ports.golden"},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -77,7 +77,6 @@ func TestRenderCNIPlugin(t *testing.T) {
 	defaultOptionsWithSkipPorts.ignoreInboundPorts = append(defaultOptionsWithSkipPorts.ignoreInboundPorts, []string{"80", "8080"}...)
 	defaultOptionsWithSkipPorts.ignoreOutboundPorts = append(defaultOptionsWithSkipPorts.ignoreOutboundPorts, []string{"443", "1000"}...)
 
-
 	testCases := []struct {
 		*cniPluginOptions
 		namespace      string

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -1,0 +1,203 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: linkerd-cni
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/cni-resource: "true"
+    config.linkerd.io/admission-webhooks: disabled
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: linkerd-linkerd-cni-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - hostPath
+  - secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+rules:
+- apiGroups: ['extensions', 'policy']
+  resources: ['podsecuritypolicies']
+  resourceNames:
+  - linkerd-linkerd-cni-cni
+  verbs: ['use']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linkerd-cni
+subjects:
+- kind: ServiceAccount
+  name: linkerd-cni
+  namespace: linkerd-cni
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "namespaces"]
+  verbs: ["list", "get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-cni
+subjects:
+- kind: ServiceAccount
+  name: linkerd-cni
+  namespace: linkerd-cni
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-cni-config
+  namespace: linkerd-cni
+  labels:
+    linkerd.io/cni-resource: "true"
+data:
+  dest_cni_net_dir: "/etc/cni/net.d"
+  dest_cni_bin_dir: "/opt/cni/bin"
+  # The CNI network configuration to install on each node. The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "linkerd-cni",
+      "type": "linkerd-cni",
+      "log_level": "info",
+      "policy": {
+          "type": "k8s",
+          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+      },
+      "kubernetes": {
+          "kubeconfig": "__KUBECONFIG_FILEPATH__"
+      },
+      "linkerd": {
+        "incoming-proxy-port": 4143,
+        "outgoing-proxy-port": 4140,
+        "proxy-uid": 2102,
+        "ports-to-redirect": [],
+        "inbound-ports-to-ignore": ["4190","4191","80","8080"],
+        "outbound-ports-to-ignore": ["443","1000"],
+        "simulate": false,
+        "use-wait-flag": false
+      }
+    }
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: linkerd-cni
+  namespace: linkerd-cni
+  labels:
+    k8s-app: linkerd-cni
+    linkerd.io/cni-resource: "true"
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+spec:
+  selector:
+    matchLabels:
+      k8s-app: linkerd-cni
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: linkerd-cni
+      annotations:
+        linkerd.io/created-by: linkerd/cli dev-undefined
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      hostNetwork: true
+      serviceAccountName: linkerd-cni
+      containers:
+      # This container installs the linkerd CNI binaries
+      # and CNI network config file on each node. The install
+      # script copies the files into place and then sleeps so
+      # that Kubernetes doesn't keep trying to restart it.
+      - name: install-cni
+        image: ghcr.io/linkerd/cni-plugin:dev-undefined
+        env:
+        - name: DEST_CNI_NET_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_net_dir
+        - name: DEST_CNI_BIN_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: dest_cni_bin_dir
+        - name: CNI_NETWORK_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: linkerd-cni-config
+              key: cni_network_config
+        - name: SLEEP
+          value: "true"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["kill","-15","1"]
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          name: cni-bin-dir
+        - mountPath: /host/etc/cni/net.d
+          name: cni-net-dir
+      volumes:
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+---

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -203,7 +203,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			if pod.GetLabels()[k8s.ControllerComponentLabel] != "" {
 				// Skip 443 outbound port if its a control plane component
 				logEntry.Debug("linkerd-cni: adding 443 to OutboundPortsToIgnore as its a control plane component")
-				options.OutboundPortsToIgnore  = append(options.OutboundPortsToIgnore, "443")
+				options.OutboundPortsToIgnore = append(options.OutboundPortsToIgnore, "443")
 			}
 
 			firewallConfiguration, err := cmd.BuildFirewallConfiguration(&options)

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"os"
 	"strings"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/linkerd/linkerd2-proxy-init/iptables"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -201,7 +201,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				UseWaitFlag:           conf.ProxyInit.UseWaitFlag,
 			}
 
-			// Get if there are any configured ports to be ignored
+			// Check if there are any overridden ports to be skipped
 			if inboundSkipOverride, err := getAnnotationOverride(client, pod, k8s.ProxyIgnoreInboundPortsAnnotation); err == nil {
 				logEntry.Debugf("linkerd-cni: overriding InboundPortsToIgnore to %s", inboundSkipOverride)
 				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
@@ -252,12 +252,12 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func getAnnotationOverride(api *k8s.KubernetesAPI, pod *v1.Pod, key string) (string, error) {
-	// Check if there is a annotation on the pod
+	// Check if the annotation is present on the pod
 	if override := pod.GetObjectMeta().GetAnnotations()[key]; override != "" {
 		return override, nil
 	}
 
-	// Check if there is a annotation on the namespace
+	// Check if the annotation is present on the namespace
 	ns, err := api.CoreV1().Namespaces().Get(pod.GetObjectMeta().GetNamespace(), metav1.GetOptions{})
 	if err != nil {
 		return "", err

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -209,6 +209,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 
 			if outboundSkipOverride != "" {
+				logEntry.Debugf("linkerd-cni: overriding OutboundPortsToIgnore to %s", outboundSkipOverride)
 				options.OutboundPortsToIgnore = strings.Split(outboundSkipOverride, ",")
 			}
 
@@ -219,6 +220,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 
 			if inboundSkipOverride != "" {
+				logEntry.Debugf("linkerd-cni: overriding InboundPortsToIgnore to %s", inboundSkipOverride)
 				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
 			}
 

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -202,14 +202,24 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 
 			// Check if there are any overridden ports to be skipped
-			if inboundSkipOverride, err := getAnnotationOverride(client, pod, k8s.ProxyIgnoreInboundPortsAnnotation); err == nil {
-				logEntry.Debugf("linkerd-cni: overriding InboundPortsToIgnore to %s", inboundSkipOverride)
-				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
+			outboundSkipOverride, err := getAnnotationOverride(client, pod, k8s.ProxyIgnoreOutboundPortsAnnotation)
+			if err != nil {
+				logEntry.Errorf("linkerd-cni: could not retrieve overridden annotations: %v", err)
+				return err
 			}
 
-			if outboundSkipOverride, err := getAnnotationOverride(client, pod, k8s.ProxyIgnoreOutboundPortsAnnotation); err == nil {
-				logEntry.Debugf("linkerd-cni: overriding OutboundPortsToIgnore to %s", outboundSkipOverride)
+			if outboundSkipOverride != "" {
 				options.OutboundPortsToIgnore = strings.Split(outboundSkipOverride, ",")
+			}
+
+			inboundSkipOverride, err := getAnnotationOverride(client, pod, k8s.ProxyIgnoreInboundPortsAnnotation)
+			if err != nil {
+				logEntry.Errorf("linkerd-cni: could not retrieve overridden annotations: %v", err)
+				return err
+			}
+
+			if inboundSkipOverride != "" {
+				options.InboundPortsToIgnore = strings.Split(inboundSkipOverride, ",")
 			}
 
 			if pod.GetLabels()[k8s.ControllerComponentLabel] != "" {
@@ -267,5 +277,5 @@ func getAnnotationOverride(api *k8s.KubernetesAPI, pod *v1.Pod, key string) (str
 		return override, nil
 	}
 
-	return "", fmt.Errorf("did not find any override annotation for %s", key)
+	return "", nil
 }

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -199,6 +199,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 				NetNs:                 args.Netns,
 				UseWaitFlag:           conf.ProxyInit.UseWaitFlag,
 			}
+
+			if pod.GetLabels()[k8s.ControllerComponentLabel] != "" {
+				// Skip 443 outbound port if its a control plane component
+				logEntry.Debug("linkerd-cni: adding 443 to OutboundPortsToIgnore as its a control plane component")
+				options.OutboundPortsToIgnore  = append(options.OutboundPortsToIgnore, "443")
+			}
+
 			firewallConfiguration, err := cmd.BuildFirewallConfiguration(&options)
 			if err != nil {
 				logEntry.Errorf("linkerd-cni: could not create a Firewall Configuration from the options: %v", options)

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containernetworking/cni v0.6.1-0.20180218032124-142cde0c766c h1:X6Gxg2GV1i0UhDodKZYrp//lg8h3KANe8l3gtFHoi9M=
 github.com/containernetworking/cni v0.6.1-0.20180218032124-142cde0c766c/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
Fixes #4792 

This PR updates the install and `cmdAdd` workflow (which is called
for each new Pod creation) to retrieve and set the configured Skip
Ports. This also updates the `cmdAdd` workflow to check if the new
pod is a control plane Pod, and add `443` to OutBoundSkipPort so
that 443 (used with k8s API) is skipped as it was causing errors
because a resolve lookup was happening for them which is not intended
after the newly added discovery to outbound TCP connections.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
