### PR TITLE
Stop publishing the linkerd2-multicluster-link chart

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -54,7 +54,6 @@ if [ "$1" = package ]; then
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/multicluster/charts/linkerd2-multicluster
-    "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/multicluster/charts/linkerd2-multicluster-link
     "$bindir"/helm --version "$version" --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/jaeger/charts/jaeger
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-"$version".yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm

--- a/multicluster/charts/linkerd2-multicluster-link/Chart.yaml
+++ b/multicluster/charts/linkerd2-multicluster-link/Chart.yaml
@@ -2,7 +2,13 @@ apiVersion: v1
 appVersion: edge-XX.X.X
 description: |
   A helm chart containing the resources to enable mirroring
-  of services from a remote cluster
+  of services from a remote cluster.
+
+  Warning: The purpose of this chart is just to support the `linkerd
+  multicluster link` CLI command, which also produces the
+  `cluster-credentials` secret and the Link CR, which are not found in this
+  chart. Therefore this chart is not a replacement for that command, and
+  shouldn't be used as-is unless you really know what you're doing ;-)
 kubeVersion: ">=1.13.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-multicluster-link"

--- a/multicluster/charts/linkerd2-multicluster-link/README.md
+++ b/multicluster/charts/linkerd2-multicluster-link/README.md
@@ -1,7 +1,13 @@
 # linkerd2-multicluster-link
 
 A helm chart containing the resources to enable mirroring
-of services from a remote cluster
+of services from a remote cluster.
+
+Warning: The purpose of this chart is just to support the `linkerd
+multicluster link` CLI command, which also produces the
+`cluster-credentials` secret and the Link CR, which are not found in this
+chart. Therefore this chart is not a replacement for that command, and
+shouldn't be used as-is unless you really know what you're doing ;-)
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
 


### PR DESCRIPTION
Closes #5348

That chart generates the service mirror resources and related RBAC, but
doesn't generate the credentials secret nor the Link CR which require
go-client logic not available from sheer Helm templates.

This PR stops publishing that chart, and adds a comment to its README
about it.
