### PR TITLE
Remove double slash in mc health probe URI

### DIFF
--- a/controller/service-mirror/probe_worker.go
+++ b/controller/service-mirror/probe_worker.go
@@ -84,7 +84,7 @@ func (pw *ProbeWorker) doProbe() {
 		Timeout: httpGatewayTimeoutMillis * time.Millisecond,
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d/%s", pw.localGatewayName, pw.probeSpec.Port, pw.probeSpec.Path), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d%s", pw.localGatewayName, pw.probeSpec.Port, pw.probeSpec.Path), nil)
 	if err != nil {
 		pw.log.Errorf("Could not create a GET request to gateway: %s", err)
 		return


### PR DESCRIPTION
This PR removes the slash duplication in the cross cluster probes URL. 

Related: #4984

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
