### PR TITLE
 CLI: Introduced `identity` command to fetch tls-certificates for a pod

### DIFF
--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"os"
 	"regexp"
 	"sync/atomic"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/api/util"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	tls1 "github.com/linkerd/linkerd2/pkg/tls"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,12 +31,14 @@ type Certificates struct {
 type identityOptions struct {
 	pod       string
 	namespace string
+	selector  string
 }
 
 func newIdentityOptions() *identityOptions {
 	return &identityOptions{
 		pod:       "",
 		namespace: "",
+		selector:  "",
 	}
 }
 
@@ -45,40 +47,48 @@ func newCmdIdentity() *cobra.Command {
 	options := newIdentityOptions()
 
 	cmd := &cobra.Command{
-		Use:   "identity [name]",
+		Use:   "identity [flags] (PODS)",
 		Short: "Display the certificate(s) of one or more selected pod(s)",
 		Long: `Display the certificate(s) of one or more selected pod(s).
 		
-		This command initiates a port-forward to a given pod or a set of pods, and
+		This command initiates a port-forward to a given pod or a set of pods and
 		fetches the tls certificate.
 		`,
-		Example: ` #Get certificate from pod foo-bar in the default namespace.
+		Example: ` 
+		#Get certificate from pod foo-bar in the default namespace.
 		linkerd identity foo-bar
 		
-		#Get certificate from all pods in the default namespace
-		linkerd identity
-		
-		#Get certificate from the web deployment in the emojivoto namespace
-		linkerd identity deploy/web -n emojivoto`,
-		Args: cobra.MinimumNArgs(1),
+		#Get certificate from all pods with name=nginx
+		linkerd identity -l name=nginx
+		`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}
-			pods, err := getPods(cmd.Context(), k8sAPI, options.namespace, args[0])
+			pods, err := getPods(cmd.Context(), k8sAPI, options.namespace, options.selector, args)
 			if err != nil {
-				//fmt.Print("")
 				return err
 			}
-			// fmt.Printf("\nPod length: %d", len(pods))
 			results := getCertificate(k8sAPI, pods, k8s.ProxyAdminPortName, 30*time.Second, emitLog)
 
-			for _, result := range results {
-				// fmt.Printf("\nDEBUG")
-				// content := fmt.Sprintf("#\n# POD %s (%d of %d)\n#\n", result.pod, i+1, len(results))
+			for i, result := range results {
+				fmt.Printf("\n POD %s (%d of %d)\n\n", result.pod, i+1, len(results))
 				if result.err == nil {
-					fmt.Printf("\n%+v\n", result.Certificate)
+					fmt.Println("Version: ", result.Certificate[0].Version)
+					fmt.Println("Serial Number: ", result.Certificate[0].SerialNumber)
+					fmt.Println("Signature Algorithm: ", result.Certificate[0].SignatureAlgorithm)
+					fmt.Println("Validity")
+					fmt.Println("\t Not Before: ", result.Certificate[0].NotBefore.Format(time.RFC3339))
+					fmt.Println("\t Not After: ", result.Certificate[0].NotAfter.Format(time.RFC3339))
+					fmt.Println("Subject: ", result.Certificate[0].Subject)
+					fmt.Println("Issuer:  ", result.Certificate[0].Issuer)
+					fmt.Println("Subject Public Key Info:")
+					fmt.Println("\tPublic Key Alogrithm: ", result.Certificate[0].PublicKeyAlgorithm)
+					fmt.Println("Signature: \n", result.Certificate[0].Signature)
+					resultCerticate := tls1.EncodeCertificatesPEM(result.Certificate[0])
+
+					fmt.Printf("\n%s", resultCerticate)
 				} else {
 					fmt.Printf("\n%s\n", result.err)
 				}
@@ -88,17 +98,16 @@ func newCmdIdentity() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy versions (default: all namespaces)")
-
+	cmd.PersistentFlags().StringVarP(&options.selector, "selector", "l", options.selector, "Selector (label query) to filter on, supports ‘=’, ‘==’, and ‘!=’ ")
 	return cmd
 }
 
+// getCertificate fetches the certificates for all the pods
 func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, waitingTime time.Duration, emitLog bool) []Certificates {
-	//fmt.Printf("\nInside getCertificate")
 	var certificates []Certificates
 	resultChan := make(chan Certificates)
 	var activeRoutines int32
 	for _, pod := range pods {
-		//fmt.Printf("in loop")
 		atomic.AddInt32(&activeRoutines, 1)
 		go func(p corev1.Pod) {
 			defer atomic.AddInt32(&activeRoutines, -1)
@@ -113,7 +122,6 @@ func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName strin
 
 			for _, c := range containers {
 				cert, err := getContainerCertificate(k8sAPI, p, c, portName, emitLog)
-
 				resultChan <- Certificates{
 					pod:         p.GetName(),
 					container:   c.Name,
@@ -125,7 +133,6 @@ func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName strin
 	}
 
 	for {
-		//fmt.Printf("stuck")
 		select {
 		case cert := <-resultChan:
 			certificates = append(certificates, cert)
@@ -140,7 +147,6 @@ func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName strin
 }
 
 func getContainersWithPort(pod corev1.Pod, portName string) ([]corev1.Container, error) {
-	// fmt.Printf("\n Inside getContainersWithPort")
 	if pod.Status.Phase != corev1.PodRunning {
 		return nil, fmt.Errorf("pod not running: %s", pod.GetName())
 	}
@@ -157,7 +163,6 @@ func getContainersWithPort(pod corev1.Pod, portName string) ([]corev1.Container,
 }
 
 func getContainerCertificate(k8sAPI *k8s.KubernetesAPI, pod corev1.Pod, container corev1.Container, portName string, emitLog bool) ([]*x509.Certificate, error) {
-	// fmt.Printf("\nInside getContainerCertificate")
 	portForward, err := k8s.NewContainerMetricsForward(k8sAPI, pod, container, emitLog, portName)
 	if err != nil {
 		return nil, err
@@ -174,50 +179,40 @@ func getContainerCertificate(k8sAPI *k8s.KubernetesAPI, pod corev1.Pod, containe
 }
 
 func getCertResponse(url string, pod corev1.Pod) ([]*x509.Certificate, error) {
-	// can we get the container env from pod spec?
-	serverName, err := getServerName(pod, "linkerd-proxy")
+	serverName, rootPEM, err := getServerName(pod, "linkerd-proxy")
 	if err != nil {
 		return nil, err
 	}
 	re := regexp.MustCompile("[0-9]+")
 	res := re.FindString(url)
-	// fmt.Printf("\nPort here: %s", res)
+
 	connURL := "localhost:" + res
-	// fmt.Printf("\n URL %s", connURL)
-	conn, err := net.Dial("tcp", connURL)
+
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM([]byte(rootPEM))
+
+	conn, err := tls.Dial("tcp", connURL, &tls.Config{
+		RootCAs:    roots,
+		ServerName: serverName,
+	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Printf("\nserver name: %s", serverName)
-
-	client := tls.Client(conn, &tls.Config{
-		// get server name from LINKERD2_PROXY_IDENTITY_LOCAL_NAME env var in the proxy container
-		ServerName: serverName,
-	})
-	defer client.Close()
-
-	if err := client.Handshake(); err != nil {
-		return nil, err
-	}
-
-	cert := client.ConnectionState().PeerCertificates
+	cert := conn.ConnectionState().PeerCertificates
 	return cert, nil
 }
 
-func getServerName(pod corev1.Pod, containerName string) (string, error) {
-	// we need to form the server name using the following env var from the proxy container:
-	// - _pod_sa: this refers to the service account name - (serviceAccountName in the pod spec)
-	// - _pod_ns: (namespace in pod spec)
-	// - _l5d_ns
-	// - _l5d_trustdomain
-	// $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+func getServerName(pod corev1.Pod, containerName string) (string, string, error) {
+
 	if pod.Status.Phase != corev1.PodRunning {
-		return "", fmt.Errorf("pod not running: %s", pod.GetName())
+		return "", "", fmt.Errorf("pod not running: %s", pod.GetName())
 	}
 
 	var l5dns string
 	var l5dtrustdomain string
+	var trustAnchor string
 	podsa := pod.Spec.ServiceAccountName
 	podns := pod.ObjectMeta.Namespace
 	for _, c := range pod.Spec.Containers {
@@ -229,39 +224,38 @@ func getServerName(pod corev1.Pod, containerName string) (string, error) {
 				if env.Name == "_l5d_trustdomain" {
 					l5dtrustdomain = env.Value
 				}
+				if env.Name == "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS" {
+					trustAnchor = env.Value
+				}
 			}
 		}
 	}
 
 	serverName := podsa + "." + podns + ".serviceaccount.identity." + l5dns + "." + l5dtrustdomain
 
-	return serverName, nil
+	return serverName, trustAnchor, nil
 }
 
-func getPods(ctx context.Context, clientset kubernetes.Interface, namespace string, arg string) ([]corev1.Pod, error) {
+func getPods(ctx context.Context, clientset kubernetes.Interface, namespace string, selector string, arg []string) ([]corev1.Pod, error) {
 
-	// var podList *corev1.PodList
-	res, err := util.BuildResource(namespace, arg)
+	if len(arg) > 0 {
+		res, err := util.BuildResource(namespace, arg[0])
+		if err != nil {
+			return nil, err
+		}
+		pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, res.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return []corev1.Pod{*pod}, nil
+	}
+
+	podList, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	// // get all pods in the current namespace
-	// if res.GetName() == "" {
-	// 	podList, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-	// }
-
-	// check if the resource is actually a pod or not
-	if res.GetType() != k8s.Pod {
-		return nil, fmt.Errorf("could not find pod %s", res.GetType())
-	}
-
-	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, res.GetName(), metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return []corev1.Pod{*pod}, nil
+	return podList.Items, nil
 }

--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/grantae/certinfo"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -84,7 +83,7 @@ func newCmdIdentity() *cobra.Command {
 				return err
 			}
 
-			resultCerts := getCertificate(k8sAPI, pods, k8s.ProxyAdminPortName, 30*time.Second, emitLog)
+			resultCerts := getCertificate(k8sAPI, pods, k8s.ProxyAdminPortName, emitLog)
 			for _, resultCert := range resultCerts {
 				if resultCert.err != nil {
 					fmt.Printf("\n%s", resultCert.err)
@@ -110,7 +109,7 @@ func newCmdIdentity() *cobra.Command {
 	return cmd
 }
 
-func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, waitingTime time.Duration, emitLog bool) []certificate {
+func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, emitLog bool) []certificate {
 	var certificates []certificate
 	for _, pod := range pods {
 		containers, err := getContainersWithPort(pod, portName)

--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -80,14 +80,14 @@ This command initiates a port-forward to a given pod or a set of pods and fetche
 			for i, resultCert := range resultCerts {
 				fmt.Printf("\nPOD %s (%d of %d)\n\n", resultCert.pod, i+1, len(resultCerts))
 				if resultCert.err != nil {
-					fmt.Printf("\n%s", resultCert.err)
+					fmt.Printf("\n%s\n", resultCert.err)
 					return nil
 				}
 				certChain := resultCert.Certificate
 				cert := certChain[len(certChain)-1]
 				result, err := certinfo.CertificateText(cert)
 				if err != nil {
-					fmt.Printf("\n%s", err)
+					fmt.Printf("\n%s\n", err)
 					return nil
 				}
 				fmt.Print(result)

--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"sync/atomic"
+	"time"
+
+	"github.com/linkerd/linkerd2/controller/api/util"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var emitLog bool
+
+type Certificates struct {
+	pod         string
+	container   string
+	Certificate []*x509.Certificate
+	err         error
+}
+
+type identityOptions struct {
+	pod       string
+	namespace string
+}
+
+func newIdentityOptions() *identityOptions {
+	return &identityOptions{
+		pod:       "",
+		namespace: "",
+	}
+}
+
+func newCmdIdentity() *cobra.Command {
+	emitLog = false
+	options := newIdentityOptions()
+
+	cmd := &cobra.Command{
+		Use:   "identity get [name]",
+		Short: "Display the certificate(s) of one or more selected pod(s)",
+		Long: `Display the certificate(s) of one or more selected pod(s).
+		
+		This command initiates a port-forward to a given pod or a set of pods, and
+		fetches the tls certificate.
+		`,
+		Example: ` #Get certificate from pod foo-bar in the default namespace.
+		linkerd identity foo-bar
+		
+		#Get certificate from all pods in the default namespace
+		linkerd identity
+		
+		#Get certificate from the web deployment in the emojivoto namespace
+		linkerd identity deploy/web -n emojivoto`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return err
+			}
+			pods, err := getPods(cmd.Context(), k8sAPI, options.namespace, args[0])
+			if err != nil {
+				//fmt.Print("")
+				return err
+			}
+			// fmt.Printf("\nPod length: %d", len(pods))
+			results := getCertificate(k8sAPI, pods, k8s.ProxyAdminPortName, 30*time.Second, emitLog)
+
+			for _, result := range results {
+				// fmt.Printf("\nDEBUG")
+				// content := fmt.Sprintf("#\n# POD %s (%d of %d)\n#\n", result.pod, i+1, len(results))
+				if result.err == nil {
+					fmt.Printf("\n%+v\n", result.Certificate)
+				} else {
+					fmt.Printf("\n%s\n", result.err)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy versions (default: all namespaces)")
+
+	return cmd
+}
+
+func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, waitingTime time.Duration, emitLog bool) []Certificates {
+	//fmt.Printf("\nInside getCertificate")
+	var certificates []Certificates
+	resultChan := make(chan Certificates)
+	var activeRoutines int32
+	for _, pod := range pods {
+		//fmt.Printf("in loop")
+		atomic.AddInt32(&activeRoutines, 1)
+		go func(p corev1.Pod) {
+			defer atomic.AddInt32(&activeRoutines, -1)
+			containers, err := getContainersWithPort(p, portName)
+			if err != nil {
+				resultChan <- Certificates{
+					pod: p.GetName(),
+					err: err,
+				}
+				return
+			}
+
+			for _, c := range containers {
+				cert, err := getContainerCertificate(k8sAPI, p, c, portName, emitLog)
+
+				resultChan <- Certificates{
+					pod:         p.GetName(),
+					container:   c.Name,
+					Certificate: cert,
+					err:         err,
+				}
+			}
+		}(pod)
+	}
+
+	for {
+		//fmt.Printf("stuck")
+		select {
+		case cert := <-resultChan:
+			certificates = append(certificates, cert)
+		case <-time.After(waitingTime):
+			break
+		}
+		if atomic.LoadInt32(&activeRoutines) == 0 {
+			break
+		}
+	}
+	return certificates
+}
+
+func getContainersWithPort(pod corev1.Pod, portName string) ([]corev1.Container, error) {
+	// fmt.Printf("\n Inside getContainersWithPort")
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil, fmt.Errorf("pod not running: %s", pod.GetName())
+	}
+	var containers []corev1.Container
+
+	for _, c := range pod.Spec.Containers {
+		for _, p := range c.Ports {
+			if p.Name == portName {
+				containers = append(containers, c)
+			}
+		}
+	}
+	return containers, nil
+}
+
+func getProxyContainerEnv(pod corev1.Pod, containerName string) (string, error) {
+	// we need to form the server name using the following env var from the proxy container:
+	// - _pod_sa: this refers to the service account name - (serviceAccountName in the pod spec)
+	// - _pod_ns: (namespace in pod spec)
+	// - _l5d_ns
+	// - _l5d_trustdomain
+	// $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+	if pod.Status.Phase != corev1.PodRunning {
+		return "", fmt.Errorf("pod not running: %s", pod.GetName())
+	}
+
+	var l5dns string
+	var l5dtrustdomain string
+	podsa := pod.Spec.ServiceAccountName
+	podns := pod.ObjectMeta.Namespace
+	for _, c := range pod.Spec.Containers {
+		if c.Name == containerName {
+			for _, env := range c.Env {
+				if env.Name == "_l5d_ns" {
+					l5dns = env.Value
+				}
+				if env.Name == "_l5d_trustdomain" {
+					l5dtrustdomain = env.Value
+				}
+			}
+		}
+	}
+
+	serverName := podsa + "." + podns + ".serviceaccount.identity." + l5dns + "." + l5dtrustdomain
+
+	return serverName, nil
+}
+
+func getContainerCertificate(k8sAPI *k8s.KubernetesAPI, pod corev1.Pod, container corev1.Container, portName string, emitLog bool) ([]*x509.Certificate, error) {
+	// fmt.Printf("\nInside getContainerCertificate")
+	portForward, err := k8s.NewContainerMetricsForward(k8sAPI, pod, container, emitLog, portName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer portForward.Stop()
+	if err = portForward.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+		return nil, err
+	}
+
+	certURL := portForward.URLFor("")
+	return getCertResponse(certURL, pod)
+}
+
+func getCertResponse(url string, pod corev1.Pod) ([]*x509.Certificate, error) {
+	// can we get the container env from pod spec?
+	serverName, err := getProxyContainerEnv(pod, "linkerd-proxy")
+	if err != nil {
+		return nil, err
+	}
+	re := regexp.MustCompile("[0-9]+")
+	res := re.FindString(url)
+	// fmt.Printf("\nPort here: %s", res)
+	connURL := "localhost:" + res
+	// fmt.Printf("\n URL %s", connURL)
+	conn, err := net.Dial("tcp", connURL)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("\nserver name: %s", serverName)
+
+	client := tls.Client(conn, &tls.Config{
+		// get server name from LINKERD2_PROXY_IDENTITY_LOCAL_NAME env var in the proxy container
+		ServerName: serverName,
+	})
+	defer client.Close()
+
+	if err := client.Handshake(); err != nil {
+		return nil, err
+	}
+
+	cert := client.ConnectionState().PeerCertificates
+	return cert, nil
+}
+
+func getPods(ctx context.Context, clientset kubernetes.Interface, namespace string, arg string) ([]corev1.Pod, error) {
+
+	// var podList *corev1.PodList
+	res, err := util.BuildResource(namespace, arg)
+	if err != nil {
+		return nil, err
+	}
+
+	// // get all pods in the current namespace
+	// if res.GetName() == "" {
+	// 	podList, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	// check if the resource is actually a pod or not
+	if res.GetType() != k8s.Pod {
+		return nil, fmt.Errorf("could not find pod %s", res.GetType())
+	}
+
+	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, res.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return []corev1.Pod{*pod}, nil
+}

--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -64,7 +64,7 @@ This command initiates a port-forward to a given pod or a set of pods and fetche
 			}
 
 			if len(args) == 0 && options.selector == "" {
-				return fmt.Errorf("Provide the pod name argument or use the selector flag\n")
+				return fmt.Errorf("Provide the pod name argument or use the selector flag")
 			}
 
 			pods, err := getPods(cmd.Context(), k8sAPI, options.namespace, options.selector, args)
@@ -139,7 +139,7 @@ func getContainerWithPort(pod corev1.Pod, portName string) (corev1.Container, er
 			}
 		}
 	}
-	return container, fmt.Errorf("failed to find %s port in %s container for given pod spec\n", portName, k8s.ProxyContainerName)
+	return container, fmt.Errorf("failed to find %s port in %s container for given pod spec", portName, k8s.ProxyContainerName)
 }
 
 func getContainerCertificate(k8sAPI *k8s.KubernetesAPI, pod corev1.Pod, container corev1.Container, portName string, emitLog bool) ([]*x509.Certificate, error) {

--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -21,7 +21,7 @@ import (
 
 var emitLog bool
 
-type Certificates struct {
+type certificate struct {
 	pod         string
 	container   string
 	Certificate []*x509.Certificate
@@ -87,7 +87,7 @@ func newCmdIdentity() *cobra.Command {
 					fmt.Println("Subject: ", result.Certificate[0].Subject)
 					fmt.Println("Issuer:  ", result.Certificate[0].Issuer)
 					fmt.Println("Subject Public Key Info:")
-					fmt.Println("\tPublic Key Alogrithm: ", result.Certificate[0].PublicKeyAlgorithm)
+					fmt.Println("\tPublic Key Algorithm: ", result.Certificate[0].PublicKeyAlgorithm)
 					fmt.Println("Signature: \n", result.Certificate[0].Signature)
 					resultCerticate := tls1.EncodeCertificatesPEM(result.Certificate[0])
 
@@ -106,9 +106,9 @@ func newCmdIdentity() *cobra.Command {
 }
 
 // getCertificate fetches the certificates for all the pods
-func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, waitingTime time.Duration, emitLog bool) []Certificates {
-	var certificates []Certificates
-	resultChan := make(chan Certificates)
+func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName string, waitingTime time.Duration, emitLog bool) []certificate {
+	var certificates []certificate
+	resultChan := make(chan certificate)
 	var activeRoutines int32
 	for _, pod := range pods {
 		atomic.AddInt32(&activeRoutines, 1)
@@ -116,7 +116,7 @@ func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName strin
 			defer atomic.AddInt32(&activeRoutines, -1)
 			containers, err := getContainersWithPort(p, portName)
 			if err != nil {
-				resultChan <- Certificates{
+				resultChan <- certificate{
 					pod: p.GetName(),
 					err: err,
 				}
@@ -125,7 +125,7 @@ func getCertificate(k8sAPI *k8s.KubernetesAPI, pods []corev1.Pod, portName strin
 
 			for _, c := range containers {
 				cert, err := getContainerCertificate(k8sAPI, p, c, portName, emitLog)
-				resultChan <- Certificates{
+				resultChan <- certificate{
 					pod:         p.GetName(),
 					container:   c.Name,
 					Certificate: cert,

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -116,6 +116,7 @@ func init() {
 	RootCmd.AddCommand(newCmdDoc())
 	RootCmd.AddCommand(newCmdEdges())
 	RootCmd.AddCommand(newCmdEndpoints())
+	RootCmd.AddCommand(newCmdIdentity())
 	RootCmd.AddCommand(newCmdInject())
 	RootCmd.AddCommand(newCmdInstall())
 	RootCmd.AddCommand(newCmdInstallCNIPlugin())

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-openapi/spec v0.19.3
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/websocket v1.4.0
+	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/imdario/mergo v0.3.8
 	github.com/julienschmidt/httprouter v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
+github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b h1:NGgE5ELokSf2tZ/bydyDUKrvd/jP8lrAoPNeBuMOTOk=
+github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b/go.mod h1:zT/uzhdQGTqlwTq7Lpbj3JoJQWfPfIJ1tE0OidAmih8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -459,14 +461,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/linkerd/linkerd2-proxy-api v0.1.15 h1:hy/36GwG+BnKxxh3BAnC5cfUsH/ZAxuzuOSsGM3KfkM=
-github.com/linkerd/linkerd2-proxy-api v0.1.15/go.mod h1:yFz+DCCEomC3vpsChFzfCuOuSJtzx7jMNNHBIlbFil0=
-github.com/linkerd/linkerd2-proxy-api v0.1.16-0.20201221204305-2913e990c702 h1:CweHoGEw9PC1uz7GaHH+N276QDcW+Svk9taapkvGqX4=
-github.com/linkerd/linkerd2-proxy-api v0.1.16-0.20201221204305-2913e990c702/go.mod h1:yFz+DCCEomC3vpsChFzfCuOuSJtzx7jMNNHBIlbFil0=
 github.com/linkerd/linkerd2-proxy-api v0.1.16 h1:Qjqbw5Bw3QYUJpUSpYHr4nkJqBRnTlsFUwncCtCdOEs=
 github.com/linkerd/linkerd2-proxy-api v0.1.16/go.mod h1:yFz+DCCEomC3vpsChFzfCuOuSJtzx7jMNNHBIlbFil0=
-github.com/linkerd/linkerd2-proxy-init v1.3.7 h1:S/xBSHArQyd+hPrnkcAr+eOf+SGOoCmxr27n40fI+fo=
-github.com/linkerd/linkerd2-proxy-init v1.3.7/go.mod h1:M6iaaLLi06ofuIV6x74SDknSFi7VS/MFqa5m+CwHgLY=
 github.com/linkerd/linkerd2-proxy-init v1.3.8 h1:fo/LbrIS3FHssAPLkVXi5h8K/3mWP7ncVwOU2oI6Dm8=
 github.com/linkerd/linkerd2-proxy-init v1.3.8/go.mod h1:M6iaaLLi06ofuIV6x74SDknSFi7VS/MFqa5m+CwHgLY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=


### PR DESCRIPTION
 CLI: Introduced `identity` command to fetch tls-certificates for a pod (#4459)


Modified and added a new cli command, which initiates a sni-tls session to the proxy's admin port and returns the certificate.

Usage:
- `linkerd identity pod/<pod-name>`   : fetches certificate from the specified pod
- `linkerd identity -n emojivoto`           : fetches certificate from all pods in the emojivoto namespace
- `linkerd identity -l app=svc/emoji`      : fetches certificate from all pods with label app=svc/emoji

Currently, I am not a 100% sure of the way I am outputting the certificates, I'll change that if needed, but overall these commands do fetch the required certificates.

Screenshot:

![Screenshot from 2020-12-18 22-11-28](https://user-images.githubusercontent.com/47107987/102638794-13466f80-417e-11eb-8861-3f709ab444f9.png)

I would be happy to work upon any changes suggested