### PR TITLE
remove check comparing `ca.crt` field in identity issuer secret and trust anchors in config

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1704,11 +1704,6 @@ func (hc *HealthChecker) checkCertificatesConfig(ctx context.Context) (*tls.Cred
 		data, err = issuercerts.FetchIssuerData(ctx, hc.kubeAPI, values.GetGlobal().IdentityTrustAnchorsPEM, hc.ControlPlaneNamespace)
 	} else {
 		data, err = issuercerts.FetchExternalIssuerData(ctx, hc.kubeAPI, hc.ControlPlaneNamespace)
-		// ensure trust anchors in config matches what's in the secret
-		if data != nil && strings.TrimSpace(values.GetGlobal().IdentityTrustAnchorsPEM) != strings.TrimSpace(data.TrustAnchors) {
-			errFormat := "IdentityContext.TrustAnchorsPem does not match %s in %s"
-			err = fmt.Errorf(errFormat, k8s.IdentityIssuerTrustAnchorsNameExternal, k8s.IdentityIssuerSecretName)
-		}
 	}
 
 	if err != nil {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2967,36 +2967,6 @@ func TestLinkerdIdentityCheckCertConfig(t *testing.T) {
 			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid: key ca.crt containing the trust anchors needs to exist in secret linkerd-identity-issuer if --identity-external-issuer=true"},
 		},
 		{
-			checkDescription: "does not get influenced by newline differences between trust anchors (missing newline in configMap)",
-			tlsSecretScheme:  string(corev1.SecretTypeTLS),
-			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
-			configMapIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
-				issuerData.TrustAnchors = strings.TrimSpace(issuerData.TrustAnchors)
-				return issuerData
-			},
-		},
-		{
-			checkDescription: "does not get influenced by newline differences between trust anchors (extra newline in configMap)",
-			tlsSecretScheme:  string(corev1.SecretTypeTLS),
-			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
-			configMapIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
-				issuerData.TrustAnchors = issuerData.TrustAnchors + "\n"
-				return issuerData
-			},
-		},
-		{
-			checkDescription: "does not get influenced by newline differences between trust anchors (missing newline in secret)",
-			tlsSecretScheme:  string(corev1.SecretTypeTLS),
-			schemeInConfig:   string(corev1.SecretTypeTLS),
-			expectedOutput:   []string{"linkerd-identity-test-cat certificate config is valid"},
-			tlsSecretIssuerDataModifier: func(issuerData issuercerts.IssuerCertData) issuercerts.IssuerCertData {
-				issuerData.TrustAnchors = strings.TrimSpace(issuerData.TrustAnchors)
-				return issuerData
-			},
-		},
-		{
 			checkDescription: "fails when trying to parse trust anchors from secret (extra newline in secret)",
 			tlsSecretScheme:  string(corev1.SecretTypeTLS),
 			schemeInConfig:   string(corev1.SecretTypeTLS),


### PR DESCRIPTION
Currently the CA bundles in the config value `global.IdentityTrustAnchorsPEM` must not contain more than one certificate when the schema type is set to `kubernetes.io/tls` or the command `linkerd check` will fail.

This change remove the comparison between the trust anchors configured in the linkerd config map and the contents of the `ca.crt` field of the identity issuer K8s secret.

This is an alternative to MR #5396, which I will close as a result of the discussion with @adleong  

Fixes #5292 

Signed-off-by: Lutz Behnke <lutz.behnke@finleap.com>
