### PR TITLE
Check correct label value when setting protocol hint

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -307,7 +307,7 @@ func toWeightedAddr(address watcher.Address, enableH2Upgrade bool, identityTrust
 	// If the pod is controlled by any Linkerd control plane, then it can be hinted
 	// that this destination knows H2 (and handles our orig-proto translation).
 	var hint *pb.ProtocolHint
-	if enableH2Upgrade && controllerNS != "" {
+	if enableH2Upgrade && controllerNSLabel != "" {
 		hint = &pb.ProtocolHint{
 			Protocol: &pb.ProtocolHint_H2_{
 				H2: &pb.ProtocolHint_H2{},


### PR DESCRIPTION
This fixes an issue where the protocol hint is always set on endpoint responses.

We now check the right value which determines if the pod has the required label.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
