### PR TITLE
upgrade: set identity.issuer.crtExpiry correctly with legacy upgrades

### DIFF
--- a/pkg/issuercerts/issuercerts.go
+++ b/pkg/issuercerts/issuercerts.go
@@ -44,7 +44,12 @@ func FetchIssuerData(ctx context.Context, api kubernetes.Interface, trustAnchors
 		return nil, fmt.Errorf(keyMissingError, k8s.IdentityIssuerKeyName, "issuer key", k8s.IdentityIssuerSecretName, true)
 	}
 
-	return &IssuerCertData{trustAnchors, string(crt), string(key), nil}, nil
+	cert, err := tls.DecodePEMCrt(string(crt))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse issuer certificate: %w", err)
+	}
+
+	return &IssuerCertData{trustAnchors, string(crt), string(key), &cert.Certificate.NotAfter}, nil
 }
 
 // FetchExternalIssuerData fetches the issuer data from the linkerd-identity-issuer secrets (used for kubernetes.io/tls schemed secrets)


### PR DESCRIPTION
With legacy upgrades, we can parse the cert and store the expiry
correctly instead of storing it as the default value which could be a
problem when we use that field. Currently, we do not use this field and
hence it did not cause any problems.

With Install on the latest edges, This field is correctly set and works
as expected. Thus, upgrades also hav the right value.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
