### PR TITLE
Add changes for edge-20.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 * Fixed an issue where TLS credentials are changed during upgrades, but the
   Linkerd webhooks would not restart, leaving them to use older credentials and
   fail requests
-* Stopped publishing the multicluster link chart as it's primary use case is in
+* Stopped publishing the multicluster link chart as its primary use case is in
   the `multicluster link` command and not being installed through Helm
 
 ## edge-20.12.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
   fail requests
 * Stopped publishing the multicluster link chart as its primary use case is in
   the `multicluster link` command and not being installed through Helm
+* Added error logs for when the multicluster gateway cannot resolve a hostname
 
 ## edge-20.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,6 @@
 * Fixed an issue where TLS credentials are changed during upgrades, but the
   Linkerd webhooks would not restart, leaving them to use older credentials and
   fail requests
-* Stopped publishing the multicluster link chart as it's primary use case is in
-  the `multicluster link` command and not being installed through Helm
 
 ## edge-20.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 * Fixed an issue where TLS credentials are changed during upgrades, but the
   Linkerd webhooks would not restart, leaving them to use older credentials and
   fail requests
+* Stopped publishing the multicluster link chart as it's primary use case is in
+  the `multicluster link` command and not being installed through Helm
 
 ## edge-20.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@
   fail requests
 * Stopped publishing the multicluster link chart as its primary use case is in
   the `multicluster link` command and not being installed through Helm
-* Added error logs for when the multicluster gateway cannot resolve a hostname
+* Added service mirror error logs for when the multicluster gateway's hostname
+  cannot be resolved.
 
 ## edge-20.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,9 @@
 ## edge-20.12.2
 
 * Fixed an issue where the `proxy-injector` and `sp-validator` did not refresh
-  their certs automatically when provided externally--like through cert-manager
-* Added support for overrides flags to the `jaeger` command
+  their certs automatically when provided externally—like through cert-manager
+* Added support for overrides flags to the `jaeger install` command to allow
+  setting Helm values when installing the Linkerd-jaeger extension
 * Added missing Helm values to the multicluster chart (thanks @DaspawnW!)
 * Moved tracing functionality to the `linkerd-jaeger` extension
 * Fixed various issues in developer shell scripts (thanks @joakimr-axis!)
@@ -15,6 +16,8 @@
 * Fixed an issue where TLS credentials are changed during upgrades, but the
   Linkerd webhooks would not restart, leaving them to use older credentials and
   fail requests
+* Stopped publishing the multicluster link chart as it's primary use case is in
+  the `multicluster link` command and not being installed through Helm
 
 ## edge-20.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 
 # Changes
 
+## edge-20.12.2
+
+* Fixed an issue where the `proxy-injector` and `sp-validator` did not refresh
+  their certs automatically when provided externally--like through cert-manager
+* Added support for overrides flags to the `jaeger` command
+* Added missing Helm values to the multicluster chart (thanks @DaspawnW!)
+* Moved tracing functionality to the `linkerd-jaeger` extension
+* Fixed various issues in developer shell scripts (thanks @joakimr-axis!)
+* Fixed an issue where `install --ha` was only partially applying the high
+  availability config
+* Updated RBAC API versions in the CNI chart (thanks @glitchcrab!)
+* Fixed an issue where TLS credentials are changed during upgrades, but the
+  Linkerd webhooks would not restart, leaving them to use older credentials and
+  fail requests
+
 ## edge-20.12.1
 
 This edge release continues the work of decoupling non-core Linkerd components


### PR DESCRIPTION
## edge-20.12.2

* Fixed an issue where the `proxy-injector` and `sp-validator` did not refresh
  their certs automatically when provided externally—like through cert-manager
* Added support for overrides flags to the `jaeger install` command to allow
  setting Helm values when installing the Linkerd-jaeger extension
* Added missing Helm values to the multicluster chart (thanks @DaspawnW!)
* Moved tracing functionality to the `linkerd-jaeger` extension
* Fixed various issues in developer shell scripts (thanks @joakimr-axis!)
* Fixed an issue where `install --ha` was only partially applying the high
  availability config
* Updated RBAC API versions in the CNI chart (thanks @glitchcrab!)
* Fixed an issue where TLS credentials are changed during upgrades, but the
  Linkerd webhooks would not restart, leaving them to use older credentials and
  fail requests
* Stopped publishing the multicluster link chart as its primary use case is in
  the `multicluster link` command and not being installed through Helm
* Added service mirror error logs for when the multicluster gateway's hostname
  cannot be resolved.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
