### PR TITLE
add jaeger check: to confirm whether the jaeger injector pod is in running state or not

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2595,7 +2595,10 @@ func CheckForPods(pods []corev1.Pod, deployNames []string) error {
 }
 
 // CheckPodsRunning checks if the given pods are in running state
-func CheckPodsRunning(pods []corev1.Pod) error {
+func CheckPodsRunning(pods []corev1.Pod, podsNotFoundMsg string) error {
+	if len(pods) == 0 && podsNotFoundMsg != "" {
+		return fmt.Errorf(podsNotFoundMsg)
+	}
 	for _, pod := range pods {
 		if pod.Status.Phase != "Running" {
 			return fmt.Errorf("%s status is %s", pod.Name, pod.Status.Phase)

--- a/viz/cmd/check.go
+++ b/viz/cmd/check.go
@@ -146,7 +146,7 @@ func vizCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
 					return err
 				}
 
-				return healthcheck.CheckPodsRunning(pods)
+				return healthcheck.CheckPodsRunning(pods, "")
 			}))
 
 	checkers = append(checkers,


### PR DESCRIPTION
closes #5495 

---

**Use case: When the jaeger injector pod is in a non-running state**
```sh
►  kgp -n linkerd-jaeger
NAME                               READY   STATUS            RESTARTS   AGE
jaeger-6f98d5c979-cmwpk            2/2     Running           0          24m
collector-69cc44dfbc-xbxzt         2/2     Running           0          24m
jaeger-injector-6786478f9f-l6gw2   0/2     PodInitializing   0          7s
```

**Output**:
```
► bin/linkerd jaeger check -n linkerd-jaeger
linkerd-jaeger
--------------
√ collector and jaeger service account exists
√ collector config map exists
√ collector pod is running
√ jaeger pod is running
\ jaeger-injector-6786478f9f-cpj8w status is Pending 
```
---
**Use case: When the jaeger injector pod is in running state**
```
►  kgp -n linkerd-jaeger
NAME                               READY   STATUS    RESTARTS   AGE
jaeger-6f98d5c979-cmwpk            2/2     Running   0          26m
collector-69cc44dfbc-xbxzt         2/2     Running   0          26m
jaeger-injector-6786478f9f-l6gw2   2/2     Running   0          92s
```

**Output**:
```
► bin/linkerd jaeger check -n linkerd-jaeger
linkerd-jaeger
--------------
√ collector and jaeger service account exists
√ collector config map exists
√ collector pod is running
√ jaeger pod is running
√ jaeger injector pod is running
√ jaeger extension pods are injected

Status check results are √
```
---

**Old output (no matter what the state of jaeger injector pod)**:
```
► bin/linkerd jaeger check -n linkerd-jaeger
linkerd-jaeger
--------------
√ collector and jaeger service account exists
√ collector config map exists
√ collector pod is running
√ jaeger pod is running
√ jaeger extension pods are injected

Status check results are √
```

