### PR TITLE
bin/tests: Improve argument parsing

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -56,12 +56,14 @@ handle_input() {
       --images)
         images=$2
         if [ -z "$images" ]; then
-          echo 'Error: the argument for --images was not specified'
-          exit 1
+          echo 'Error: the argument for --images was not specified' >&2
+          usage "$0" >&2
+          exit 64
         fi
         if [[ $images != "docker" && $images != "archive" && $images != "skip" ]]; then
-          echo 'Error: the argument for --images was invalid'
-          exit 1
+          echo 'Error: the argument for --images was invalid' >&2
+          usage "$0" >&2
+          exit 64
         fi
         shift
         shift
@@ -69,8 +71,9 @@ handle_input() {
       --name)
         test_name=$2
         if [ -z "$test_name" ]; then
-          echo 'Error: the argument for --name was not specified'
-          exit 1
+          echo 'Error: the argument for --name was not specified' >&2
+          usage "$0" >&2
+          exit 64
         fi
         shift
         shift

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -85,6 +85,13 @@ handle_input() {
           usage "$0" >&2
           exit 64
         fi
+        if [ -n "$linkerd_path" ]; then
+          echo "Multliple linkerd paths specified:" >&2
+          echo "  $linkerd_path" >&2
+          echo "  $1" >&2
+          usage "$0" >&2
+          exit 64
+        fi
         linkerd_path="$1"
         shift
         ;;

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -9,42 +9,48 @@ set +e
 export default_test_names=(deep external-issuer helm-deep helm-upgrade multicluster uninstall upgrade-edge upgrade-stable cni-calico-deep)
 export all_test_names=(cluster-domain "${default_test_names[*]}")
 
-handle_input() {
-  export images="docker"
-  export test_name=''
-  export skip_cluster_create=''
-
-  while :
-  do
-    case $1 in
-      -h|--help)
-        echo "Run Linkerd integration tests.
+usage() {
+  progname="${0##*/}"
+  echo "Run Linkerd integration tests.
 
 Optionally specify a test with the --name flag: [${all_test_names[*]}]
 
 Note: The cluster-domain test requires a cluster configuration with a custom cluster domain (see test/configs/cluster-domain.yaml)
 
 Usage:
-    ${0##*/} [--images docker|archive|skip] [--name test-name] [--skip-cluster-create] /path/to/linkerd
+    ${progname} [--images docker|archive|skip] [--name test-name] [--skip-cluster-create] /path/to/linkerd
 
 Examples:
     # Run all tests in isolated clusters
-    ${0##*/} /path/to/linkerd
+    ${progname} /path/to/linkerd
 
     # Run single test in isolated clusters
-    ${0##*/} --name test-name /path/to/linkerd
+    ${progname} --name test-name /path/to/linkerd
 
     # Skip KinD/k3d cluster creation and run all tests in default cluster context
-    ${0##*/} --skip-cluster-create /path/to/linkerd
+    ${progname} --skip-cluster-create /path/to/linkerd
 
     # Load images from tar files located under the 'image-archives' directory
     # Note: This is primarily for CI
-    ${0##*/} --images archive /path/to/linkerd
+    ${progname} --images archive /path/to/linkerd
 
 Available Commands:
     --name: the argument to this option is the specific test to run
     --skip-cluster-create: skip KinD/k3d cluster creation step and run tests in an existing cluster.
     --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)."
+}
+
+
+handle_input() {
+  export images="docker"
+  export test_name=''
+  export skip_cluster_create=''
+  export linkerd_path=""
+
+  while  [ "$#" -ne 0 ]; do
+    case $1 in
+      -h|--help)
+        usage "$0"
         exit 0
         ;;
       --images)
@@ -58,6 +64,7 @@ Available Commands:
           exit 1
         fi
         shift
+        shift
         ;;
       --name)
         test_name=$2
@@ -66,23 +73,27 @@ Available Commands:
           exit 1
         fi
         shift
+        shift
         ;;
       --skip-cluster-create)
         skip_cluster_create=1
+        shift
         ;;
       *)
-        break
+        if echo "$1" | grep -q '^-.*' ; then
+          echo "Unexpected flag: $1" >&2
+          usage "$0" >&2
+          exit 64
+        fi
+        linkerd_path="$1"
+        shift
+        ;;
     esac
-    shift
   done
 
-  export linkerd_path="$1"
   if [ -z "$linkerd_path" ]; then
-    echo "Error: path to linkerd binary is required
-Help:
-     ${0##*/} -h|--help
-Basic usage:
-     ${0##*/} /path/to/linkerd"
+    echo "Error: path to linkerd binary is required" >&2
+    usage "$0" >&2
     exit 64
   fi
 }


### PR DESCRIPTION
The `bin/tests` script takes command-line arguments, but it requires
that all arguments are specified before the linkerd binary path; and it
silently ignores flags that follow the linkerd binary. Furthermore,
unexpected flags may be incorrectly parsed as the linkerd binary path.

This changes argument parsing to be more flexible about ordering; and it
prints the full usage error when unexpected flags are encountered.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
