### PR TITLE
Add linkerd.io/extension label

### DIFF
--- a/jaeger/charts/jaeger/templates/namespace.yaml
+++ b/jaeger/charts/jaeger/templates/namespace.yaml
@@ -3,5 +3,7 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-jaeger
   annotations:
     linkerd.io/inject: enabled


### PR DESCRIPTION
The namespace that Linkerd extensions are installed into is configurable.  This can make it difficult to know which extensions are installed and where they are located.  We add a `linkerd.io/extension` namespace label to easily enumerate and locate Linkerd extensions.  This can be used, for example, to enable certain features only when certain extensions are installed.  All new Linkerd extensions should include this namespace label.

Signed-off-by: Alex Leong <alex@buoyant.io>