### PR TITLE
cli: add `--ingress` flag to inject cmd

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -188,6 +188,10 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 
 	if len(rt.overrideAnnotations) > 0 {
+		// Do not set ingress annotation if its manual
+		if val, ok := rt.overrideAnnotations[k8s.ProxyInjectAnnotation]; ok && val == k8s.ProxyInjectIngress && rt.injectProxy {
+			delete(rt.overrideAnnotations, k8s.ProxyInjectAnnotation)
+		}
 		conf.AppendPodAnnotations(rt.overrideAnnotations)
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -181,6 +181,9 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 
 	if rt.injectProxy {
+		// delete the inject annotation if present as its not needed in the manual case
+		// prevents injector from taking a different code path in the ignress mode
+		delete(rt.overrideAnnotations, k8s.ProxyInjectAnnotation)
 		conf.AppendPodAnnotation(k8s.CreatedByAnnotation, k8s.CreatedByAnnotationValue())
 	} else {
 		// flag the auto-injector to inject the proxy, regardless of the namespace annotation
@@ -188,10 +191,6 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 
 	if len(rt.overrideAnnotations) > 0 {
-		// Do not set ingress annotation if its manual
-		if val, ok := rt.overrideAnnotations[k8s.ProxyInjectAnnotation]; ok && val == k8s.ProxyInjectIngress && rt.injectProxy {
-			delete(rt.overrideAnnotations, k8s.ProxyInjectAnnotation)
-		}
 		conf.AppendPodAnnotations(rt.overrideAnnotations)
 	}
 

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -423,6 +423,10 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 		overrideAnnotations[k8s.ProxyEnableExternalProfilesAnnotation] = strconv.FormatBool(proxy.EnableExternalProfiles)
 	}
 
+	if proxy.IsIngress != baseProxy.IsIngress {
+		overrideAnnotations[k8s.ProxyInjectAnnotation] = k8s.ProxyInjectIngress
+	}
+
 	if proxy.Resources.CPU.Request != baseProxy.Resources.CPU.Request {
 		overrideAnnotations[k8s.ProxyCPURequestAnnotation] = proxy.Resources.CPU.Request
 	}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -418,6 +418,12 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 
+		flag.NewBoolFlag(proxyFlags, "ingress", defaults.Global.Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
+			func(values *l5dcharts.Values, value bool) error {
+				values.Global.Proxy.IsIngress = value
+				return nil
+			}),
+
 		// Deprecated flags
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.Global.Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -418,12 +418,6 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 
-		flag.NewBoolFlag(proxyFlags, "ingress", defaults.Global.Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
-			func(values *l5dcharts.Values, value bool) error {
-				values.Global.Proxy.IsIngress = value
-				return nil
-			}),
-
 		// Deprecated flags
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.Global.Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
@@ -502,6 +496,12 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.Global.Proxy.RequireIdentityOnInboundPorts, ","),
 			"Inbound ports on which the proxy should require identity", func(values *l5dcharts.Values, value []string) error {
 				values.Global.Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
+				return nil
+			}),
+
+		flag.NewBoolFlag(injectFlags, "ingress", defaults.Global.Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
+			func(values *l5dcharts.Values, value bool) error {
+				values.Global.Proxy.IsIngress = value
 				return nil
 			}),
 	}


### PR DESCRIPTION
This PR adds a new inject flag called `--ingress` which when enabled
adds a new annotation i.e `linkerd.io/inject: ingress`.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
