### PR TITLE
add some missing helm values for multicluster setup

### DIFF
--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -28,7 +28,9 @@ Kubernetes: `>=1.13.0-0`
 | gatewayProbePort | int | `4181` | The port used for liveliness probing |
 | gatewayProbeSeconds | int | `3` | The interval (in seconds) between liveness probes |
 | gatewayServiceType | string | `"LoadBalancer"` | Service Type of gateway Service |
+| identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | installNamespace | bool | `true` | If the namespace should be installed |
+| linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
 | namespace | string | `"linkerd-multicluster"` | Service Mirror component namespace |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |

--- a/charts/linkerd2-multicluster/values.yaml
+++ b/charts/linkerd2-multicluster/values.yaml
@@ -40,3 +40,7 @@ remoteMirrorServiceAccount: true
 remoteMirrorServiceAccountName: linkerd-service-mirror-remote-access-default
 # -- Service Type of gateway Service
 gatewayServiceType: LoadBalancer
+# -- Namespace of linkerd installation
+linkerdNamespace: linkerd
+# -- Identity Trust Domain of the certificate authority
+identityTrustDomain: cluster.local


### PR DESCRIPTION
**Subject**
Add missing helm values for multicluster setup

**Problem**
When executing this without the linkerd command the two variables are missing and the rendering will generate empty values.
This produces the following gateway identity, that is also used in the gateway link command to generate the link crd:

```
mirror.linkerd.io/gateway-identity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity..
```

**Solution**
Add the values as defaults to the helm chart values.yaml file. If the cli is used they are overwritten by the following parameters:
* https://github.com/linkerd/linkerd2/blob/main/cli/cmd/multicluster.go#L197
* https://github.com/linkerd/linkerd2/blob/main/cli/cmd/multicluster.go#L196

