### PR TITLE
Rename --addon-config flag to --config

### DIFF
--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -236,16 +236,11 @@ func makeAllStageFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet)
 				return nil
 			}),
 
-		flag.NewStringFlag(allStageFlags, "addon-config", "",
-			"A path to a configuration file of add-ons. If add-on config already exists, this new config gets merged with the existing one (unless --addon-overwrite is used)",
+		flag.NewStringFlag(allStageFlags, "config", "",
+			"A path to a yaml configuration file. The fields in this file will override the values used to install or upgrade Linkerd.",
 			func(values *l5dcharts.Values, value string) error {
 				if value != "" {
 					data, err := ioutil.ReadFile(value)
-					if err != nil {
-						return err
-					}
-					addonConfigs := make(map[string]interface{})
-					err = yaml.Unmarshal(data, &addonConfigs)
 					if err != nil {
 						return err
 					}

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -206,7 +206,7 @@ func makeUpgradeFlags() *pflag.FlagSet {
 	)
 	upgradeFlags.BoolVar(
 		&addOnOverwrite, "addon-overwrite", false,
-		"Overwrite (instead of merge) existing add-ons config with file in --addon-config (or reset to defaults if no new config is passed)",
+		"Overwrite add-on configuration instead of loading the existing config (or reset to defaults if no new config is specified)",
 	)
 	return upgradeFlags
 }

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -282,7 +282,7 @@ func TestUpgradeTracingAddon(t *testing.T) {
 
 	install := renderInstall(t, installOpts)
 
-	flagSet.Set("addon-config", filepath.Join("testdata", "addon_config.yaml"))
+	flagSet.Set("config", filepath.Join("testdata", "addon_config.yaml"))
 
 	upgrade, err := renderUpgrade(install.String(), upgradeOpts)
 	if err != nil {
@@ -331,7 +331,7 @@ func TestUpgradeOverwriteTracingAddon(t *testing.T) {
 
 	install := renderInstall(t, installOpts)
 
-	flagSet.Set("addon-config", filepath.Join("testdata", "addon_config_overwrite.yaml"))
+	flagSet.Set("config", filepath.Join("testdata", "addon_config_overwrite.yaml"))
 	flagSet.Set("trace-collector", "overwrite-collector")
 	flagSet.Set("trace-collector-svc-account", "overwrite-collector.default")
 
@@ -511,7 +511,7 @@ func TestUpgradeEnableAddon(t *testing.T) {
 
 	install := renderInstall(t, installOpts)
 
-	flagSet.Set("addon-config", filepath.Join("testdata", "grafana_enabled.yaml"))
+	flagSet.Set("config", filepath.Join("testdata", "grafana_enabled.yaml"))
 
 	upgrade, err := renderUpgrade(install.String(), upgradeOpts)
 	if err != nil {
@@ -563,7 +563,7 @@ func TestUpgradeRemoveAddonKeys(t *testing.T) {
 
 	install := renderInstall(t, installOpts)
 
-	flagSet.Set("addon-config", filepath.Join("testdata", "grafana_enabled.yaml"))
+	flagSet.Set("config", filepath.Join("testdata", "grafana_enabled.yaml"))
 
 	upgrade, err := renderUpgrade(install.String(), upgradeOpts)
 	if err != nil {
@@ -597,7 +597,7 @@ func TestUpgradeOverwriteRemoveAddonKeys(t *testing.T) {
 
 	install := renderInstall(t, installOpts)
 
-	flagSet.Set("addon-config", filepath.Join("testdata", "grafana_enabled.yaml"))
+	flagSet.Set("config", filepath.Join("testdata", "grafana_enabled.yaml"))
 	flagSet.Set("addon-override", "true")
 
 	upgrade, err := renderUpgrade(install.String(), upgradeOpts)


### PR DESCRIPTION
The `--addon-config` flag allows users to supply a yaml config file which will override the Values used to install or upgrade Linkerd.  While this is useful for supplying config for addons, it can be used to configure any part of the Values struct.  Thus, we rename the flag to `--config`.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
