### PR TITLE
Fix upgrade test

### DIFF
--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -390,6 +390,9 @@ func TestUpgradeWebhookCrtsNameChange(t *testing.T) {
 	expectedManifests := parseManifestList(expected)
 	upgradeManifests := parseManifestList(upgrade.String())
 	for id, diffs := range diffManifestLists(expectedManifests, upgradeManifests) {
+		if id == overridesSecret {
+			continue
+		}
 		for _, diff := range diffs {
 			t.Errorf("Unexpected diff in %s:\n%s", id, diff.String())
 		}


### PR DESCRIPTION
A conflict between https://github.com/linkerd/linkerd2/pull/4911 and https://github.com/linkerd/linkerd2/pull/4737 caused unit test to be broken.

https://github.com/linkerd/linkerd2/pull/4737 added a new test to `upgrade_test.go` and the changes in https://github.com/linkerd/linkerd2/pull/4911 updated all of these test to ignore differences in the config overrides secret.  Since these two PRs merged in parallel, the new test was missing this update.

Update the new test to also ignore differences in the config overrides secret as the other ones do.

Signed-off-by: Alex Leong <alex@buoyant.io>

