### PR TITLE
Added support for custom registries in the linkerd-viz helm chart

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -85,6 +85,7 @@ Kubernetes: `>=1.13.0-0`
 | dashboard.resources.memory.limit | string | `nil` | Maximum amount of memory that web container can use |
 | dashboard.resources.memory.request | string | `nil` | Amount of memory that the web container requests |
 | dashboard.restrictPrivileges | bool | `false` | Restrict the Linkerd Dashboard's default privileges to disallow Tap and Check |
+| defaultRegistry | string | `"ghcr.io/linkerd"` | Default Docker Registry |
 | extensionAnnotation | string | `"linkerd.io/extension"` |  |
 | globalLogLevel | string | `"info"` | Log level for all the viz components |
 | globalUID | int | `2103` | UID for all the viz components |
@@ -124,9 +125,9 @@ Kubernetes: `>=1.13.0-0`
 | tap.caBundle | string | `""` | Bundle of CA certificates for Tap component. If not provided then Helm will use the certificate generated  for `tap.crtPEM`. If `tap.externalSecret` is set to true, this value must be set, as no certificate will be generated. |
 | tap.crtPEM | string | `""` | Certificate for the Tap component. If not provided then Helm will generate one. |
 | tap.externalSecret | bool | `false` | Do not create a secret resource for the Tap component. If this is set to `true`, the value `tap.caBundle` must be set (see below). |
-| tap.image.name | string | `"controller"` | Docker image name for the grafana instance |
-| tap.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the grafana instance |
-| tap.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the grafana instance |
+| tap.image.name | string | `"controller"` | Docker image name for the tap instance |
+| tap.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the tap instance |
+| tap.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the tap instance |
 | tap.keyPEM | string | `""` | Certificate key for Tap component. If not provided then Helm will generate one.  |
 | tap.logLevel | string | `"info"` | log level of the tap component |
 | tap.replicas | int | `1` |  |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -75,7 +75,8 @@ Kubernetes: `>=1.13.0-0`
 | createdByAnnotation | string | `"linkerd.io/created-by"` |  |
 | dashboard.UID | int | `2103` |  |
 | dashboard.enforcedHostRegexp | string | `""` | Host header validation regex for the dashboard. See the [Linkerd documentation](https://linkerd.io/2/tasks/exposing-dashboard) for more information |
-| dashboard.image.name | string | `"ghcr.io/linkerd/web"` | Docker image name for the web instance |
+| dashboard.image.name | string | `"web"` | Docker image name for the web instance |
+| dashboard.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the web instance |
 | dashboard.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the web instance |
 | dashboard.logLevel | string | `"info"` | log level of the dashboard component |
 | dashboard.replicas | int | `1` | Number of replicas of dashboard |
@@ -88,7 +89,8 @@ Kubernetes: `>=1.13.0-0`
 | globalLogLevel | string | `"info"` | Log level for all the viz components |
 | globalUID | int | `2103` | UID for all the viz components |
 | grafana.enabled | bool | `true` | toggle field to enable or disable grafana |
-| grafana.image.name | string | `"ghcr.io/linkerd/grafana"` | Docker image name for the grafana instance |
+| grafana.image.name | string | `"grafana"` | Docker image name for the grafana instance |
+| grafana.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the grafana instance |
 | grafana.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the grafana instance |
 | grafana.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the grafana container can use |
 | grafana.resources.cpu.request | string | `nil` | Amount of CPU units that the grafana container requests |
@@ -105,8 +107,9 @@ Kubernetes: `>=1.13.0-0`
 | prometheus.args | object | `{"config.file":"/etc/prometheus/prometheus.yml","log.level":"info","storage.tsdb.path":"/data","storage.tsdb.retention.time":"6h"}` | Command line options for Prometheus binary |
 | prometheus.enabled | bool | `true` | toggle field to enable or disable prometheus |
 | prometheus.globalConfig | object | `{"evaluation_interval":"10s","scrape_interval":"10s","scrape_timeout":"10s"}` | The global configuration specifies parameters that are valid in all other configuration contexts. |
-| prometheus.image.name | string | `"prom/prometheus"` | Docker image name for the prometheus instance |
+| prometheus.image.name | string | `"prometheus"` | Docker image name for the prometheus instance |
 | prometheus.image.pullPolicy | string | `"Always"` |  |
+| prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
 | prometheus.image.tag | string | `"v2.19.3"` | Docker image tag for the prometheus instance |
 | prometheus.remoteWrite | string | `nil` | Allows transparently sending samples to an endpoint. Mostly used for long term storage. |
 | prometheus.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the prometheus container can use |
@@ -121,7 +124,8 @@ Kubernetes: `>=1.13.0-0`
 | tap.caBundle | string | `""` | Bundle of CA certificates for Tap component. If not provided then Helm will use the certificate generated  for `tap.crtPEM`. If `tap.externalSecret` is set to true, this value must be set, as no certificate will be generated. |
 | tap.crtPEM | string | `""` | Certificate for the Tap component. If not provided then Helm will generate one. |
 | tap.externalSecret | bool | `false` | Do not create a secret resource for the Tap component. If this is set to `true`, the value `tap.caBundle` must be set (see below). |
-| tap.image.name | string | `"ghcr.io/linkerd/controller"` | Docker image name for the grafana instance |
+| tap.image.name | string | `"controller"` | Docker image name for the grafana instance |
+| tap.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the grafana instance |
 | tap.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the grafana instance |
 | tap.keyPEM | string | `""` | Certificate key for Tap component. If not provided then Helm will generate one.  |
 | tap.logLevel | string | `"info"` | log level of the tap component |

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -127,7 +127,7 @@ spec:
         # see https://github.com/grafana/grafana/issues/20096
         - name: GODEBUG
           value: netdns=go
-        image: {{.Values.grafana.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.grafana.image.tag}}
+        image: {{.Values.grafana.image.registry}}/{{.Values.grafana.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.grafana.image.tag}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -242,7 +242,7 @@ spec:
         {{- range $key, $value := .Values.prometheus.args}}
         - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
         {{- end }}
-        image: {{.Values.prometheus.image.name}}:{{.Values.prometheus.image.tag}}
+        image: {{.Values.prometheus.image.registry}}/{{.Values.prometheus.image.name}}:{{.Values.prometheus.image.tag}}
         imagePullPolicy: {{.Values.prometheus.imagepullPolicy}}
         livenessProbe:
           httpGet:

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -81,7 +81,7 @@ spec:
         - -controller-namespace={{.Values.linkerdNamespace}}
         - -log-level={{.Values.tap.logLevel}}
         - -identity-trust-domain={{.Values.identityTrustDomain}}
-        image: {{.Values.tap.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.tap.image.tag}}
+        image: {{.Values.tap.image.registry}}/{{.Values.tap.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.tap.image.tag}}
         imagePullPolicy: {{.Values.tap.image.pullPolicy}}
         livenessProbe:
           httpGet:

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -84,7 +84,7 @@ spec:
         {{- $hostAbbrev := replace "." "\\." (printf "linkerd-web.%s.svc" .Values.namespace) }}
         - -enforced-host=^(localhost|127\.0\.0\.1|{{ $hostFull }}|{{ $hostAbbrev }}|\[::1\])(:\d+)?$
         {{- end}}
-        image: {{.Values.dashboard.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.dashboard.image.tag}}
+        image: {{.Values.dashboard.image.registry}}/{{.Values.dashboard.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.dashboard.image.tag}}
         imagePullPolicy: {{.Values.dashboard.image.pullPolicy}}
         livenessProbe:
           httpGet:

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -59,8 +59,10 @@ tap:
   # -- log level of the tap component
   logLevel: *log_level
   image:
+    # -- Docker registry for the grafana instance
+    registry: ghcr.io/linkerd
     # -- Docker image name for the grafana instance
-    name: ghcr.io/linkerd/controller
+    name: controller
     # -- Docker image tag for the grafana instance
     tag: *linkerd_version
   # -- Do not create a secret resource for the Tap component. If this is set to
@@ -101,8 +103,10 @@ dashboard:
   # -- log level of the dashboard component
   logLevel: *log_level
   image:
+    # -- Docker registry for the web instance
+    registry: ghcr.io/linkerd
     # -- Docker image name for the web instance
-    name: ghcr.io/linkerd/web
+    name: web
     # -- Docker image tag for the web instance
     tag: *linkerd_version
 
@@ -132,8 +136,10 @@ grafana:
   # -- toggle field to enable or disable grafana
   enabled: true
   image:
+    # -- Docker registry for the grafana instance
+    registry: ghcr.io/linkerd
     # -- Docker image name for the grafana instance
-    name: ghcr.io/linkerd/grafana
+    name: grafana
     # -- Docker image tag for the grafana instance
     tag: *linkerd_version
 
@@ -152,9 +158,11 @@ grafana:
 prometheus:
   # -- toggle field to enable or disable prometheus
   enabled: true
-  image: 
+  image:
+    # -- Docker registry for the prometheus instance
+    registry: prom
     # -- Docker image name for the prometheus instance
-    name: prom/prometheus
+    name: prometheus
     # -- Docker image tag for the prometheus instance
     tag: v2.19.3
     # == Pull policy for the prometheus instance

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -7,6 +7,9 @@
 # -- control plane version. See Proxy section for proxy version
 linkerdVersion: &linkerd_version linkerdVersionValue
 
+# -- Default Docker Registry
+defaultRegistry: &default_registry ghcr.io/linkerd
+
 # -- Kubernetes DNS Domain name to use  
 clusterDomain: &cluster_domain cluster.local
 
@@ -59,11 +62,11 @@ tap:
   # -- log level of the tap component
   logLevel: *log_level
   image:
-    # -- Docker registry for the grafana instance
-    registry: ghcr.io/linkerd
-    # -- Docker image name for the grafana instance
+    # -- Docker registry for the tap instance
+    registry: *default_registry
+    # -- Docker image name for the tap instance
     name: controller
-    # -- Docker image tag for the grafana instance
+    # -- Docker image tag for the tap instance
     tag: *linkerd_version
   # -- Do not create a secret resource for the Tap component. If this is set to
   # `true`, the value `tap.caBundle` must be set (see below).
@@ -104,7 +107,7 @@ dashboard:
   logLevel: *log_level
   image:
     # -- Docker registry for the web instance
-    registry: ghcr.io/linkerd
+    registry: *default_registry
     # -- Docker image name for the web instance
     name: web
     # -- Docker image tag for the web instance
@@ -137,7 +140,7 @@ grafana:
   enabled: true
   image:
     # -- Docker registry for the grafana instance
-    registry: ghcr.io/linkerd
+    registry: *default_registry
     # -- Docker image name for the grafana instance
     name: grafana
     # -- Docker image tag for the grafana instance


### PR DESCRIPTION
Split the image `name` field in `viz/charts/linkerd-viz/values.yaml` into `name` and `registry` to support custom registries. Changed the template files accordingly.

Just like other values, the registry can now be configured via CLI via the `--set-*` flags.

Fixes #5430

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
