### PR TITLE
Cleanup dependencies in bin/helm-build

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -21,6 +21,13 @@ trap 'showErr' ERR
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
+# cleanup dependencies
+rm -f charts/linkerd2/charts/*
+rm -f charts/linkerd2-cni/charts/*
+rm -f charts/patch/charts/*
+rm -f jaeger/charts/jaeger/charts/*
+rm -f viz/charts/linkerd-viz/charts/*
+
 "$bindir"/helm lint "$rootdir"/multicluster/charts/linkerd2-multicluster
 "$bindir"/helm lint "$rootdir"/multicluster/charts/linkerd2-multicluster-link
 "$bindir"/helm lint "$rootdir"/charts/partials


### PR DESCRIPTION
Chart dependencies are added as tarballs under the chart's `chart`
subdirectory. When we move chart dependencies around this can leave
stale dependencies behind, ensuing havoc. This PR removes those deps
before calling `helm dep up`.
