### PR TITLE
Allows tracing ServiceAccounts to use the PSP

### DIFF
--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -84,6 +84,11 @@ roleRef:
   name: linkerd-psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
+{{ if .Values.tracing.enabled -}}
+- kind: ServiceAccount
+  name: linkerd-collector
+  namespace: {{.Values.global.namespace}}
+{{ end -}}
 - kind: ServiceAccount
   name: linkerd-controller
   namespace: {{.Values.global.namespace}}
@@ -103,6 +108,11 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-identity
   namespace: {{.Values.global.namespace}}
+{{ if .Values.tracing.enabled -}}
+- kind: ServiceAccount
+  name: linkerd-jaeger
+  namespace: {{.Values.global.namespace}}
+{{ end -}}
 {{ if .Values.prometheus.enabled -}}
 - kind: ServiceAccount
   name: linkerd-prometheus

--- a/cli/cmd/testdata/install_addon.golden
+++ b/cli/cmd/testdata/install_addon.golden
@@ -757,6 +757,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
+  name: linkerd-collector
+  namespace: linkerd
+- kind: ServiceAccount
   name: linkerd-controller
   namespace: linkerd
 - kind: ServiceAccount
@@ -770,6 +773,9 @@ subjects:
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-identity
+  namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-jaeger
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-prometheus

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -781,6 +781,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
+  name: linkerd-collector
+  namespace: linkerd
+- kind: ServiceAccount
   name: linkerd-controller
   namespace: linkerd
 - kind: ServiceAccount
@@ -794,6 +797,9 @@ subjects:
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-identity
+  namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-jaeger
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-prometheus

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -757,6 +757,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
+  name: linkerd-collector
+  namespace: linkerd
+- kind: ServiceAccount
   name: linkerd-controller
   namespace: linkerd
 - kind: ServiceAccount
@@ -770,6 +773,9 @@ subjects:
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-identity
+  namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-jaeger
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-prometheus

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -757,6 +757,9 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
+  name: linkerd-collector
+  namespace: linkerd
+- kind: ServiceAccount
   name: linkerd-controller
   namespace: linkerd
 - kind: ServiceAccount
@@ -770,6 +773,9 @@ subjects:
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-identity
+  namespace: linkerd
+- kind: ServiceAccount
+  name: linkerd-jaeger
   namespace: linkerd
 - kind: ServiceAccount
   name: linkerd-prometheus

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -295,7 +295,7 @@ func TestUpgradeTracingAddon(t *testing.T) {
 	tracingManifests := []string{
 		"Service/linkerd-jaeger", "Deployment/linkerd-jaeger", "ConfigMap/linkerd-config-addons",
 		"ServiceAccount/linkerd-jaeger", "Service/linkerd-collector", "ConfigMap/linkerd-collector-config",
-		"ServiceAccount/linkerd-collector", "Deployment/linkerd-collector",
+		"ServiceAccount/linkerd-collector", "Deployment/linkerd-collector", "RoleBinding/linkerd-psp",
 	}
 	for _, id := range tracingManifests {
 		if _, ok := diffMap[id]; ok {


### PR DESCRIPTION
#### Problem

Currently the tracing deployments do not start on clusters where restricted PodSecurityPolicies are enforced.

#### Solution

This PR adds the subchart's ServiceAccounts to the `linkerd-psp` RoleBinding, thereby allowing the deployments to be satisfied.

#### Validation

Deploy the current chart to a cluster where PodSecurityPolicies must be provided. It will fail with the following:

```
message: 'pods "linkerd-jaeger-77dd585d5c-" is forbidden: unable to validate against
      any pod security policy: [spec.volumes[0]: Invalid value: "emptyDir": emptyDir
      volumes are not allowed to be used spec.initContainers[0].securityContext.runAsUser:
      Invalid value: 0: must be in the ranges: [{1000 65535}] spec.initContainers[0].securityContext.capabilities.add:
      Invalid value: "NET_ADMIN": capability may not be added spec.initContainers[0].securityContext.capabilities.add:
      Invalid value: "NET_RAW": capability may not be added]'
```

This PR mitigates this problem.

---

Signed-off-by: Simon Weald <glitchcrab-github@simonweald.com>