### PR TITLE
test: Relax regex for Endpoint Slices update error

### DIFF
--- a/testutil/logs_events.go
+++ b/testutil/logs_events.go
@@ -49,8 +49,7 @@ var (
 		`(Liveness|Readiness) probe failed: Get http://.*: read tcp .*: read: connection reset by peer`,
 		`(Liveness|Readiness) probe failed: Get http://.*: net/http: request canceled .*\(Client\.Timeout exceeded while awaiting headers\)`,
 		`Failed to update endpoint .*/linkerd-.*: Operation cannot be fulfilled on endpoints "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
-		`Error updating Endpoint Slices for Service .*/linkerd-.*: Error deleting linkerd-.* EndpointSlice for Service .*/linkerd-.*: endpointslices.discovery.k8s.io "linkerd-.*" not found`,
-		`Error updating Endpoint Slices for Service .*/linkerd-.*: Error updating linkerd-.* EndpointSlice for Service .*/linkerd-.*: Operation cannot be fulfilled on endpointslices.discovery.k8s.io "linkerd-.*": the object has been modified; please apply your changes to the latest version and try again`,
+		`Error updating Endpoint Slices for Service .*`,
 		`error killing pod: failed to "KillPodSandbox" for ".*" with KillPodSandboxError: "rpc error: code = Unknown desc`,
 		`failed to create containerd task: failed to start io pipe copy: unable to copy pipes: containerd-shim: opening w/o fifo "/run/containerd/io.containerd.grpc.v1.cri/containers/linkerd-proxy/io/\d+/linkerd-proxy-stdout"`,
 	}, "|"))


### PR DESCRIPTION
We've encountered errors like the following in CI:

```
Error updating Endpoint Slices for Service linkerd/linkerd-proxy-injector: Error updating linkerd-proxy-injector-27vgh EndpointSlice for Service linkerd/linkerd-proxy-injector: endpointslices.discovery.k8s.io "linkerd-proxy-injector-27vgh" not found
```

There is a regex to prevent similar errors from failing a test, but it
is too restrictive. This change relaxes the regex to ignore all errors
of this kind ("updating Endpoint Slices for Service").

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
