### PR TITLE
Uninstall the viz and jaeger extensions in test-cleanup

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -79,12 +79,17 @@ if [[ ${namespaces_controlplane[*]}   || \
     ${apiservices:+"${apiservices[@]}"}
 fi
 
-echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"
-
-populate_array rolebindings              rolebindings                    control-plane-ns
+echo "cleaning up viz extension resources, if present [${k8s_context}]"
+linkerd viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up multicluster resources, if present [${k8s_context}]"
-linkerd mc uninstall 2> /dev/null  | kubectl --context="$k8s_context" delete -f -
+linkerd mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
+linkerd jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"
+populate_array rolebindings              rolebindings                    control-plane-ns
 
 # No action if array is empty
 if [[ ${rolebindings[*]} ]]; then


### PR DESCRIPTION
Use the `uninstall` command for the viz and jaeger extensions to ensure clusters
are cleaned up properly after tests

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
