### PR TITLE
extensions: add links to configurable fields in install cmds help

### DIFF
--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -44,7 +44,7 @@ func newCmdInstall() *cobra.Command {
   linkerd jaeger install --namespace custom | kubectl apply -f -
   
 The installation can be configured by using the --set, --values, --set-string and --set-file flags.
-A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/jaeger
+A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/jaeger/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -41,7 +41,10 @@ func newCmdInstall() *cobra.Command {
 		Example: `  # Default install.
   linkerd jaeger install | kubectl apply -f -
   # Install Jaeger extension into a non-default namespace.
-  linkerd jaeger install --namespace custom | kubectl apply -f -`,
+  linkerd jaeger install --namespace custom | kubectl apply -f -
+  
+Configurable fields can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/jaeger
+  `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {
 				// Ensure there is a Linkerd installation.

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -43,7 +43,8 @@ func newCmdInstall() *cobra.Command {
   # Install Jaeger extension into a non-default namespace.
   linkerd jaeger install --namespace custom | kubectl apply -f -
   
-Configurable fields can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/jaeger
+The installation can be configured by using the --set, --values, --set-string and --set-file flags.
+A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/jaeger
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -45,7 +45,10 @@ func newCmdInstall() *cobra.Command {
 		Short: "Output Kubernetes resources to install linkerd-viz extension",
 		Long:  `Output Kubernetes resources to install linkerd-viz extension.`,
 		Example: `  # Default install.
-  linkerd viz install | kubectl apply -f -`,
+  linkerd viz install | kubectl apply -f -
+ 
+ Configurable fields can be found at https://www.github.com/linkerd/linkerd2/tree/main/viz/charts/linkerd-viz
+  `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {
 				// Ensure there is a Linkerd installation.

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -47,7 +47,8 @@ func newCmdInstall() *cobra.Command {
 		Example: `  # Default install.
   linkerd viz install | kubectl apply -f -
  
- Configurable fields can be found at https://www.github.com/linkerd/linkerd2/tree/main/viz/charts/linkerd-viz
+The installation can be configured by using the --set, --values, --set-string and --set-file flags.
+A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/viz/charts/linkerd-viz/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {


### PR DESCRIPTION
This branch adds links to the configurable fields list for
each extension's install cmd.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
