### PR TITLE
Refactor handling of the `--multicluster` flag in integration tests

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -101,6 +101,7 @@ jobs:
         - external-issuer
         - helm-deep
         - helm-upgrade
+        - multicluster
         - uninstall
         - upgrade-edge
         - upgrade-stable

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -183,6 +183,7 @@ start_kind_test() {
   if [ -z "$skip_cluster_create" ]; then
     create_kind_cluster "$name" "$config"
     "$bindir"/image-load --kind ${images:+'--images'} "$name"
+    exit_on_err "error calling '$bindir/image-load'"
   fi
   check_cluster
   run_"$name"_test
@@ -374,13 +375,15 @@ run_uninstall_test() {
 }
 
 run_multicluster_test() {
-  #placeholder for now
-  true
+  export context="k3d-source"
+  run_test "$test_directory/install_test.go" --multicluster
+  export context="k3d-target"
+  run_test "$test_directory/install_test.go" --multicluster
 }
 
 run_deep_test() {
   local tests=()
-  run_test "$test_directory/install_test.go" --multicluster
+  run_test "$test_directory/install_test.go"
   while IFS= read -r line; do tests+=("$line"); done <<< "$(go list "$test_directory"/.../...)"
   for test in "${tests[@]}"; do
     run_test "$test"
@@ -402,7 +405,7 @@ run_helm-deep_test() {
   helm_multicluster_chart="$( cd "$bindir"/.. && pwd )"/charts/linkerd2-multicluster
   run_test "$test_directory/install_test.go" --helm-path="$helm_path" --helm-chart="$helm_chart" \
   --helm-release="$helm_release_name" --multicluster-helm-chart="$helm_multicluster_chart" \
-  --multicluster-helm-release="$helm_multicluster_release_name" --multicluster
+  --multicluster-helm-release="$helm_multicluster_release_name"
   while IFS= read -r line; do tests+=("$line"); done <<< "$(go list "$test_directory"/.../...)"
   for test in "${tests[@]}"; do
     run_test "$test"
@@ -411,12 +414,12 @@ run_helm-deep_test() {
 }
 
 run_external-issuer_test() {
-  run_test "$test_directory/install_test.go" --external-issuer=true --multicluster
+  run_test "$test_directory/install_test.go" --external-issuer=true
   run_test "$test_directory/externalissuer/external_issuer_test.go" --external-issuer=true
 }
 
 run_cluster-domain_test() {
-  run_test "$test_directory/install_test.go" --cluster-domain='custom.domain' --multicluster
+  run_test "$test_directory/install_test.go" --cluster-domain='custom.domain'
 }
 
 # exit_on_err should be called right after a command to check the result status

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -454,9 +454,6 @@ func TestControlPlaneResourcesPostInstall(t *testing.T) {
 }
 
 func TestInstallMulticluster(t *testing.T) {
-	if !TestHelper.Multicluster() {
-		return
-	}
 	if TestHelper.GetMulticlusterHelmReleaseName() != "" {
 		flags := []string{
 			"--set", "linkerdVersion=" + TestHelper.GetVersion(),
@@ -466,7 +463,7 @@ func TestInstallMulticluster(t *testing.T) {
 			testutil.AnnotatedFatalf(t, "'helm install' command failed",
 				"'helm install' command failed\n%s\n%s", stdout, stderr)
 		}
-	} else {
+	} else if TestHelper.Multicluster() {
 		exec := append([]string{"multicluster"}, []string{
 			"install",
 			"--namespace", TestHelper.GetMulticlusterNamespace(),
@@ -679,7 +676,7 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 	var golden string
 	if stage == "proxy" {
 		cmd = []string{"check", "--proxy", "--expected-version", expectedVersion, "--namespace", namespace, "--wait=0"}
-		if TestHelper.Multicluster() {
+		if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
 			golden = "check.multicluster.proxy.golden"
 		} else if TestHelper.CNI() {
 			golden = "check.cni.proxy.golden"
@@ -691,7 +688,7 @@ func testCheckCommand(t *testing.T, stage string, expectedVersion string, namesp
 		golden = "check.config.golden"
 	} else {
 		cmd = []string{"check", "--expected-version", expectedVersion, "--wait=0"}
-		if TestHelper.Multicluster() {
+		if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
 			golden = "check.multicluster.golden"
 		} else if TestHelper.CNI() {
 			golden = "check.cni.golden"
@@ -943,36 +940,6 @@ func TestRestarts(t *testing.T) {
 			} else {
 				testutil.AnnotatedFatal(t, "CheckPods timed-out", err)
 			}
-		}
-	}
-}
-
-//TODO Put that in test_cleanup when we have adequate resource labels
-func TestUninstallMulticluster(t *testing.T) {
-	if !TestHelper.Multicluster() {
-		return
-	}
-
-	if TestHelper.GetMulticlusterHelmReleaseName() != "" {
-		if stdout, stderr, err := TestHelper.HelmUninstallMulticluster(TestHelper.GetMulticlusterHelmChart()); err != nil {
-			testutil.AnnotatedFatalf(t, "'helm delete' command failed",
-				"'helm delete' command failed\n%s\n%s", stdout, stderr)
-		}
-	} else {
-		exec := append([]string{"multicluster"}, []string{
-			"install",
-			"--namespace", TestHelper.GetMulticlusterNamespace(),
-		}...)
-		out, stderr, err := TestHelper.LinkerdRun(exec...)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "'linkerd multicluster install' command failed",
-				"'linkerd multicluster' command failed: \n%s\n%s", out, stderr)
-		}
-
-		out, err = TestHelper.Kubectl(out, []string{"delete", "-f", "-"}...)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "'kubectl delete' command failed",
-				"'kubectl apply' command failed\n%s", out)
 		}
 	}
 }


### PR DESCRIPTION
Followup to #4994, based off of that branch (`alpeb/k3d-tests`).
This is more preliminary work previous to the more complete multicluster integration test.

- Removed the `--multicluster` flag from all the tests we had in `bin/_test-helpers.sh`, so only the new "multicluster" integration test will make use of that. Also got rid of the `TestUninstallMulticluster()` test in `install_test.go` to keep the multicluster stuff around, needed for the more complete multicluster test that will be implemented in a followup PR.
- Added "multicluster" to the list of tests in the `kind_integration.yml` workflow.
- For now, this new "multicluster" test in `run_multicluster_test()` is just running the install tests (`test/integration/install_test.go`) with the `--multicluster` flag.