### PR TITLE
 cli: make check return SkipError when there is no prometheus configured

### DIFF
--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -118,7 +117,7 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 
 	// Query Prometheus for all pods present
 	vec, err := s.queryProm(ctx, processStartTimeQuery)
-	if err != nil && !strings.Contains(err.Error(), ErrNoPrometheusInstance) {
+	if err != nil && !errors.Is(err, ErrNoPrometheusInstance) {
 		return nil, err
 	}
 

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -117,9 +118,10 @@ func (s *grpcServer) ListPods(ctx context.Context, req *pb.ListPodsRequest) (*pb
 
 	// Query Prometheus for all pods present
 	vec, err := s.queryProm(ctx, processStartTimeQuery)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), ErrNoPrometheusInstance) {
 		return nil, err
 	}
+
 	for _, sample := range vec {
 		pod := string(sample.Metric["pod"])
 		timestamp := sample.Timestamp

--- a/controller/api/public/prometheus.go
+++ b/controller/api/public/prometheus.go
@@ -40,9 +40,11 @@ const (
 	gatewayNameLabel       = model.LabelName("gateway_name")
 	gatewayNamespaceLabel  = model.LabelName("gateway_namespace")
 	remoteClusterNameLabel = model.LabelName("target_cluster_name")
+)
 
+var (
 	// ErrNoPrometheusInstance is returned when there is no prometheus instance configured
-	ErrNoPrometheusInstance = "No prometheus instance to connect"
+	ErrNoPrometheusInstance = errors.New("No prometheus instance to connect")
 )
 
 func extractSampleValue(sample *model.Sample) uint64 {
@@ -61,7 +63,7 @@ func (s *grpcServer) queryProm(ctx context.Context, query string) (model.Vector,
 	span.AddAttributes(trace.StringAttribute("queryString", query))
 
 	if s.prometheusAPI == nil {
-		return nil, errors.New(ErrNoPrometheusInstance)
+		return nil, ErrNoPrometheusInstance
 	}
 
 	// single data point (aka summary) query

--- a/controller/api/public/prometheus.go
+++ b/controller/api/public/prometheus.go
@@ -40,6 +40,9 @@ const (
 	gatewayNameLabel       = model.LabelName("gateway_name")
 	gatewayNamespaceLabel  = model.LabelName("gateway_namespace")
 	remoteClusterNameLabel = model.LabelName("target_cluster_name")
+
+	// ErrNoPrometheusInstance is returned when there is no prometheus instance configured
+	ErrNoPrometheusInstance = "No prometheus instance to connect"
 )
 
 func extractSampleValue(sample *model.Sample) uint64 {
@@ -58,7 +61,7 @@ func (s *grpcServer) queryProm(ctx context.Context, query string) (model.Vector,
 	span.AddAttributes(trace.StringAttribute("queryString", query))
 
 	if s.prometheusAPI == nil {
-		return nil, errors.New("No prometheus instance to connect")
+		return nil, errors.New(ErrNoPrometheusInstance)
 	}
 
 	// single data point (aka summary) query

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2113,7 +2113,7 @@ func (hc *HealthChecker) getDataPlanePods(ctx context.Context) ([]*pb.Pod, error
 	resp, err := hc.apiClient.ListPods(ctx, req)
 	if err != nil {
 		// return a SkipError if there is no prometheus present
-		if strings.HasSuffix(err.Error(), "No prometheus instance to connect") {
+		if strings.Contains(err.Error(), public.ErrNoPrometheusInstance) {
 			return nil, &SkipError{Reason: err.Error()}
 		}
 		return nil, err

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2112,6 +2112,10 @@ func (hc *HealthChecker) getDataPlanePods(ctx context.Context) ([]*pb.Pod, error
 
 	resp, err := hc.apiClient.ListPods(ctx, req)
 	if err != nil {
+		// return a SkipError if there is no prometheus present
+		if strings.HasSuffix(err.Error(), "No prometheus instance to connect") {
+			return nil, &SkipError{Reason: err.Error()}
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #5143

Check currently keeps retrying for a bit when there is no prometheus
instnace configured i.e both linkerd and external prometheus instance
(through global.prometheusUrl).

The availability of prometheus is useful for some calls in public-api
that the check uses. This change updates the `ListPods` in `public-api` 
to still return the pods even when prometheus is not configured.

For a test that exclusively checks for prometheus metrics, we have a gate
which checks if a prometheus is configured and skips it othervise.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
