### PR TITLE
Use linkerd path in test-cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Test cleanup
       if: ${{ always() }}
       # will fail if other steps didn't run, so ignore error
-      run: bin/test-cleanup --linkerd_path "$CMD" || true
+      run: bin/test-cleanup "$CMD" || true
   choco_pack:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Test cleanup
       if: ${{ always() }}
       # will fail if other steps didn't run, so ignore error
-      run: bin/test-cleanup || true
+      run: bin/test-cleanup --linkerd_path "$CMD" || true
   choco_pack:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run

--- a/TEST.md
+++ b/TEST.md
@@ -157,7 +157,7 @@ If using an existing cluster to run tests, the resources can be cleaned up
 manually with:
 
 ```bash
-bin/test-cleanup
+bin/test-cleanup /path/to/linkerd
 ```
 
 #### Testing against a locally-built version of the CLI
@@ -334,7 +334,7 @@ bin/test-scale `pwd`/bin/linkerd
 ## Cleanup
 
 ```bash
-bin/test-cleanup
+bin/test-cleanup /path/to/linkerd
 ```
 
 ## Test against multiple cloud providers

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -147,7 +147,7 @@ handle_cleanup_input() {
           echo "Multliple linkerd paths specified:" >&2
           echo "  $linkerd_path" >&2
           echo "  $1" >&2
-          tests_usage "$0" >&2
+          cleanup_usage "$0" >&2
           exit 64
         fi
         linkerd_path="$1"
@@ -158,7 +158,7 @@ handle_cleanup_input() {
 
   if [ -z "$linkerd_path" ]; then
     echo "Error: path to linkerd binary is required" >&2
-    tests_usage "$0" >&2
+    cleanup_usage "$0" >&2
     exit 64
   fi
 }

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -9,7 +9,7 @@ set +e
 export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
 export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_test_names[*]}")
 
-usage() {
+tests_usage() {
   progname="${0##*/}"
   echo "Run Linkerd integration tests.
 
@@ -40,8 +40,23 @@ Available Commands:
     --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)."
 }
 
+cleanup_usage() {
+  progname="${0##*/}"
+  echo "Cleanup Linkerd integration tests.
 
-handle_input() {
+Usage:
+    ${progname} [--context k8s_context] [--linkerd_path /path/to/linkerd]
+
+Examples:
+    # Cleanup tests using specified Linkerd binary
+    ${progname} --linkerd_path /path/to/linkerd
+
+Available Commands:
+    --context: use a non-default k8s context
+    --linkerd_path: use a specific Linkerd binary"
+}
+
+handle_tests_input() {
   export images="docker"
   export test_name=''
   export skip_cluster_create=''
@@ -50,19 +65,19 @@ handle_input() {
   while  [ "$#" -ne 0 ]; do
     case $1 in
       -h|--help)
-        usage "$0"
+        tests_usage "$0"
         exit 0
         ;;
       --images)
         images=$2
         if [ -z "$images" ]; then
           echo 'Error: the argument for --images was not specified' >&2
-          usage "$0" >&2
+          tests_usage "$0" >&2
           exit 64
         fi
         if [[ $images != "docker" && $images != "archive" && $images != "skip" ]]; then
           echo 'Error: the argument for --images was invalid' >&2
-          usage "$0" >&2
+          tests_usage "$0" >&2
           exit 64
         fi
         shift
@@ -72,7 +87,7 @@ handle_input() {
         test_name=$2
         if [ -z "$test_name" ]; then
           echo 'Error: the argument for --name was not specified' >&2
-          usage "$0" >&2
+          tests_usage "$0" >&2
           exit 64
         fi
         shift
@@ -85,14 +100,14 @@ handle_input() {
       *)
         if echo "$1" | grep -q '^-.*' ; then
           echo "Unexpected flag: $1" >&2
-          usage "$0" >&2
+          tests_usage "$0" >&2
           exit 64
         fi
         if [ -n "$linkerd_path" ]; then
           echo "Multliple linkerd paths specified:" >&2
           echo "  $linkerd_path" >&2
           echo "  $1" >&2
-          usage "$0" >&2
+          tests_usage "$0" >&2
           exit 64
         fi
         linkerd_path="$1"
@@ -103,8 +118,48 @@ handle_input() {
 
   if [ -z "$linkerd_path" ]; then
     echo "Error: path to linkerd binary is required" >&2
-    usage "$0" >&2
+    tests_usage "$0" >&2
     exit 64
+  fi
+}
+
+handle_cleanup_input() {
+  export k8s_context=""
+  export linkerd_path=""
+
+  while  [ "$#" -ne 0 ]; do
+    case $1 in
+      -h|--help)
+        cleanup_usage "$0"
+        exit 0
+        ;;
+      --context)
+        k8s_context=$2
+        shift
+        shift
+        ;;
+      --linkerd_path)
+        linkerd_path=$2
+        if [ -z "$linkerd_path" ]; then
+          echo 'Error: the argument for --linkerd_path was not specified' >&2
+          cleanup_usage "$0" >&2
+          exit 64
+        fi
+        shift
+        shift
+        ;;
+      *)
+        if echo "$1" | grep -q '^-.*' ; then
+          echo "Unexpected flag: $1" >&2
+          cleanup_usage "$0" >&2
+          exit 64
+        fi
+        ;;
+    esac
+  done
+
+  if [ -z "$linkerd_path" ]; then
+    linkerd_path=linkerd
   fi
 }
 
@@ -151,7 +206,7 @@ delete_cluster() {
 }
 
 cleanup_cluster() {
-  "$bindir"/test-cleanup "$context" > /dev/null 2>&1
+  "$bindir"/test-cleanup --linkerd_path "$linkerd_path" --context "$context" > /dev/null 2>&1
   exit_on_err 'error removing existing Linkerd resources'
 }
 
@@ -193,7 +248,7 @@ check_if_l5d_exists() {
 Linkerd resources exist on cluster:
 \n%s\n
 Help:
-    Run: [%s/test-cleanup]' "$resources" "$bindir"
+    Run: [%s/test-cleanup] --linkerd_path ' "$linkerd_path"
     exit 1
   fi
   printf '[ok]\n'

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -28,6 +28,15 @@ Usage: ${FUNCNAME[0]} TARGET_ARRAY RESOURCE_TYPE LINKERD_LABEL (FRIENDLY_NAME)" 
   [ -z "$(eval "[[ \${$1[0]} ]]")" ] && echo "no ${4:-$2} found" >&2
 }
 
+echo "cleaning up viz extension resources, if present [${k8s_context}]"
+"$linkerd_path" viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up multicluster resources, if present [${k8s_context}]"
+"$linkerd_path" mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
+"$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
 # Initialize empty arrays
 namespaces_controlplane=()
 namespaces_cni=()
@@ -40,15 +49,6 @@ podsecuritypolicies=()
 customresourcedefinitions=()
 apiservices=()
 rolebindings=()
-
-echo "cleaning up viz extension resources, if present [${k8s_context}]"
-"$linkerd_path" viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
-
-echo "cleaning up multicluster resources, if present [${k8s_context}]"
-"$linkerd_path" mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
-
-echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
-"$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up control-plane namespaces in k8s-context [${k8s_context}]"
 

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu -o pipefail
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -8,6 +8,8 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 . "$bindir"/_test-helpers.sh
 handle_cleanup_input "$@"
 
+check_linkerd_binary
+
 populate_array() {
   [ $# -ge 3 ] || {
     echo "function ${FUNCNAME[0]} expects 3 mandatory inparameters but got $#

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -2,8 +2,11 @@
 
 set -eu
 
-k8s_context=${1:-""}
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+
+# shellcheck source=_test-helpers.sh
+. "$bindir"/_test-helpers.sh
+handle_cleanup_input "$@"
 
 populate_array() {
   [ $# -ge 3 ] || {
@@ -80,13 +83,13 @@ if [[ ${namespaces_controlplane[*]}   || \
 fi
 
 echo "cleaning up viz extension resources, if present [${k8s_context}]"
-linkerd viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+"$linkerd_path" viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up multicluster resources, if present [${k8s_context}]"
-linkerd mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+"$linkerd_path" mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
-linkerd jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+"$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"
 populate_array rolebindings              rolebindings                    control-plane-ns

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -41,6 +41,15 @@ customresourcedefinitions=()
 apiservices=()
 rolebindings=()
 
+echo "cleaning up viz extension resources, if present [${k8s_context}]"
+"$linkerd_path" viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up multicluster resources, if present [${k8s_context}]"
+"$linkerd_path" mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
+echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
+"$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+
 echo "cleaning up control-plane namespaces in k8s-context [${k8s_context}]"
 
 populate_array namespaces_controlplane   ns                              is-control-plane 'control-plane namespaces'
@@ -83,15 +92,6 @@ if [[ ${namespaces_controlplane[*]}   || \
     ${customresourcedefinitions:+"${customresourcedefinitions[@]}"} \
     ${apiservices:+"${apiservices[@]}"}
 fi
-
-echo "cleaning up viz extension resources, if present [${k8s_context}]"
-"$linkerd_path" viz uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
-
-echo "cleaning up multicluster resources, if present [${k8s_context}]"
-"$linkerd_path" mc uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
-
-echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
-"$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 echo "cleaning up rolebindings in kube-system namespace in k8s-context [${k8s_context}]"
 populate_array rolebindings              rolebindings                    control-plane-ns

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -13,6 +13,13 @@
 
 set -e
 
+if [ $# -ne 1 ]; then
+  echo "Error: accepts 1 argument"
+  echo "Usage:"
+  echo "  "${0##*/}" /path/to/linkerd"
+  exit 1
+fi
+
 for CLUSTER in 'AKS' 'DO' 'EKS' 'GKE'; do
   if [ -z "${!CLUSTER}" ]; then
     echo "\$$CLUSTER not set" >&2
@@ -23,5 +30,5 @@ done
 for CLUSTER in $AKS $DO $EKS $GKE
 do
   printf '\n%s\n' "$CLUSTER"
-  bin/test-cleanup --context "$CLUSTER"
+  bin/test-cleanup --context "$CLUSTER" $1
 done

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -23,5 +23,5 @@ done
 for CLUSTER in $AKS $DO $EKS $GKE
 do
   printf '\n%s\n' "$CLUSTER"
-  bin/test-cleanup "$CLUSTER"
+  bin/test-cleanup --context "$CLUSTER"
 done

--- a/bin/test-clouds-cleanup
+++ b/bin/test-clouds-cleanup
@@ -16,7 +16,7 @@ set -e
 if [ $# -ne 1 ]; then
   echo "Error: accepts 1 argument"
   echo "Usage:"
-  echo "  "${0##*/}" /path/to/linkerd"
+  echo "  ${0##*/} /path/to/linkerd"
   exit 1
 fi
 
@@ -30,5 +30,5 @@ done
 for CLUSTER in $AKS $DO $EKS $GKE
 do
   printf '\n%s\n' "$CLUSTER"
-  bin/test-cleanup --context "$CLUSTER" $1
+  bin/test-cleanup --context "$CLUSTER" "$1"
 done

--- a/bin/tests
+++ b/bin/tests
@@ -4,7 +4,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
 # shellcheck source=_test-helpers.sh
 . "$bindir"/_test-helpers.sh
-handle_input "$@"
+handle_tests_input "$@"
 
 if [ -n "$test_name" ]; then
   start_test "$test_name"


### PR DESCRIPTION
## What this fixes

When clusters are cleaned up after tests in CI, the `bin/test-cleanup` script is
responsible for clearing the cluster of all testing resources.

Right now this does not work as expected because the script uses the `linkerd`
binary instead of the Linkerd path that is passed in to the `tests` script.

There are cases where different binaries have different uninstall behavior and
the script can complete with an incomplete uninstallation.

## How it fixes

`test-cleanup` now takes a linkerd path argument. This is used to specify the
Linkerd binary that should be used when running in the `uninstall` commands.

This value is passed through from the `tests` invocation which means that in CI,
the same binary is used for running tests as well as cleaning up the cluster.

Additionally, specifying the k8s context has now moved from an argument to the
`--context` flag. This is similar to how `tests` script works because it's not
always required.

## How to use

Shown here:

``` $ bin/test-cleanup -h Cleanup Linkerd integration tests.

Usage:
    test-cleanup [--context k8s_context] /path/to/linkerd

Examples:
    # Cleanup tests in non-default context test-cleanup --context k8s_context
    /path/to/linkerd

Available Commands:
    --context: use a non-default k8s context
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
