### PR TITLE
MC chart load balancer ip

### DIFF
--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -38,4 +38,4 @@ linkerd2-multicluster chart and their default values.
 |`logLevel`                       | Log level for the Multicluster components                                                   |`info`                                        |
 |`serviceMirrorRetryLimit`        | Number of times update from the remote cluster is allowed to be requeued (retried)          |`3`                                           |
 |`serviceMirrorUID`               | User id under which the Service Mirror shall be ran                                         |`2103`                                        |
-|`loadBalancerIP:               | If you for example reserved and IP in GKE and want to use exactly that IP for your gateway                                  |emptyString                                        |
+|`loadBalancerIP`               | If you for example reserved and IP in GKE and want to use exactly that IP for your gateway                                  |emptyString                                        |

--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -38,3 +38,4 @@ linkerd2-multicluster chart and their default values.
 |`logLevel`                       | Log level for the Multicluster components                                                   |`info`                                        |
 |`serviceMirrorRetryLimit`        | Number of times update from the remote cluster is allowed to be requeued (retried)          |`3`                                           |
 |`serviceMirrorUID`               | User id under which the Service Mirror shall be ran                                         |`2103`                                        |
+|`loadBalancerIP:               | If you for example reserved and IP in GKE and want to use exactly that IP for your gateway                                  |emptyString                                        |

--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -38,4 +38,4 @@ linkerd2-multicluster chart and their default values.
 |`logLevel`                       | Log level for the Multicluster components                                                   |`info`                                        |
 |`serviceMirrorRetryLimit`        | Number of times update from the remote cluster is allowed to be requeued (retried)          |`3`                                           |
 |`serviceMirrorUID`               | User id under which the Service Mirror shall be ran                                         |`2103`                                        |
-|`loadBalancerIP`               | If you for example reserved and IP in GKE and want to use exactly that IP for your gateway                                  |emptyString                                        |
+|`loadBalancerIP`               | Request a specific IP address for the gateway service (e.g. use an IP address you have reserved)                                  |emptyString                                        |

--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -133,6 +133,9 @@ spec:
   selector:
     app: {{.Values.gatewayName}}
   type: LoadBalancer
+{{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
+{{- end }}
 ---
 kind: ServiceAccount
 apiVersion: v1


### PR DESCRIPTION
adding loadBalancerIP to linkerd2-multicluster chart

Sometimes you are in need to tell the gateway service to pick up / request a specific IP from the LB.
e.g. when you talk to another cluster that is having another firewall in front and not permitting access from random IPs.

Solution
Minor change in the chart for Multicluster.

Validation
Example in a GKE:
Register a static IP, note it. Then

helm install linkerd-mc linkerd2/linkerd2-multicluster --set loadBalancerIP="<IP>"

Your gateway service will come up with the IP you have given it.
If you don't set the parameter, then the LB will give out a random IP.

If you don't have a cluster, look at the yaml produced by helm template...
and look if the loadBalancerIP: <IP>  is there

```
`apiVersion: v1
kind: Service
.
.
.
  selector:
    app: linkerd-gateway
  type: LoadBalancer
  loadBalancerIP: 1.1.1.1`
```

Signed-off-by: Markus Bettsteller <markus@bettsteller.de>