### PR TITLE
upgrade: do not use external certs with upgrades

### DIFF
--- a/cli/cmd/upgrade_legacy.go
+++ b/cli/cmd/upgrade_legacy.go
@@ -234,7 +234,9 @@ func fetchIssuer(ctx context.Context, k kubernetes.Interface, trustPEM string, s
 	)
 	switch scheme {
 	case string(corev1.SecretTypeTLS):
-		issuerData, err = issuercerts.FetchExternalIssuerData(ctx, k, controlPlaneNamespace)
+		// Do not return external issuer certs as no need of storing them in config and upgrade secrets
+		// Also contradicts condition in https://github.com/linkerd/linkerd2/blob/main/cli/cmd/options.go#L550
+		return &issuercerts.IssuerCertData{}, nil
 	default:
 		issuerData, err = issuercerts.FetchIssuerData(ctx, k, trustPEM, controlPlaneNamespace)
 		if issuerData != nil && issuerData.TrustAnchors != trustPEM {


### PR DESCRIPTION
Currently, For legacy upgrades we are fetching even external certs and
using it for upgrades which contradicts the condition at
https://github.com/linkerd/linkerd2/blob/master/cli/cmd/options.go#L550
used with install and thus causing errors.

Instead we don't retrieve them with upgrades and hence they don't get
stored into the config and secrets which seems correct as we do not want
to store certs in the config and use them with upgrades when they are
created externally.

This touches only the upgrade path i.e `fetchIssuers` and would not
effect the retrievel of external certs for checks, etc.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
