### PR TITLE
Restrict controlPlaneTracing field only to control plane components

### DIFF
--- a/charts/add-ons/grafana/templates/grafana.yaml
+++ b/charts/add-ons/grafana/templates/grafana.yaml
@@ -167,6 +167,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/add-ons/grafana/templates/grafana.yaml
+++ b/charts/add-ons/grafana/templates/grafana.yaml
@@ -167,7 +167,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/add-ons/grafana/templates/grafana.yaml
+++ b/charts/add-ons/grafana/templates/grafana.yaml
@@ -167,7 +167,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/add-ons/prometheus/templates/prometheus.yaml
+++ b/charts/add-ons/prometheus/templates/prometheus.yaml
@@ -285,7 +285,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/add-ons/prometheus/templates/prometheus.yaml
+++ b/charts/add-ons/prometheus/templates/prometheus.yaml
@@ -285,6 +285,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/add-ons/prometheus/templates/prometheus.yaml
+++ b/charts/add-ons/prometheus/templates/prometheus.yaml
@@ -285,7 +285,7 @@ spec:
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -112,7 +112,7 @@ spec:
       {{- $r := merge .Values.publicAPIProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -112,7 +112,7 @@ spec:
       {{- $r := merge .Values.publicAPIProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -112,6 +112,7 @@ spec:
       {{- $r := merge .Values.publicAPIProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -129,6 +129,7 @@ spec:
       {{- $r := merge .Values.destinationProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+            {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -129,7 +129,7 @@ spec:
       {{- $r := merge .Values.destinationProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-            {{- include "partials.linkerd.trace.proxy" $tree }}
+            {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -129,7 +129,7 @@ spec:
       {{- $r := merge .Values.destinationProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-            {{- include "partials.controlPlaneTracing.proxy" $tree }}
+            {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -152,7 +152,7 @@ spec:
       {{- $r := merge .Values.identityProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -152,7 +152,7 @@ spec:
       {{- $r := merge .Values.identityProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -152,6 +152,7 @@ spec:
       {{- $r := merge .Values.identityProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -91,7 +91,7 @@ spec:
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -91,6 +91,7 @@ spec:
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -91,7 +91,7 @@ spec:
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -108,7 +108,7 @@ spec:
       {{- $r := merge .Values.spValidatorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -108,7 +108,7 @@ spec:
       {{- $r := merge .Values.spValidatorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -108,6 +108,7 @@ spec:
       {{- $r := merge .Values.spValidatorProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -118,7 +118,7 @@ spec:
       {{- $r := merge .Values.tapProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -118,6 +118,7 @@ spec:
       {{- $r := merge .Values.tapProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/tap.yaml
+++ b/charts/linkerd2/templates/tap.yaml
@@ -118,7 +118,7 @@ spec:
       {{- $r := merge .Values.tapProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -115,7 +115,7 @@ spec:
       {{- $r := merge .Values.webProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.controlPlaneTracing.proxy" $tree }}
+      {{- include "partials.setControlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -115,6 +115,7 @@ spec:
       {{- $r := merge .Values.webProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
+      {{- include "partials.linkerd.trace.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/linkerd2/templates/web.yaml
+++ b/charts/linkerd2/templates/web.yaml
@@ -115,7 +115,7 @@ spec:
       {{- $r := merge .Values.webProxyResources .Values.global.proxy.resources }}
       {{- $_ := set $tree.Values.global.proxy "resources" $r }}
       {{- end }}
-      {{- include "partials.linkerd.trace.proxy" $tree }}
+      {{- include "partials.controlPlaneTracing.proxy" $tree }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ if not .Values.global.cniEnabled -}}
       initContainers:

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -39,7 +39,7 @@ env:
   value: 10000ms
 - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
   value: 10000ms
-{{ if or (.Values.global.proxy.trace.collectorSvcAddr) (.Values.global.controlPlaneTracing) -}}
+{{ if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) -}}
 - name: LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH
   value: /var/run/linkerd/podinfo/labels
 {{ end -}}
@@ -143,9 +143,9 @@ lifecycle:
         - -c
         - sleep {{.Values.global.proxy.waitBeforeExitSeconds}}
 {{- end }}
-{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (.Values.global.controlPlaneTracing)  (not .Values.global.proxy.disableIdentity) (.Values.global.proxy.saMountPath) }}
+{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing)  (not .Values.global.proxy.disableIdentity) (.Values.global.proxy.saMountPath) }}
 volumeMounts:
-{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (.Values.global.controlPlaneTracing) }}
+{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) }}
 - mountPath: var/run/linkerd/podinfo
   name: podinfo
 {{- end -}}

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -94,7 +94,7 @@ env:
 - name: LINKERD2_PROXY_TAP_SVC_NAME
   value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
-{{ if .Values.global.controlPlaneTracing -}}
+{{ if  (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) -}}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
   value: linkerd-collector.{{.Values.global.namespace}}.svc.{{.Values.global.clusterDomain}}:55678
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -39,7 +39,7 @@ env:
   value: 10000ms
 - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
   value: 10000ms
-{{ if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) -}}
+{{ if .Values.global.proxy.trace.collectorSvcAddr -}}
 - name: LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH
   value: /var/run/linkerd/podinfo/labels
 {{ end -}}
@@ -94,12 +94,7 @@ env:
 - name: LINKERD2_PROXY_TAP_SVC_NAME
   value: linkerd-tap.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
 {{ end -}}
-{{ if  (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) -}}
-- name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
-  value: linkerd-collector.{{.Values.global.namespace}}.svc.{{.Values.global.clusterDomain}}:55678
-- name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME
-  value: linkerd-collector.{{.Values.global.namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
-{{ else if .Values.global.proxy.trace.collectorSvcAddr -}}
+{{ if .Values.global.proxy.trace.collectorSvcAddr -}}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR
   value: {{ .Values.global.proxy.trace.collectorSvcAddr }}
 - name: LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME
@@ -143,9 +138,9 @@ lifecycle:
         - -c
         - sleep {{.Values.global.proxy.waitBeforeExitSeconds}}
 {{- end }}
-{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing)  (not .Values.global.proxy.disableIdentity) (.Values.global.proxy.saMountPath) }}
+{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (not .Values.global.proxy.disableIdentity) (.Values.global.proxy.saMountPath) }}
 volumeMounts:
-{{- if or (.Values.global.proxy.trace.collectorSvcAddr) (and (hasPrefix "linkerd-" .Values.global.proxy.component) .Values.global.controlPlaneTracing) }}
+{{- if .Values.global.proxy.trace.collectorSvcAddr }}
 - mountPath: var/run/linkerd/podinfo
   name: podinfo
 {{- end -}}

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -4,7 +4,7 @@
 {{ end -}}
 {{- end }}
 
-{{ define "partials.controlPlaneTracing.proxy" -}}
+{{ define "partials.setControlPlaneTracing.proxy" -}}
 {{ if .Values.global.controlPlaneTracing -}}
 {{ $_ := set .Values.global.proxy.trace "collectorSvcAddr" (printf "linkerd-collector.%s.svc.%s:55678" .Values.global.namespace .Values.global.clusterDomain) -}}
 {{ $_ := set .Values.global.proxy.trace "collectorSvcAccount" (printf "linkerd-collector.%s" .Values.global.namespace) -}}

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -3,3 +3,10 @@
 - -trace-collector=linkerd-collector.{{.Values.global.namespace}}.svc.{{.Values.global.clusterDomain}}:55678
 {{ end -}}
 {{- end }}
+
+{{ define "partials.linkerd.trace.proxy" -}}
+{{ if .Values.global.controlPlaneTracing -}}
+{{ $_ := set .Values.global.proxy.trace "collectorSvcAddr" (printf "linkerd-collector.%s.svc.%s:55678" .Values.global.namespace .Values.global.clusterDomain) -}}
+{{ $_ := set .Values.global.proxy.trace "collectorSvcAccount" (printf "linkerd-collector.%s" .Values.global.namespace) -}}
+{{ end -}}
+{{- end }}

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -4,7 +4,7 @@
 {{ end -}}
 {{- end }}
 
-{{ define "partials.linkerd.trace.proxy" -}}
+{{ define "partials.controlPlaneTracing.proxy" -}}
 {{ if .Values.global.controlPlaneTracing -}}
 {{ $_ := set .Values.global.proxy.trace "collectorSvcAddr" (printf "linkerd-collector.%s.svc.%s:55678" .Values.global.namespace .Values.global.clusterDomain) -}}
 {{ $_ := set .Values.global.proxy.trace "collectorSvcAccount" (printf "linkerd-collector.%s" .Values.global.namespace) -}}


### PR DESCRIPTION
Previously, `global.controlPlaneTracing` was not available during
application injections and thus not affecting them. It was restricted to
install only.

But now that it is stored and retrieved, It causes problems when
`global.controlPlaneTracing` is enabled while no `trace-collector` value
is present or specified(through flags) during injection.

With the latest changes, This can be further be simplified by
removing `controlPlaneTracing` altogether and have trace flags 
under `install` command do the same.
This effort could be part of the minimal control plane changes.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
