### PR TITLE
Add support for global deployment annotations

### DIFF
--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -141,6 +141,7 @@ Kubernetes: `>=1.13.0-0`
 | global.controllerLogLevel | string | `"info"` | Log level for the control plane components |
 | global.controllerNamespaceLabel | string | `"linkerd.io/control-plane-ns"` | Control plane label. Do not edit   |
 | global.createdByAnnotation | string | `"linkerd.io/created-by"` | Annotation label for the proxy create. Do not edit.  |
+| global.deploymentAnnotations | object | `{}` | Additional annotations to add to all deployments |
 | global.enableEndpointSlices | bool | `false` | enables the use of EndpointSlice informers for the destination service; enableEndpointSlices should be set to true only if EndpointSlice K8s feature gate is on; the feature is still experimental. |
 | global.grafanaUrl | string | `""` | url of external grafana instance with reverse proxy configured. |
 | global.identityTrustAnchorsPEM | string | `""` | Trust root certificate (ECDSA). It must be provided during install.  |

--- a/charts/linkerd2/templates/controller.yaml
+++ b/charts/linkerd2/templates/controller.yaml
@@ -49,6 +49,9 @@ kind: Deployment
 metadata:
   annotations:
     {{.Values.global.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.global.linkerdVersion) .Values.global.cliVersion}}
+    {{- if .Values.global.deploymentAnnotations }}
+    {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -68,6 +68,9 @@ kind: Deployment
 metadata:
   annotations:
     {{.Values.global.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.global.linkerdVersion) .Values.global.cliVersion}}
+    {{- if .Values.global.deploymentAnnotations }}
+    {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: destination
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -88,6 +88,9 @@ kind: Deployment
 metadata:
   annotations:
     {{.Values.global.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.global.linkerdVersion) .Values.global.cliVersion}}
+    {{- if .Values.global.deploymentAnnotations }}
+    {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: identity
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -12,6 +12,9 @@ kind: Deployment
 metadata:
   annotations:
     {{.Values.global.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.global.linkerdVersion) .Values.global.cliVersion}}
+    {{- if .Values.global.deploymentAnnotations }}
+    {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: proxy-injector
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd2/templates/sp-validator.yaml
+++ b/charts/linkerd2/templates/sp-validator.yaml
@@ -49,6 +49,9 @@ kind: Deployment
 metadata:
   annotations:
     {{.Values.global.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.global.linkerdVersion) .Values.global.cliVersion}}
+    {{- if .Values.global.deploymentAnnotations }}
+    {{- toYaml .Values.global.deploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: sp-validator
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -50,6 +50,9 @@ global:
   # -- url of external grafana instance with reverse proxy configured.
   grafanaUrl: ""
 
+  # -- Additional annotations to add to all deployments
+  deploymentAnnotations: {}
+
   # -- Additional annotations to add to all pods
   podAnnotations: {}
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -87,6 +87,7 @@ Kubernetes: `>=1.13.0-0`
 | dashboard.restrictPrivileges | bool | `false` | Restrict the Linkerd Dashboard's default privileges to disallow Tap and Check |
 | defaultRegistry | string | `"ghcr.io/linkerd"` | Default Docker Registry |
 | extensionAnnotation | string | `"linkerd.io/extension"` |  |
+| globalDeploymentAnnotations | object | `{}` | Annotations for all the viz deployments |
 | globalLogLevel | string | `"info"` | Log level for all the viz components |
 | globalUID | int | `2103` | UID for all the viz components |
 | grafana.enabled | bool | `true` | toggle field to enable or disable grafana |

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -32,6 +32,9 @@ apiVersion: apps/v1
 metadata:
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
+    {{- if .Values.globalDeploymentAnnotations }}
+    {{- toYaml .Values.globalDeploymentAnnotations | nindent 4 }}
+    {{- end }}
   labels:
     {{.Values.extensionAnnotation}}: linkerd-viz
     app.kubernetes.io/name: tap

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -25,6 +25,9 @@ globalLogLevel: &log_level info
 # -- UID for all the viz components
 globalUID: &uid 2103
 
+# -- Annotations for all the viz deployments
+globalDeploymentAnnotations: {}
+
 #  Annotation labels. Do not edit.
 createdByAnnotation: linkerd.io/created-by
 proxyInjectAnnotation: linkerd.io/inject


### PR DESCRIPTION
When secrets and configmaps change in a cluster via
https://linkerd.io/2/tasks/automatically-rotating-control-plane-tls-credentials/,
pods don't restart with the new secret/configmap information and
therefore end up using stale data.

The mechanism we use to restart deployments requires the use of
an annotation in the deployment metadata. This change enables users to
add their deployment annotations to the values.yaml.

This chart was deployed in a test cluster, and it was confirmed that
the annotations we added to our values.yaml file were propagated to the
deployments. Changing configmap/secret data resulted in deployments
restarting, as expected.

Fixes #5489

Signed-off-by: Gabrielle Madden <gabriellemadden333@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
