### PR TITLE
add annotations and labels to service in multicluster helm chart fixe…

### DIFF
--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -13,7 +13,7 @@ linkerd2-multicluster chart and their default values.
 | Parameter                       | Description                                                                                 | Default                                      |
 |---------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------|
 |`controllerComponentLabel`       | Control plane label. Do not edit                                                            |`linkerd.io/control-plane-component`          |
-|`controllerImage`                | Docker image for the Service mirror component (uses the Linkerd controller image)           |`ghcr.io/linkerd/controller`                |
+|`controllerImage`                | Docker image for the Service mirror component (uses the Linkerd controller image)           |`ghcr.io/linkerd/controller`                  |
 |`controllerImageVersion`         | Tag for the Service Mirror container Docker image                                           |`latest version`                              |
 |`createdByAnnotation`            | Annotation label for the proxy create. Do not edit.                                         |`linkerd.io/created-by`                       |
 |`gateway`                        | If the gateway component should be installed                                                |`true`                                        |
@@ -38,3 +38,5 @@ linkerd2-multicluster chart and their default values.
 |`logLevel`                       | Log level for the Multicluster components                                                   |`info`                                        |
 |`serviceMirrorRetryLimit`        | Number of times update from the remote cluster is allowed to be requeued (retried)          |`3`                                           |
 |`serviceMirrorUID`               | User id under which the Service Mirror shall be ran                                         |`2103`                                        |
+|`service.annotations`            | Annotations to add to the service                                                           |`{}`                                          |
+|`service.labels`                 | Labels to add to the service                                                                |`{}`                                          |

--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -122,6 +122,12 @@ metadata:
     mirror.linkerd.io/multicluster-gateway: "true"
     {{.Values.controllerComponentLabel}}: gateway
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.service.labels }}
+  labels: {{ toYaml .Values.service.labels | nindent 4}}
+{{- end }}
 spec:
   ports:
   - name: mc-gateway

--- a/charts/linkerd2-multicluster/values.yaml
+++ b/charts/linkerd2-multicluster/values.yaml
@@ -16,3 +16,6 @@ namespace: linkerd-multicluster
 proxyOutboundPort: 4140
 remoteMirrorServiceAccount: true
 remoteMirrorServiceAccountName: linkerd-service-mirror-remote-access-default
+service:
+  labels: {}
+  annotations: {}

--- a/cli/cmd/multicluster.go
+++ b/cli/cmd/multicluster.go
@@ -58,6 +58,12 @@ type (
 		gatewayNginxVersion     string
 		dockerRegistry          string
 		remoteMirrorCredentials bool
+		service                 *service
+	}
+
+	service struct {
+		annotations []map[string]string
+		labels      []map[string]string
 	}
 
 	linkOptions struct {
@@ -97,6 +103,10 @@ func newMulticlusterInstallOptionsWithDefault() (*multiclusterInstallOptions, er
 		gatewayNginxVersion:     defaults.GatewayNginxImageVersion,
 		dockerRegistry:          defaultDockerRegistry,
 		remoteMirrorCredentials: true,
+		service: &service{
+			annotations: defaults.Service.Annotations,
+			labels:      defaults.Service.Labels,
+		},
 	}, nil
 }
 
@@ -198,6 +208,8 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 	defaults.ProxyOutboundPort = global.Proxy.OutboundPort.Port
 	defaults.LinkerdVersion = version.Version
 	defaults.RemoteMirrorServiceAccount = opts.remoteMirrorCredentials
+	defaults.Service.Annotations = opts.service.annotations
+	defaults.Service.Labels = opts.service.labels
 
 	return defaults, nil
 }

--- a/pkg/charts/multicluster/values.go
+++ b/pkg/charts/multicluster/values.go
@@ -14,37 +14,46 @@ const (
 	helmDefaultLinkChartDir = "linkerd2-multicluster-link"
 )
 
-// Values contains the top-level elements in the Helm charts
-type Values struct {
-	CliVersion                     string `json:"cliVersion"`
-	ControllerComponentLabel       string `json:"controllerComponentLabel"`
-	ControllerImage                string `json:"controllerImage"`
-	ControllerImageVersion         string `json:"controllerImageVersion"`
-	CreatedByAnnotation            string `json:"createdByAnnotation"`
-	Gateway                        bool   `json:"gateway"`
-	GatewayLocalProbePath          string `json:"gatewayLocalProbePath"`
-	GatewayLocalProbePort          uint32 `json:"gatewayLocalProbePort"`
-	GatewayName                    string `json:"gatewayName"`
-	GatewayNginxImage              string `json:"gatewayNginxImage"`
-	GatewayNginxImageVersion       string `json:"gatewayNginxImageVersion"`
-	GatewayPort                    uint32 `json:"gatewayPort"`
-	GatewayProbePath               string `json:"gatewayProbePath"`
-	GatewayProbePort               uint32 `json:"gatewayProbePort"`
-	GatewayProbeSeconds            uint32 `json:"gatewayProbeSeconds"`
-	IdentityTrustDomain            string `json:"identityTrustDomain"`
-	InstallNamespace               bool   `json:"installNamespace"`
-	LinkerdNamespace               string `json:"linkerdNamespace"`
-	LinkerdVersion                 string `json:"linkerdVersion"`
-	Namespace                      string `json:"namespace"`
-	ProxyOutboundPort              uint32 `json:"proxyOutboundPort"`
-	ServiceMirror                  bool   `json:"serviceMirror"`
-	LogLevel                       string `json:"logLevel"`
-	ServiceMirrorRetryLimit        uint32 `json:"serviceMirrorRetryLimit"`
-	ServiceMirrorUID               int64  `json:"serviceMirrorUID"`
-	RemoteMirrorServiceAccount     bool   `json:"remoteMirrorServiceAccount"`
-	RemoteMirrorServiceAccountName string `json:"remoteMirrorServiceAccountName"`
-	TargetClusterName              string `json:"targetClusterName"`
-}
+type (
+	// Values contains the top-level elements in the Helm charts
+	Values struct {
+		CliVersion                     string   `json:"cliVersion"`
+		ControllerComponentLabel       string   `json:"controllerComponentLabel"`
+		ControllerImage                string   `json:"controllerImage"`
+		ControllerImageVersion         string   `json:"controllerImageVersion"`
+		CreatedByAnnotation            string   `json:"createdByAnnotation"`
+		Gateway                        bool     `json:"gateway"`
+		GatewayLocalProbePath          string   `json:"gatewayLocalProbePath"`
+		GatewayLocalProbePort          uint32   `json:"gatewayLocalProbePort"`
+		GatewayName                    string   `json:"gatewayName"`
+		GatewayNginxImage              string   `json:"gatewayNginxImage"`
+		GatewayNginxImageVersion       string   `json:"gatewayNginxImageVersion"`
+		GatewayPort                    uint32   `json:"gatewayPort"`
+		GatewayProbePath               string   `json:"gatewayProbePath"`
+		GatewayProbePort               uint32   `json:"gatewayProbePort"`
+		GatewayProbeSeconds            uint32   `json:"gatewayProbeSeconds"`
+		IdentityTrustDomain            string   `json:"identityTrustDomain"`
+		InstallNamespace               bool     `json:"installNamespace"`
+		LinkerdNamespace               string   `json:"linkerdNamespace"`
+		LinkerdVersion                 string   `json:"linkerdVersion"`
+		Namespace                      string   `json:"namespace"`
+		ProxyOutboundPort              uint32   `json:"proxyOutboundPort"`
+		ServiceMirror                  bool     `json:"serviceMirror"`
+		LogLevel                       string   `json:"logLevel"`
+		ServiceMirrorRetryLimit        uint32   `json:"serviceMirrorRetryLimit"`
+		ServiceMirrorUID               int64    `json:"serviceMirrorUID"`
+		RemoteMirrorServiceAccount     bool     `json:"remoteMirrorServiceAccount"`
+		RemoteMirrorServiceAccountName string   `json:"remoteMirrorServiceAccountName"`
+		TargetClusterName              string   `json:"targetClusterName"`
+		Service                        *Service `json:"service"`
+	}
+
+	// Service contains the detauls to be applied to the service
+	Service struct {
+		Annotations []map[string]string `json:"annotations"`
+		Labels      []map[string]string `json:"labels"`
+	}
+)
 
 // NewInstallValues returns a new instance of the Values type.
 func NewInstallValues() (*Values, error) {


### PR DESCRIPTION
Add annotations and labels to service in multicluster helm chart

fixes #5024

helm template renders:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: linkerd-gateway
  namespace: linkerd-multicluster
  annotations:
    mirror.linkerd.io/gateway-identity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity..
    mirror.linkerd.io/probe-period: "3"
    mirror.linkerd.io/probe-path: /health
    mirror.linkerd.io/multicluster-gateway: "true"
    linkerd.io/control-plane-component: gateway
    linkerd.io/created-by: linkerd/helm linkerdVersionValue
    app: test
  labels:
    app: test
spec:
  ports:
  - name: mc-gateway
    port: 4143
    protocol: TCP
  - name: mc-probe
    port: 4181
    protocol: TCP
  selector:
    app: linkerd-gateway
  type: LoadBalancer

```
