### PR TITLE
viz: make viz cmds available at root

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -125,15 +125,15 @@ func init() {
 	RootCmd.AddCommand(viz.NewCmdViz())
 
 	// Viz Extension sub commands
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdDashboard()))
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdEdges()))
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdRoutes()))
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdStat()))
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdTap()))
-	RootCmd.AddCommand(depreciateCmd(viz.NewCmdTop()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdDashboard()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdEdges()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdRoutes()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStat()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTap()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTop()))
 }
 
-func depreciateCmd(cmd *cobra.Command) *cobra.Command {
+func deprecateCmd(cmd *cobra.Command) *cobra.Command {
 	cmd.Deprecated = fmt.Sprintf("use instead 'linkerd viz %s'", cmd.Use)
 	return cmd
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -123,6 +123,19 @@ func init() {
 	RootCmd.AddCommand(jaeger.NewCmdJaeger())
 	RootCmd.AddCommand(multicluster.NewCmdMulticluster())
 	RootCmd.AddCommand(viz.NewCmdViz())
+
+	// Viz Extension sub commands
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdDashboard()))
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdEdges()))
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdRoutes()))
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdStat()))
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdTap()))
+	RootCmd.AddCommand(depreciateCmd(viz.NewCmdTop()))
+}
+
+func depreciateCmd(cmd *cobra.Command) *cobra.Command {
+	cmd.Deprecated = fmt.Sprintf("use instead 'linkerd viz %s'", cmd.Use)
+	return cmd
 }
 
 // registryOverride replaces the registry-portion of the provided image with the provided registry.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -134,7 +134,7 @@ func init() {
 }
 
 func deprecateCmd(cmd *cobra.Command) *cobra.Command {
-	cmd.Deprecated = fmt.Sprintf("use instead 'linkerd viz %s'", cmd.Use)
+	cmd.Deprecated = fmt.Sprintf("use instead 'linkerd viz %s'\n", cmd.Use)
 	return cmd
 }
 

--- a/viz/cmd/dashboard.go
+++ b/viz/cmd/dashboard.go
@@ -61,10 +61,10 @@ func newDashboardOptions() *dashboardOptions {
 	}
 }
 
-// newCmdDashboard creates a new cobra command `dashboard` which contains commands for visualizing linkerd's dashboards.
+// NewCmdDashboard creates a new cobra command `dashboard` which contains commands for visualizing linkerd's dashboards.
 // After validating flag values, it will use the Kubernetes API to portforward requests to the Grafana and Web Deployments
 // until the process gets killed/canceled
-func newCmdDashboard() *cobra.Command {
+func NewCmdDashboard() *cobra.Command {
 	options := newDashboardOptions()
 
 	cmd := &cobra.Command{

--- a/viz/cmd/edges.go
+++ b/viz/cmd/edges.go
@@ -43,7 +43,8 @@ type indexedEdgeResults struct {
 	err  error
 }
 
-func newCmdEdges() *cobra.Command {
+// NewCmdEdges creates a new cobra command `edges` for edges functionality
+func NewCmdEdges() *cobra.Command {
 	options := newEdgesOptions()
 
 	cmd := &cobra.Command{
@@ -73,13 +74,13 @@ func newCmdEdges() *cobra.Command {
   * replicationcontrollers
   * statefulsets`,
 		Example: `  # Get all edges between pods that either originate from or terminate in the test namespace.
-  linkerd edges po -n test
+  linkerd viz edges po -n test
 
   # Get all edges between pods that either originate from or terminate in the default namespace.
-  linkerd edges po
+  linkerd viz edges po
 
   # Get all edges between pods in all namespaces.
-  linkerd edges po --all-namespaces`,
+  linkerd viz edges po --all-namespaces`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -66,12 +66,12 @@ func NewCmdViz() *cobra.Command {
 	vizCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
 	vizCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 	vizCmd.AddCommand(newCmdInstall())
-	vizCmd.AddCommand(newCmdRoutes())
-	vizCmd.AddCommand(newCmdStat())
-	vizCmd.AddCommand(newCmdTap())
-	vizCmd.AddCommand(newCmdTop())
-	vizCmd.AddCommand(newCmdEdges())
-	vizCmd.AddCommand(newCmdDashboard())
+	vizCmd.AddCommand(NewCmdRoutes())
+	vizCmd.AddCommand(NewCmdStat())
+	vizCmd.AddCommand(NewCmdTap())
+	vizCmd.AddCommand(NewCmdTop())
+	vizCmd.AddCommand(NewCmdEdges())
+	vizCmd.AddCommand(NewCmdDashboard())
 	vizCmd.AddCommand(newCmdUninstall())
 
 	return vizCmd

--- a/viz/cmd/routes.go
+++ b/viz/cmd/routes.go
@@ -44,7 +44,8 @@ func newRoutesOptions() *routesOptions {
 	}
 }
 
-func newCmdRoutes() *cobra.Command {
+// NewCmdRoutes creates a new cobra command `routes` for routes functionality
+func NewCmdRoutes() *cobra.Command {
 	options := newRoutesOptions()
 
 	cmd := &cobra.Command{
@@ -54,10 +55,10 @@ func newCmdRoutes() *cobra.Command {
 
 This command will only display traffic which is sent to a service that has a Service Profile defined.`,
 		Example: `  # Routes for the webapp service in the test namespace.
-  linkerd routes service/webapp -n test
+  linkerd viz routes service/webapp -n test
 
   # Routes for calls from the traffic deployment to the webapp service in the test namespace.
-  linkerd routes deploy/traffic -n test --to svc/webapp`,
+  linkerd viz routes deploy/traffic -n test --to svc/webapp`,
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -74,7 +74,8 @@ func newStatOptions() *statOptions {
 	}
 }
 
-func newCmdStat() *cobra.Command {
+// NewCmdStat creates a new cobra command `stat` for stat functionality
+func NewCmdStat() *cobra.Command {
 	options := newStatOptions()
 
 	cmd := &cobra.Command{
@@ -124,46 +125,46 @@ func newCmdStat() *cobra.Command {
 This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases.
 If no resource name is specified, displays stats about all resources of the specified RESOURCETYPE`,
 		Example: `  # Get all deployments in the test namespace.
-  linkerd stat deployments -n test
+  linkerd viz stat deployments -n test
 
   # Get the hello1 replication controller in the test namespace.
-  linkerd stat replicationcontrollers hello1 -n test
+  linkerd viz stat replicationcontrollers hello1 -n test
 
   # Get all namespaces.
-  linkerd stat namespaces
+  linkerd viz stat namespaces
 
   # Get all inbound stats to the web deployment.
-  linkerd stat deploy/web
+  linkerd viz stat deploy/web
 
   # Get all inbound stats to the pod1 and pod2 pods
-  linkerd stat po pod1 pod2
+  linkerd viz stat po pod1 pod2
 
   # Get all inbound stats to the pod1 pod and the web deployment
-  linkerd stat po/pod1 deploy/web
+  linkerd viz stat po/pod1 deploy/web
 
   # Get all pods in all namespaces that call the hello1 deployment in the test namespace.
-  linkerd stat pods --to deploy/hello1 --to-namespace test --all-namespaces
+  linkerd viz stat pods --to deploy/hello1 --to-namespace test --all-namespaces
 
   # Get all pods in all namespaces that call the hello1 service in the test namespace.
-  linkerd stat pods --to svc/hello1 --to-namespace test --all-namespaces
+  linkerd viz stat pods --to svc/hello1 --to-namespace test --all-namespaces
 
   # Get all services in all namespaces that receive calls from hello1 deployment in the test namespace.
-  linkerd stat services --from deploy/hello1 --from-namespace test --all-namespaces
+  linkerd viz stat services --from deploy/hello1 --from-namespace test --all-namespaces
 
   # Get all trafficsplits and their leaf services.
-  linkerd stat ts
+  linkerd viz stat ts
 
   # Get the hello-split trafficsplit and its leaf services.
-  linkerd stat ts/hello-split
+  linkerd viz stat ts/hello-split
 
   # Get all trafficsplits and their leaf services, and metrics for any traffic coming to the leaf services from the hello1 deployment.
-  linkerd stat ts --from deploy/hello1
+  linkerd viz stat ts --from deploy/hello1
 
   # Get all namespaces that receive traffic from the default namespace.
-  linkerd stat namespaces --from ns/default
+  linkerd viz stat namespaces --from ns/default
 
   # Get all inbound stats to the test namespace.
-  linkerd stat ns/test`,
+  linkerd viz stat ns/test`,
 		Args:      cobra.MinimumNArgs(1),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -125,7 +125,8 @@ func (o *tapOptions) validate() error {
 	return fmt.Errorf("output format \"%s\" not recognized", o.output)
 }
 
-func newCmdTap() *cobra.Command {
+// NewCmdTap creates a new cobra command `tap` for tap functionality
+func NewCmdTap() *cobra.Command {
 	options := newTapOptions()
 
 	cmd := &cobra.Command{
@@ -161,13 +162,13 @@ func newCmdTap() *cobra.Command {
   * statefulsets
   * services (only supported as a --to resource)`,
 		Example: `  # tap the web deployment in the default namespace
-  linkerd tap deploy/web
+  linkerd viz tap deploy/web
 
   # tap the web-dlbvj pod in the default namespace
-  linkerd tap pod/web-dlbvj
+  linkerd viz tap pod/web-dlbvj
 
   # tap the test namespace, filter by request to prod namespace
-  linkerd tap ns/test --to ns/prod`,
+  linkerd viz tap ns/test --to ns/prod`,
 		Args:      cobra.RangeArgs(1, 2),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/viz/cmd/top.go
+++ b/viz/cmd/top.go
@@ -274,7 +274,8 @@ func newTopOptions() *topOptions {
 	}
 }
 
-func newCmdTop() *cobra.Command {
+// NewCmdTop creates a new cobra command `top` for top functionality
+func NewCmdTop() *cobra.Command {
 	options := newTopOptions()
 
 	table := newTopTable()
@@ -312,10 +313,10 @@ func newCmdTop() *cobra.Command {
   * statefulsets
   * services (only supported as a --to resource)`,
 		Example: `  # display traffic for the web deployment in the default namespace
-  linkerd top deploy/web
+  linkerd viz top deploy/web
 
   # display traffic for the web-dlbvj pod in the default namespace
-  linkerd top pod/web-dlbvj`,
+  linkerd viz top pod/web-dlbvj`,
 		Args:      cobra.RangeArgs(1, 2),
 		ValidArgs: util.ValidTargets,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Fixes #5523

This branch makes viz commands that were previously available
under root to be available at both places i.e `linkerd` and
`linkerd viz`.

We also show a depreciated notice when ran under root, asking
to use them with the `viz` prefix.

This also updates all the help messages to address these cmds
as `linkerd viz xyz` instead of `linkerd xyz`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
