### PR TITLE
`linkerd install --ha` was only partially applying HA config

### DIFF
--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -58,11 +58,10 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 					if err != nil {
 						return err
 					}
-					changedValues, err := (*values).Merge(*haValues)
+					*values, err = values.Merge(*haValues)
 					if err != nil {
 						return err
 					}
-					*values = changedValues
 				}
 				return nil
 			}),

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -300,7 +300,7 @@ func readDefaults(chartDir string, ha bool) (*Values, error) {
 		}
 
 		var err error
-		values, err = values.merge(v)
+		values, err = values.Merge(v)
 		if err != nil {
 			return nil, err
 		}
@@ -309,10 +309,10 @@ func readDefaults(chartDir string, ha bool) (*Values, error) {
 	return &values, nil
 }
 
-// merge merges the non-empty properties of src into v.
+// Merge merges the non-empty properties of src into v.
 // A new Values instance is returned. Neither src nor v are mutated after
 // calling merge.
-func (v Values) merge(src Values) (Values, error) {
+func (v Values) Merge(src Values) (Values, error) {
 	// By default, mergo.Merge doesn't overwrite any existing non-empty values
 	// in its first argument. So in HA mode, we are merging values.yaml into
 	// values-ha.yaml, instead of the other way round (like Helm). This ensures


### PR DESCRIPTION
Fixes #5342

`values-ha.yml` contains the specific config for HA, but only the proxy
resources controller replicas settings were applied. This PR adds
EnablePodAntiafinity, WebhookFailurePolicy and all the resource settings
for the other CP pods.

Also the `--controller-replicas` flag is moved after the HA flags so it
can override the HA settings.

Finally, some comments no longer relevant were removed.

## How to test

Perform `linkerd install --ha` and make sure the values in
`values-ha.yml` are propagated correctly in the produced yaml.

## 2.9.1

After merging to `main`, this should be cherry-picked into the
`release/stable-2.9` branch.