### PR TITLE
Decode durations from protobuf into golang correctly

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	pb "github.com/linkerd/linkerd2/controller/gen/config"
 	charts "github.com/linkerd/linkerd2/pkg/charts/linkerd2"
 	"github.com/linkerd/linkerd2/pkg/config"
@@ -587,6 +588,16 @@ func (options *upgradeOptions) fetchIdentityValues(k kubernetes.Interface, idctx
 		}
 	}
 
+	clockSkewDuration, err := ptypes.Duration(idctx.GetClockSkewAllowance())
+	if err != nil {
+		return nil, fmt.Errorf("could not convert clock skew protobuf Duration format into golang Duration: %s", err)
+	}
+
+	issuanceLifetimeDuration, err := ptypes.Duration(idctx.GetIssuanceLifetime())
+	if err != nil {
+		return nil, fmt.Errorf("could not convert issuance Lifetime protobuf Duration format into golang Duration: %s", err)
+	}
+
 	return &identityWithAnchorsAndTrustDomain{
 		TrustDomain:     idctx.GetTrustDomain(),
 		TrustAnchorsPEM: trustAnchorsPEM,
@@ -594,8 +605,8 @@ func (options *upgradeOptions) fetchIdentityValues(k kubernetes.Interface, idctx
 
 			Issuer: &charts.Issuer{
 				Scheme:              idctx.Scheme,
-				ClockSkewAllowance:  idctx.GetClockSkewAllowance().String(),
-				IssuanceLifetime:    idctx.GetIssuanceLifetime().String(),
+				ClockSkewAllowance:  clockSkewDuration.String(),
+				IssuanceLifetime:    issuanceLifetimeDuration.String(),
 				CrtExpiry:           *issuerData.Expiry,
 				CrtExpiryAnnotation: k8s.IdentityIssuerExpiryAnnotation,
 				TLS: &charts.IssuerTLS{

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -93,6 +93,8 @@ func TestUpgradeExternalIssuer(t *testing.T) {
 					CrtPEM: issuer.crt,
 					KeyPEM: issuer.key,
 				},
+				ClockSkewAllowance: "20s",
+				IssuanceLifetime:   "24h0m0s",
 			},
 		},
 	}


### PR DESCRIPTION
This PR updates the retrieval of durations from `linkerd-config`
to have conversion into the normal Go duration. This is needed
as the duration types in protobuf and golang are different.

This did not break anything previously, as we were directly using
these fields only for protobuf generation with upgrades, but now that
we are trying to use these fields with the `Values` go types (with the
new config format) this causes the upgrade tests to fail.

This is in sync with the encoding part here https://github.com/linkerd/linkerd2/blob/db57611a33b00a8f005a7ac65c4eeb7658189e50/cli/cmd/install.go#L1255

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
