### PR TITLE
Enable upgrade integration tests for ARM

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -394,11 +394,6 @@ run_upgrade-edge_test() {
 # Run the upgrade-stable test by upgrading the most-recent stable release to the
 # HEAD of this branch.
 run_upgrade-stable_test() {
-  if [ -n "$RUN_ARM_TEST" ]; then
-    echo "Skipped. Linkerd stable version does not support ARM yet"
-    return
-  fi
-
   stable_install_url="https://run.linkerd.io/install"
   upgrade_test "stable" "$stable_install_url"
 }
@@ -430,11 +425,6 @@ helm_cleanup() {
 }
 
 run_helm-upgrade_test() {
-  if [ -n "$RUN_ARM_TEST" ]; then
-    echo "Skipped. Linkerd stable version does not support ARM yet"
-    return
-  fi
-
   local stable_version
   stable_version=$(latest_release_channel "stable")
 


### PR DESCRIPTION
This enables the `helm-upgrade` and `upgrade-stable` integration tests,
that were disabled because the previous versions didn't have ARM
support, but now 2.9 does.