### PR TITLE
Make multicluster gateway replicas configurable and define linkerd mu…

### DIFF
--- a/charts/linkerd2-multicluster/README.md
+++ b/charts/linkerd2-multicluster/README.md
@@ -27,6 +27,7 @@ Kubernetes: `>=1.13.0-0`
 | gatewayProbePath | string | `"/health"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gatewayProbePort | int | `4181` | The port used for liveliness probing |
 | gatewayProbeSeconds | int | `3` | The interval (in seconds) between liveness probes |
+| gatewayReplicas | int | `1` | Specifies the replica count of gateway deployment |
 | gatewayServiceType | string | `"LoadBalancer"` | Service Type of gateway Service |
 | installNamespace | bool | `true` | If the namespace should be installed |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |

--- a/charts/linkerd2-multicluster/templates/gateway.yaml
+++ b/charts/linkerd2-multicluster/templates/gateway.yaml
@@ -61,7 +61,7 @@ metadata:
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
 spec:
-  replicas: 1
+  replicas: {{ .Values.gatewayReplicas }}
   selector:
     matchLabels:
       app: {{.Values.gatewayName}}

--- a/charts/linkerd2-multicluster/values.yaml
+++ b/charts/linkerd2-multicluster/values.yaml
@@ -4,6 +4,8 @@ controllerComponentLabel: linkerd.io/control-plane-component
 createdByAnnotation: linkerd.io/created-by
 # -- If the gateway component should be installed
 gateway: true
+# -- Specifies the replica count of gateway deployment
+gatewayReplicas: 1
 # -- The path that will be used by the local liveness checks to ensure the
 # gateway is alive
 gatewayLocalProbePath: /health-local

--- a/cli/cmd/multicluster.go
+++ b/cli/cmd/multicluster.go
@@ -52,6 +52,7 @@ type (
 
 	multiclusterInstallOptions struct {
 		gateway                 bool
+		gatewayHighAvailability bool
 		gatewayPort             uint32
 		gatewayProbeSeconds     uint32
 		gatewayProbePort        uint32
@@ -203,6 +204,9 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 	defaults.LinkerdVersion = version.Version
 	defaults.RemoteMirrorServiceAccount = opts.remoteMirrorCredentials
 	defaults.GatewayServiceType = opts.gatewayServiceType
+	if opts.gatewayHighAvailability {
+		defaults.GatewayReplicas = uint32(3)
+	}
 
 	return defaults, nil
 }
@@ -401,6 +405,7 @@ func newMulticlusterInstallCommand() *cobra.Command {
 	cmd.Flags().StringVar(&options.gatewayNginxVersion, "gateway-nginx-image-version", options.gatewayNginxVersion, "The version of nginx to be used")
 	cmd.Flags().BoolVar(&options.remoteMirrorCredentials, "service-mirror-credentials", options.remoteMirrorCredentials, "Whether to install the service account which can be used by service mirror components in source clusters to discover exported services")
 	cmd.Flags().StringVar(&options.gatewayServiceType, "gateway-service-type", options.gatewayServiceType, "Overwrite Service type for gateway service")
+	cmd.Flags().BoolVar(&options.gatewayHighAvailability, "ha", options.gatewayHighAvailability, "Enable HA deployment for the gateway (default false)")
 
 	// Hide developer focused flags in release builds.
 	release, err := version.IsReleaseChannel(version.Version)

--- a/pkg/charts/multicluster/values.go
+++ b/pkg/charts/multicluster/values.go
@@ -24,6 +24,7 @@ type Values struct {
 	ControllerImageVersion         string `json:"controllerImageVersion"`
 	CreatedByAnnotation            string `json:"createdByAnnotation"`
 	Gateway                        bool   `json:"gateway"`
+	GatewayReplicas                uint32 `json:"gatewayReplicas"`
 	GatewayLocalProbePath          string `json:"gatewayLocalProbePath"`
 	GatewayLocalProbePort          uint32 `json:"gatewayLocalProbePort"`
 	GatewayName                    string `json:"gatewayName"`


### PR DESCRIPTION
**Subject**
Make multicluster gateway replicas configurable

**Problem**
By default the Multicluster gateway is configured as a single deployment replica count.

**Solution**
Add a similar solution as for high available installation of linkerd also to multicluster install.

