### PR TITLE
 Make service profile generation work offline using --ignore-cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor
 **/*.swp
 **/charts/**/charts
 package-lock.json
+.vscode

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -34,6 +34,7 @@
 - [Novolabs](https://novolabs.com)
 - [Paybase](https://paybase.io/)
 - [PlayStudios Asia](https://www.playstudios.asia)
+- [PlexTrac](https://plextrac.com)
 - [PriceKinetics (GVC Australia)](https://www.pricekinetics.com.au/)
 - [Projector](https://projector.com)
 - [Purdue University Global](https://www.purdueglobal.edu/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -23,6 +23,7 @@
 - [Kairos](https://kairos.com)
 - [Kurio](https://kurio.id)
 - [LeadIQ](https://leadiq.com)
+- [Lendico](https://www.lendico.de/)
 - [M1 Finance](https://www.m1finance.com/)
 - [MattePaint](https://www.mattepaint.com/)
 - [MercedesBenz.io](https://www.mercedes-benz.io/)

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -92,9 +92,6 @@ func newCmdProfile() *cobra.Command {
 
   # Generate a profile by watching live traffic based off tap data.
   linkerd profile -n emojivoto web-svc --tap deploy/web --tap-duration 10s --tap-route-limit 5
-
-  # Generate a profile without requiring cluster access
-  linkerd profile -n emojivoto --ignore-cluster
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -53,11 +53,8 @@ func (options *profileOptions) validate() error {
 	if options.tap != "" {
 		outputs++
 	}
-	if options.ignoreCluster {
-		outputs++
-	}
 	if outputs != 1 {
-		return errors.New("You must specify exactly one of --template or --open-api or --proto or --tap or --ignore-cluster")
+		return errors.New("You must specify exactly one of --template or --open-api or --proto or --tap")
 	}
 
 	// a DNS-1035 label must consist of lower case alphanumeric characters or '-',
@@ -81,7 +78,7 @@ func newCmdProfile() *cobra.Command {
 	options := newProfileOptions()
 
 	cmd := &cobra.Command{
-		Use:   "profile [flags] (--template | --open-api file | --proto file | --tap resource | --ignore-cluster) (SERVICE)",
+		Use:   "profile [flags] (--template | --open-api file | --proto file | --tap resource) (SERVICE)",
 		Short: "Output service profile config for Kubernetes",
 		Long:  "Output service profile config for Kubernetes.",
 		Example: `  # Output a basic template to apply after modification.

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -105,7 +105,8 @@ func newCmdProfile() *cobra.Command {
 			}
 			// performs an online profile generation and access-check to k8s cluster to extract
 			// clusterDomain from linkerd configuration
-			if !options.ignoreCluster {
+			// profile generation based on tap data requires access to k8s cluster
+			if !options.ignoreCluster || options.tap != "" {
 				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 				if err != nil {
 					return err

--- a/controller/api/destination/opaque_ports_adaptor.go
+++ b/controller/api/destination/opaque_ports_adaptor.go
@@ -1,7 +1,6 @@
 package destination
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
@@ -11,7 +10,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/util"
 	logging "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 // opaquePortsAdaptor implements EndpointUpdateListener so that it can watch
@@ -73,7 +71,7 @@ func (opa *opaquePortsAdaptor) getOpaquePorts(set watcher.AddressSet) map[uint32
 	for _, address := range set.Addresses {
 		pod := address.Pod
 		if pod != nil {
-			override, err := getOpaquePortsAnnotations(opa.k8sAPI, pod)
+			override, err := getOpaquePortsAnnotations(pod)
 			if err != nil {
 				opa.log.Errorf("Failed to get opaque ports annotation for pod %s: %s", pod, err)
 			}
@@ -91,36 +89,14 @@ func (opa *opaquePortsAdaptor) publish() {
 		merged = *opa.profile
 	}
 	merged.Spec.OpaquePorts = opa.opaquePorts
-	fmt.Printf("publishing SP: %v", merged)
 	opa.listener.Update(&merged)
 }
 
-func getOpaquePortsAnnotations(k8sAPI *k8s.API, pod *corev1.Pod) (map[uint32]struct{}, error) {
+func getOpaquePortsAnnotations(pod *corev1.Pod) (map[uint32]struct{}, error) {
 	opaquePorts := make(map[uint32]struct{})
-	obj, err := k8sAPI.GetObjects("", pkgk8s.Namespace, pod.Namespace, labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-	if len(obj) > 1 {
-		return nil, fmt.Errorf("Namespace conflict: %v, %v", obj[0], obj[1])
-	}
-	if len(obj) != 1 {
-		return nil, fmt.Errorf("Namespace not found: %v", pod.Namespace)
-	}
-	ns, ok := obj[0].(*corev1.Namespace)
-	if !ok {
-		// This is very unlikely due to how `GetObjects` works
-		return nil, fmt.Errorf("Object with name %s was not a namespace", pod.Namespace)
-	}
-	override := ns.Annotations[pkgk8s.ProxyOpaquePortsAnnotation]
-
-	// Pod annotations override namespace annotations
-	if podOverride, ok := pod.Annotations[pkgk8s.ProxyOpaquePortsAnnotation]; ok {
-		override = podOverride
-	}
-
-	if override != "" {
-		for _, portStr := range util.ParseOpaquePorts(override, pod.Spec.Containers) {
+	annotation := pod.Annotations[pkgk8s.ProxyOpaquePortsAnnotation]
+	if annotation != "" {
+		for _, portStr := range util.ParseOpaquePorts(annotation, pod.Spec.Containers) {
 			port, err := strconv.ParseUint(portStr, 10, 32)
 			if err != nil {
 				return nil, err
@@ -128,6 +104,5 @@ func getOpaquePortsAnnotations(k8sAPI *k8s.API, pod *corev1.Pod) (map[uint32]str
 			opaquePorts[uint32(port)] = struct{}{}
 		}
 	}
-
 	return opaquePorts, nil
 }

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -208,19 +208,21 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 					Namespace: pod.Namespace,
 					Name:      pod.Name,
 				}
-				endpoint, err = toWeightedAddr(podSet.Addresses[podID], s.enableH2Upgrade, s.identityTrustDomain, s.controllerNS, log)
+				err := watcher.SetPodOpaquePortAnnotation(s.k8sAPI, pod, pod.Namespace)
+				if err != nil {
+					log.Errorf("failed to set opaque port annotation on pod: %s", err)
+				}
+				opaquePorts, err = getOpaquePortsAnnotations(pod)
+				if err != nil {
+					log.Errorf("failed to get opaque ports annotation for pod: %s", err)
+				}
+				endpoint, err = toWeightedAddr(podSet.Addresses[podID], opaquePorts, s.enableH2Upgrade, s.identityTrustDomain, s.controllerNS, log)
 				if err != nil {
 					return err
 				}
-
 				// `Get` doesn't include the namespace in the per-endpoint
 				// metadata, so it needs to be special-cased.
 				endpoint.MetricLabels["namespace"] = pod.Namespace
-
-				opaquePorts, err = getOpaquePortsAnnotations(s.k8sAPI, pod)
-				if err != nil {
-					return err
-				}
 			}
 
 			// When the IP does not map to a service, the default profile is

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -14,9 +14,12 @@ import (
 )
 
 const fullyQualifiedName = "name1.ns.svc.mycluster.local"
+const fullyQualifiedNameOpaque = "name3.ns.svc.mycluster.local"
 const clusterIP = "172.17.12.0"
+const clusterIPOpaque = "172.17.12.1"
 const podIP1 = "172.17.0.12"
 const podIP2 = "172.17.0.13"
+const podIPOpaque = "172.17.0.14"
 const port uint32 = 8989
 const opaquePort uint32 = 4242
 
@@ -41,7 +44,7 @@ func (m *mockDestinationGetProfileServer) Send(profile *pb.DestinationProfile) e
 }
 
 func makeServer(t *testing.T) *server {
-	k8sAPI, err := k8s.NewFakeAPI(`
+	meshedPodResources := []string{`
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -78,8 +81,6 @@ kind: Pod
 metadata:
   labels:
     linkerd.io/control-plane-ns: linkerd
-  annotations:
-    config.linkerd.io/opaque-ports: "4242"
   name: name1-1
   namespace: ns
 status:
@@ -92,15 +93,6 @@ spec:
         value: 0.0.0.0:4143
       name: linkerd-proxy`,
 		`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: name2-1
-  namespace: ns
-status:
-  phase: Running
-  podIP: 172.17.0.13`,
-		`
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
@@ -112,6 +104,9 @@ spec:
     isRetryable: false
     condition:
       pathRegex: "/a/b/c"`,
+	}
+
+	clientSP := []string{
 		`
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
@@ -124,7 +119,69 @@ spec:
     isRetryable: true
     condition:
       pathRegex: "/x/y/z"`,
-	)
+	}
+
+	unmeshedPod := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name2
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.13`
+
+	meshedOpaquePodResources := []string{
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: name3
+  namespace: ns
+spec:
+  type: LoadBalancer
+  clusterIP: 172.17.12.1
+  ports:
+  - port: 4242`,
+		`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: name3
+  namespace: ns
+subsets:
+- addresses:
+  - ip: 172.17.0.14
+    targetRef:
+      kind: Pod
+      name: name3
+      namespace: ns
+  ports:
+  - port: 4242`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    linkerd.io/control-plane-ns: linkerd
+  annotations:
+    config.linkerd.io/opaque-ports: "4242"
+  name: name3
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.14
+spec:
+  containers:
+    - env:
+      - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+        value: 0.0.0.0:4143
+      name: linkerd-proxy`,
+	}
+	res := append(meshedPodResources, clientSP...)
+	res = append(res, unmeshedPod)
+	res = append(res, meshedOpaquePodResources...)
+	k8sAPI, err := k8s.NewFakeAPI(res...)
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
@@ -482,8 +539,8 @@ func TestGetProfiles(t *testing.T) {
 		if first.Endpoint.ProtocolHint == nil {
 			t.Fatalf("Expected protocol hint but found none")
 		}
-		if first.Endpoint.ProtocolHint.GetOpaqueTransport().InboundPort != 4143 {
-			t.Fatalf("Expected pod to support opaque traffic on port 4143")
+		if first.Endpoint.ProtocolHint.GetOpaqueTransport() != nil {
+			t.Fatalf("Expected pod to not support opaque traffic on port %d", port)
 		}
 		if first.Endpoint.Addr.String() != epAddr.String() {
 			t.Fatalf("Expected endpoint IP to be %s, but it was %s", epAddr.Ip, first.Endpoint.Addr.Ip)
@@ -556,7 +613,7 @@ func TestGetProfiles(t *testing.T) {
 		stream.Cancel()
 		err := server.GetProfile(&pb.GetDestination{
 			Scheme: "k8s",
-			Path:   fmt.Sprintf("%s:%d", clusterIP, opaquePort),
+			Path:   fmt.Sprintf("%s:%d", clusterIPOpaque, opaquePort),
 		}, stream)
 		if err != nil {
 			t.Fatalf("Got error: %s", err)
@@ -569,15 +626,11 @@ func TestGetProfiles(t *testing.T) {
 		}
 
 		last := stream.updates[len(stream.updates)-1]
-		if last.FullyQualifiedName != fullyQualifiedName {
-			t.Fatalf("Expected fully qualified name '%s', but got '%s'", fullyQualifiedName, last.FullyQualifiedName)
+		if last.FullyQualifiedName != fullyQualifiedNameOpaque {
+			t.Fatalf("Expected fully qualified name '%s', but got '%s'", fullyQualifiedNameOpaque, last.FullyQualifiedName)
 		}
 		if !last.OpaqueProtocol {
 			t.Fatalf("Expected port %d to be an opaque protocol, but it was not", opaquePort)
-		}
-		routes := last.GetRoutes()
-		if len(routes) != 1 {
-			t.Fatalf("Expected 1 route but got %d: %v", len(routes), routes)
 		}
 	})
 
@@ -589,14 +642,14 @@ func TestGetProfiles(t *testing.T) {
 		}
 		stream.Cancel()
 
-		epAddr, err := toAddress(podIP1, opaquePort)
+		epAddr, err := toAddress(podIPOpaque, opaquePort)
 		if err != nil {
 			t.Fatalf("Got error: %s", err)
 		}
 
 		err = server.GetProfile(&pb.GetDestination{
 			Scheme: "k8s",
-			Path:   fmt.Sprintf("%s:%d", podIP1, opaquePort),
+			Path:   fmt.Sprintf("%s:%d", podIPOpaque, opaquePort),
 		}, stream)
 		if err != nil {
 			t.Fatalf("Got error: %s", err)

--- a/controller/api/public/grpc_server.go
+++ b/controller/api/public/grpc_server.go
@@ -45,11 +45,11 @@ type podReport struct {
 }
 
 const (
-	podQuery                   = "max(process_start_time_seconds{%s}) by (pod, namespace)"
-	k8sClientSubsystemName     = "kubernetes"
-	k8sClientCheckDescription  = "control plane can talk to Kubernetes"
-	promClientSubsystemName    = "prometheus"
-	promClientCheckDescription = "control plane can talk to Prometheus"
+	podQuery                  = "max(process_start_time_seconds{%s}) by (pod, namespace)"
+	k8sClientSubsystemName    = "kubernetes"
+	k8sClientCheckDescription = "control plane can talk to Kubernetes"
+	// promClientSubsystemName    = "prometheus"
+	// promClientCheckDescription = "control plane can talk to Prometheus"
 )
 
 func newGrpcServer(
@@ -206,20 +206,23 @@ func (s *grpcServer) SelfCheck(ctx context.Context, in *healthcheckPb.SelfCheckR
 		},
 	}
 
-	if s.prometheusAPI != nil {
-		promClientCheck := &healthcheckPb.CheckResult{
-			SubsystemName:    promClientSubsystemName,
-			CheckDescription: promClientCheckDescription,
-			Status:           healthcheckPb.CheckStatus_OK,
-		}
-		_, err = s.queryProm(ctx, fmt.Sprintf(podQuery, ""))
-		if err != nil {
-			promClientCheck.Status = healthcheckPb.CheckStatus_ERROR
-			promClientCheck.FriendlyMessageToUser = fmt.Sprintf("Error calling Prometheus from the control plane: %s", err)
-		}
+	// TODO: viz: Enable this check once controller moves to viz
+	/*
+		if s.prometheusAPI != nil {
+			promClientCheck := &healthcheckPb.CheckResult{
+				SubsystemName:    promClientSubsystemName,
+				CheckDescription: promClientCheckDescription,
+				Status:           healthcheckPb.CheckStatus_OK,
+			}
+			_, err = s.queryProm(ctx, fmt.Sprintf(podQuery, ""))
+			if err != nil {
+				promClientCheck.Status = healthcheckPb.CheckStatus_ERROR
+				promClientCheck.FriendlyMessageToUser = fmt.Sprintf("Error calling Prometheus from the control plane: %s", err)
+			}
 
-		response.Results = append(response.Results, promClientCheck)
-	}
+			response.Results = append(response.Results, promClientCheck)
+		}
+	*/
 
 	return response, nil
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1733,12 +1733,12 @@ func (hc *HealthChecker) fetchCredsFromOldSecret(ctx context.Context, secretName
 
 	crt, ok := secret.Data[certOldKeyName]
 	if !ok {
-		return nil, fmt.Errorf("key %s needs to exist in secret %s", certKeyName, secretName)
+		return nil, fmt.Errorf("key %s needs to exist in secret %s", certOldKeyName, secretName)
 	}
 
 	key, ok := secret.Data[keyOldKeyName]
 	if !ok {
-		return nil, fmt.Errorf("key %s needs to exist in secret %s", keyKeyName, secretName)
+		return nil, fmt.Errorf("key %s needs to exist in secret %s", keyOldKeyName, secretName)
 	}
 
 	cred, err := tls.ValidateAndCreateCreds(string(crt), string(key))

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -815,6 +814,10 @@ func TestInstallSP(t *testing.T) {
 	}
 }
 
+// This test fails because no web component is installed during this phase of
+// the extension split. It should be renabled after the issue below is closed.
+// Issue: https://github.com/linkerd/linkerd2/issues/5478
+/*
 func TestDashboard(t *testing.T) {
 	dashboardPort := 52237
 	dashboardURL := fmt.Sprintf("http://localhost:%d", dashboardPort)
@@ -851,6 +854,7 @@ func TestDashboard(t *testing.T) {
 			resp, TestHelper.GetVersion())
 	}
 }
+*/
 
 func TestInject(t *testing.T) {
 	resources, err := testutil.ReadFile("testdata/smoke_test.yaml")

--- a/test/integration/opaqueports/opaque_ports_test.go
+++ b/test/integration/opaqueports/opaque_ports_test.go
@@ -19,7 +19,7 @@ var (
 
 	// With the app's port marked as opaque, we expect to find a single open
 	// TCP connection that is not TLS'd because the port is skipped.
-	tcpMetric = "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"port_skipped\"}"
+	tcpMetric = "tcp_open_connections{peer=\"src\",direction=\"inbound\",tls=\"true\",client_id=\"default.linkerd-opaque-ports-test.serviceaccount.identity.linkerd.cluster.local\"}"
 )
 
 func TestMain(m *testing.M) {
@@ -64,7 +64,7 @@ func TestOpaquePorts(t *testing.T) {
 		testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", appName, err)
 	}
 
-	t.Run("expect inbound TCP connection with no TLS for port_skipped reason", func(t *testing.T) {
+	t.Run("expect inbound TCP connection metric with expected TLS identity", func(t *testing.T) {
 		pods, err := TestHelper.GetPods(ctx, opaquePortsNs, map[string]string{"app": appName})
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "error getting opaque ports app pods", "error getting opaque ports app pods\n%s", err)

--- a/test/integration/testdata/check.cni.golden
+++ b/test/integration/testdata/check.cni.golden
@@ -64,7 +64,6 @@ linkerd-api
 √ control plane pods are ready
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.cni.proxy.golden
+++ b/test/integration/testdata/check.cni.proxy.golden
@@ -68,7 +68,6 @@ linkerd-api
 √ control plane pods are ready
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -52,7 +52,6 @@ linkerd-api
 √ control plane pods are ready
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -56,7 +56,6 @@ linkerd-api
 √ control plane pods are ready
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -56,7 +56,6 @@ linkerd-api
 √ control plane pods are ready
 √ control plane self-check
 √ [kubernetes] control plane can talk to Kubernetes
-√ [prometheus] control plane can talk to Prometheus
 
 linkerd-version
 ---------------


### PR DESCRIPTION
Subject
Related to issue #5401 

Problem
Introduce offline profile generation to skip the access check to k8s cluster

Solution
the `profile` command be updated to support the `--ignore-cluster` flag to skip the check and generate a profile offline

Fixes #[GitHub issue ID]
#5401 

Signed-off-by: Piyush Singariya piyushsingariya@gmail.com
