### PR TITLE
actions: Limit job runtime to <= 30 minutes

### DIFF
--- a/.github/workflows/kind_integration.yml
+++ b/.github/workflows/kind_integration.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         target: [proxy, controller, web, cni-plugin, debug, cli-bin, grafana]
     name: Docker build (${{ matrix.target }})
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -72,6 +73,7 @@ jobs:
     name: Static CLI tests (windows)
     runs-on: windows-latest
     needs: [docker_build]
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -109,6 +111,7 @@ jobs:
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         target: [proxy, controller, web, cni-plugin, debug, cli-bin, grafana]
     name: Docker build (${{ matrix.target }})
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -71,6 +72,7 @@ jobs:
   # todo: Keep in sync with `kind_integration.yml`
   windows_static_cli_tests:
     name: Static CLI tests (windows)
+    timeout-minutes: 30
     runs-on: windows-latest
     needs: [docker_build]
     steps:
@@ -106,6 +108,7 @@ jobs:
         - cni-calico-deep
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
@@ -133,6 +136,7 @@ jobs:
         bin/tests --images skip --name ${{ matrix.integration_test }} "$CMD"
   arm64_integration_tests:
     name: ARM64 integration tests
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     needs: [docker_build]
     steps:
@@ -185,6 +189,7 @@ jobs:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
+    timeout-minutes: 30
     needs: [kind_integration_tests, arm64_integration_tests]
     runs-on: windows-2019
     steps:
@@ -212,6 +217,7 @@ jobs:
         path: ./linkerd.*.nupkg
   gh_release:
     name: Create GH release
+    timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
     needs: [choco_pack]
@@ -258,6 +264,7 @@ jobs:
           ./target/release/linkerd2-cli-*.nupkg
   website_publish:
     name: Linkerd website publish
+    timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
     needs: [gh_release]
@@ -271,6 +278,7 @@ jobs:
         event-type: release
   website_publish_check:
     name: Linkerd website publish check
+    timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-18.04
     needs: [website_publish]
@@ -301,6 +309,7 @@ jobs:
         fi
   chart_deploy:
     name: Helm chart deploy
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     needs: [gh_release]
     steps:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   go_lint:
     name: Go lint
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     container:
       image: golang:1.13.4
@@ -21,6 +22,7 @@ jobs:
       run: bin/lint --verbose
   go_format:
     name: Go format
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     container:
       image: golang:1.13.4
@@ -32,6 +34,7 @@ jobs:
       run: bin/fmt
   proto_diff:
     name: Proto diff
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     container:
       image: golang:1.13.4
@@ -43,6 +46,7 @@ jobs:
         run: bin/protoc-diff
   shellcheck:
     name: shellcheck
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
@@ -54,6 +58,7 @@ jobs:
         bin/shellcheck-all
   psscript-analyzer:
     name: PSScriptAnalyzer
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code
@@ -70,6 +75,7 @@ jobs:
         failOnInfos: true
   markdown_lint:
     name: Markdown lint
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   go_unit_tests:
     name: Go unit tests
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     container:
       image: golang:1.14.2
@@ -24,6 +25,7 @@ jobs:
         gotestsum -- -cover -race -v -mod=readonly ./...
   js_unit_tests:
     name: JS unit tests
+    timeout-minutes: 30
     runs-on: ubuntu-18.04
     container:
       image: node:14-stretch


### PR DESCRIPTION
The default job timeout is 6 hours! This allows runaway builds to
consume our actions resources unnecessarily.

This change limits integration test jobs to 30 minutes. Static checks
are limited to 10 minutes.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
