### PR TITLE
Fixed releases.yaml by pulling images directly from ghcr.io

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -145,4 +145,4 @@ jobs:
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Run integration tests
       run: |
-        bin/tests --images --name ${{ matrix.integration_test }} "$HOME/.linkerd"
+        bin/tests --images archive --name ${{ matrix.integration_test }} "$HOME/.linkerd"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         bin/docker-pull-binaries $TAG
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($CMD version --short --client)" ]]
-        bin/tests --images --name ${{ matrix.integration_test }} "$CMD"
+        bin/tests --images skip --name ${{ matrix.integration_test }} "$CMD"
   arm64_integration_tests:
     name: ARM64 integration tests
     runs-on: ubuntu-18.04
@@ -171,7 +171,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/stable')
       env:
         RUN_ARM_TEST: 1
-      run: bin/tests --skip-kind-create "$CMD"
+      run: bin/tests --images skip --skip-kind-create "$CMD"
     - name: CNI tests
       if: startsWith(github.ref, 'refs/tags/stable')
       run: |

--- a/bin/image-load
+++ b/bin/image-load
@@ -4,7 +4,7 @@ set -eo pipefail
 
 kind=""
 k3d=""
-images=""
+archive=""
 
 while :
 do
@@ -13,7 +13,7 @@ do
       echo "Load into KinD/k3d the images for Linkerd's proxy, controller, web, grafana, cli-bin, debug and cni-plugin."
       echo ""
       echo "Usage:"
-      echo "    bin/image-load [--kind] [--k3d] [--images]"
+      echo "    bin/image-load [--kind] [--k3d] [--archive]"
       echo ""
       echo "Examples:"
       echo ""
@@ -21,12 +21,12 @@ do
       echo "    bin/image-load"
       echo ""
       echo "    # Load images from tar files located under the 'image-archives' directory into k3d"
-      echo "    bin/image-load --k3d --images"
+      echo "    bin/image-load --k3d --archive"
       echo ""
       echo "Available Commands:"
       echo "    --kind: use a KinD cluster (default)."
       echo "    --k3d: use a k3d cluster."
-      echo "    --images: Load the images from local .tar files in the current directory."
+      echo "    --archive: load the images from local .tar files in the current directory."
       exit 0
       ;;
     --kind)
@@ -35,8 +35,8 @@ do
     --k3d)
       k3d=1
       ;;
-    --images)
-      images=1
+    --archive)
+      archive=1
       ;;
     *)
       break
@@ -59,14 +59,14 @@ else
   kind=1
   cluster=${1:-"kind"}
   bin="$bindir"/kind
-  if [ $images ]; then
+  if [ $archive ]; then
     image_sub_cmd=(load image-archive --name "$cluster")
   else
     image_sub_cmd=(load docker-image --name "$cluster")
   fi
 fi
 
-if [ -z "$images" ]; then
+if [ -z "$archive" ]; then
   # shellcheck source=_tag.sh
   . "$bindir"/_tag.sh
   # shellcheck source=_docker.sh
@@ -80,7 +80,7 @@ fi
 
 rm -f load_fail
 for img in proxy controller web grafana cli-bin debug cni-plugin ; do
-  if [ $images ]; then
+  if [ $archive ]; then
     param="image-archives/$img.tar"
   else
     param="$DOCKER_REGISTRY/$img:$TAG"


### PR DESCRIPTION
Previously, `releases.yaml` was trying to load images into the kind
clusters but that failed because those images were already in `ghcr.io`
and not in the local docker cache, but that failure was masked.
Unmasking that failure revealed some flaws that this change addresses:

- In `bin/_test_helpers` (used by `bin/tests`), modified the `images`
arg to accept `docker(default)|archive|skip`, for determining how to
load the images into the cluster (if loading them at all)
- In `bin/image-load`, changed arg `images` to `archive` which is more
descriptive.
- Have `kind_integration.yml` call `bin/tests --images archive`.
- Have `release.yml` call `bin/tests --images skip`.