### PR TITLE
Fix a CLI crash

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -350,17 +350,17 @@ func fetchConfigs(ctx context.Context) (*linkerd2.Values, error) {
 func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[string]string {
 	overrideAnnotations := make(map[string]string)
 
-	proxy := values.Global.Proxy
-	baseProxy := base.Global.Proxy
+	proxy := values.GetGlobal().Proxy
+	baseProxy := base.GetGlobal().Proxy
 	if proxy.Image.Version != baseProxy.Image.Version {
 		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = proxy.Image.Version
 	}
 
-	if values.Global.ProxyInit.IgnoreInboundPorts != base.Global.ProxyInit.IgnoreInboundPorts {
-		overrideAnnotations[k8s.ProxyIgnoreInboundPortsAnnotation] = values.Global.ProxyInit.IgnoreInboundPorts
+	if values.GetGlobal().ProxyInit.IgnoreInboundPorts != base.GetGlobal().ProxyInit.IgnoreInboundPorts {
+		overrideAnnotations[k8s.ProxyIgnoreInboundPortsAnnotation] = values.GetGlobal().ProxyInit.IgnoreInboundPorts
 	}
-	if values.Global.ProxyInit.IgnoreOutboundPorts != base.Global.ProxyInit.IgnoreOutboundPorts {
-		overrideAnnotations[k8s.ProxyIgnoreOutboundPortsAnnotation] = values.Global.ProxyInit.IgnoreOutboundPorts
+	if values.GetGlobal().ProxyInit.IgnoreOutboundPorts != base.GetGlobal().ProxyInit.IgnoreOutboundPorts {
+		overrideAnnotations[k8s.ProxyIgnoreOutboundPortsAnnotation] = values.GetGlobal().ProxyInit.IgnoreOutboundPorts
 	}
 
 	if proxy.Ports.Admin != baseProxy.Ports.Admin {
@@ -379,15 +379,15 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 	if proxy.Image.Name != baseProxy.Image.Name {
 		overrideAnnotations[k8s.ProxyImageAnnotation] = proxy.Image.Name
 	}
-	if values.Global.ProxyInit.Image.Name != base.Global.ProxyInit.Image.Name {
-		overrideAnnotations[k8s.ProxyInitImageAnnotation] = values.Global.ProxyInit.Image.Name
+	if values.GetGlobal().ProxyInit.Image.Name != base.GetGlobal().ProxyInit.Image.Name {
+		overrideAnnotations[k8s.ProxyInitImageAnnotation] = values.GetGlobal().ProxyInit.Image.Name
 	}
 	if values.DebugContainer.Image.Name != base.DebugContainer.Image.Name {
 		overrideAnnotations[k8s.DebugImageAnnotation] = values.DebugContainer.Image.Name
 	}
 
-	if values.Global.ProxyInit.Image.Version != base.Global.ProxyInit.Image.Version {
-		overrideAnnotations[k8s.ProxyInitImageVersionAnnotation] = values.Global.ProxyInit.Image.Version
+	if values.GetGlobal().ProxyInit.Image.Version != base.GetGlobal().ProxyInit.Image.Version {
+		overrideAnnotations[k8s.ProxyInitImageVersionAnnotation] = values.GetGlobal().ProxyInit.Image.Version
 	}
 
 	if values.DebugContainer.Image.Version != base.DebugContainer.Image.Version {
@@ -455,7 +455,7 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 	}
 
 	// Set fields that can't be converted into annotations
-	values.Global.Namespace = controlPlaneNamespace
+	values.GetGlobal().Namespace = controlPlaneNamespace
 
 	return overrideAnnotations
 }

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -63,8 +63,8 @@ func defaultConfig() *linkerd2.Values {
 	if err != nil {
 		log.Fatalf("Unexpected error: %v", err)
 	}
-	defaultConfig.Global.LinkerdVersion = "test-inject-control-plane-version"
-	defaultConfig.Global.Proxy.Image.Version = "test-inject-proxy-version"
+	defaultConfig.GetGlobal().LinkerdVersion = "test-inject-control-plane-version"
+	defaultConfig.GetGlobal().Proxy.Image.Version = "test-inject-proxy-version"
 	defaultConfig.DebugContainer.Image.Version = "test-inject-debug-version"
 
 	return defaultConfig
@@ -74,10 +74,10 @@ func TestUninjectAndInject(t *testing.T) {
 	defaultValues := defaultConfig()
 
 	overrideConfig := defaultConfig()
-	overrideConfig.Global.Proxy.Image.Version = "override"
+	overrideConfig.GetGlobal().Proxy.Image.Version = "override"
 
 	proxyResourceConfig := defaultConfig()
-	proxyResourceConfig.Global.Proxy.Resources = &linkerd2.Resources{
+	proxyResourceConfig.GetGlobal().Proxy.Resources = &linkerd2.Resources{
 		CPU: linkerd2.Constraints{
 			Request: "110m",
 			Limit:   "160m",
@@ -89,11 +89,11 @@ func TestUninjectAndInject(t *testing.T) {
 	}
 
 	cniEnabledConfig := defaultConfig()
-	cniEnabledConfig.Global.CNIEnabled = true
+	cniEnabledConfig.GetGlobal().CNIEnabled = true
 
 	proxyIgnorePortsConfig := defaultConfig()
-	proxyIgnorePortsConfig.Global.ProxyInit.IgnoreInboundPorts = "22,8100-8102"
-	proxyIgnorePortsConfig.Global.ProxyInit.IgnoreOutboundPorts = "5432"
+	proxyIgnorePortsConfig.GetGlobal().ProxyInit.IgnoreInboundPorts = "22,8100-8102"
+	proxyIgnorePortsConfig.GetGlobal().ProxyInit.IgnoreOutboundPorts = "5432"
 
 	testCases := []testCase{
 		{
@@ -110,7 +110,7 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:    false,
 			testInjectConfig: func() *linkerd2.Values {
 				values := defaultConfig()
-				values.Global.Proxy.Ports.Admin = 1234
+				values.GetGlobal().Proxy.Ports.Admin = 1234
 				return values
 			}(),
 		},
@@ -121,7 +121,7 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:    true,
 			testInjectConfig: func() *linkerd2.Values {
 				values := defaultConfig()
-				values.Global.Proxy.Ports.Admin = 1234
+				values.GetGlobal().Proxy.Ports.Admin = 1234
 				return values
 			}(),
 		},
@@ -295,8 +295,8 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:    true,
 			testInjectConfig: func() *linkerd2.Values {
 				values := defaultConfig()
-				values.Global.Proxy.Trace.CollectorSvcAddr = "linkerd-collector"
-				values.Global.Proxy.Trace.CollectorSvcAccount = "linkerd-collector.linkerd"
+				values.GetGlobal().Proxy.Trace.CollectorSvcAddr = "linkerd-collector"
+				values.GetGlobal().Proxy.Trace.CollectorSvcAccount = "linkerd-collector.linkerd"
 				return values
 			}(),
 		},
@@ -328,7 +328,7 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	testConfig.Global.Proxy.Image.Version = "testinjectversion"
+	testConfig.GetGlobal().Proxy.Image.Version = "testinjectversion"
 
 	errBuffer := &bytes.Buffer{}
 	outBuffer := &bytes.Buffer{}
@@ -595,25 +595,25 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.Global.ProxyInit.IgnoreInboundPorts = "8500-8505"
-	values.Global.ProxyInit.IgnoreOutboundPorts = "3306"
-	values.Global.Proxy.Ports.Admin = 1234
-	values.Global.Proxy.Ports.Control = 4191
-	values.Global.Proxy.Ports.Inbound = 4144
-	values.Global.Proxy.Ports.Outbound = 4141
-	values.Global.Proxy.UID = 999
-	values.Global.Proxy.LogLevel = "debug"
-	values.Global.Proxy.LogFormat = "cool"
-	values.Global.Proxy.DisableIdentity = true
-	values.Global.Proxy.DisableTap = true
-	values.Global.Proxy.EnableExternalProfiles = true
-	values.Global.Proxy.Resources.CPU.Request = "10m"
-	values.Global.Proxy.Resources.CPU.Limit = "100m"
-	values.Global.Proxy.Resources.Memory.Request = "10Mi"
-	values.Global.Proxy.Resources.Memory.Limit = "50Mi"
-	values.Global.Proxy.Trace.CollectorSvcAddr = "oc-collector.tracing:55678"
-	values.Global.Proxy.Trace.CollectorSvcAccount = "svcAccount"
-	values.Global.Proxy.WaitBeforeExitSeconds = 10
+	values.GetGlobal().ProxyInit.IgnoreInboundPorts = "8500-8505"
+	values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "3306"
+	values.GetGlobal().Proxy.Ports.Admin = 1234
+	values.GetGlobal().Proxy.Ports.Control = 4191
+	values.GetGlobal().Proxy.Ports.Inbound = 4144
+	values.GetGlobal().Proxy.Ports.Outbound = 4141
+	values.GetGlobal().Proxy.UID = 999
+	values.GetGlobal().Proxy.LogLevel = "debug"
+	values.GetGlobal().Proxy.LogFormat = "cool"
+	values.GetGlobal().Proxy.DisableIdentity = true
+	values.GetGlobal().Proxy.DisableTap = true
+	values.GetGlobal().Proxy.EnableExternalProfiles = true
+	values.GetGlobal().Proxy.Resources.CPU.Request = "10m"
+	values.GetGlobal().Proxy.Resources.CPU.Limit = "100m"
+	values.GetGlobal().Proxy.Resources.Memory.Request = "10Mi"
+	values.GetGlobal().Proxy.Resources.Memory.Limit = "50Mi"
+	values.GetGlobal().Proxy.Trace.CollectorSvcAddr = "oc-collector.tracing:55678"
+	values.GetGlobal().Proxy.Trace.CollectorSvcAccount = "svcAccount"
+	values.GetGlobal().Proxy.WaitBeforeExitSeconds = 10
 
 	expectedOverrides := map[string]string{
 		k8s.ProxyIgnoreInboundPortsAnnotation:       "8500-8505",
@@ -651,7 +651,7 @@ func TestProxyImageAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.Global.Proxy.Image = &linkerd2.Image{
+	values.GetGlobal().Proxy.Image = &linkerd2.Image{
 		Name:       "my.registry/linkerd/proxy",
 		Version:    "test-proxy-version",
 		PullPolicy: "Always",
@@ -677,7 +677,7 @@ func TestProxyInitImageAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.Global.ProxyInit.Image = &linkerd2.Image{
+	values.GetGlobal().ProxyInit.Image = &linkerd2.Image{
 		Name:    "my.registry/linkerd/proxy-init",
 		Version: "test-proxy-init-version",
 	}

--- a/cli/cmd/install-sp.go
+++ b/cli/cmd/install-sp.go
@@ -32,7 +32,7 @@ support, verify "kubectl api-versions" outputs "linkerd.io/v1alpha2".`,
 				return err
 			}
 
-			clusterDomain := values.Global.ClusterDomain
+			clusterDomain := values.GetGlobal().ClusterDomain
 			if clusterDomain == "" {
 				clusterDomain = defaultClusterDomain
 			}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -123,7 +123,7 @@ resources for the Linkerd control plane. This command should be followed by
 			}
 			if !ignoreCluster {
 				// Ensure k8s is reachable and that Linkerd is not already installed.
-				if err := errAfterRunningChecks(values.Global.CNIEnabled); err != nil {
+				if err := errAfterRunningChecks(values.GetGlobal().CNIEnabled); err != nil {
 					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 					} else {
@@ -173,7 +173,7 @@ control plane. It should be run after "linkerd install config".`,
 			if !skipChecks {
 				// check if global resources exist to determine if the `install config`
 				// stage succeeded
-				if err := errAfterRunningChecks(values.Global.CNIEnabled); err == nil {
+				if err := errAfterRunningChecks(values.GetGlobal().CNIEnabled); err == nil {
 					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 					} else {
@@ -296,7 +296,7 @@ func install(ctx context.Context, w io.Writer, values *l5dcharts.Values, flags [
 func render(w io.Writer, values *l5dcharts.Values, stage string) error {
 
 	// Set any global flags if present, common with install and upgrade
-	values.Global.Namespace = controlPlaneNamespace
+	values.GetGlobal().Namespace = controlPlaneNamespace
 
 	// Render raw values and create chart config
 	rawValues, err := yaml.Marshal(values)
@@ -384,7 +384,7 @@ func render(w io.Writer, values *l5dcharts.Values, stage string) error {
 	}
 
 	if stage == "" || stage == controlPlaneStage {
-		overrides, err := renderOverrides(values, values.Global.Namespace)
+		overrides, err := renderOverrides(values, values.GetGlobal().Namespace)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -323,8 +323,8 @@ func readTestValues(ha bool, ignoreOutboundPorts string, ignoreInboundPorts stri
 	if err != nil {
 		return nil, err
 	}
-	values.Global.ProxyInit.IgnoreOutboundPorts = ignoreOutboundPorts
-	values.Global.ProxyInit.IgnoreInboundPorts = ignoreInboundPorts
+	values.GetGlobal().ProxyInit.IgnoreOutboundPorts = ignoreOutboundPorts
+	values.GetGlobal().ProxyInit.IgnoreInboundPorts = ignoreInboundPorts
 
 	return values, nil
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -58,8 +58,8 @@ func TestRender(t *testing.T) {
 			LinkerdNamespaceLabel:    "LinkerdNamespaceLabel",
 			ProxyContainerName:       "ProxyContainerName",
 			CNIEnabled:               false,
-			IdentityTrustDomain:      defaultValues.Global.IdentityTrustDomain,
-			IdentityTrustAnchorsPEM:  defaultValues.Global.IdentityTrustAnchorsPEM,
+			IdentityTrustDomain:      defaultValues.GetGlobal().IdentityTrustDomain,
+			IdentityTrustAnchorsPEM:  defaultValues.GetGlobal().IdentityTrustAnchorsPEM,
 			PodAnnotations:           map[string]string{},
 			PodLabels:                map[string]string{},
 			Proxy: &charts.Proxy{
@@ -152,10 +152,10 @@ func TestRender(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	haWithOverridesValues.Global.HighAvailability = true
+	haWithOverridesValues.GetGlobal().HighAvailability = true
 	haWithOverridesValues.ControllerReplicas = 2
-	haWithOverridesValues.Global.Proxy.Resources.CPU.Request = "400m"
-	haWithOverridesValues.Global.Proxy.Resources.Memory.Request = "300Mi"
+	haWithOverridesValues.GetGlobal().Proxy.Resources.CPU.Request = "400m"
+	haWithOverridesValues.GetGlobal().Proxy.Resources.Memory.Request = "300Mi"
 	addFakeTLSSecrets(haWithOverridesValues)
 
 	cniEnabledValues, err := testInstallOptions()
@@ -163,15 +163,15 @@ func TestRender(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	cniEnabledValues.Global.CNIEnabled = true
+	cniEnabledValues.GetGlobal().CNIEnabled = true
 	addFakeTLSSecrets(cniEnabledValues)
 
 	withProxyIgnoresValues, err := testInstallOptions()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withProxyIgnoresValues.Global.ProxyInit.IgnoreInboundPorts = "22,8100-8102"
-	withProxyIgnoresValues.Global.ProxyInit.IgnoreOutboundPorts = "5432"
+	withProxyIgnoresValues.GetGlobal().ProxyInit.IgnoreInboundPorts = "22,8100-8102"
+	withProxyIgnoresValues.GetGlobal().ProxyInit.IgnoreOutboundPorts = "5432"
 	addFakeTLSSecrets(withProxyIgnoresValues)
 
 	withHeartBeatDisabledValues, err := testInstallOptions()
@@ -192,7 +192,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withControlPlaneTracingValues.Global.ControlPlaneTracing = true
+	withControlPlaneTracingValues.GetGlobal().ControlPlaneTracing = true
 	addFakeTLSSecrets(withControlPlaneTracingValues)
 
 	customRegistryOverride := "my.custom.registry/linkerd-io"
@@ -222,7 +222,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withCustomDestinationGetNetsValues.Global.ClusterNetworks = "10.0.0.0/8,100.64.0.0/10,172.0.0.0/8"
+	withCustomDestinationGetNetsValues.GetGlobal().ClusterNetworks = "10.0.0.0/8,100.64.0.0/10,172.0.0.0/8"
 	addFakeTLSSecrets(withCustomDestinationGetNetsValues)
 
 	testCases := []struct {
@@ -261,7 +261,7 @@ func TestValidateAndBuild_Errors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
-		values.Global.ProxyInit.IgnoreInboundPorts = "-25"
+		values.GetGlobal().ProxyInit.IgnoreInboundPorts = "-25"
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {
 			t.Fatal("expected error but got nothing")
@@ -273,7 +273,7 @@ func TestValidateAndBuild_Errors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
-		values.Global.ProxyInit.IgnoreOutboundPorts = "-25"
+		values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "-25"
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {
 			t.Fatal("expected error but got nothing")
@@ -313,7 +313,7 @@ func testInstallOptionsHA(ha bool) (*charts.Values, error) {
 	if err != nil {
 		return nil, err
 	}
-	values.Global.IdentityTrustAnchorsPEM = string(data)
+	values.GetGlobal().IdentityTrustAnchorsPEM = string(data)
 
 	return values, nil
 }
@@ -324,9 +324,9 @@ func testInstallOptionsNoCerts(ha bool) (*charts.Values, error) {
 		return nil, err
 	}
 
-	values.Global.Proxy.Image.Version = installProxyVersion
+	values.GetGlobal().Proxy.Image.Version = installProxyVersion
 	values.DebugContainer.Image.Version = installDebugVersion
-	values.Global.ControllerImageVersion = installControlPlaneVersion
+	values.GetGlobal().ControllerImageVersion = installControlPlaneVersion
 	values.HeartbeatSchedule = fakeHeartbeatSchedule()
 
 	return values, nil
@@ -338,10 +338,10 @@ func testInstallValues() (*charts.Values, error) {
 		return nil, err
 	}
 
-	values.Global.Proxy.Image.Version = installProxyVersion
+	values.GetGlobal().Proxy.Image.Version = installProxyVersion
 	values.DebugContainer.Image.Version = installDebugVersion
-	values.Global.LinkerdVersion = installControlPlaneVersion
-	values.Global.ControllerImageVersion = installControlPlaneVersion
+	values.GetGlobal().LinkerdVersion = installControlPlaneVersion
+	values.GetGlobal().ControllerImageVersion = installControlPlaneVersion
 	values.HeartbeatSchedule = fakeHeartbeatSchedule()
 
 	identityCert, err := ioutil.ReadFile(filepath.Join("testdata", "valid-crt.pem"))
@@ -359,7 +359,7 @@ func testInstallValues() (*charts.Values, error) {
 
 	values.Identity.Issuer.TLS.CrtPEM = string(identityCert)
 	values.Identity.Issuer.TLS.KeyPEM = string(identityKey)
-	values.Global.IdentityTrustAnchorsPEM = string(trustAnchorsPEM)
+	values.GetGlobal().IdentityTrustAnchorsPEM = string(trustAnchorsPEM)
 	return values, nil
 }
 
@@ -381,7 +381,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 
-		values.Global.ClusterNetworks = "wrong"
+		values.GetGlobal().ClusterNetworks = "wrong"
 		expected := "cannot parse destination get networks: invalid CIDR address: wrong"
 
 		err = validateValues(context.Background(), nil, values)
@@ -399,7 +399,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 
-		values.Global.ControllerLogLevel = "super"
+		values.GetGlobal().ControllerLogLevel = "super"
 		expected := "--controller-log-level must be one of: panic, fatal, error, warn, info, debug"
 
 		err = validateValues(context.Background(), nil, values)
@@ -435,7 +435,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			values.Global.Proxy.LogLevel = tc.input
+			values.GetGlobal().Proxy.LogLevel = tc.input
 			err := validateValues(context.Background(), nil, values)
 			if tc.valid && err != nil {
 				t.Fatalf("Error not expected: %s", err)
@@ -487,7 +487,7 @@ func TestValidate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			values.Global.IdentityTrustAnchorsPEM = string(ca)
+			values.GetGlobal().IdentityTrustAnchorsPEM = string(ca)
 
 			err = validateValues(context.Background(), nil, values)
 

--- a/cli/cmd/multicluster.go
+++ b/cli/cmd/multicluster.go
@@ -191,9 +191,9 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 	defaults.GatewayProbePort = opts.gatewayProbePort
 	defaults.GatewayNginxImage = opts.gatewayNginxImage
 	defaults.GatewayNginxImageVersion = opts.gatewayNginxVersion
-	defaults.IdentityTrustDomain = values.Global.IdentityTrustDomain
+	defaults.IdentityTrustDomain = values.GetGlobal().IdentityTrustDomain
 	defaults.LinkerdNamespace = controlPlaneNamespace
-	defaults.ProxyOutboundPort = uint32(values.Global.Proxy.Ports.Outbound)
+	defaults.ProxyOutboundPort = uint32(values.GetGlobal().Proxy.Ports.Outbound)
 	defaults.LinkerdVersion = version.Version
 	defaults.RemoteMirrorServiceAccount = opts.remoteMirrorCredentials
 
@@ -651,7 +651,7 @@ func newLinkCommand() *cobra.Command {
 				Name:                          opts.clusterName,
 				Namespace:                     opts.namespace,
 				TargetClusterName:             opts.clusterName,
-				TargetClusterDomain:           configMap.Global.ClusterDomain,
+				TargetClusterDomain:           configMap.GetGlobal().ClusterDomain,
 				TargetClusterLinkerdNamespace: controlPlaneNamespace,
 				ClusterCredentialsSecret:      fmt.Sprintf("cluster-credentials-%s", opts.clusterName),
 				GatewayAddress:                strings.Join(gatewayAddresses, ","),

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -48,15 +48,15 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 				return nil
 			}),
 
-		flag.NewStringFlag(installUpgradeFlags, "controller-log-level", defaults.Global.ControllerLogLevel,
+		flag.NewStringFlag(installUpgradeFlags, "controller-log-level", defaults.GetGlobal().ControllerLogLevel,
 			"Log level for the controller and web components", func(values *l5dcharts.Values, value string) error {
-				values.Global.ControllerLogLevel = value
+				values.GetGlobal().ControllerLogLevel = value
 				return nil
 			}),
 
 		flag.NewBoolFlag(installUpgradeFlags, "ha", false, "Enable HA deployment config for the control plane (default false)",
 			func(values *l5dcharts.Values, value bool) error {
-				values.Global.HighAvailability = value
+				values.GetGlobal().HighAvailability = value
 				if value {
 					haValues, err := l5dcharts.NewValues(true)
 					if err != nil {
@@ -66,12 +66,12 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 					// individual flags can override the HA defaults.  This means that the HA flag must appear
 					// before the individual flags in the slice passed to flags.ApplyIfSet.
 					values.ControllerReplicas = haValues.ControllerReplicas
-					values.Global.Proxy.Resources.CPU.Request = haValues.Global.Proxy.Resources.CPU.Request
-					values.Global.Proxy.Resources.Memory.Request = haValues.Global.Proxy.Resources.Memory.Request
+					values.GetGlobal().Proxy.Resources.CPU.Request = haValues.GetGlobal().Proxy.Resources.CPU.Request
+					values.GetGlobal().Proxy.Resources.Memory.Request = haValues.GetGlobal().Proxy.Resources.Memory.Request
 					// NOTE: CPU Limits are not currently set by default HA charts.
 					//values.Global.Proxy.Cores = haValues.Global.Proxy.Cores
 					//values.Global.Proxy.Resources.CPU.Limit = haValues.Global.Proxy.Resources.CPU.Limit
-					values.Global.Proxy.Resources.Memory.Limit = haValues.Global.Proxy.Resources.Memory.Limit
+					values.GetGlobal().Proxy.Resources.Memory.Limit = haValues.GetGlobal().Proxy.Resources.Memory.Limit
 				}
 				return nil
 			}),
@@ -116,9 +116,9 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 				return nil
 			}),
 
-		flag.NewBoolFlag(installUpgradeFlags, "control-plane-tracing", defaults.Global.ControlPlaneTracing,
+		flag.NewBoolFlag(installUpgradeFlags, "control-plane-tracing", defaults.GetGlobal().ControlPlaneTracing,
 			"Enables Control Plane Tracing with the defaults", func(values *l5dcharts.Values, value bool) error {
-				defaults.Global.ControlPlaneTracing = value
+				defaults.GetGlobal().ControlPlaneTracing = value
 				return nil
 			}),
 
@@ -156,22 +156,22 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 					if err != nil {
 						return err
 					}
-					values.Global.IdentityTrustAnchorsPEM = string(data)
+					values.GetGlobal().IdentityTrustAnchorsPEM = string(data)
 				}
 				return nil
 			}),
 
-		flag.NewBoolFlag(installUpgradeFlags, "enable-endpoint-slices", defaults.Global.EnableEndpointSlices,
+		flag.NewBoolFlag(installUpgradeFlags, "enable-endpoint-slices", defaults.GetGlobal().EnableEndpointSlices,
 			"Enables the usage of EndpointSlice informers and resources for destination service",
 			func(values *l5dcharts.Values, value bool) error {
-				values.Global.EnableEndpointSlices = value
+				values.GetGlobal().EnableEndpointSlices = value
 				return nil
 			}),
 
-		flag.NewStringFlag(installUpgradeFlags, "control-plane-version", defaults.Global.ControllerImageVersion,
+		flag.NewStringFlag(installUpgradeFlags, "control-plane-version", defaults.GetGlobal().ControllerImageVersion,
 			"Tag to be used for the control plane component images",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.ControllerImageVersion = value
+				values.GetGlobal().ControllerImageVersion = value
 				return nil
 			}),
 	}
@@ -224,10 +224,10 @@ func makeAllStageFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet)
 	allStageFlags := pflag.NewFlagSet("all-stage", pflag.ExitOnError)
 
 	flags := []flag.Flag{
-		flag.NewBoolFlag(allStageFlags, "linkerd-cni-enabled", defaults.Global.CNIEnabled,
+		flag.NewBoolFlag(allStageFlags, "linkerd-cni-enabled", defaults.GetGlobal().CNIEnabled,
 			"Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed",
 			func(values *l5dcharts.Values, value bool) error {
-				values.Global.CNIEnabled = value
+				values.GetGlobal().CNIEnabled = value
 				return nil
 			}),
 
@@ -266,15 +266,15 @@ func makeInstallFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) 
 	installOnlyFlags := pflag.NewFlagSet("install-only", pflag.ExitOnError)
 
 	flags := []flag.Flag{
-		flag.NewStringFlag(installOnlyFlags, "cluster-domain", defaults.Global.ClusterDomain,
+		flag.NewStringFlag(installOnlyFlags, "cluster-domain", defaults.GetGlobal().ClusterDomain,
 			"Set custom cluster domain", func(values *l5dcharts.Values, value string) error {
-				values.Global.ClusterDomain = value
+				values.GetGlobal().ClusterDomain = value
 				return nil
 			}),
 
-		flag.NewStringFlag(installOnlyFlags, "identity-trust-domain", defaults.Global.IdentityTrustDomain,
+		flag.NewStringFlag(installOnlyFlags, "identity-trust-domain", defaults.GetGlobal().IdentityTrustDomain,
 			"Configures the name suffix used for identities.", func(values *l5dcharts.Values, value string) error {
-				values.Global.IdentityTrustDomain = value
+				values.GetGlobal().IdentityTrustDomain = value
 				return nil
 			}),
 
@@ -300,27 +300,27 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 	proxyFlags := pflag.NewFlagSet("proxy", pflag.ExitOnError)
 
 	flags := []flag.Flag{
-		flag.NewStringFlagP(proxyFlags, "proxy-version", "v", defaults.Global.Proxy.Image.Version, "Tag to be used for the Linkerd proxy images",
+		flag.NewStringFlagP(proxyFlags, "proxy-version", "v", defaults.GetGlobal().Proxy.Image.Version, "Tag to be used for the Linkerd proxy images",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Image.Version = value
+				values.GetGlobal().Proxy.Image.Version = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-image", defaults.Global.Proxy.Image.Name, "Linkerd proxy container image name",
+		flag.NewStringFlag(proxyFlags, "proxy-image", defaults.GetGlobal().Proxy.Image.Name, "Linkerd proxy container image name",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Image.Name = value
+				values.GetGlobal().Proxy.Image.Name = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "init-image", defaults.Global.ProxyInit.Image.Name, "Linkerd init container image name",
+		flag.NewStringFlag(proxyFlags, "init-image", defaults.GetGlobal().ProxyInit.Image.Name, "Linkerd init container image name",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.ProxyInit.Image.Name = value
+				values.GetGlobal().ProxyInit.Image.Name = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "init-image-version", defaults.Global.ProxyInit.Image.Version,
+		flag.NewStringFlag(proxyFlags, "init-image-version", defaults.GetGlobal().ProxyInit.Image.Version,
 			"Linkerd init container image version", func(values *l5dcharts.Values, value string) error {
-				values.Global.ProxyInit.Image.Version = value
+				values.GetGlobal().ProxyInit.Image.Version = value
 				return nil
 			}),
 
@@ -329,81 +329,81 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				values.WebImage = registryOverride(values.WebImage, value)
 				values.ControllerImage = registryOverride(values.ControllerImage, value)
 				values.DebugContainer.Image.Name = registryOverride(values.DebugContainer.Image.Name, value)
-				values.Global.Proxy.Image.Name = registryOverride(values.Global.Proxy.Image.Name, value)
-				values.Global.ProxyInit.Image.Name = registryOverride(values.Global.ProxyInit.Image.Name, value)
+				values.GetGlobal().Proxy.Image.Name = registryOverride(values.GetGlobal().Proxy.Image.Name, value)
+				values.GetGlobal().ProxyInit.Image.Name = registryOverride(values.GetGlobal().ProxyInit.Image.Name, value)
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "image-pull-policy", defaults.Global.ImagePullPolicy,
+		flag.NewStringFlag(proxyFlags, "image-pull-policy", defaults.GetGlobal().ImagePullPolicy,
 			"Docker image pull policy", func(values *l5dcharts.Values, value string) error {
-				values.Global.ImagePullPolicy = value
-				values.Global.Proxy.Image.PullPolicy = value
-				values.Global.ProxyInit.Image.PullPolicy = value
+				values.GetGlobal().ImagePullPolicy = value
+				values.GetGlobal().Proxy.Image.PullPolicy = value
+				values.GetGlobal().ProxyInit.Image.PullPolicy = value
 				values.DebugContainer.Image.PullPolicy = value
 				return nil
 			}),
 
-		flag.NewUintFlag(proxyFlags, "inbound-port", uint(defaults.Global.Proxy.Ports.Inbound),
+		flag.NewUintFlag(proxyFlags, "inbound-port", uint(defaults.GetGlobal().Proxy.Ports.Inbound),
 			"Proxy port to use for inbound traffic", func(values *l5dcharts.Values, value uint) error {
-				values.Global.Proxy.Ports.Inbound = int32(value)
+				values.GetGlobal().Proxy.Ports.Inbound = int32(value)
 				return nil
 			}),
 
-		flag.NewUintFlag(proxyFlags, "outbound-port", uint(defaults.Global.Proxy.Ports.Outbound),
+		flag.NewUintFlag(proxyFlags, "outbound-port", uint(defaults.GetGlobal().Proxy.Ports.Outbound),
 			"Proxy port to use for outbound traffic", func(values *l5dcharts.Values, value uint) error {
-				values.Global.Proxy.Ports.Outbound = int32(value)
+				values.GetGlobal().Proxy.Ports.Outbound = int32(value)
 				return nil
 			}),
 
 		flag.NewStringSliceFlag(proxyFlags, "skip-inbound-ports", nil, "Ports and/or port ranges (inclusive) that should skip the proxy and send directly to the application",
 			func(values *l5dcharts.Values, value []string) error {
-				values.Global.ProxyInit.IgnoreInboundPorts = strings.Join(value, ",")
+				values.GetGlobal().ProxyInit.IgnoreInboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
 		flag.NewStringSliceFlag(proxyFlags, "skip-outbound-ports", nil, "Outbound ports and/or port ranges (inclusive) that should skip the proxy",
 			func(values *l5dcharts.Values, value []string) error {
-				values.Global.ProxyInit.IgnoreOutboundPorts = strings.Join(value, ",")
+				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
-		flag.NewInt64Flag(proxyFlags, "proxy-uid", defaults.Global.Proxy.UID, "Run the proxy under this user ID",
+		flag.NewInt64Flag(proxyFlags, "proxy-uid", defaults.GetGlobal().Proxy.UID, "Run the proxy under this user ID",
 			func(values *l5dcharts.Values, value int64) error {
-				values.Global.Proxy.UID = value
+				values.GetGlobal().Proxy.UID = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-log-level", defaults.Global.Proxy.LogLevel, "Log level for the proxy",
+		flag.NewStringFlag(proxyFlags, "proxy-log-level", defaults.GetGlobal().Proxy.LogLevel, "Log level for the proxy",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.LogLevel = value
+				values.GetGlobal().Proxy.LogLevel = value
 				return nil
 			}),
 
-		flag.NewUintFlag(proxyFlags, "control-port", uint(defaults.Global.Proxy.Ports.Control), "Proxy port to use for control",
+		flag.NewUintFlag(proxyFlags, "control-port", uint(defaults.GetGlobal().Proxy.Ports.Control), "Proxy port to use for control",
 			func(values *l5dcharts.Values, value uint) error {
-				values.Global.Proxy.Ports.Control = int32(value)
+				values.GetGlobal().Proxy.Ports.Control = int32(value)
 				return nil
 			}),
 
-		flag.NewUintFlag(proxyFlags, "admin-port", uint(defaults.Global.Proxy.Ports.Admin), "Proxy port to serve metrics on",
+		flag.NewUintFlag(proxyFlags, "admin-port", uint(defaults.GetGlobal().Proxy.Ports.Admin), "Proxy port to serve metrics on",
 			func(values *l5dcharts.Values, value uint) error {
-				values.Global.Proxy.Ports.Admin = int32(value)
+				values.GetGlobal().Proxy.Ports.Admin = int32(value)
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-cpu-request", defaults.Global.Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
+		flag.NewStringFlag(proxyFlags, "proxy-cpu-request", defaults.GetGlobal().Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Resources.CPU.Request = value
+				values.GetGlobal().Proxy.Resources.CPU.Request = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-memory-request", defaults.Global.Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
+		flag.NewStringFlag(proxyFlags, "proxy-memory-request", defaults.GetGlobal().Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Resources.Memory.Request = value
+				values.GetGlobal().Proxy.Resources.Memory.Request = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-cpu-limit", defaults.Global.Proxy.Resources.CPU.Limit, "Maximum amount of CPU units that the proxy sidecar can use",
+		flag.NewStringFlag(proxyFlags, "proxy-cpu-limit", defaults.GetGlobal().Proxy.Resources.CPU.Limit, "Maximum amount of CPU units that the proxy sidecar can use",
 			func(values *l5dcharts.Values, value string) error {
 				q, err := k8sResource.ParseQuantity(value)
 				if err != nil {
@@ -413,34 +413,34 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				if err != nil {
 					return err
 				}
-				values.Global.Proxy.Cores = c
-				values.Global.Proxy.Resources.CPU.Limit = value
+				values.GetGlobal().Proxy.Cores = c
+				values.GetGlobal().Proxy.Resources.CPU.Limit = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-memory-limit", defaults.Global.Proxy.Resources.Memory.Limit, "Maximum amount of Memory that the proxy sidecar can use",
+		flag.NewStringFlag(proxyFlags, "proxy-memory-limit", defaults.GetGlobal().Proxy.Resources.Memory.Limit, "Maximum amount of Memory that the proxy sidecar can use",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Resources.Memory.Limit = value
+				values.GetGlobal().Proxy.Resources.Memory.Limit = value
 				return nil
 			}),
 
-		flag.NewBoolFlag(proxyFlags, "enable-external-profiles", defaults.Global.Proxy.EnableExternalProfiles, "Enable service profiles for non-Kubernetes services",
+		flag.NewBoolFlag(proxyFlags, "enable-external-profiles", defaults.GetGlobal().Proxy.EnableExternalProfiles, "Enable service profiles for non-Kubernetes services",
 			func(values *l5dcharts.Values, value bool) error {
-				values.Global.Proxy.EnableExternalProfiles = value
+				values.GetGlobal().Proxy.EnableExternalProfiles = value
 				return nil
 			}),
 
 		// Deprecated flags
 
-		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.Global.Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
+		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.GetGlobal().Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Resources.Memory.Request = value
+				values.GetGlobal().Proxy.Resources.Memory.Request = value
 				return nil
 			}),
 
-		flag.NewStringFlag(proxyFlags, "proxy-cpu", defaults.Global.Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
+		flag.NewStringFlag(proxyFlags, "proxy-cpu", defaults.GetGlobal().Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Resources.CPU.Request = value
+				values.GetGlobal().Proxy.Resources.CPU.Request = value
 				return nil
 			}),
 	}
@@ -473,47 +473,47 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 	injectFlags := pflag.NewFlagSet("inject", pflag.ExitOnError)
 
 	flags := []flag.Flag{
-		flag.NewInt64Flag(injectFlags, "wait-before-exit-seconds", int64(defaults.Global.Proxy.WaitBeforeExitSeconds),
+		flag.NewInt64Flag(injectFlags, "wait-before-exit-seconds", int64(defaults.GetGlobal().Proxy.WaitBeforeExitSeconds),
 			"The period during which the proxy sidecar must stay alive while its pod is terminating. "+
 				"Must be smaller than terminationGracePeriodSeconds for the pod (default 0)",
 			func(values *l5dcharts.Values, value int64) error {
-				values.Global.Proxy.WaitBeforeExitSeconds = uint64(value)
+				values.GetGlobal().Proxy.WaitBeforeExitSeconds = uint64(value)
 				return nil
 			}),
 
-		flag.NewBoolFlag(injectFlags, "disable-identity", defaults.Global.Proxy.DisableIdentity,
+		flag.NewBoolFlag(injectFlags, "disable-identity", defaults.GetGlobal().Proxy.DisableIdentity,
 			"Disables resources from participating in TLS identity", func(values *l5dcharts.Values, value bool) error {
-				values.Global.Proxy.DisableIdentity = value
+				values.GetGlobal().Proxy.DisableIdentity = value
 				return nil
 			}),
 
-		flag.NewBoolFlag(injectFlags, "disable-tap", defaults.Global.Proxy.DisableTap,
+		flag.NewBoolFlag(injectFlags, "disable-tap", defaults.GetGlobal().Proxy.DisableTap,
 			"Disables resources from being tapped", func(values *l5dcharts.Values, value bool) error {
-				values.Global.Proxy.DisableTap = value
+				values.GetGlobal().Proxy.DisableTap = value
 				return nil
 			}),
 
-		flag.NewStringFlag(injectFlags, "trace-collector", defaults.Global.Proxy.Trace.CollectorSvcAddr,
+		flag.NewStringFlag(injectFlags, "trace-collector", defaults.GetGlobal().Proxy.Trace.CollectorSvcAddr,
 			"Collector Service address for the proxies to send Trace Data", func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Trace.CollectorSvcAddr = value
+				values.GetGlobal().Proxy.Trace.CollectorSvcAddr = value
 				return nil
 			}),
 
-		flag.NewStringFlag(injectFlags, "trace-collector-svc-account", defaults.Global.Proxy.Trace.CollectorSvcAccount,
+		flag.NewStringFlag(injectFlags, "trace-collector-svc-account", defaults.GetGlobal().Proxy.Trace.CollectorSvcAccount,
 			"Service account associated with the Trace collector instance", func(values *l5dcharts.Values, value string) error {
-				values.Global.Proxy.Trace.CollectorSvcAccount = value
+				values.GetGlobal().Proxy.Trace.CollectorSvcAccount = value
 				return nil
 			}),
 
-		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.Global.Proxy.RequireIdentityOnInboundPorts, ","),
+		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.GetGlobal().Proxy.RequireIdentityOnInboundPorts, ","),
 			"Inbound ports on which the proxy should require identity", func(values *l5dcharts.Values, value []string) error {
-				values.Global.Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
+				values.GetGlobal().Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
-		flag.NewBoolFlag(injectFlags, "ingress", defaults.Global.Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
+		flag.NewBoolFlag(injectFlags, "ingress", defaults.GetGlobal().Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
 			func(values *l5dcharts.Values, value bool) error {
-				values.Global.Proxy.IsIngress = value
+				values.GetGlobal().Proxy.IsIngress = value
 				return nil
 			}),
 	}
@@ -524,19 +524,19 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 /* Validation */
 
 func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts.Values) error {
-	if !alphaNumDashDot.MatchString(values.Global.ControllerImageVersion) {
-		return fmt.Errorf("%s is not a valid version", values.Global.ControllerImageVersion)
+	if !alphaNumDashDot.MatchString(values.GetGlobal().ControllerImageVersion) {
+		return fmt.Errorf("%s is not a valid version", values.GetGlobal().ControllerImageVersion)
 	}
 
-	if _, err := log.ParseLevel(values.Global.ControllerLogLevel); err != nil {
+	if _, err := log.ParseLevel(values.GetGlobal().ControllerLogLevel); err != nil {
 		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
 	}
 
-	if values.Global.Proxy.LogLevel == "" {
+	if values.GetGlobal().Proxy.LogLevel == "" {
 		return errors.New("--proxy-log-level must not be empty")
 	}
 
-	if values.Global.EnableEndpointSlices && k != nil {
+	if values.GetGlobal().EnableEndpointSlices && k != nil {
 		k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 		if err != nil {
 			return err
@@ -548,8 +548,8 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		}
 	}
 
-	if errs := validation.IsDNS1123Subdomain(values.Global.IdentityTrustDomain); len(errs) > 0 {
-		return fmt.Errorf("invalid trust domain '%s': %s", values.Global.IdentityTrustDomain, errs[0])
+	if errs := validation.IsDNS1123Subdomain(values.GetGlobal().IdentityTrustDomain); len(errs) > 0 {
+		return fmt.Errorf("invalid trust domain '%s': %s", values.GetGlobal().IdentityTrustDomain, errs[0])
 	}
 
 	err := validateProxyValues(values)
@@ -581,7 +581,7 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		issuerData := issuercerts.IssuerCertData{
 			IssuerCrt:    values.Identity.Issuer.TLS.CrtPEM,
 			IssuerKey:    values.Identity.Issuer.TLS.KeyPEM,
-			TrustAnchors: values.Global.IdentityTrustAnchorsPEM,
+			TrustAnchors: values.GetGlobal().IdentityTrustAnchorsPEM,
 		}
 		_, err := issuerData.VerifyAndBuildCreds()
 		if err != nil {
@@ -593,76 +593,76 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 }
 
 func validateProxyValues(values *l5dcharts.Values) error {
-	networks := strings.Split(values.Global.ClusterNetworks, ",")
+	networks := strings.Split(values.GetGlobal().ClusterNetworks, ",")
 	for _, network := range networks {
 		if _, _, err := net.ParseCIDR(network); err != nil {
 			return fmt.Errorf("cannot parse destination get networks: %s", err)
 		}
 	}
 
-	if values.Global.Proxy.DisableIdentity && len(values.Global.Proxy.RequireIdentityOnInboundPorts) > 0 {
+	if values.GetGlobal().Proxy.DisableIdentity && len(values.GetGlobal().Proxy.RequireIdentityOnInboundPorts) > 0 {
 		return errors.New("Identity must be enabled when  --require-identity-on-inbound-ports is specified")
 	}
 
-	if values.Global.Proxy.Image.Version != "" && !alphaNumDashDot.MatchString(values.Global.Proxy.Image.Version) {
-		return fmt.Errorf("%s is not a valid version", values.Global.Proxy.Image.Version)
+	if values.GetGlobal().Proxy.Image.Version != "" && !alphaNumDashDot.MatchString(values.GetGlobal().Proxy.Image.Version) {
+		return fmt.Errorf("%s is not a valid version", values.GetGlobal().Proxy.Image.Version)
 	}
 
-	if !alphaNumDashDot.MatchString(values.Global.ProxyInit.Image.Version) {
-		return fmt.Errorf("%s is not a valid version", values.Global.ProxyInit.Image.Version)
+	if !alphaNumDashDot.MatchString(values.GetGlobal().ProxyInit.Image.Version) {
+		return fmt.Errorf("%s is not a valid version", values.GetGlobal().ProxyInit.Image.Version)
 	}
 
-	if values.Global.ImagePullPolicy != "Always" && values.Global.ImagePullPolicy != "IfNotPresent" && values.Global.ImagePullPolicy != "Never" {
+	if values.GetGlobal().ImagePullPolicy != "Always" && values.GetGlobal().ImagePullPolicy != "IfNotPresent" && values.GetGlobal().ImagePullPolicy != "Never" {
 		return fmt.Errorf("--image-pull-policy must be one of: Always, IfNotPresent, Never")
 	}
 
-	if values.Global.Proxy.Resources.CPU.Request != "" {
-		if _, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Request); err != nil {
-			return fmt.Errorf("Invalid cpu request '%s' for --proxy-cpu-request flag", values.Global.Proxy.Resources.CPU.Request)
+	if values.GetGlobal().Proxy.Resources.CPU.Request != "" {
+		if _, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Request); err != nil {
+			return fmt.Errorf("Invalid cpu request '%s' for --proxy-cpu-request flag", values.GetGlobal().Proxy.Resources.CPU.Request)
 		}
 	}
 
-	if values.Global.Proxy.Resources.Memory.Request != "" {
-		if _, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Request); err != nil {
-			return fmt.Errorf("Invalid memory request '%s' for --proxy-memory-request flag", values.Global.Proxy.Resources.Memory.Request)
+	if values.GetGlobal().Proxy.Resources.Memory.Request != "" {
+		if _, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Request); err != nil {
+			return fmt.Errorf("Invalid memory request '%s' for --proxy-memory-request flag", values.GetGlobal().Proxy.Resources.Memory.Request)
 		}
 	}
 
-	if values.Global.Proxy.Resources.CPU.Limit != "" {
-		cpuLimit, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Limit)
+	if values.GetGlobal().Proxy.Resources.CPU.Limit != "" {
+		cpuLimit, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Limit)
 		if err != nil {
-			return fmt.Errorf("Invalid cpu limit '%s' for --proxy-cpu-limit flag", values.Global.Proxy.Resources.CPU.Limit)
+			return fmt.Errorf("Invalid cpu limit '%s' for --proxy-cpu-limit flag", values.GetGlobal().Proxy.Resources.CPU.Limit)
 		}
 		// Not checking for error because option proxyCPURequest was already validated
-		if cpuRequest, _ := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Request); cpuRequest.MilliValue() > cpuLimit.MilliValue() {
-			return fmt.Errorf("The cpu limit '%s' cannot be lower than the cpu request '%s'", values.Global.Proxy.Resources.CPU.Limit, values.Global.Proxy.Resources.CPU.Request)
+		if cpuRequest, _ := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Request); cpuRequest.MilliValue() > cpuLimit.MilliValue() {
+			return fmt.Errorf("The cpu limit '%s' cannot be lower than the cpu request '%s'", values.GetGlobal().Proxy.Resources.CPU.Limit, values.GetGlobal().Proxy.Resources.CPU.Request)
 		}
 	}
 
-	if values.Global.Proxy.Resources.Memory.Limit != "" {
-		memoryLimit, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Limit)
+	if values.GetGlobal().Proxy.Resources.Memory.Limit != "" {
+		memoryLimit, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Limit)
 		if err != nil {
-			return fmt.Errorf("Invalid memory limit '%s' for --proxy-memory-limit flag", values.Global.Proxy.Resources.Memory.Limit)
+			return fmt.Errorf("Invalid memory limit '%s' for --proxy-memory-limit flag", values.GetGlobal().Proxy.Resources.Memory.Limit)
 		}
 		// Not checking for error because option proxyMemoryRequest was already validated
-		if memoryRequest, _ := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Request); memoryRequest.Value() > memoryLimit.Value() {
-			return fmt.Errorf("The memory limit '%s' cannot be lower than the memory request '%s'", values.Global.Proxy.Resources.Memory.Limit, values.Global.Proxy.Resources.Memory.Request)
+		if memoryRequest, _ := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Request); memoryRequest.Value() > memoryLimit.Value() {
+			return fmt.Errorf("The memory limit '%s' cannot be lower than the memory request '%s'", values.GetGlobal().Proxy.Resources.Memory.Limit, values.GetGlobal().Proxy.Resources.Memory.Request)
 		}
 	}
 
-	if !validProxyLogLevel.MatchString(values.Global.Proxy.LogLevel) {
+	if !validProxyLogLevel.MatchString(values.GetGlobal().Proxy.LogLevel) {
 		return fmt.Errorf("\"%s\" is not a valid proxy log level - for allowed syntax check https://docs.rs/env_logger/0.6.0/env_logger/#enabling-logging",
-			values.Global.Proxy.LogLevel)
+			values.GetGlobal().Proxy.LogLevel)
 	}
 
-	if values.Global.ProxyInit.IgnoreInboundPorts != "" {
-		if err := validateRangeSlice(strings.Split(values.Global.ProxyInit.IgnoreInboundPorts, ",")); err != nil {
+	if values.GetGlobal().ProxyInit.IgnoreInboundPorts != "" {
+		if err := validateRangeSlice(strings.Split(values.GetGlobal().ProxyInit.IgnoreInboundPorts, ",")); err != nil {
 			return err
 		}
 	}
 
-	if values.Global.ProxyInit.IgnoreOutboundPorts != "" {
-		if err := validateRangeSlice(strings.Split(values.Global.ProxyInit.IgnoreOutboundPorts, ",")); err != nil {
+	if values.GetGlobal().ProxyInit.IgnoreOutboundPorts != "" {
+		if err := validateRangeSlice(strings.Split(values.GetGlobal().ProxyInit.IgnoreOutboundPorts, ",")); err != nil {
 			return err
 		}
 	}
@@ -685,11 +685,11 @@ func initializeIssuerCredentials(ctx context.Context, k *k8s.KubernetesAPI, valu
 		if err != nil {
 			return err
 		}
-		values.Global.IdentityTrustAnchorsPEM = externalIssuerData.TrustAnchors
-	} else if values.Identity.Issuer.TLS.CrtPEM != "" || values.Identity.Issuer.TLS.KeyPEM != "" || values.Global.IdentityTrustAnchorsPEM != "" {
+		values.GetGlobal().IdentityTrustAnchorsPEM = externalIssuerData.TrustAnchors
+	} else if values.Identity.Issuer.TLS.CrtPEM != "" || values.Identity.Issuer.TLS.KeyPEM != "" || values.GetGlobal().IdentityTrustAnchorsPEM != "" {
 		// If any credentials have already been supplied, check that they are
 		// all present.
-		if values.Global.IdentityTrustAnchorsPEM == "" {
+		if values.GetGlobal().IdentityTrustAnchorsPEM == "" {
 			return errors.New("a trust anchors file must be specified if other credentials are provided")
 		}
 		if values.Identity.Issuer.TLS.CrtPEM == "" {
@@ -700,14 +700,14 @@ func initializeIssuerCredentials(ctx context.Context, k *k8s.KubernetesAPI, valu
 		}
 	} else {
 		// No credentials have been supplied so we will generate them.
-		root, err := tls.GenerateRootCAWithDefaults(issuerName(values.Global.IdentityTrustDomain))
+		root, err := tls.GenerateRootCAWithDefaults(issuerName(values.GetGlobal().IdentityTrustDomain))
 		if err != nil {
 			return fmt.Errorf("failed to generate root certificate for identity: %s", err)
 		}
 		values.Identity.Issuer.CrtExpiry = root.Cred.Crt.Certificate.NotAfter
 		values.Identity.Issuer.TLS.KeyPEM = root.Cred.EncodePrivateKeyPEM()
 		values.Identity.Issuer.TLS.CrtPEM = root.Cred.Crt.EncodeCertificatePEM()
-		values.Global.IdentityTrustAnchorsPEM = root.Cred.Crt.EncodeCertificatePEM()
+		values.GetGlobal().IdentityTrustAnchorsPEM = root.Cred.Crt.EncodeCertificatePEM()
 	}
 	return nil
 }

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -110,7 +110,7 @@ func newCmdProfile() *cobra.Command {
 				return err
 			}
 
-			clusterDomain := values.Global.ClusterDomain
+			clusterDomain := values.GetGlobal().ClusterDomain
 			if clusterDomain == "" {
 				clusterDomain = defaultClusterDomain
 			}

--- a/cli/cmd/upgrade_legacy.go
+++ b/cli/cmd/upgrade_legacy.go
@@ -214,7 +214,7 @@ func fetchIdentityValues(ctx context.Context, k kubernetes.Interface, idctx *pb.
 		return fmt.Errorf("could not convert issuance Lifetime protobuf Duration format into golang Duration: %s", err)
 	}
 
-	values.Global.IdentityTrustAnchorsPEM = trustAnchorsPEM
+	values.GetGlobal().IdentityTrustAnchorsPEM = trustAnchorsPEM
 	values.Identity.Issuer.Scheme = idctx.Scheme
 	values.Identity.Issuer.ClockSkewAllowance = clockSkewDuration.String()
 	values.Identity.Issuer.IssuanceLifetime = issuanceLifetimeDuration.String()

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -71,7 +71,7 @@ func TestUpgradeDefault(t *testing.T) {
 
 func TestUpgradeHA(t *testing.T) {
 	installOpts, upgradeOpts, _ := testOptions(t)
-	installOpts.Global.HighAvailability = true
+	installOpts.GetGlobal().HighAvailability = true
 	install, upgrade, err := renderInstallAndUpgrade(t, installOpts, upgradeOpts)
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +108,7 @@ func TestUpgradeExternalIssuer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	installOpts.Global.IdentityTrustAnchorsPEM = string(ca)
+	installOpts.GetGlobal().IdentityTrustAnchorsPEM = string(ca)
 	install := renderInstall(t, installOpts)
 	upgrade, err := renderUpgrade(install.String()+externalIssuerSecret(issuer), upgradeOpts)
 
@@ -135,8 +135,8 @@ func TestUpgradeIssuerWithExternalIssuerFails(t *testing.T) {
 	issuer := generateIssuerCerts(t, true)
 	defer issuer.cleanup()
 
-	installOpts.Global.IdentityTrustDomain = "cluster.local"
-	installOpts.Global.IdentityTrustDomain = issuer.ca
+	installOpts.GetGlobal().IdentityTrustDomain = "cluster.local"
+	installOpts.GetGlobal().IdentityTrustDomain = issuer.ca
 	installOpts.Identity.Issuer.Scheme = string(corev1.SecretTypeTLS)
 	installOpts.Identity.Issuer.TLS.CrtPEM = issuer.crt
 	installOpts.Identity.Issuer.TLS.KeyPEM = issuer.key

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -36,8 +36,8 @@ func confNsDisabled() *inject.ResourceConfig {
 
 func TestGetPatch(t *testing.T) {
 
-	values.Global.Proxy.DisableIdentity = true
-	values.Global.Proxy.DisableTap = true
+	values.GetGlobal().Proxy.DisableIdentity = true
+	values.GetGlobal().Proxy.DisableTap = true
 
 	factory := fake.NewFactory(filepath.Join("fake", "data"))
 	nsEnabled, err := factory.Namespace("namespace-inject-enabled.yaml")

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -342,3 +342,12 @@ func (v *Values) String() string {
 	bytes, _ := yaml.Marshal(v)
 	return string(bytes)
 }
+
+// GetGlobal is a safe accessor for Global. It initializes Global on the first
+// access.
+func (v *Values) GetGlobal() *Global {
+	if v.Global == nil {
+		v.Global = &Global{}
+	}
+	return v.Global
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,14 +189,14 @@ func ToValues(configs *pb.All) *l5dcharts.Values {
 	}
 
 	if configs.GetProxy().GetLogLevel() != nil {
-		values.Global.Proxy.LogLevel = configs.GetProxy().GetLogLevel().String()
+		values.GetGlobal().Proxy.LogLevel = configs.GetProxy().GetLogLevel().String()
 
 	}
 
 	// set HA, and Heartbeat flags as health-check needs them for old config installs
 	for _, flag := range configs.GetInstall().GetFlags() {
 		if flag.GetName() == "ha" && flag.GetValue() == "true" {
-			values.Global.HighAvailability = true
+			values.GetGlobal().HighAvailability = true
 		}
 
 		if flag.GetName() == "disable-heartbeat" && flag.GetValue() == "true" {

--- a/pkg/healthcheck/healthcheck_multicluster.go
+++ b/pkg/healthcheck/healthcheck_multicluster.go
@@ -341,7 +341,7 @@ func (hc *HealthChecker) checkRemoteClusterConnectivity(ctx context.Context) err
 }
 
 func (hc *HealthChecker) checkRemoteClusterAnchors(ctx context.Context) error {
-	localAnchors, err := tls.DecodePEMCertificates(hc.linkerdConfig.Global.IdentityTrustAnchorsPEM)
+	localAnchors, err := tls.DecodePEMCertificates(hc.linkerdConfig.GetGlobal().IdentityTrustAnchorsPEM)
 	if err != nil {
 		return fmt.Errorf("Cannot parse source trust anchors: %s", err)
 	}
@@ -379,7 +379,7 @@ func (hc *HealthChecker) checkRemoteClusterAnchors(ctx context.Context) error {
 			continue
 		}
 
-		remoteAnchors, err := tls.DecodePEMCertificates(values.Global.IdentityTrustAnchorsPEM)
+		remoteAnchors, err := tls.DecodePEMCertificates(values.GetGlobal().IdentityTrustAnchorsPEM)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("* %s: cannot parse trust anchors", link.TargetClusterName))
 			continue

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1798,6 +1798,29 @@ metadata:
 				"cat1 'linkerd-config' config map exists",
 			},
 		},
+		{
+			checkDescription: "'linkerd-config' config map exists",
+			resources: []string{`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linkerd-config
+  namespace: test-ns
+data:
+  values: |-
+    tracing:
+      collector:
+        name: linkerd-collector
+      enabled: false
+      jaeger:
+        name: linkerd-jaeger
+      enabled: true
+`,
+			},
+			expected: []string{
+				"cat1 'linkerd-config' config map exists",
+			},
+		},
 	}
 
 	for id, testCase := range testCases {
@@ -2696,7 +2719,7 @@ data:
 					LinkerdNamespaceLabel:    "LinkerdNamespaceLabel",
 					ProxyContainerName:       "ProxyContainerName",
 					CNIEnabled:               false,
-					IdentityTrustDomain:      defaultValues.Global.IdentityTrustDomain,
+					IdentityTrustDomain:      defaultValues.GetGlobal().IdentityTrustDomain,
 					Proxy: &linkerd2.Proxy{
 						Image: &linkerd2.Image{
 							Name:       "ProxyImageName",

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -74,19 +74,19 @@ func TestGetOverriddenValues(t *testing.T) {
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues(false)
 
-				values.Global.Proxy.Cores = 2
-				values.Global.Proxy.DisableIdentity = true
-				values.Global.Proxy.Image.Name = "ghcr.io/linkerd/proxy"
-				values.Global.Proxy.Image.PullPolicy = pullPolicy
-				values.Global.Proxy.Image.Version = proxyVersionOverride
-				values.Global.Proxy.Ports.Control = 4000
-				values.Global.Proxy.Ports.Inbound = 5000
-				values.Global.Proxy.Ports.Admin = 5001
-				values.Global.Proxy.Ports.Outbound = 5002
-				values.Global.Proxy.WaitBeforeExitSeconds = 123
-				values.Global.Proxy.LogLevel = "debug,linkerd=debug"
-				values.Global.Proxy.LogFormat = "json"
-				values.Global.Proxy.Resources = &l5dcharts.Resources{
+				values.GetGlobal().Proxy.Cores = 2
+				values.GetGlobal().Proxy.DisableIdentity = true
+				values.GetGlobal().Proxy.Image.Name = "ghcr.io/linkerd/proxy"
+				values.GetGlobal().Proxy.Image.PullPolicy = pullPolicy
+				values.GetGlobal().Proxy.Image.Version = proxyVersionOverride
+				values.GetGlobal().Proxy.Ports.Control = 4000
+				values.GetGlobal().Proxy.Ports.Inbound = 5000
+				values.GetGlobal().Proxy.Ports.Admin = 5001
+				values.GetGlobal().Proxy.Ports.Outbound = 5002
+				values.GetGlobal().Proxy.WaitBeforeExitSeconds = 123
+				values.GetGlobal().Proxy.LogLevel = "debug,linkerd=debug"
+				values.GetGlobal().Proxy.LogFormat = "json"
+				values.GetGlobal().Proxy.Resources = &l5dcharts.Resources{
 					CPU: l5dcharts.Constraints{
 						Limit:   "1.5",
 						Request: "0.15",
@@ -96,20 +96,20 @@ func TestGetOverriddenValues(t *testing.T) {
 						Request: "120",
 					},
 				}
-				values.Global.Proxy.UID = 8500
-				values.Global.ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
-				values.Global.ProxyInit.Image.PullPolicy = pullPolicy
-				values.Global.ProxyInit.Image.Version = version.ProxyInitVersion
-				values.Global.ProxyInit.IgnoreInboundPorts = "4222,6222"
-				values.Global.ProxyInit.IgnoreOutboundPorts = "8079,8080"
-				values.Global.Proxy.Trace = &l5dcharts.Trace{
+				values.GetGlobal().Proxy.UID = 8500
+				values.GetGlobal().ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
+				values.GetGlobal().ProxyInit.Image.PullPolicy = pullPolicy
+				values.GetGlobal().ProxyInit.Image.Version = version.ProxyInitVersion
+				values.GetGlobal().ProxyInit.IgnoreInboundPorts = "4222,6222"
+				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "8079,8080"
+				values.GetGlobal().Proxy.Trace = &l5dcharts.Trace{
 					CollectorSvcAddr:    "oc-collector.tracing:55678",
 					CollectorSvcAccount: "default.tracing",
 				}
-				values.Global.Proxy.RequireIdentityOnInboundPorts = "8888,9999"
-				values.Global.Proxy.OutboundConnectTimeout = "6000ms"
-				values.Global.Proxy.InboundConnectTimeout = "600ms"
-				values.Global.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.GetGlobal().Proxy.RequireIdentityOnInboundPorts = "8888,9999"
+				values.GetGlobal().Proxy.OutboundConnectTimeout = "6000ms"
+				values.GetGlobal().Proxy.InboundConnectTimeout = "600ms"
+				values.GetGlobal().Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				return values
 			},
 		},
@@ -162,19 +162,19 @@ func TestGetOverriddenValues(t *testing.T) {
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues(false)
 
-				values.Global.Proxy.Cores = 2
-				values.Global.Proxy.DisableIdentity = true
-				values.Global.Proxy.Image.Name = "ghcr.io/linkerd/proxy"
-				values.Global.Proxy.Image.PullPolicy = pullPolicy
-				values.Global.Proxy.Image.Version = proxyVersionOverride
-				values.Global.Proxy.Ports.Control = 4000
-				values.Global.Proxy.Ports.Inbound = 5000
-				values.Global.Proxy.Ports.Admin = 5001
-				values.Global.Proxy.Ports.Outbound = 5002
-				values.Global.Proxy.WaitBeforeExitSeconds = 123
-				values.Global.Proxy.LogLevel = "debug,linkerd=debug"
-				values.Global.Proxy.LogFormat = "json"
-				values.Global.Proxy.Resources = &l5dcharts.Resources{
+				values.GetGlobal().Proxy.Cores = 2
+				values.GetGlobal().Proxy.DisableIdentity = true
+				values.GetGlobal().Proxy.Image.Name = "ghcr.io/linkerd/proxy"
+				values.GetGlobal().Proxy.Image.PullPolicy = pullPolicy
+				values.GetGlobal().Proxy.Image.Version = proxyVersionOverride
+				values.GetGlobal().Proxy.Ports.Control = 4000
+				values.GetGlobal().Proxy.Ports.Inbound = 5000
+				values.GetGlobal().Proxy.Ports.Admin = 5001
+				values.GetGlobal().Proxy.Ports.Outbound = 5002
+				values.GetGlobal().Proxy.WaitBeforeExitSeconds = 123
+				values.GetGlobal().Proxy.LogLevel = "debug,linkerd=debug"
+				values.GetGlobal().Proxy.LogFormat = "json"
+				values.GetGlobal().Proxy.Resources = &l5dcharts.Resources{
 					CPU: l5dcharts.Constraints{
 						Limit:   "1.5",
 						Request: "0.15",
@@ -184,19 +184,19 @@ func TestGetOverriddenValues(t *testing.T) {
 						Request: "120",
 					},
 				}
-				values.Global.Proxy.UID = 8500
-				values.Global.ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
-				values.Global.ProxyInit.Image.PullPolicy = pullPolicy
-				values.Global.ProxyInit.Image.Version = version.ProxyInitVersion
-				values.Global.ProxyInit.IgnoreInboundPorts = "4222,6222"
-				values.Global.ProxyInit.IgnoreOutboundPorts = "8079,8080"
-				values.Global.Proxy.Trace = &l5dcharts.Trace{
+				values.GetGlobal().Proxy.UID = 8500
+				values.GetGlobal().ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
+				values.GetGlobal().ProxyInit.Image.PullPolicy = pullPolicy
+				values.GetGlobal().ProxyInit.Image.Version = version.ProxyInitVersion
+				values.GetGlobal().ProxyInit.IgnoreInboundPorts = "4222,6222"
+				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "8079,8080"
+				values.GetGlobal().Proxy.Trace = &l5dcharts.Trace{
 					CollectorSvcAddr:    "oc-collector.tracing:55678",
 					CollectorSvcAccount: "default.tracing",
 				}
-				values.Global.Proxy.OutboundConnectTimeout = "6000ms"
-				values.Global.Proxy.InboundConnectTimeout = "600ms"
-				values.Global.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.GetGlobal().Proxy.OutboundConnectTimeout = "6000ms"
+				values.GetGlobal().Proxy.InboundConnectTimeout = "600ms"
+				values.GetGlobal().Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				return values
 			},
 		},
@@ -230,8 +230,8 @@ func TestGetOverriddenValues(t *testing.T) {
 			},
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues(false)
-				values.Global.Proxy.OutboundConnectTimeout = "6005ms"
-				values.Global.Proxy.InboundConnectTimeout = "2005ms"
+				values.GetGlobal().Proxy.OutboundConnectTimeout = "6005ms"
+				values.GetGlobal().Proxy.InboundConnectTimeout = "2005ms"
 				return values
 			},
 		},
@@ -260,7 +260,7 @@ func TestGetOverriddenValues(t *testing.T) {
 			},
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues(false)
-				values.Global.Proxy.OpaquePorts = "3306"
+				values.GetGlobal().Proxy.OpaquePorts = "3306"
 				return values
 			},
 		},


### PR DESCRIPTION
CLI crashes if linkerd-config contains unexpected values.

Add a safe accessor that initializes an empty Global on the first
access. Refactor all accesses to use the newly introduced accessor using
gopls.

Add test for linkerd-config data without Global.

Fixes #5215

Co-authored-by: Itai Schwartz <yitai27@gmail.com>
Signed-off-by: Hod Bin Noon <bin.noon.hod@gmail.com>
