### PR TITLE
jaeger: Add support for override flags

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,7 @@ github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAO
 github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995/go.mod h1:lJgMEyOkYFkPcDKwRXegd+iM6E7matEszMG5HhwytU8=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -374,6 +375,7 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
+github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -453,6 +455,7 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -572,6 +575,7 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
@@ -1029,6 +1033,7 @@ k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apimachinery v0.19.3/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apiserver v0.18.8/go.mod h1:12u5FuGql8Cc497ORNj79rhPdiXQC4bf53X/skR/1YM=
 k8s.io/apiserver v0.19.3/go.mod h1:bx6dMm+H6ifgKFpCQT/SAhPwhzoeIMlHIaibomUDec0=
+k8s.io/cli-runtime v0.19.3 h1:vZUTphJIvlh7+867cXiLmyzoCAuQdukbPLIad6eEajQ=
 k8s.io/cli-runtime v0.19.3/go.mod h1:q+l845i5/uWzcUpCrl+L4f3XLaJi8ZeLVQ/decwty0A=
 k8s.io/client-go v0.18.0/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwUggLVEF64HOD37boKAtF8=
 k8s.io/client-go v0.18.8/go.mod h1:HqFqMllQ5NnQJNwjro9k5zMyfhZlOwpuTLVrxjkYSxU=
@@ -1067,6 +1072,7 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
+sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -1,22 +1,26 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"github.com/linkerd/linkerd2/jaeger/static"
-	jaeger "github.com/linkerd/linkerd2/jaeger/values"
 	"github.com/linkerd/linkerd2/pkg/charts"
+	partials "github.com/linkerd/linkerd2/pkg/charts/static"
+	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/engine"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -30,12 +34,7 @@ var (
 
 func newCmdInstall() *cobra.Command {
 	var skipChecks bool
-
-	values, err := jaeger.NewValues()
-	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
-		os.Exit(1)
-	}
+	var options values.Options
 
 	cmd := &cobra.Command{
 		Use:   "install [flags]",
@@ -59,7 +58,7 @@ func newCmdInstall() *cobra.Command {
 				}
 			}
 
-			return install(os.Stdout, values)
+			return install(os.Stdout, options)
 		},
 	}
 
@@ -68,27 +67,28 @@ func newCmdInstall() *cobra.Command {
 		`Skip checks for namespace existence`,
 	)
 
-	// TODO: Add --set flag set and also config
+	flags.AddValueOptionsFlags(cmd.Flags(), &options)
 
 	return cmd
 }
 
-func install(w io.Writer, values *jaeger.Values) error {
-
-	// TODO: Add any validation logic here
-
-	return render(w, values)
-}
-
-func render(w io.Writer, values *jaeger.Values) error {
-	// Render raw values and create chart config
-	rawValues, err := yaml.Marshal(values)
+func install(w io.Writer, options values.Options) error {
+	// Merge and create final set of values
+	rawMap, err := options.MergeValues(nil)
 	if err != nil {
 		return err
 	}
 
+	// TODO: Add any validation logic here
+
+	return render(w, rawMap)
+}
+
+func render(w io.Writer, rawValues map[string]interface{}) error {
+
 	files := []*loader.BufferedFile{
 		{Name: chartutil.ChartfileName},
+		{Name: chartutil.ValuesfileName},
 	}
 
 	for _, template := range templatesJaeger {
@@ -97,17 +97,50 @@ func render(w io.Writer, values *jaeger.Values) error {
 		)
 	}
 
-	chart := &charts.Chart{
-		Name:      "jaeger",
-		Dir:       "jaeger",
-		Namespace: values.Namespace,
-		RawValues: rawValues,
-		Files:     files,
-		Fs:        static.Templates,
+	var partialFiles []*loader.BufferedFile
+	for _, template := range charts.L5dPartials {
+		partialFiles = append(partialFiles,
+			&loader.BufferedFile{Name: template},
+		)
 	}
-	buf, err := chart.Render()
+
+	// Load all jaeger chart files into buffer
+	if err := charts.FilesReader(static.Templates, "jaeger/", files); err != nil {
+		return err
+	}
+
+	// Load all partial chart files into buffer
+	if err := charts.FilesReader(partials.Templates, "", partialFiles); err != nil {
+		return err
+	}
+
+	// Create a Chart obj from the files
+	chart, err := loader.LoadFiles(append(files, partialFiles...))
 	if err != nil {
 		return err
+	}
+
+	vals, err := chartutil.CoalesceValues(chart, rawValues)
+	if err != nil {
+		return err
+	}
+
+	// Attach the final values into the `Values` field for rendering to work
+	finalValues := make(map[string]interface{})
+	finalValues["Values"] = vals
+
+	renderedTemplates, err := engine.Render(chart, finalValues)
+	if err != nil {
+		return err
+	}
+
+	// Merge templates and inject
+	var buf bytes.Buffer
+	for _, tmpl := range chart.Templates {
+		t := path.Join(chart.Metadata.Name, tmpl.Name)
+		if _, err := buf.WriteString(renderedTemplates[t]); err != nil {
+			return err
+		}
 	}
 
 	_, err = w.Write(buf.Bytes())

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -74,7 +74,7 @@ func newCmdInstall() *cobra.Command {
 
 func install(w io.Writer, options values.Options) error {
 
-	// Create final values override
+	// Create values override
 	valuesOverrides, err := options.MergeValues(nil)
 	if err != nil {
 		return err

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -73,18 +73,19 @@ func newCmdInstall() *cobra.Command {
 }
 
 func install(w io.Writer, options values.Options) error {
-	// Merge and create final set of values
-	rawMap, err := options.MergeValues(nil)
+
+	// Create final values override
+	valuesOverrides, err := options.MergeValues(nil)
 	if err != nil {
 		return err
 	}
 
 	// TODO: Add any validation logic here
 
-	return render(w, rawMap)
+	return render(w, valuesOverrides)
 }
 
-func render(w io.Writer, rawValues map[string]interface{}) error {
+func render(w io.Writer, valuesOverrides map[string]interface{}) error {
 
 	files := []*loader.BufferedFile{
 		{Name: chartutil.ChartfileName},
@@ -120,16 +121,13 @@ func render(w io.Writer, rawValues map[string]interface{}) error {
 		return err
 	}
 
-	vals, err := chartutil.CoalesceValues(chart, rawValues)
+	vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
 	if err != nil {
 		return err
 	}
 
 	// Attach the final values into the `Values` field for rendering to work
-	finalValues := make(map[string]interface{})
-	finalValues["Values"] = vals
-
-	renderedTemplates, err := engine.Render(chart, finalValues)
+	renderedTemplates, err := engine.Render(chart, map[string]interface{}{"Values": vals})
 	if err != nil {
 		return err
 	}

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -16,6 +16,29 @@ import (
 
 const versionPlaceholder = "linkerdVersionValue"
 
+var (
+	// L5dPartials is the list of templates in partials chart
+	// Keep this slice synced with the contents of /charts/partials
+	L5dPartials = []string{
+		"charts/partials/" + chartutil.ChartfileName,
+		"charts/partials/templates/_proxy.tpl",
+		"charts/partials/templates/_proxy-init.tpl",
+		"charts/partials/templates/_volumes.tpl",
+		"charts/partials/templates/_resources.tpl",
+		"charts/partials/templates/_metadata.tpl",
+		"charts/partials/templates/_helpers.tpl",
+		"charts/partials/templates/_debug.tpl",
+		"charts/partials/templates/_capabilities.tpl",
+		"charts/partials/templates/_trace.tpl",
+		"charts/partials/templates/_nodeselector.tpl",
+		"charts/partials/templates/_tolerations.tpl",
+		"charts/partials/templates/_affinity.tpl",
+		"charts/partials/templates/_addons.tpl",
+		"charts/partials/templates/_validate.tpl",
+		"charts/partials/templates/_pull-secrets.tpl",
+	}
+)
+
 // Chart holds the necessary info to render a Helm chart
 type Chart struct {
 	Name      string
@@ -80,25 +103,13 @@ func (c *Chart) render(partialsFiles []*loader.BufferedFile) (bytes.Buffer, erro
 // Render returns a bytes buffer with the result of rendering a Helm chart
 func (c *Chart) Render() (bytes.Buffer, error) {
 
-	// Keep this slice synced with the contents of /charts/partials
-	l5dPartials := []*loader.BufferedFile{
-		{Name: "charts/partials/" + chartutil.ChartfileName},
-		{Name: "charts/partials/templates/_proxy.tpl"},
-		{Name: "charts/partials/templates/_proxy-init.tpl"},
-		{Name: "charts/partials/templates/_volumes.tpl"},
-		{Name: "charts/partials/templates/_resources.tpl"},
-		{Name: "charts/partials/templates/_metadata.tpl"},
-		{Name: "charts/partials/templates/_helpers.tpl"},
-		{Name: "charts/partials/templates/_debug.tpl"},
-		{Name: "charts/partials/templates/_capabilities.tpl"},
-		{Name: "charts/partials/templates/_trace.tpl"},
-		{Name: "charts/partials/templates/_nodeselector.tpl"},
-		{Name: "charts/partials/templates/_tolerations.tpl"},
-		{Name: "charts/partials/templates/_affinity.tpl"},
-		{Name: "charts/partials/templates/_addons.tpl"},
-		{Name: "charts/partials/templates/_validate.tpl"},
-		{Name: "charts/partials/templates/_pull-secrets.tpl"},
+	l5dPartials := []*loader.BufferedFile{}
+	for _, template := range L5dPartials {
+		l5dPartials = append(l5dPartials, &loader.BufferedFile{
+			Name: template,
+		})
 	}
+
 	return c.render(l5dPartials)
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/version"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"helm.sh/helm/v3/pkg/cli/values"
 	klog "k8s.io/klog/v2"
 )
 
@@ -63,4 +65,12 @@ func maybePrintVersionAndExit(printVersion bool) {
 		os.Exit(0)
 	}
 	log.Infof("running version %s", version.Version)
+}
+
+// AddValueOptionsFlags adds flags used to override default values
+func AddValueOptionsFlags(f *pflag.FlagSet, v *values.Options) {
+	f.StringSliceVarP(&v.ValueFiles, "values", "f", []string{}, "specify values in a YAML file or a URL (can specify multiple)")
+	f.StringArrayVar(&v.Values, "set", []string{}, "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.StringArrayVar(&v.StringValues, "set-string", []string{}, "set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	f.StringArrayVar(&v.FileValues, "set-file", []string{}, "set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)")
 }


### PR DESCRIPTION
This change adds flags `set`, `set-string`, `values`, `set-files`,
etc flags which are used to override the default values. This is
similar to that of Helm.

This also updates the install workflow to directly use Helm v3
pkg for chart loading and generation, without having to use
our chart type, etc.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
