### PR TITLE
Don't swallow error when MC gateway hostname can't be resolved

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -691,7 +691,9 @@ func (rcsw *RemoteClusterServiceWatcher) resolveGatewayAddress() ([]corev1.Endpo
 				IP: ipAddr.String(),
 			})
 		} else {
-			errors = append(errors, fmt.Errorf("Error resolving '%s': %s", addr, err))
+			err = fmt.Errorf("Error resolving '%s': %s", addr, err)
+			rcsw.log.Warn(err)
+			errors = append(errors, err)
 		}
 	}
 	// one resolved address is enough


### PR DESCRIPTION
Ref #5343

When none of the gateway addresses is resolvable, propagate the error as
a retryable error so it gets retried and logged. Don't create the
mirrored resources if there's no success after the retries.
