### PR TITLE
Fix Dependabot alert for `node-forge`

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -88,7 +88,8 @@
     "webpack-dev-server": "3.11.0"
   },
   "resolutions": {
-    "@lingui/**/**/minimist": ">=1.2.5"
+    "@lingui/**/**/minimist": ">=1.2.5",
+    "webpack-dev-server/selfsigned/node-forge": ">=0.10.0"
   },
   "jest": {
     "testEnvironment": "enzyme",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -8245,10 +8245,10 @@ node-fetch@1.6.3:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
-  integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+node-forge@0.9.0, node-forge@>=0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Override the `node-forge` version requested by `webpack-dev-server/selfsigned` to `>=0.10.0` in order to address [CVE-2020-7720](https://github.com/advisories/GHSA-92xj-mqp7-vmcj).
