### PR TITLE
Add warnings for failed secred mounts to expected warnings in it

### DIFF
--- a/testutil/logs_events.go
+++ b/testutil/logs_events.go
@@ -43,6 +43,7 @@ var (
 	knownEventWarningsRegex = regexp.MustCompile(strings.Join([]string{
 		`MountVolume.SetUp failed for volume .* : couldn't propagate object cache: timed out waiting for the condition`, // pre k8s 1.16
 		`MountVolume.SetUp failed for volume .* : failed to sync .* cache: timed out waiting for the condition`,         // post k8s 1.16
+		`MountVolume.SetUp failed for volume "tls" : secret "linkerd-.*" not found`,
 		`(Liveness|Readiness) probe failed: HTTP probe failed with statuscode: 50(2|3)`,
 		`(Liveness|Readiness) probe failed: Get http://.*: dial tcp .*: connect: connection refused`,
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,


### PR DESCRIPTION
Seems that Helm is cleaning orphaned resources. Pods that depend on them seem to be not upgraded on time, causing some warnings to be emitted and he CI process to fail