### PR TITLE
Fix unit test error for TestValidate

### DIFF
--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -352,7 +352,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration foo"),
+			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration \"foo\""),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:


### PR DESCRIPTION
When I run go test:
```
Running tool: /usr/local/go/bin/go test -timeout 30s github.com/linkerd/linkerd2/pkg/profiles -run ^TestValidate$

--- FAIL: TestValidate (0.00s)
    --- FAIL: TestValidate/9 (0.00s)
        profiles_test.go:418: Unexpected error (Expected: failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: unknown field foo, Got: failed to validate ServiceProfile: error unmarshaling JSON: while decoding JSON: json: unknown field "foo")
FAIL
FAIL	github.com/linkerd/linkerd2/pkg/profiles	0.032s
FAIL
```

go version go1.15.2 linux/amd64

Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
