### PR TITLE
Clear endpoint state in EndpointTranslator

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -184,6 +184,9 @@ func (et *endpointTranslator) diffEndpoints(filtered watcher.AddressSet) (watche
 func (et *endpointTranslator) NoEndpoints(exists bool) {
 	et.log.Debugf("NoEndpoints(%+v)", exists)
 
+	et.availableEndpoints.Addresses = map[watcher.ID]watcher.Address{}
+	et.filteredSnapshot.Addresses = map[watcher.ID]watcher.Address{}
+
 	u := &pb.Update{
 		Update: &pb.Update_NoEndpoints{
 			NoEndpoints: &pb.NoEndpoints{


### PR DESCRIPTION
The EndpointTraslator holds the full set of endpoints that it knows about as well as a filtered set of these addresses that it has sent to clients.  It needs both of these so that it can properly compute the correct diff to send to clients when it gets updates.  When it gets a NoEndpoints message, it passes this message on to clients but does not clear its own state.  If those same endpoints are subsequently added back, it will not detect this as a diff and will fail to send the update to clients.

We now clear out the full endpoint set and the filtered set from the EndpointTranslator state when it gets a NoEndpoints message.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
