### PR TITLE
Ability for int tests to use external certs generated with openssl

### DIFF
--- a/bin/certs-openssl
+++ b/bin/certs-openssl
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+#
+set -eu
+
+# Creates the root and issuer (intermediary) self-signed certificates for the control plane using openssl.
+#
+# For instructions on doing this with step-cli, check https://linkerd.io/2/tasks/generate-certificates
+
+# Generate CA config
+cat > ca.cnf << EOF
+[ req ]
+distinguished_name=dn
+prompt = no
+[ ext ]
+basicConstraints = CA:TRUE
+keyUsage = digitalSignature, keyCertSign, cRLSign
+[ dn ]
+CN = identity.linkerd.cluster.local
+EOF
+
+# Generate CA key
+openssl ecparam -out ca.key -name prime256v1 -genkey -noout
+
+# Generate CA cert
+openssl req -key ca.key -new -x509 -days 7300 -sha256 -out ca.crt -config ca.cnf -extensions ext
+
+# Generate the intermediate issuer key
+openssl ecparam -out issuer.key -name prime256v1 -genkey -noout
+
+# Generate the intermediate issuer csr and cert
+openssl req -new -sha256 -key issuer.key -out issuer.csr  -config ca.cnf
+openssl x509 -sha256 -req -in issuer.csr -out issuer.crt -CA ca.crt -CAkey ca.key -days 7300 -extfile ca.cnf -extensions ext -CAcreateserial

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -258,6 +258,14 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 	)
 
+	if certsPath := TestHelper.CertsPath(); certsPath != "" {
+		args = append(args,
+			"--identity-trust-anchors-file", certsPath+"/ca.crt",
+			"--identity-issuer-certificate-file", certsPath+"/issuer.crt",
+			"--identity-issuer-key-file", certsPath+"/issuer.key",
+		)
+	}
+
 	if TestHelper.GetClusterDomain() != "cluster.local" {
 		args = append(args, "--cluster-domain", TestHelper.GetClusterDomain())
 	}

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -32,6 +32,7 @@ type TestHelper struct {
 	uninstall          bool
 	cni                bool
 	calico             bool
+	certsPath          string
 	httpClient         http.Client
 	KubernetesHelper
 	helm
@@ -149,7 +150,7 @@ func NewTestHelper() *TestHelper {
 	uninstall := flag.Bool("uninstall", false, "whether to run the 'linkerd uninstall' integration test")
 	cni := flag.Bool("cni", false, "whether to install linkerd with CNI enabled")
 	calico := flag.Bool("calico", false, "whether to install calico CNI plugin")
-
+	certsPath := flag.String("certs-path", "", "if non-empty, 'linkerd install' will use the files ca.crt, issuer.crt and issuer.key under this path in its --identity-* flags")
 	flag.Parse()
 
 	if !*runTests {
@@ -194,6 +195,7 @@ func NewTestHelper() *TestHelper {
 		cni:            *cni,
 		calico:         *calico,
 		uninstall:      *uninstall,
+		certsPath:      *certsPath,
 	}
 
 	version, stderr, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -283,6 +285,12 @@ func (h *TestHelper) Multicluster() bool {
 // Uninstall determines whether the "linkerd uninstall" integration test should be run
 func (h *TestHelper) Uninstall() bool {
 	return h.uninstall
+}
+
+// CertsPath returns the path for the ca.cert, issuer.crt and issuer.key files that `linkerd install`
+// will use in its --identity-* flags
+func (h *TestHelper) CertsPath() string {
+	return h.certsPath
 }
 
 // UpgradeFromVersion returns the base version of the upgrade test.


### PR DESCRIPTION
- Adds `bin/certs-openssl`, which creates self-signed root cert/key and issuer cert/key using `openssl`. This will be used in the two clusters set up in the multicluster integration test (followup PR), given CI already has `openssl` and to avoid having to install `step`.
- Adds a new flag `--certs-path` to the integration tests, pointing to the path where those certs (ca.crt, ca.key, issuer.key and issuer.crt) will be located to be fed into `linkerd install`'s `--identity-*` flags.