### PR TITLE
Remove count from opaque ports tcp metric

### DIFF
--- a/test/integration/opaqueports/opaque_ports_test.go
+++ b/test/integration/opaqueports/opaque_ports_test.go
@@ -19,7 +19,7 @@ var (
 
 	// With the app's port marked as opaque, we expect to find a single open
 	// TCP connection that is not TLS'd because the port is skipped.
-	tcpMetric = "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"port_skipped\"} 1"
+	tcpMetric = "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"port_skipped\"}"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
We need to test for the presence of the TCP metric labels, not the exact count.
This change removes the count of `1` so that it can match any count.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
