### PR TITLE
Fix how env vars are set in CI

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -24,11 +24,11 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
 
         . bin/_docker.sh
-        echo ::set-env name=DOCKER_REGISTRY::$DOCKER_REGISTRY
-        echo ::set-env name=DOCKER_BUILDKIT_CACHE::${{ runner.temp }}/.buildx-cache
+        echo "DOCKER_REGISTRY=$DOCKER_REGISTRY" >> $GITHUB_ENV
+        echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
       # actions/cache@v2.0.0
       uses: actions/cache@b820478
@@ -124,10 +124,10 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
 
         . bin/_docker.sh
-        echo ::set-env name=DOCKER_REGISTRY::$DOCKER_REGISTRY
+        echo "DOCKER_REGISTRY=$DOCKER_REGISTRY" >> $GITHUB_ENV
     - name: Download image archives
       # actions/download-artifact@v1
       uses: actions/download-artifact@18f0f59

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
 
         . bin/_docker.sh
-        echo ::set-env name=DOCKER_REGISTRY::$DOCKER_REGISTRY
-        echo ::set-env name=DOCKER_BUILDKIT_CACHE::${{ runner.temp }}/.buildx-cache
+        echo "DOCKER_REGISTRY=$DOCKER_REGISTRY" >> $GITHUB_ENV
+        echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
       # actions/cache@v2.0.0
       uses: actions/cache@b820478
@@ -123,8 +123,8 @@ jobs:
       run: |
         TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
         CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
-        echo "::set-env name=CMD::$CMD"
-        echo "::set-env name=TAG::$TAG"
+        echo "CMD=$CMD" >> $GITHUB_ENV
+        echo "TAG=$TAG" >> $GITHUB_ENV
     - name: Run integration tests
       run: |
         bin/docker-pull-binaries $TAG
@@ -159,13 +159,13 @@ jobs:
         # validate CLI version matches the repo
         [[ "$TAG" == "$($CMD version --short --client)" ]]
         echo "Installed Linkerd CLI version: $TAG"
-        echo "::set-env name=CMD::$CMD"
+        echo "CMD=$CMD" >> $GITHUB_ENV
     - name: Set KUBECONFIG environment variables
       if: startsWith(github.ref, 'refs/tags/stable')
       run: |
         mkdir -p $HOME/.kube
         echo "${{ secrets.ARM64_KUBECONFIG }}" > $HOME/.kube/config
-        echo ::set-env name=KUBECONFIG::$HOME/.kube/config
+        echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
         kubectl cluster-info
     - name: Run integration tests
       if: startsWith(github.ref, 'refs/tags/stable')
@@ -223,7 +223,7 @@ jobs:
       run: |
         . bin/_tag.sh
         . bin/_release.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
         extract_release_notes NOTES.md
     - name: Download choco package
       if: startsWith(github.ref, 'refs/tags/stable')
@@ -281,13 +281,13 @@ jobs:
     - name: Set environment variables from scripts
       run: |
         . bin/_tag.sh
-        echo ::set-env name=TAG::$(CI_FORCE_CLEAN=1 bin/root-tag)
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
     - name: Set install target for stable
       if: startsWith(github.ref, 'refs/tags/stable')
-      run: echo ::set-env name=INSTALL::install
+      run: echo "INSTALL=install" >> $GITHUB_ENV
     - name: Set install target for edge
       if: startsWith(github.ref, 'refs/tags/edge')
-      run: echo ::set-env name=INSTALL::install-edge
+      run: echo "INSTALL=install-edge" >> $GITHUB_ENV
     - name: Check published version
       run: |
         until RES=$(curl -sL https://run.linkerd.io/$INSTALL | grep "LINKERD2_VERSION=\${LINKERD2_VERSION:-$TAG}") \


### PR DESCRIPTION
Replaced `set-env` directives with environment files, as explained [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

This gets rids of warnings of the sort:
```
The `set-env` command is deprecated and will be disabled soon. Please
upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
