### PR TITLE
Delete multicluster resources in `bin/test-cleanup`

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -83,6 +83,9 @@ echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_co
 
 populate_array rolebindings              rolebindings                    control-plane-ns
 
+echo "cleaning up multicluster resources, if present [${k8s_context}]"
+linkerd mc uninstall 2> /dev/null  | kubectl --context="$k8s_context" delete -f -
+
 # No action if array is empty
 if [[ ${rolebindings[*]} ]]; then
   kubectl --context="$k8s_context" delete "${rolebindings[@]}" -n kube-system


### PR DESCRIPTION
When some test failed in the middle of the
`./tests/integration/install_test.go` suite, multicluster resources can
be left-over, which `./bin/test-cleanup` wasn't removing.

This was affecting the ARM integration tests, that require good cleanup
since they use a non-transient cluster.