### PR TITLE
fix(linkerd2-cni): execute container preStop command `kill` command as shell-builtin

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -220,9 +220,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
         - mountPath: /host{{.Values.destCNIBinDir}}

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -185,9 +185,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -186,9 +186,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/my-cni/bin
           name: cni-bin-dir

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -186,9 +186,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/etc/kubernetes/cni/net.d
           name: cni-net-dir

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -176,9 +176,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/my-cni/bin
           name: cni-bin-dir

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -185,9 +185,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -187,9 +187,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           name: cni-bin-dir

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -188,9 +188,14 @@ spec:
         - name: SLEEP
           value: "true"
         lifecycle:
+          # In some edge-cases this helps ensure that cleanup() is called in the container's script
+          # https://github.com/linkerd/linkerd2/issues/2355
           preStop:
             exec:
-              command: ["kill","-15","1"]
+              command:
+              - /bin/sh
+              - -c
+              - kill -15 1
         volumeMounts:
         - mountPath: /host/opt/cni/bin-test
           name: cni-bin-dir


### PR DESCRIPTION
The container-image `ghcr.io/linkerd/cni-plugin:stable-2.9.1` does not contain the `kill` command as an executable. Instead, it is available as a shell built-in. In its current state, Kubernetes emits error events whenever linkerd2-cni pods are terminated because the `kill` command can not be found.