### PR TITLE
Fill data field when api error is not nil on web index

### DIFF
--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -55,6 +55,11 @@ func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httpro
 	if err != nil {
 		params.Error = true
 		params.ErrorMessage = err.Error()
+		params.Data = &pb.VersionInfo{
+			GoVersion:      "Unavailable",
+			BuildDate:      "Unavailable",
+			ReleaseVersion: "Unavailable",
+		}
 		log.Error(err)
 	} else {
 		params.Data = version

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -1,6 +1,7 @@
 package srv
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -54,6 +55,51 @@ func TestHandleIndex(t *testing.T) {
 		"<div class=\"main\" id=\"main\"",
 		"data-release-version=\"0.3.3\"",
 		"data-go-version=\"the best one\"",
+		"data-controller-namespace=\"\"",
+		"data-uuid=\"\"",
+	}
+	for _, expectedSubstring := range expectedSubstrings {
+		if !strings.Contains(actualBody, expectedSubstring) {
+			t.Fatalf("Expected string [%s] to be present in [%s]", expectedSubstring, actualBody)
+		}
+	}
+}
+
+func TestHandleIndexPublicAPIFail(t *testing.T) {
+	mockAPIClient := &public.MockAPIClient{
+		ErrorToReturn: fmt.Errorf("failed to call public API"),
+	}
+
+	server := FakeServer()
+
+	handler := &handler{
+		render:    server.RenderTemplate,
+		apiClient: mockAPIClient,
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	handler.handleIndex(recorder, req, httprouter.Params{})
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Incorrect StatusCode: %+v", recorder.Code)
+		t.Errorf("Expected              %+v", http.StatusOK)
+	}
+
+	header := http.Header{
+		"Content-Type": []string{"text/html"},
+	}
+	if !reflect.DeepEqual(recorder.Header(), header) {
+		t.Errorf("Incorrect headers: %+v", recorder.Header())
+		t.Errorf("Expected:          %+v", header)
+	}
+
+	actualBody := recorder.Body.String()
+
+	expectedSubstrings := []string{
+		"<div class=\"main\" id=\"main\"",
+		"data-release-version=\"Unavailable\"",
+		"data-go-version=\"Unavailable\"",
 		"data-controller-namespace=\"\"",
 		"data-uuid=\"\"",
 	}


### PR DESCRIPTION
app.tmpl.html does not expect the Data field to be empty which only is the case when api call is successful.

This PR fills the Data field with appropriate values when api call returns an error.

Fixes #5354 

Signed-off-by: Keyhan Asadi <keyhana97@gmail.com>