### PR TITLE
Ignore pods with status.phase=Succeeded when watching IP addresses

### DIFF
--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -95,6 +95,24 @@ status:
   phase: Running
   podIP: 172.17.0.13`,
 		`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name2-2
+  namespace: ns
+status:
+  phase: Succeeded
+  podIP: 172.17.0.13`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name2-3
+  namespace: ns
+status:
+  phase: Failed
+  podIP: 172.17.0.13`,
+		`
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:


### PR DESCRIPTION
Ignore pods with status.phase=Succeeded when watching IP addresses

When a pod terminates successfully, some CNIs will assign its IP address
to newly created pods. This can lead to duplicate pod IPs in the same
Kubernetes cluster.

Filter out pods which are in a Succeeded phase since they are not 
routable anymore.

Fixes #5394
