### PR TITLE
default install of linkerd2 interferes with apiserver reliability

### DIFF
--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -97,7 +97,6 @@ webhooks:
     matchLabels:
       config.linkerd.io/admission-webhooks: enabled
 {{- end }}
-{{/* Object selectors are supported in k8s 1.15+ */}}
 {{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
 {{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
 {{- if .Values.proxyInjector.objectSelector.enabled }}
@@ -113,7 +112,8 @@ webhooks:
       "linkerd.io/inject": "true"
 {{- end }}
 {{- end }}
-{{- end }}  clientConfig:
+{{- end }}
+  clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: {{ .Values.global.namespace }}

--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -83,12 +83,37 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
+{{- if .Values.proxyInjector.enableNamespacesByDefault }}
     matchExpressions:
+    - key: name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
     - key: config.linkerd.io/admission-webhooks
       operator: NotIn
       values:
       - disabled
-  clientConfig:
+{{- else }}
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
+{{- end }}
+{{/* Object selectors are supported in k8s 1.15+ */}}
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if semverCompare "> 1.15.0-0" $kubeTargetVersion }}
+{{- if .Values.proxyInjector.objectSelector.enabled }}
+  objectSelector:
+{{- if .Values.proxyInjector.objectSelector.autoInject }}
+    matchExpressions:
+    - key: linkerd.io/inject
+      operator: NotIn
+      values:
+      - "false"
+{{- else }}
+    matchLabels:
+      "linkerd.io/inject": "true"
+{{- end }}
+{{- end }}
+{{- end }}  clientConfig:
     service:
       name: linkerd-proxy-injector
       namespace: {{ .Values.global.namespace }}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -166,7 +166,11 @@ heartbeatSchedule: "0 0 * * *"
 
 # proxy injector configuration
 proxyInjector:
+  enableNamespacesByDefault: false
   externalSecret: false
+  objectSelector:
+    enabled: true
+    autoInject: false
   # if empty, Helm will auto-generate these fields
   crtPEM: |
 

--- a/cli/cmd/main_test.go
+++ b/cli/cmd/main_test.go
@@ -62,6 +62,7 @@ func writeRejects(t *testing.T, origFileName string, data []byte) {
 
 // TODO: share this with integration tests
 func diffTestdata(t *testing.T, path, actual string) {
+	t.Helper()
 	expected := readTestdata(t, path)
 	if actual == expected {
 		return

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: nginx
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/inject: "true"
         linkerd.io/proxy-deployment: nginx
         linkerd.io/workload-ns: ""
     spec:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -182,6 +182,7 @@ spec:
       labels:
         app: nginx
         linkerd.io/control-plane-ns: linkerd
+        linkerd.io/inject: "true"
         linkerd.io/proxy-deployment: nginx
         linkerd.io/workload-ns: ""
     spec:

--- a/cli/cmd/testdata/inject-filepath/resources/nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/resources/nginx.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: nginx
+        linkerd.io/inject: "true"
     spec:
       containers:
       - name: nginx

--- a/cli/cmd/testdata/install_addon_config.golden
+++ b/cli/cmd/testdata/install_addon_config.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_config.golden
+++ b/cli/cmd/testdata/install_config.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -417,11 +417,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -476,11 +476,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1947,7 +1944,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e734f618da84e77b839fe4aef71fef3292e197e2315d8f5c96811ce4ee133e3
+        checksum/config: 1affd472ca17bf87183247dbb58c1a4941ae15a73d42b17fbc8979c27b94af9a
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -476,11 +476,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1948,7 +1945,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e734f618da84e77b839fe4aef71fef3292e197e2315d8f5c96811ce4ee133e3
+        checksum/config: 1affd472ca17bf87183247dbb58c1a4941ae15a73d42b17fbc8979c27b94af9a
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -476,11 +476,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -2078,7 +2075,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ba3686271c366717fdceb99d6391b8a4c74a07f06e361a76754ca2231c69b7c8
+        checksum/config: 6b703206d392312183616ebf06519270506302d531a120b04c6889ea9916f153
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_prometheus_overwrite.golden
+++ b/cli/cmd/testdata/install_prometheus_overwrite.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -390,11 +390,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -458,11 +458,8 @@ metadata:
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
-    matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
+    matchLabels:
+      config.linkerd.io/admission-webhooks: enabled
   clientConfig:
     service:
       name: linkerd-proxy-injector


### PR DESCRIPTION
The default installation of linkerd2 uses an opt-out model. If you
consider an existing cluster with 1000s of pods and 100s of nodes, and
add linkerd2 without customizing coniguration, it's very likely to
impact cluster reliability.

This PR adds objectSelector from k8s 1.15+ that moves the
linkerd.io/inject selector from the apiservice to the apiserver
configuration. This is an important when the linkerd2 proxy injector
is down, the pods that have no interest in linkerd will not be
prevented from pod creation.

This configuration is almost identical to istio's istio/istio#16539

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
