### PR TITLE
Enable setting gateway addresses from ExternalIPs or ExternalName

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -171,12 +171,8 @@ func newLinkCommand() *cobra.Command {
 				}
 				gatewayAddresses = append(gatewayAddresses, addr)
 			}
-			if len(gatewayAddresses) == 0 {
-				if len(gateway.Spec.ExternalIPs) > 0 {
-					gatewayAddresses = append(gatewayAddresses, gateway.Spec.ExternalIPs...)
-				} else if gateway.Spec.ExternalName != "" {
-					gatewayAddresses = append(gatewayAddresses, gateway.Spec.ExternalName)
-				}
+			if len(gatewayAddresses) == 0 && gateway.Spec.ExternalName != "" {
+				gatewayAddresses = append(gatewayAddresses, gateway.Spec.ExternalName)
 			}
 			if len(gatewayAddresses) == 0 {
 				return fmt.Errorf("Gateway %s.%s has no ingress addresses", gateway.Name, gateway.Namespace)

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -172,6 +172,13 @@ func newLinkCommand() *cobra.Command {
 				gatewayAddresses = append(gatewayAddresses, addr)
 			}
 			if len(gatewayAddresses) == 0 {
+				if len(gateway.Spec.ExternalIPs) > 0 {
+					gatewayAddresses = append(gatewayAddresses, gateway.Spec.ExternalIPs...)
+				} else if gateway.Spec.ExternalName != "" {
+					gatewayAddresses = append(gatewayAddresses, gateway.Spec.ExternalName)
+				}
+			}
+			if len(gatewayAddresses) == 0 {
 				return fmt.Errorf("Gateway %s.%s has no ingress addresses", gateway.Name, gateway.Namespace)
 			}
 


### PR DESCRIPTION
Problem: LoadBalancer type Services may not be supported or allowed in some Kubernetes clusters, so fetching the gateway address from the status.loadBalancer.ingress field of the Service object doesn't work.

Solution: Enable setting the gateway address using the spec.ExternalName field of the Service object as this can be set without LoadBalancer support.

Fixes #5462

Signed-off-by: Keith Burdis <keith.burdis@gs.com>
