### PR TITLE
Refactor webhook framework to allow webhooks define their flags

### DIFF
--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -22,7 +22,7 @@ func Main(args []string) {
 	webhook.Launch(
 		context.Background(),
 		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod, k8s.CJ},
-		injector.Inject(*foobar),
+		injector.Inject,
 		"linkerd-proxy-injector",
 		*metricsAddr,
 		*addr,

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -2,21 +2,30 @@ package proxyinjector
 
 import (
 	"context"
+	"flag"
+	"fmt"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	injector "github.com/linkerd/linkerd2/controller/proxy-injector"
 	"github.com/linkerd/linkerd2/controller/webhook"
+	"github.com/linkerd/linkerd2/pkg/flags"
 )
 
 // Main executes the proxy-injector subcommand
 func Main(args []string) {
+	cmd := flag.NewFlagSet("proxy-injector", flag.ExitOnError)
+	metricsAddr := cmd.String("metrics-addr", fmt.Sprintf(":%d", 9995), "address to serve scrapable metrics on")
+	addr := cmd.String("addr", ":8443", "address to serve on")
+	kubeconfig := cmd.String("kubeconfig", "", "path to kubeconfig")
+	flags.ConfigureAndParse(cmd, args)
+
 	webhook.Launch(
 		context.Background(),
 		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod, k8s.CJ},
-		9995,
-		injector.Inject,
+		injector.Inject(*foobar),
 		"linkerd-proxy-injector",
-		"proxy-injector",
-		args,
+		*metricsAddr,
+		*addr,
+		*kubeconfig,
 	)
 }

--- a/controller/cmd/sp-validator/main.go
+++ b/controller/cmd/sp-validator/main.go
@@ -2,20 +2,29 @@ package spvalidator
 
 import (
 	"context"
+	"flag"
+	"fmt"
 
 	validator "github.com/linkerd/linkerd2/controller/sp-validator"
 	"github.com/linkerd/linkerd2/controller/webhook"
+	"github.com/linkerd/linkerd2/pkg/flags"
 )
 
 // Main executes the sp-validator subcommand
 func Main(args []string) {
+	cmd := flag.NewFlagSet("sp-validator", flag.ExitOnError)
+	metricsAddr := cmd.String("metrics-addr", fmt.Sprintf(":%d", 9997), "address to serve scrapable metrics on")
+	addr := cmd.String("addr", ":8443", "address to serve on")
+	kubeconfig := cmd.String("kubeconfig", "", "path to kubeconfig")
+	flags.ConfigureAndParse(cmd, args)
+
 	webhook.Launch(
 		context.Background(),
 		nil,
-		9997,
 		validator.AdmitSP,
 		"linkerd-sp-validator",
-		"sp-validator",
-		args,
+		*metricsAddr,
+		*addr,
+		*kubeconfig,
 	)
 }

--- a/controller/webhook/launcher.go
+++ b/controller/webhook/launcher.go
@@ -2,8 +2,6 @@ package webhook
 
 import (
 	"context"
-	"flag"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,27 +9,26 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
-	"github.com/linkerd/linkerd2/pkg/flags"
 	pkgk8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
 )
 
 // Launch sets up and starts the webhook and metrics servers
-func Launch(ctx context.Context, APIResources []k8s.APIResource, metricsPort uint32, handler handlerFunc, component, subcommand string, args []string) {
-	cmd := flag.NewFlagSet(subcommand, flag.ExitOnError)
-
-	metricsAddr := cmd.String("metrics-addr", fmt.Sprintf(":%d", metricsPort), "address to serve scrapable metrics on")
-	addr := cmd.String("addr", ":8443", "address to serve on")
-	kubeconfig := cmd.String("kubeconfig", "", "path to kubeconfig")
-
-	flags.ConfigureAndParse(cmd, args)
-
+func Launch(
+	ctx context.Context,
+	APIResources []k8s.APIResource,
+	handler Handler,
+	component,
+	metricsAddr string,
+	addr string,
+	kubeconfig string,
+) {
 	stop := make(chan os.Signal, 1)
 	defer close(stop)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
-	k8sAPI, err := k8s.InitializeAPI(ctx, *kubeconfig, true, APIResources...)
+	k8sAPI, err := k8s.InitializeAPI(ctx, kubeconfig, false, APIResources...)
 	if err != nil {
 		log.Fatalf("failed to initialize Kubernetes API: %s", err)
 	}
@@ -41,7 +38,7 @@ func Launch(ctx context.Context, APIResources []k8s.APIResource, metricsPort uin
 		log.Fatalf("failed to read TLS secrets: %s", err)
 	}
 
-	s, err := NewServer(k8sAPI, *addr, cred, handler, component)
+	s, err := NewServer(k8sAPI, addr, cred, handler, component)
 	if err != nil {
 		log.Fatalf("failed to initialize the webhook server: %s", err)
 	}
@@ -49,7 +46,7 @@ func Launch(ctx context.Context, APIResources []k8s.APIResource, metricsPort uin
 	k8sAPI.Sync(nil)
 
 	go s.Start()
-	go admin.StartServer(*metricsAddr)
+	go admin.StartServer(metricsAddr)
 
 	<-stop
 	log.Info("shutting down webhook server")

--- a/controller/webhook/server.go
+++ b/controller/webhook/server.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Handler is the signature for the functions that ultimately deal with
+// the admission request
 type Handler func(
 	context.Context,
 	*k8s.API,


### PR DESCRIPTION
Pulled out of `launcher.go` the flag parsing logic and moved it into the `Main` methods of the webhooks (under `controller/cmd/proxy.injector/main.go` and `controller/cmd/sp-validator/main.go`), so that individual webhooks themselves can define the flags they want to use.

Also no longer require that webhooks have cluster-wide access.

Finally, renamed the type `webhook.handlerFunc` to `webhook.Handler` so it can be exported. This will be used in the upcoming jaeger webhook.
