### PR TITLE
Fix integration tests to run better on ARM

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -265,7 +265,7 @@ start_kind_test() {
 start_k3d_test() {
   if [ -n "$RUN_ARM_TEST" ]; then
     echo "Skipped because ARM tests run on a dedicated cluster."
-    exit 0
+    return
   fi
 
   test_setup
@@ -395,7 +395,7 @@ run_upgrade-edge_test() {
 run_upgrade-stable_test() {
   if [ -n "$RUN_ARM_TEST" ]; then
     echo "Skipped. Linkerd stable version does not support ARM yet"
-    exit 0
+    return
   fi
 
   stable_install_url="https://run.linkerd.io/install"
@@ -431,7 +431,7 @@ helm_cleanup() {
 run_helm-upgrade_test() {
   if [ -n "$RUN_ARM_TEST" ]; then
     echo "Skipped. Linkerd stable version does not support ARM yet"
-    exit 0
+    return
   fi
 
   local stable_version

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -416,8 +416,8 @@ setup_helm() {
 helm_cleanup() {
   (
     set -e
-    "$helm_path" --kube-context="$context" delete "$helm_release_name"
-    "$helm_path" --kube-context="$context" delete "$helm_multicluster_release_name"
+    "$helm_path" --kube-context="$context" delete "$helm_release_name" || true
+    "$helm_path" --kube-context="$context" delete "$helm_multicluster_release_name" || true
     # `helm delete` doesn't wait for resources to be deleted, so we wait explicitly.
     # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
     # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).


### PR DESCRIPTION
In order for the integration tests to run successfully on a dedicated ARM cluster, two small changes are necessary:

* We need to skip the multicluster test since this test uses two separate clusters (source and target)
* We need to properly uninstall the multicluster helm chart during cleanup.

With these changes, I was able to successfully run the integration tests on a dedicated ARM cluster.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
