### PR TITLE
Use errors.Is instead of checking underlying err messages

### DIFF
--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -434,7 +435,7 @@ func recvEvents(tapByteStream *bufio.Reader, eventCh chan<- *pb.TapEvent, closin
 		if err != nil {
 			if err == io.EOF {
 				fmt.Println("Tap stream terminated")
-			} else if !strings.HasSuffix(err.Error(), "http2: response body closed") {
+			} else if !errors.Is(err, tap.ErrClosedResponseBody) {
 				fmt.Println(err.Error())
 			}
 

--- a/cli/cmd/top.go
+++ b/cli/cmd/top.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -435,7 +434,7 @@ func recvEvents(tapByteStream *bufio.Reader, eventCh chan<- *pb.TapEvent, closin
 		if err != nil {
 			if err == io.EOF {
 				fmt.Println("Tap stream terminated")
-			} else if !errors.Is(err, tap.ErrClosedResponseBody) {
+			} else if !strings.HasSuffix(err.Error(), tap.ErrClosedResponseBody) {
 				fmt.Println(err.Error())
 			}
 

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -3,10 +3,7 @@ package profiles
 import (
 	"bufio"
 	"context"
-<<<<<<< HEAD
 	"errors"
-=======
->>>>>>> main
 	"fmt"
 	"io"
 	"net"

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -84,7 +85,7 @@ func routeSpecFromTap(tapByteStream *bufio.Reader, routeLimit int) []*sp.RouteSp
 			// expected errors when hitting the tapDuration deadline
 			var e net.Error
 			if err != io.EOF &&
-				!errors.Is(err, tap.ErrClosedResponseBody) &&
+				!strings.HasSuffix(err.Error(), tap.ErrClosedResponseBody) &&
 				!errors.Is(err, context.DeadlineExceeded) &&
 				!(errors.As(err, &e) && e.Timeout()) {
 				fmt.Fprintln(os.Stderr, err)

--- a/pkg/profiles/tap.go
+++ b/pkg/profiles/tap.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -85,9 +84,9 @@ func routeSpecFromTap(tapByteStream *bufio.Reader, routeLimit int) []*sp.RouteSp
 			// expected errors when hitting the tapDuration deadline
 			var e net.Error
 			if err != io.EOF &&
-				!strings.HasSuffix(err.Error(), "(Client.Timeout or context cancellation while reading body)") &&
+				!errors.Is(err, tap.ErrClosedResponseBody) &&
 				!errors.Is(err, context.DeadlineExceeded) &&
-				(errors.As(err, &e) && e.Timeout()) {
+				!(errors.As(err, &e) && e.Timeout()) {
 				fmt.Fprintln(os.Stderr, err)
 			}
 			break

--- a/pkg/protohttp/protohttp.go
+++ b/pkg/protohttp/protohttp.go
@@ -131,14 +131,14 @@ func deserializePayloadFromReader(reader *bufio.Reader) ([]byte, error) {
 	messageLengthAsBytes := make([]byte, numBytesForMessageLength)
 	_, err := io.ReadFull(reader, messageLengthAsBytes)
 	if err != nil {
-		return nil, fmt.Errorf("error while reading message length: %v", err)
+		return nil, fmt.Errorf("error while reading message length: %w", err)
 	}
 	messageLength := int(binary.LittleEndian.Uint32(messageLengthAsBytes))
 
 	messageContentsAsBytes := make([]byte, messageLength)
 	_, err = io.ReadFull(reader, messageContentsAsBytes)
 	if err != nil {
-		return nil, fmt.Errorf("error while reading bytes from message: %v", err)
+		return nil, fmt.Errorf("error while reading bytes from message: %w", err)
 	}
 
 	return messageContentsAsBytes, nil
@@ -190,12 +190,12 @@ func CheckIfResponseHasError(rsp *http.Response) error {
 func FromByteStreamToProtocolBuffers(byteStreamContainingMessage *bufio.Reader, out proto.Message) error {
 	messageAsBytes, err := deserializePayloadFromReader(byteStreamContainingMessage)
 	if err != nil {
-		return fmt.Errorf("error reading byte stream header: %v", err)
+		return fmt.Errorf("error reading byte stream header: %w", err)
 	}
 
 	err = proto.Unmarshal(messageAsBytes, out)
 	if err != nil {
-		return fmt.Errorf("error unmarshalling array of [%d] bytes error: %v", len(messageAsBytes), err)
+		return fmt.Errorf("error unmarshalling array of [%d] bytes error: %w", len(messageAsBytes), err)
 	}
 
 	return nil

--- a/pkg/tap/tap.go
+++ b/pkg/tap/tap.go
@@ -3,6 +3,7 @@ package tap
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,11 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrClosedResponseBody is returned when response body is closed in http2
+	ErrClosedResponseBody = errors.New("http2: response body closed")
 )
 
 // TapRbacURL is the link users should visit to remedy issues when attempting

--- a/pkg/tap/tap.go
+++ b/pkg/tap/tap.go
@@ -3,7 +3,6 @@ package tap
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,9 +16,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
+const (
 	// ErrClosedResponseBody is returned when response body is closed in http2
-	ErrClosedResponseBody = errors.New("http2: response body closed")
+	ErrClosedResponseBody = "http2: response body closed"
 )
 
 // TapRbacURL is the link users should visit to remedy issues when attempting


### PR DESCRIPTION
Fixes #5132

This PR replaces the usage of `strings.hasSuffix` with `errors.Is`
wherever error messages are being checked. So, that the code is not
effected by changes in the underlying message.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
