### PR TITLE
Add missing icon entry to jaeger chart

### DIFF
--- a/jaeger/charts/jaeger/Chart.yaml
+++ b/jaeger/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for the jaeger add-on in Linkerd
 name: jaeger
 version: 0.1.0
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.15.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/jaeger/Chart.yaml
+++ b/jaeger/charts/jaeger/Chart.yaml
@@ -3,6 +3,8 @@ appVersion: "1.0"
 description: A Helm chart for the jaeger add-on in Linkerd
 name: jaeger
 version: 0.1.0
+kubeVersion: ">=1.13.0-0"
+icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors
     email: cncf-linkerd-dev@lists.cncf.io

--- a/jaeger/charts/jaeger/README.md
+++ b/jaeger/charts/jaeger/README.md
@@ -8,7 +8,7 @@ A Helm chart for the jaeger add-on in Linkerd
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.15.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/jaeger/README.md
+++ b/jaeger/charts/jaeger/README.md
@@ -8,6 +8,8 @@ A Helm chart for the jaeger add-on in Linkerd
 
 ## Requirements
 
+Kubernetes: `>=1.13.0-0`
+
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../../../charts/partials | partials | 0.1.0 |


### PR DESCRIPTION
This is required for `helm lint` to pass. Its absence was what caused
the last CI edge release to fail and so we had to manually upload the
charts.
