### PR TITLE
Support multi-cert CA bundles in healthcheck

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -934,7 +934,7 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
-					description: "CA certificates match",
+					description: "trust anchors in config and secret  match",
 					hintAnchor:  "l5d-identity-cert-config-valid",
 					fatal:       true,
 					check: func(ctx context.Context) (err error) {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -934,7 +934,7 @@ func (hc *HealthChecker) allCategories() []category {
 					},
 				},
 				{
-					description: "trust anchors in config and secret  match",
+					description: "trust anchors in config and secret match",
 					hintAnchor:  "l5d-identity-cert-config-valid",
 					fatal:       true,
 					check: func(ctx context.Context) (err error) {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1661,6 +1661,7 @@ func (hc *HealthChecker) checkCertificatesConfig(ctx context.Context) (*tls.Cred
 			errFormat := "IdentityContext.TrustAnchorsPem does not match %s in %s"
 			err = fmt.Errorf(errFormat, k8s.IdentityIssuerTrustAnchorsNameExternal, k8s.IdentityIssuerSecretName)
 		}
+
 	}
 
 	if err != nil {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2870,6 +2870,7 @@ data:
 `, base64.StdEncoding.EncodeToString([]byte(issuerCerts.TrustAnchors)), base64.StdEncoding.EncodeToString([]byte(issuerCerts.IssuerCrt)), base64.StdEncoding.EncodeToString([]byte(issuerCerts.IssuerKey)))
 }
 
+//nolint:unparam
 func createIssuerData(dnsName string, notBefore, notAfter time.Time) *issuercerts.IssuerCertData {
 	// Generate a new root key.
 	key, _ := tls.GenerateKey()

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3006,6 +3006,19 @@ func TestLinkerdIdentityCheckCertConfig(t *testing.T) {
 				return issuerData
 			},
 		},
+		{
+			checkDescription: "supports multiple CA certs in IdentityContext.TrustAnchorsPEM",
+			tlsSecretScheme:  string(corev1.SecretTypeTLS),
+			schemeInConfig:   string(corev1.SecretTypeTLS),
+			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
+			configMapIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
+				extraIssuer := createIssuerData("identity.linkerd.cluster.local", time.Now().AddDate(-2, 2, 0), time.Now().AddDate(0, 2, 0))
+
+				issuerData.TrustAnchors = issuerData.TrustAnchors +
+					extraIssuer.TrustAnchors
+				return issuerData
+			},
+		},
 	}
 
 	for id, testCase := range testCases {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3056,20 +3056,20 @@ func TestLinkerdIdentityCheckAnchorsMatch(t *testing.T) {
 			checkDescription: "works with valid cert and linkerd.io/tls secret for linkder scheme",
 			tlsSecretScheme:  k8s.IdentityIssuerSchemeLinkerd,
 			schemeInConfig:   k8s.IdentityIssuerSchemeLinkerd,
-			expectedOutput:   []string{"linkerd-identity-test-cat CA certificates match"},
+			expectedOutput:   []string{"linkerd-identity-test-cat trust anchors in config and secret match"},
 		},
 		{
 			// missmatch is not tested, since this will already fail checkCertificatesConfig above.
 			checkDescription: "works with valid cert and linkerd.io/tls secret for k8s scheme",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat CA certificates match"},
+			expectedOutput:   []string{"linkerd-identity-test-cat trust anchors in config and secret match"},
 		},
 		{
 			checkDescription: "ca.crt contains root not in config map",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat CA certificates match: no path for cert with subject 'CN=identity.linkerd.cluster.local' in field ca.crt of secret linkerd-identity-issuer to trust anchor defined in value 'global.identityTrustAnchorsPEM' of linkerd config"},
+			expectedOutput:   []string{"linkerd-identity-test-cat trust anchors in config and secret match: no path for cert with subject 'CN=identity.linkerd.cluster.local' in field ca.crt of secret linkerd-identity-issuer to trust anchor defined in value 'global.identityTrustAnchorsPEM' of linkerd config"},
 			tlsSecretIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
 				extraRoot := createIssuerData("identity.linkerd.cluster.local", time.Now().AddDate(-2, 2, 0), time.Now().AddDate(0, 2, 0))
 
@@ -3081,7 +3081,7 @@ func TestLinkerdIdentityCheckAnchorsMatch(t *testing.T) {
 			checkDescription: "supports multiple CA certs in IdentityContext.TrustAnchorsPEM",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat CA certificates match"},
+			expectedOutput:   []string{"linkerd-identity-test-cat trust anchors in config and secret match"},
 			configMapIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
 				extraIssuer := createIssuerData("identity.linkerd.cluster.local", time.Now().AddDate(-2, 2, 0), time.Now().AddDate(0, 2, 0))
 
@@ -3111,7 +3111,7 @@ func TestLinkerdIdentityCheckAnchorsMatch(t *testing.T) {
 		} else {
 			fakeSecret = getFakeSecret(testCase.tlsSecretScheme, issuerData)
 		}
-		runIdentityCheckTestCase(context.Background(), t, id, testCase.checkDescription, "CA certificates match", fakeConfigMap, fakeSecret, testCase.expectedOutput)
+		runIdentityCheckTestCase(context.Background(), t, id, testCase.checkDescription, "trust anchors in config and secret match", fakeConfigMap, fakeSecret, testCase.expectedOutput)
 	}
 }
 

--- a/test/integration/testdata/check.cni.golden
+++ b/test/integration/testdata/check.cni.golden
@@ -44,6 +44,7 @@ linkerd-cni-plugin
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days

--- a/test/integration/testdata/check.cni.proxy.golden
+++ b/test/integration/testdata/check.cni.proxy.golden
@@ -44,6 +44,7 @@ linkerd-cni-plugin
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -32,6 +32,7 @@ linkerd-config
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days

--- a/test/integration/testdata/check.multicluster.golden
+++ b/test/integration/testdata/check.multicluster.golden
@@ -32,6 +32,7 @@ linkerd-config
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -32,6 +32,7 @@ linkerd-config
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -32,6 +32,7 @@ linkerd-config
 linkerd-identity
 ----------------
 √ certificate config is valid
+√ trust anchors in config and secret match
 √ trust anchors are using supported crypto algorithm
 √ trust anchors are within their validity period
 √ trust anchors are valid for at least 60 days


### PR DESCRIPTION
Currently the CA bundles in the config value `global.IdentityTrustAnchorsPEM` must not contain more than one certificate when the schema type is set to `kubernetes.io/tls` or the command `linkerd check` will fail.

This change will place the comparison of the contents of `ca.cert` of the secret and the trust anchors into a separate test and support arbitrary long chains in ca.crt.

Fixes #5292 
