### PR TITLE
Use namespace in titles for grafana topline dashboard

### DIFF
--- a/grafana/dashboards/top-line.json
+++ b/grafana/dashboards/top-line.json
@@ -683,7 +683,7 @@
           "selected": false
         }
       },
-      "title": "",
+      "title": "$namespace",
       "type": "row"
     },
     {


### PR DESCRIPTION
The topline grafana dashboard show - as the title for the rows showing stats for namespaces

![image](https://user-images.githubusercontent.com/1157293/100363397-f5fa0780-2ffc-11eb-821f-d1f9a367a09a.png)

This commit use the namespace name instead

![image](https://user-images.githubusercontent.com/1157293/100363419-fc887f00-2ffc-11eb-996b-7e80957ce923.png)

You can validate this by doing the same change directly in grafana, get the json (e.g. by saving it), and compare

Fixes https://github.com/linkerd/linkerd2/issues/5289

Signed-off-by: Mads Sejersen <ms@raffle.ai>