### PR TITLE
Add podLabels and podAnnotations to Values struct

### DIFF
--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -91,6 +91,8 @@ func TestRender(t *testing.T) {
 			CNIEnabled:               false,
 			IdentityTrustDomain:      defaultValues.Global.IdentityTrustDomain,
 			IdentityTrustAnchorsPEM:  defaultValues.Global.IdentityTrustAnchorsPEM,
+			PodAnnotations:           map[string]string{},
+			PodLabels:                map[string]string{},
 			Proxy: &charts.Proxy{
 				DestinationGetNetworks: "DestinationGetNetworks",
 				Image: &charts.Image{

--- a/cli/cmd/testdata/install_addon_control-plane.golden
+++ b/cli/cmd/testdata/install_addon_control-plane.golden
@@ -65,6 +65,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_control-plane.golden
+++ b/cli/cmd/testdata/install_control-plane.golden
@@ -65,6 +65,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -850,6 +850,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -859,6 +859,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -859,6 +859,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -809,6 +809,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -929,6 +929,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: linkerd-version
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null
@@ -1014,6 +1016,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1100,6 +1104,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null
@@ -1211,6 +1217,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1300,6 +1308,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -929,6 +929,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: linkerd-version
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null
@@ -1014,6 +1016,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1100,6 +1104,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null
@@ -1211,6 +1217,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1300,6 +1308,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null
@@ -1406,6 +1416,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1492,6 +1504,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -935,6 +935,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: linkerd-version
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null
@@ -1019,6 +1021,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1104,6 +1108,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null
@@ -1233,6 +1239,8 @@ data:
         linkerdNamespaceLabel: linkerd.io/is-control-plane
         linkerdVersion: linkerd-version
         namespace: linkerd
+        podAnnotations: {}
+        podLabels: {}
         prometheusUrl: ""
         proxy:
           capabilities: null
@@ -1321,6 +1329,8 @@ data:
           linkerdNamespaceLabel: linkerd.io/is-control-plane
           linkerdVersion: linkerd-version
           namespace: linkerd
+          podAnnotations: {}
+          podLabels: {}
           prometheusUrl: ""
           proxy:
             capabilities: null

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -850,6 +850,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: LinkerdNamespaceLabel
       linkerdVersion: ""
       namespace: Namespace
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_prometheus_overwrite.golden
+++ b/cli/cmd/testdata/install_prometheus_overwrite.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -785,6 +785,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -853,6 +853,8 @@ data:
       linkerdNamespaceLabel: linkerd.io/is-control-plane
       linkerdVersion: dev-undefined
       namespace: linkerd
+      podAnnotations: {}
+      podLabels: {}
       prometheusUrl: ""
       proxy:
         capabilities: null

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -94,6 +94,9 @@ type (
 		ImagePullSecrets         []map[string]string `json:"imagePullSecrets"`
 		LinkerdVersion           string              `json:"linkerdVersion"`
 
+		PodAnnotations map[string]string `json:"podAnnotations"`
+		PodLabels      map[string]string `json:"podLabels"`
+
 		Proxy     *Proxy     `json:"proxy"`
 		ProxyInit *ProxyInit `json:"proxyInit"`
 	}

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -52,6 +52,8 @@ func TestNewValues(t *testing.T) {
 			ControlPlaneTracing:      false,
 			HighAvailability:         false,
 			IdentityTrustDomain:      "cluster.local",
+			PodAnnotations:           map[string]string{},
+			PodLabels:                map[string]string{},
 			Proxy: &Proxy{
 				EnableExternalProfiles: false,
 				Image: &Image{


### PR DESCRIPTION
PR https://github.com/linkerd/linkerd2/pull/5027 added `podLabels` and `podAnnotations` to `values.yaml` to allow setting labels and annotations on pods in the Helm template.  However, these fields were not added to the `Values` struct in `Values.go`.  This means that these fields were not serialized out to the `linkerd-config` or to the `linkerd-config-overrides`.  Furthermore, in PR #5005 which moves to using the `Values` struct more authoritatively, the `podLabels` and `podAnnotations` fields would not take effect at all.

Add these fields to the `Values` struct and update all test fixtures accordingly.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
