### PR TITLE
Update ADOPTERS.md M1 Finance 

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -21,6 +21,7 @@
 - [Kairos](https://kairos.com)
 - [Kurio](https://kurio.id)
 - [LeadIQ](https://leadiq.com)
+- [M1 Finance](https://www.m1finance.com/)
 - [MattePaint](https://www.mattepaint.com/)
 - [MercedesBenz.io](https://www.mercedes-benz.io/)
 - [Mulligan Funding](https://www.mulliganfunding.com/)


### PR DESCRIPTION
Updating ADOPTERS.md to include M1 Finance

Adopters did not include M1 Finance.

Add M1 Finance to ADOPTERS.md

Once Merged, Check https://github.com/linkerd/linkerd2/blob/main/ADOPTERS.md

Fixes #N/A

Signed-off-by: Ty Schreiner <t.schreiner@m1finance.com>
