### PR TITLE
Upgrade Grafana to v7.1.5 to get CVE fixes

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:7.0.3
+FROM grafana/grafana:7.1.5
 
 COPY LICENSE                          /linkerd/LICENSE
 COPY grafana/dashboards               /var/lib/grafana/dashboards


### PR DESCRIPTION
Fixes #4884

Upgrades the underlying Alpine base distro, which resolves [CVE-2020-12723](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12723) and [CVE-2020-13777](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13777)

I tested Grafana continues to work as expected.