### PR TITLE
Add 'linkerd.io/inject: ingress' mode

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -32,6 +32,10 @@ env:
 - name: LINKERD2_PROXY_INBOUND_GATEWAY_SUFFIXES
   value: {{printf "svc.%s." .Values.global.clusterDomain}}
 {{ end -}}
+{{ if .Values.global.proxy.isIngress -}}
+- name: LINKERD2_PROXY_INGRESS_MODE
+  value: "true"
+{{ end -}}
 - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
   {{- $internalDomain := printf "svc.%s." .Values.global.clusterDomain }}
   value: {{ternary "." $internalDomain .Values.global.proxy.enableExternalProfiles}}

--- a/cli/cmd/testdata/install_addon.golden
+++ b/cli/cmd/testdata/install_addon.golden
@@ -868,6 +868,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_grafana_existing.golden
+++ b/cli/cmd/testdata/install_grafana_existing.golden
@@ -859,6 +859,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -868,6 +868,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -868,6 +868,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -818,6 +818,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -876,6 +876,7 @@ data:
           version: test-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""
@@ -963,6 +964,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1051,6 +1053,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1170,6 +1173,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1261,6 +1265,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""

--- a/cli/cmd/testdata/install_helm_output_addons.golden
+++ b/cli/cmd/testdata/install_helm_output_addons.golden
@@ -882,6 +882,7 @@ data:
           version: test-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""
@@ -969,6 +970,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1057,6 +1059,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1176,6 +1179,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1267,6 +1271,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1380,6 +1385,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1468,6 +1474,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -882,6 +882,7 @@ data:
           version: test-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""
@@ -968,6 +969,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1055,6 +1057,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1192,6 +1195,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1282,6 +1286,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -886,6 +886,7 @@ data:
           version: test-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""
@@ -976,6 +977,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1067,6 +1069,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1208,6 +1211,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1302,6 +1306,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -882,6 +882,7 @@ data:
           version: test-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""
@@ -968,6 +969,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1055,6 +1057,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""
@@ -1192,6 +1195,7 @@ data:
             version: test-proxy-version
           inboundConnectTimeout: 100ms
           isGateway: false
+          isIngress: false
           logFormat: plain
           logLevel: warn,linkerd=info
           opaquePorts: ""
@@ -1282,6 +1286,7 @@ data:
               version: test-proxy-version
             inboundConnectTimeout: 100ms
             isGateway: false
+            isIngress: false
             logFormat: plain
             logLevel: warn,linkerd=info
             opaquePorts: ""

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -859,6 +859,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -862,6 +862,7 @@ data:
           version: ProxyVersion
         inboundConnectTimeout: ""
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_prometheus_overwrite.golden
+++ b/cli/cmd/testdata/install_prometheus_overwrite.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -862,6 +862,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_restricted_dashboard.golden
+++ b/cli/cmd/testdata/install_restricted_dashboard.golden
@@ -794,6 +794,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -868,6 +868,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/cli/cmd/testdata/install_tracing_overwrite.golden
+++ b/cli/cmd/testdata/install_tracing_overwrite.golden
@@ -868,6 +868,7 @@ data:
           version: install-proxy-version
         inboundConnectTimeout: 100ms
         isGateway: false
+        isIngress: false
         logFormat: plain
         logLevel: warn,linkerd=info
         opaquePorts: ""

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -127,6 +127,7 @@ type (
 		UID                           int64            `json:"uid"`
 		WaitBeforeExitSeconds         uint64           `json:"waitBeforeExitSeconds"`
 		IsGateway                     bool             `json:"isGateway"`
+		IsIngress                     bool             `json:"isIngress"`
 		RequireIdentityOnInboundPorts string           `json:"requireIdentityOnInboundPorts"`
 		OutboundConnectTimeout        string           `json:"outboundConnectTimeout"`
 		InboundConnectTimeout         string           `json:"inboundConnectTimeout"`

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -676,6 +676,12 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		annotations[k] = v
 	}
 
+	if override, ok := annotations[k8s.ProxyInjectAnnotation]; ok {
+		if override == k8s.ProxyInjectIngress {
+			values.Global.Proxy.IsIngress = true
+		}
+	}
+
 	if override, ok := annotations[k8s.ProxyImageAnnotation]; ok {
 		values.Global.Proxy.Image.Name = override
 	}

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -180,14 +180,14 @@ func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string, string
 		return true, invalidInjectAnnotationWorkload, ""
 	}
 
-	if nsAnnotation == k8s.ProxyInjectEnabled {
+	if nsAnnotation == k8s.ProxyInjectEnabled || nsAnnotation == k8s.ProxyInjectIngress {
 		if podAnnotation == k8s.ProxyInjectDisabled {
 			return true, injectDisableAnnotationPresent, annotationAtWorkload
 		}
 		return false, "", annotationAtNamespace
 	}
 
-	if podAnnotation != k8s.ProxyInjectEnabled {
+	if podAnnotation != k8s.ProxyInjectEnabled && podAnnotation != k8s.ProxyInjectIngress {
 		return true, injectEnableAnnotationAbsent, ""
 	}
 
@@ -195,7 +195,7 @@ func (r *Report) disableByAnnotation(conf *ResourceConfig) (bool, string, string
 }
 
 func isInjectAnnotationValid(annotation string) bool {
-	if annotation != "" && !(annotation == k8s.ProxyInjectEnabled || annotation == k8s.ProxyInjectDisabled) {
+	if annotation != "" && !(annotation == k8s.ProxyInjectEnabled || annotation == k8s.ProxyInjectDisabled || annotation == k8s.ProxyInjectIngress) {
 		return false
 	}
 	return true

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -103,6 +103,10 @@ const (
 	// enable injection for a pod or namespace.
 	ProxyInjectEnabled = "enabled"
 
+	// ProxyInjectIngress is assigned to the ProxyInjectAnnotation annotation to
+	// enable injection in ingress mode for a pod.
+	ProxyInjectIngress = "ingress"
+
 	// ProxyInjectDisabled is assigned to the ProxyInjectAnnotation annotation to
 	// disable injection for a pod or namespace.
 	ProxyInjectDisabled = "disabled"


### PR DESCRIPTION
Fixes #5118

This PR adds a new supported value for the `linkerd.io/inject` annotation.  In addition to `enabled` and `disabled`, this annotation may now be set to `ingress`.  This functions identically to `enabled` but it also causes the `LINKERD2_PROXY_INGRESS_MODE="true"` environment variable to be set on the proxy.  This causes the proxy to operate in ingress mode as described in #5118 

With this set, ingresses are able to properly load service profiles based on the l5d-dst-override header.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
