### PR TITLE
Have webhooks refresh their certs automatically

### DIFF
--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -116,7 +116,7 @@ func Main(args []string) {
 	//
 	// Create and start FS creds watcher
 	//
-	watcher := idctl.NewFsCredsWatcher(*issuerPath, issuerEvent, issuerError)
+	watcher := tls.NewFsCredsWatcher(*issuerPath, issuerEvent, issuerError)
 	go func() {
 		if err := watcher.StartWatching(ctx); err != nil {
 			log.Fatalf("Failed to start creds watcher: %s", err)

--- a/controller/webhook/launcher.go
+++ b/controller/webhook/launcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	pkgk8s "github.com/linkerd/linkerd2/pkg/k8s"
-	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -33,12 +32,7 @@ func Launch(
 		log.Fatalf("failed to initialize Kubernetes API: %s", err)
 	}
 
-	cred, err := tls.ReadPEMCreds(pkgk8s.MountPathTLSKeyPEM, pkgk8s.MountPathTLSCrtPEM)
-	if err != nil {
-		log.Fatalf("failed to read TLS secrets: %s", err)
-	}
-
-	s, err := NewServer(k8sAPI, addr, cred, handler, component)
+	s, err := NewServer(ctx, k8sAPI, addr, pkgk8s.MountPathTLSBase, handler, component)
 	if err != nil {
 		log.Fatalf("failed to initialize the webhook server: %s", err)
 	}

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -3,15 +3,20 @@ package webhook
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 )
+
+var mockHTTPServer = &http.Server{
+	Addr:      ":0",
+	TLSConfig: &tls.Config{},
+}
 
 func TestServe(t *testing.T) {
 	t.Run("with empty http request body", func(t *testing.T) {
@@ -19,8 +24,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		testServer := &Server{nil, k8sAPI, nil, nil, &sync.RWMutex{}, nil}
-
+		testServer := getConfiguredServer(mockHTTPServer, k8sAPI, nil, nil)
 		in := bytes.NewReader(nil)
 		request := httptest.NewRequest(http.MethodGet, "/", in)
 
@@ -38,8 +42,7 @@ func TestServe(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
-	server := &http.Server{Addr: ":0"}
-	testServer := &Server{server, nil, nil, nil, &sync.RWMutex{}, nil}
+	testServer := getConfiguredServer(mockHTTPServer, nil, nil, nil)
 
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil {

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ func TestServe(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		testServer := &Server{nil, k8sAPI, nil, nil}
+		testServer := &Server{nil, k8sAPI, nil, nil, &sync.RWMutex{}, nil}
 
 		in := bytes.NewReader(nil)
 		request := httptest.NewRequest(http.MethodGet, "/", in)
@@ -38,7 +39,7 @@ func TestServe(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	server := &http.Server{Addr: ":0"}
-	testServer := &Server{server, nil, nil, nil}
+	testServer := &Server{server, nil, nil, nil, &sync.RWMutex{}, nil}
 
 	go func() {
 		if err := testServer.ListenAndServe(); err != nil {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -357,11 +357,14 @@ const (
 	// store identity credentials.
 	MountPathEndEntity = MountPathBase + "/identity/end-entity"
 
+	// MountPathTLSBase is the path at which the TLS cert and key PEM files are mounted
+	MountPathTLSBase = MountPathBase + "/tls"
+
 	// MountPathTLSKeyPEM is the path at which the TLS key PEM file is mounted.
-	MountPathTLSKeyPEM = MountPathBase + "/tls/tls.key"
+	MountPathTLSKeyPEM = MountPathTLSBase + "/tls.key"
 
 	// MountPathTLSCrtPEM is the path at which the TLS cert PEM file is mounted.
-	MountPathTLSCrtPEM = MountPathBase + "/tls/tls.crt"
+	MountPathTLSCrtPEM = MountPathTLSBase + "/tls.crt"
 
 	// MountPathXtablesLock is the path at which the proxy init container mounts xtables
 	// This is necessary for xtables-legacy support


### PR DESCRIPTION
Fixes partially #5272

In 2.9 we introduced the ability for providing the certs for `proxy-injector` and `sp-validator` through some external means like cert-manager, through the new helm setting `externalSecret`.
We forgot however to have those services watch changes in their secrets, so whenever they were rotated they would fail with a cert error, with the only workaround being to restart those pods to pick the new secrets.

This addresses that by first abstracting out `FsCredsWatcher` from the identity controller, which now lives under `pkg/tls`.

The webhook's logic in `launcher.go` no longer reads the certs before starting the https server, moving that instead into `server.go` which in a similar way as identity will receive events from `FsCredsWatcher` and update `Server.cert`. We're leveraging `http.Server.TLSConfig.GetCertificate` which allows us to provide a function that will return the current cert for every incoming request.

### How to test

```bash
# Create some root cert
$ step certificate create linkerd-proxy-injector.linkerd.svc ca.crt ca.key \
  --profile root-ca --no-password --insecure --san linkerd-proxy-injector.linkerd.svc

# configure injector's caBundle to be that root cert
$ cat > linkerd-overrides.yaml << EOF
proxyInjector:
  externalSecret: true
  caBundle: |
    < ca.crt contents>
EOF

# Install linkerd. The injector won't start untill we create the secret below
$ bin/linkerd install --controller-log-level debug --config linkerd-overrides.yaml | k apply -f -

# Generate an intermediatery cert with short lifespan
$ step certificate create linkerd-proxy-injector.linkerd.svc ca-int.crt ca-int.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 4m --no-password --insecure --san linkerd-proxy-injector.linkerd.svc

# Create the secret using that intermediate cert
$ kubectl create secret tls \
  linkerd-proxy-injector-k8s-tls \
   --cert=ca-int.crt \
   --key=ca-int.key \
   --namespace=linkerd

# start following the injector log
$ k -n linkerd logs -f -l linkerd.io/control-plane-component=proxy-injector -c proxy-injector

# Inject emojivoto. The pods should be injected normally
$ bin/linkerd inject https://run.linkerd.io/emojivoto.yml | kubectl apply -f -

# Wait about 5 minutes and delete a pod
$ k -n emojivoto delete po -l app=emoji-svc

# You'll see it won't be injected, and something like "remote error: tls: bad certificate" will appear in the injector logs.

# Regenerate the intermediate cert
$ step certificate create linkerd-proxy-injector.linkerd.svc ca-int.crt ca-int.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 4m --no-password --insecure --san linkerd-proxy-injector.linkerd.svc

# Delete the secret and recreate it
$ k -n linkerd delete secret linkerd-proxy-injector-k8s-tls
$ kubectl create secret tls \
  linkerd-proxy-injector-k8s-tls \
   --cert=ca-int.crt \
   --key=ca-int.key \
   --namespace=linkerd

# Wait a couple of minutes and you'll see some filesystem events in the injector log along with a "Certificate has been updated" entry
# Then delete the pod again and you'll see it gets injected this time
$ k -n emojivoto delete po -l app=emoji-svc

```
