### PR TITLE
Add changes for edge-20.12.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 
 # Changes
 
+## edge-20.12.3
+
+This edge release is functionally the same as `edge-20.12.2`. It fixes an issue
+that prevented the release build from occurring.
+
 ## edge-20.12.2
 
 * Fixed an issue where the `proxy-injector` and `sp-validator` did not refresh


### PR DESCRIPTION
## edge-20.12.3

This edge release is functionally the same as `edge-20.12.2`. It fixes an issue
that prevented the release build from occurring.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
