### PR TITLE
Add collector.jaegerAddr value to allow BYOJ

### DIFF
--- a/jaeger/charts/jaeger/README.md
+++ b/jaeger/charts/jaeger/README.md
@@ -21,7 +21,7 @@ Kubernetes: `>=1.15.0-0`
 | collector.image.name | string | `"omnition/opencensus-collector"` |  |
 | collector.image.pullPolicy | string | `"Always"` |  |
 | collector.image.version | string | `"0.1.11"` |  |
-| collector.jaegerAddr | string | `nil` |  |
+| collector.jaegerAddr | string | `nil` | address of the jaeger backend to send traces to |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
 | jaeger.image.version | string | `"1.19.2"` |  |

--- a/jaeger/charts/jaeger/README.md
+++ b/jaeger/charts/jaeger/README.md
@@ -21,6 +21,7 @@ Kubernetes: `>=1.15.0-0`
 | collector.image.name | string | `"omnition/opencensus-collector"` |  |
 | collector.image.pullPolicy | string | `"Always"` |  |
 | collector.image.version | string | `"0.1.11"` |  |
+| collector.jaegerAddr | string | `nil` |  |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
 | jaeger.image.version | string | `"1.19.2"` |  |

--- a/jaeger/charts/jaeger/templates/tracing.yaml
+++ b/jaeger/charts/jaeger/templates/tracing.yaml
@@ -26,7 +26,7 @@ data:
         retry-on-failure: true
         sender-type: jaeger-thrift-http
         jaeger-thrift-http:
-          collector-endpoint: {{printf "http://%s.%s:14268/api/traces" "jaeger" .Values.namespace }}
+          collector-endpoint: {{.Values.collector.jaegerAddr | default (printf "http://%s.%s:14268/api/traces" "jaeger" .Values.namespace) }}
           timeout: 5s
 ---
 apiVersion: v1

--- a/jaeger/charts/jaeger/values.yaml
+++ b/jaeger/charts/jaeger/values.yaml
@@ -8,6 +8,7 @@ collector:
     version: 0.1.11
     pullPolicy: Always
   # resources:
+
   # -- address of the jaeger backend to send traces to
   jaegerAddr:
 

--- a/jaeger/charts/jaeger/values.yaml
+++ b/jaeger/charts/jaeger/values.yaml
@@ -8,6 +8,8 @@ collector:
     version: 0.1.11
     pullPolicy: Always
   # resources:
+  # -- address of the jaeger backend to send traces to
+  jaegerAddr:
 
 jaeger:
   image: 


### PR DESCRIPTION
Users may have an existing Jaeger deployment and want to send traces to it from Linkerd.

We add the `collector.jaegerAddr` value to the Linkerd-Jaeger chart which configures the address of the jaeger backend which the opencensus collector sends to.  If left unspecified, the collector will use the jaeger instance in the linkerd-jaeger extension.

To test:

Install Jaeger backend separately:

```
curl https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/examples/simplest.yaml | docker run -i --rm jaegertracing/jaeger-operator:master generate | kubectl apply -n jaeger-test -f -
```

Install Linkerd and Linkerd-jaeger, specifying the existing jaeger backend

```
linkerd install | kubectl apply -f -
linkerd jaeger install --set collector.jaegerAddr='http://my-jaeger-collector.jaeger-test:14268/api/traces' | kubectl apply -f -
```

Install emojivoto and configure it:

```
linkerd inject https://run.linkerd.io/emojivoto.yml  | kubectl apply -f -
kubectl -n emojivoto set env --all deploy OC_AGENT_HOST=collector.linkerd-jaeger:55678
```

View traces in your custom jaeger backend:

```
kubectl -n jaeger-test port-forward svc/my-jaeger-query 16686 &
open http://localhost:16686
```

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
