### PR TITLE
Fix incorrect usage of --skip-kind-create flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
       #if: startsWith(github.ref, 'refs/tags/stable')
       env:
         RUN_ARM_TEST: 1
-      run: bin/tests --images skip --skip-kind-create "$CMD"
+      run: bin/tests --images skip --skip-cluster-create "$CMD"
     - name: CNI tests
       #if: startsWith(github.ref, 'refs/tags/stable')
       run: |

--- a/TEST.md
+++ b/TEST.md
@@ -102,7 +102,7 @@ are no prerequisites for this test path.
 ### Prerequisites for existing cluster
 
 If integration tests should run on an existing Kubernetes cluster, then the
-`--skip-kind-create` flag should be passed. This will disable the tests from
+`--skip-cluster-create` flag should be passed. This will disable the tests from
 creating their own clusters and instead use the current Kubernetes context.
 
 In this case, ensure the following:
@@ -125,7 +125,7 @@ Optional flags can be passed that change the testing behavior:
 - `--name`: Pass an argument with this flag to specify a specific test that
   should be run; all tests are run in the absence of this flag. Valid test names
   are included in the `bin/tests --help` output
-- `--skip-kind-create`: Skip KinD cluster creation for each test and use an
+- `--skip-cluster-create`: Skip KinD cluster creation for each test and use an
   existing Kubernetes cluster
 - `--images`: (Primarily for CI) Loads images from the `image-archive/`
   directory into the KinD clusters created for each test
@@ -179,7 +179,7 @@ bin/tests $PWD/bin/linkerd
 ```
 
 **Note**: As stated above, if running tests in an existing KinD cluster by
-passing `--skip-kind-create`, `bin/kind-load` must be run so that the images are
+passing `--skip-cluster-create`, `bin/kind-load` must be run so that the images are
 available to the cluster
 
 #### Testing the dashboard


### PR DESCRIPTION
The release workflow uses the `-skip-kind-create` flag when the flag is actually called `-skip-cluster-create`.  This causes the workflow to fail.

We correct the flag name.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
