### PR TITLE
Change injector proxy version annotation

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -599,7 +599,7 @@ func (conf *ResourceConfig) serviceAccountVolumeMount() *corev1.VolumeMount {
 // annotations.
 func (conf *ResourceConfig) injectObjectMeta(values *patch) {
 
-	values.Annotations[k8s.ProxyVersionAnnotation] = conf.values.GetGlobal().Proxy.Image.Version
+	values.Annotations[k8s.ProxyVersionAnnotation] = values.GetGlobal().Proxy.Image.Version
 
 	if values.Identity == nil || values.GetGlobal().Proxy.DisableIdentity {
 		values.Annotations[k8s.IdentityModeAnnotation] = k8s.IdentityModeDisabled


### PR DESCRIPTION
### What

When overriding the proxy version using annotations, the respective annotation displays the wrong information (`linkerd.io/proxy-version`). This is a simple fix to display the correct version for the annotation; instead of using the proxy image from the config for the annotation's value, we take it from the overriden values instead.

Based on the discussion from #5338 I understood that when the image is updated it is reflected in the container image version but not the annotation. Alex's proposed fix seems to work like a charm so I can't really take credit for anything. I have attached below some before/after snippets of the deployments & pods. If there any additional changes required (or if I misunderstood anything) let me know and I'll gladly get it sorted :) 

#### Tests
---

Didn't add any new tests, I built the images and just tested the annotation displays the correct version. 

To test:
* I first injected an emojivoto-web deployment, its respective pod had the proxy version set to `dev-...`;
* I then re-injected the same deployment using a different proxy version and restarted the pods, its respective pod displayed the expected annotation value `stable-2.9.0` (whereas before it would have still been `dev-...`)

`Before`
```
# Deployment
apiVersion: apps/v1
kind: Deployment
...
   template:
    metadata:
      annotations:
        kubectl.kubernetes.io/restartedAt: "2021-01-04T12:41:47Z"
        linkerd.io/inject: enabled

# Pod
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubectl.kubernetes.io/restartedAt: "2021-01-04T12:41:47Z"
    linkerd.io/created-by: linkerd/proxy-injector dev-8d506317-madavid
    linkerd.io/identity-mode: default
    linkerd.io/inject: enabled
    linkerd.io/proxy-version: dev-8d506317-madavid
```
 
`After`
```sh
$ linkerd inject --proxy-version stable-2.9.0 - | kubectl apply -f -  

# Deployment
apiVersion: apps/v1
kind: Deployment
...
  template:
    metadata:
      annotations:
        config.linkerd.io/proxy-version: stable-2.9.0
        
# Pod
apiVersion: v1
kind: Pod
metadata:
  annotations:
    config.linkerd.io/proxy-version: stable-2.9.0
    kubectl.kubernetes.io/restartedAt: "2021-01-04T12:41:47Z"
    linkerd.io/created-by: linkerd/proxy-injector dev-8d506317-madavid
    linkerd.io/identity-mode: default
    linkerd.io/inject: enabled
    linkerd.io/proxy-version: stable-2.9.0

# linkerd.io/proxy-version changed after injection and now matches the config (and the proxy img)
```

_Fixes #5338_

Signed-off-by: Matei David <matei.david.35@gmail.com>

