### PR TITLE
Don't skip pushing images if tag is already there

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -65,15 +65,6 @@ docker_build() {
 
       output_params="--load"
       if [ -n "$DOCKER_MULTIARCH" ]; then
-
-        # Pushing multi-arch images to gcr.io with the same tag that already exists is not possible
-        # The issue is on gcr as pushing the same tag in docker hub works fine
-        # Related issues: https://github.com/eclipse/che/issues/16983, https://github.com/open-policy-agent/gatekeeper/issues/665
-        if (docker buildx imagetools inspect "$repo:$tag"); then
-          echo "Build skipped. Image already exists"
-          exit 0
-        fi
-
         output_params="--platform $SUPPORTED_ARCHS"
         if [ -n "$DOCKER_PUSH" ]; then
           output_params+=" --push"


### PR DESCRIPTION
gcr.io and quay.io have an issue that it's not possible to update multi-arch images
(see eclipse/che#16983 and open-policy-agent/gatekeeper#665).

We're now relying on ghcr.io instead, which I verified doesn't have this
bug, so we can stop skipping these pushes.