### PR TITLE
Update pod affinity key for tap

### DIFF
--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -72,7 +72,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "tap" "label" .Values.controllerComponentLabel -}}
+      {{- $local := dict "component" "tap" "label" "component" -}}
       {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
       {{- end }}
       containers:


### PR DESCRIPTION
Subject: Update the `tap` Deployment YAML to use the `component` label when applying podAntiAffinity

Problem: The helm chart for the `tap` Deployment used `.Values.controllerComponentLabel` as the key in the `_affinity.tpl` partial, however, tap is no longer part of the core control plane components, so the `linkerd.io/control-plane-component` label should not be set on the resource.

Solution: Update the `dict` in tap.yaml to use the `component` label for the podAntiAffinity key

Validation: Ran tests and installed `linkerd` and `linkerd-viz`

Fixes #5511

Signed-off-by: Charles Pretzer <charles@buoyant.io>
