### PR TITLE
Fixed multicluster Grafana chart

### DIFF
--- a/grafana/dashboards/multicluster.json
+++ b/grafana/dashboards/multicluster.json
@@ -20,7 +20,7 @@
     "links": [],
     "panels": [
         {
-            "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">Cluster: $cluster, Gateway: $gateway</span>\n</div>",
+            "content": "<div style=\"display: flex; align-items: center\">\n  <img src=\"https://linkerd.io/images/identity/favicon/linkerd-favicon.png\" style=\"height:32px;\"/>&nbsp;\n  <span style=\"font-size: 32px\">Cluster: $cluster</span>\n</div>",
             "gridPos": {
                 "h": 2,
                 "w": 24,
@@ -98,7 +98,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "sum(irate(response_total{classification=\"success\", dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) / sum(irate(response_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s]))",
+                    "expr": "sum(irate(response_total{classification=\"success\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) / sum(irate(response_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s]))",
                     "format": "time_series",
                     "instant": false,
                     "intervalFactor": 1,
@@ -183,7 +183,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "sum(irate(request_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s]))",
+                    "expr": "sum(irate(request_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s]))",
                     "format": "time_series",
                     "instant": false,
                     "intervalFactor": 1,
@@ -268,7 +268,7 @@
             "tableColumn": "",
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le))",
+                    "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le))",
                     "format": "time_series",
                     "instant": false,
                     "intervalFactor": 1,
@@ -344,10 +344,10 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(response_total{classification=\"success\", dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_gateway) / sum(irate(response_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_gateway)",
+                    "expr": "sum(irate(response_total{classification=\"success\",dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) / sum(irate(response_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s]))",
                     "format": "time_series",
                     "intervalFactor": 1,
-                    "legendFormat": "gateway/{{dst_target_gateway}}",
+                    "legendFormat": "",
                     "refId": "A"
                 }
             ],
@@ -431,17 +431,17 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(request_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\", tls=\"true\"}[30s])) by (dst_target_gateway)",
+                    "expr": "sum(irate(request_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\", tls=\"true\"}[30s]))",
                     "format": "time_series",
                     "intervalFactor": 1,
-                    "legendFormat": "🔒gateway/{{dst_target_gateway}}",
+                    "legendFormat": "",
                     "refId": "A"
                 },
                 {
-                    "expr": "sum(irate(request_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls!=\"true\"}[30s])) by (dst_target_gateway)",
+                    "expr": "sum(irate(request_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls!=\"true\"}[30s]))",
                     "format": "time_series",
                     "intervalFactor": 1,
-                    "legendFormat": "gateway/{{dst_target_gateway}}",
+                    "legendFormat": "",
                     "refId": "B"
                 }
             ],
@@ -525,25 +525,25 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le, dst_target_gateway))",
+                    "expr": "histogram_quantile(0.5, sum(irate(response_latency_ms_bucket{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le))",
                     "format": "time_series",
                     "intervalFactor": 1,
-                    "legendFormat": "p50 gateway/{{dst_target_gateway}}",
+                    "legendFormat": "p50 gateway",
                     "refId": "A"
                 },
                 {
-                    "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le, dst_target_gateway))",
+                    "expr": "histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le))",
                     "format": "time_series",
                     "hide": false,
                     "intervalFactor": 1,
-                    "legendFormat": "p95 gateway/{{dst_target_gateway}}",
+                    "legendFormat": "p95 gateway",
                     "refId": "B"
                 },
                 {
-                    "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le, dst_target_gateway))",
+                    "expr": "histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le))",
                     "format": "time_series",
                     "intervalFactor": 1,
-                    "legendFormat": "p99 gateway/{{dst_target_gateway}}",
+                    "legendFormat": "p99 gateway",
                     "refId": "C"
                 }
             ],
@@ -643,7 +643,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(response_total{classification=\"success\", dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_service) / sum(irate(response_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_service)",
+                    "expr": "sum(irate(response_total{classification=\"success\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_service) / sum(irate(response_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (dst_target_service)",
                     "format": "time_series",
                     "intervalFactor": 1,
                     "legendFormat": "target-svc/{{dst_target_service}}",
@@ -730,14 +730,14 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "sum(irate(request_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls=\"true\"}[30s])) by (dst_target_service)",
+                    "expr": "sum(irate(request_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls=\"true\"}[30s])) by (dst_target_service)",
                     "format": "time_series",
                     "intervalFactor": 1,
                     "legendFormat": "🔒target-svc/{{dst_target_service}}",
                     "refId": "A"
                 },
                 {
-                    "expr": "sum(irate(request_total{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls!=\"true\"}[30s])) by (dst_target_service)",
+                    "expr": "sum(irate(request_total{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", tls!=\"true\"}[30s])) by (dst_target_service)",
                     "format": "time_series",
                     "intervalFactor": 1,
                     "legendFormat": "target-svc/{{dst_target_service}}",
@@ -823,7 +823,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{dst_target_gateway=\"$gateway\", dst_target_gateway!=\"\", dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le, dst_target_service))",
+                    "expr": "histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{dst_target_cluster=\"$cluster\", dst_target_cluster!=\"\", direction=\"outbound\"}[30s])) by (le, dst_target_service))",
                     "format": "time_series",
                     "intervalFactor": 1,
                     "legendFormat": "P95 target-svc/{{dst_target_service}}",
@@ -895,31 +895,6 @@
                 "name": "cluster",
                 "options": [],
                 "query": "label_values(request_total, dst_target_cluster)",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "allValue": ".*",
-                "current": {
-                    "text": "All",
-                    "value": "$__all"
-                },
-                "datasource": "prometheus",
-                "definition": "",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Gateway",
-                "multi": false,
-                "name": "gateway",
-                "options": [],
-                "query": "label_values(request_total{dst_target_cluster=\"$cluster\"}, dst_target_gateway)",
                 "refresh": 2,
                 "regex": "",
                 "skipUrlSync": false,


### PR DESCRIPTION
The graphs were empty because they were relying on the metric label `dst_target_gateway` which is no longer relevant.

When mirroring the `emoji` and `voting` services after this fix:

![image](https://user-images.githubusercontent.com/554287/96655037-2960bc80-1302-11eb-99bf-995283b7ccfd.png)
