### PR TITLE
add release notes for edge-20.12.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ async runtime.
   `linkerd-jaeger` extension is working correctly
 * Added new `linkerd jaeger uninstall` CLI command to print the `linkerd-jaeger`
   extension's resources so that they can be piped into `kubectl delete`
-* Fixed an issue where the `linkerd-cni` daemonset may not be installed on all
+* Fixed an issue where the `linkerd-cni` daemgitonset may not be installed on all
   intended nodes, due to missing tolerations to the `linkerd-cni` Helm chart
   (thanks @rish-onesignal!)
 * Fixed an issue where the `tap` APIServer would not refresh its certs
@@ -35,6 +35,7 @@ async runtime.
   connection pools which might open conenctions without immediately making a
   request
 * Updated the proxy's Tokio dependency to v0.3
+
 ## edge-20.12.3
 
 This edge release is functionally the same as `edge-20.12.2`. It fixes an issue

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ async runtime.
   detection
 * Fixed an issue where `linkerd install --ha` failed to honor flags
 * Fixed an issue where `linkerd upgrade --ha` can override existing configs
+* Added missing label to the `linkerd-config-overrides` secret to avoid breaking
+  upgrades performed with the help of `kubectl apply --prune`
 * Added a missing icon to Jaeger Helm chart
 * Added new `linkerd jaeger check` CLI command to validate that the
   `linkerd-jaeger` extension is working correctly

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,40 @@
 
 # Changes
 
+## edge-20.12.4
+
+This edge release adds support for the `config.linkerd.io/opaque-ports`
+annotation on pods and namespaces, to configure ports that should skip the
+proxy's protocol detection. In addition, it adds new CLI commands related to the
+`linkerd-jaeger` extension, fixes bugs in the CLI `install` and `upgrade`
+commands and Helm charts, and fixes a potential false positive in the proxy's
+HTTP protocol detection. Finally, it includes improvements in proxy performance
+and memory usage, including an upgrade for the proxy's dependency on the Tokio
+async runtime.
+
+* Added support for the `config.linkerd.io/opaque-ports` annotation on pods and
+  namespaces, to indicate to the proxy that some ports should skip protocol
+  detection
+* Fixed an issue where `linkerd install --ha` failed to honor flags
+* Fixed an issue where `linkerd upgrade --ha` can override existing configs
+* Added a missing icon to Jaeger Helm chart
+* Added new `linkerd jaeger check` CLI command to validate that the
+  `linkerd-jaeger` extension is working correctly
+* Added new `linkerd jaeger uninstall` CLI command to print the `linkerd-jaeger`
+  extension's resources so that they can be piped into `kubectl delete`
+* Fixed an issue where the `linkerd-cni` daemonset may not be installed on all
+  intended nodes, due to missing tolerations to the `linkerd-cni` Helm chart
+  (thanks @rish-onesignal!)
+* Fixed an issue where the `tap` APIServer would not refresh its certs
+  automatically when provided externally—like through cert-manager
+* Changed the proxy's cache eviction strategy to reduce memory consumption,
+  especially for busy HTTP/1.1 clients
+* Fixed an issue in the proxy's HTTP protocol detection which could cause false
+  positives for non-HTTP traffic
+* Increased the proxy's default dispatch timeout to 5 seconds to accomodate
+  connection pools which might open conenctions without immediately making a
+  request
+* Updated the proxy's Tokio dependency to v0.3
 ## edge-20.12.3
 
 This edge release is functionally the same as `edge-20.12.2`. It fixes an issue


### PR DESCRIPTION
This edge release adds support for the `config.linkerd.io/opaque-ports`
annotation on pods and namespaces, to configure ports that should skip
the proxy's protocol detection. In addition, it adds new CLI commands
related to the `linkerd-jaeger` extension, fixes bugs in the CLI
`install` and `upgrade` commands and Helm charts, and fixes a potential
false positive in the proxy's HTTP protocol detection. Finally, it
includes improvements in proxy performance and memory usage, including
an upgrade for the proxy's dependency on the Tokio async runtime.

* Added support for the `config.linkerd.io/opaque-ports` annotation on
  pods and namespaces, to indicate to the proxy that some ports should
  skip protocol detection
* Fixed an issue where `linkerd install --ha` failed to honor flags
* Fixed an issue where `linkerd upgrade --ha` can override existing
  configs
* Added missing label to the `linkerd-config-overrides` secret to avoid 
  breaking upgrades performed with the help of `kubectl apply --prune`
* Added a missing icon to Jaeger Helm chart
* Added new `linkerd jaeger check` CLI command to validate that the
  `linkerd-jaeger` extension is working correctly
* Added new `linkerd jaeger uninstall` CLI command to print the
  `linkerd-jaeger` extension's resources so that they can be piped into
  `kubectl delete`
* Fixed an issue where the `linkerd-cni` daemonset may not be installed
  on all intended nodes, due to missing tolerations to the `linkerd-cni`
  Helm chart (thanks @rish-onesignal!)
* Fixed an issue where the `tap` APIServer would not refresh its certs
  automatically when provided externally—like through cert-manager
* Changed the proxy's cache eviction strategy to reduce memory
  consumption, especially for busy HTTP/1.1 clients
* Fixed an issue in the proxy's HTTP protocol detection which could
  cause false positives for non-HTTP traffic
* Increased the proxy's default dispatch timeout to 5 seconds to
  accomodate connection pools which might open conenctions without
  immediately making a request
* Updated the proxy's Tokio dependency to v0.3

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
