### PR TITLE
bin/protoc-diff: Don't assume Debian and don't install unzip

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -39,6 +39,8 @@ jobs:
     container:
       image: golang:1.13.4
     steps:
+      - name: Prerequisites
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install unzip
       - name: Checkout code
         # actions/checkout@v2
         uses: actions/checkout@722adc6

--- a/bin/protoc
+++ b/bin/protoc
@@ -15,7 +15,16 @@ protocversion=3.6.0
 protocbin=$targetbin/protoc-$protocversion
 protocurl=https://github.com/google/protobuf/releases/download/v$protocversion/protoc-$protocversion-$os-$arch.zip
 
+require_from() {
+    if ! command -v "$1" >/dev/null 2>/dev/null ; then
+        echo "Please acquire $1 from $2" >&2
+        return 1
+    fi
+}
+
 if [ ! -f "$protocbin" ]; then
+  require_from curl 'https://curl.se/download.html'
+  require_from unzip 'http://infozip.sourceforge.net/UnZip.html#Downloads'
   tmp=$(mktemp -d -t protoc.XXX)
   mkdir -p "$targetbin"
   (

--- a/bin/protoc-diff
+++ b/bin/protoc-diff
@@ -2,14 +2,8 @@
 
 set -eu
 
-# Install unzip if not already installed (Linux only)
-system=$(uname -s)
-if [ "$system" = Linux ] && ! [ -x "$(command -v unzip)" ]; then
-  apt-get update
-  apt-get install unzip
-fi
-
-bin/protoc-go.sh
+bindir=$( cd "${0%/*}" && pwd )
+"$bindir"/protoc-go.sh
 
 dir_dirty=$(git diff HEAD)
 if [ -z "$dir_dirty" ]; then

--- a/bin/protoc-go.sh
+++ b/bin/protoc-go.sh
@@ -2,9 +2,11 @@
 
 set -eu
 
+bindir=$( cd "${0%/*}" && pwd )
+
 gen() {
     for f in "$@"; do
-        bin/protoc -I proto --go_out=plugins=grpc,paths=source_relative:controller/gen "$f"
+        "$bindir"/protoc -I proto --go_out=plugins=grpc,paths=source_relative:controller/gen "$f"
     done
 }
 


### PR DESCRIPTION
- Do unzip check but don't install; leave installation to user
- Move unzip check to bin/protoc that actually uses unzip
- Make sure the protoc scripts can be called from any directory

Fixes #5337
