### PR TITLE
Move @klingerf to emeritus maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,6 @@
 The Linkerd maintainers are:
 
 * Oliver Gould <ver@buoyant.io> @olix0r (super-maintainer)
-* Kevin Lingerfelt <kl@buoyant.io> @klingerf (super-maintainer)
 * Alejandro Pedraza <alejandro@buoyant.io> @alpeb
 * Alex Leong <alex@buoyant.io> @adleong
 * Andrew Seigner <siggy@buoyant.io> @siggy
@@ -17,7 +16,7 @@ The Linkerd maintainers are:
 
 Former maintainers include:
 
-* ...
+* Kevin Ingleman <ki@buoyant.io> @klingerf
 
 <!--
 # Adding a new maintainer
@@ -26,6 +25,6 @@ Former maintainers include:
 * Add maintainer to .github/CODEOWNERS
 * Obtain approvals per GOVERNANCE.md
 * Invite maintainer to
-  https://github.com/orgs/linkerd/teams/linkerd2-maintainers/members
+  https://github.com/orgs/linkerd/teams/maintainers/members
 * Invite maintainer to https://github.com/orgs/linkerd/people
 -->


### PR DESCRIPTION
While he is still overwhelmingly excited about the project, @klingerf isn't participating in the day-to-day tasks outlined in the updated GOVERNANCE.md, and therefore requests to be moved to emeritus status.

Signed-off-by: Kevin Ingelman <ki@buoyant.io>
