### PR TITLE
Add changes for edge-21.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,19 +4,19 @@
 ## edge-21.1.2
 
 This edge release continues the work on decoupling non-core Linkerd components.
-Commands that use the viz-extension i.e, `dashboard`, `edges`, `routes`,
+Commands that use the viz extension i.e, `dashboard`, `edges`, `routes`,
 `stat`, `tap` and `top` are moved to the `viz` sub-command. These commands are still
-available under root but are marked deprecated and will be removed in a
+available under root but are marked as deprecated and will be removed in a
 later stable release.
 
 This release also features proxy's dependencies upgrade to the
 Tokio v1 ecosystem.
 
-* Moved sub-commands that use the viz-extension under `viz`
-* Started ignoring pods with status.phase=Succeeded when watching IP addresses
-  in destination. This is useful for re-use of IPs of terminated pods
+* Moved sub-commands that use the viz extension under `viz`
+* Started ignoring pods with `Succeeded` status when watching IP addresses
+  in destination. This allows the re-use of IPs of terminated pods
 * Support Bring your own Jaeger use-case by adding `collector.jaegerAddr` in
-  the jaeger extension.
+  the Jaeger extension.
 * Fixed an issue with the generation of working manifests in the
   `podAntiAffinity` use-case
 * Added support for the modification of proxy resources in the viz

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,7 @@ Commands that use the viz extension i.e, `dashboard`, `edges`, `routes`,
 available under root but are marked as deprecated and will be removed in a
 later stable release.
 
-This release also features proxy's dependencies upgrade to the
-Tokio v1 ecosystem.
+This release also upgrades the proxy's dependencies to the Tokio v1 ecosystem.
 
 * Moved sub-commands that use the viz extension under `viz`
 * Started ignoring pods with `Succeeded` status when watching IP addresses
@@ -28,10 +27,7 @@ Tokio v1 ecosystem.
   resource in the viz extension (thanks @nlamirault)
 * Made service-profile generation work offline with `--ignore-cluster`
   flag (thanks @piyushsingariya)
-* Proxy's Tap API is disabled by default and it is enabled only when
-  `LINKERD2_PROXY_TAP_SVC_NAME` configuration is set. This means that
-  `LINKERD2_PROXY_TAP_DISABLED` is no longer honored
-* Upgraded the proxy's dependencies to Tokio v1 ecosystem
+* Upgraded the proxy's dependencies to the Tokio v1 ecosystem
 
 ## edge-21.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,39 @@
 
 # Changes
 
+## edge-21.1.2
+
+This edge release continues the work on de-coupling non-core Linkerd components,
+with good amount of clean up work in th CLI and proxy. This release also moves
+sub-commands that use the viz-extension i.e `dashboard`, `edges`, `routes`,
+`stat`, `tap` and `top` under the `viz` sub-command. These commands are still
+available under root but are marked depreciated and will be removed in a
+later stable release.
+
+This release also features proxy's dependencies upgrade to the
+Tokio v1 ecosystem.
+
+* Moves sub-commands that use the viz-extension under `viz`
+* Ignore pods with status.phase=Succeeded when watching IP addresses
+  in destination. This is useful for re-use of IPs of terminated pods
+* Support Bring your own Jaeger use-case by adding `collector.jaegerAddr` in
+  the jaeger extension.
+* Fixed an issue with the generation of working manifests in the
+  `podAntiAffinity` use-case
+* Added support for the modification of proxy resources in the viz
+  extension through `Values.yaml` in Helm and flags in CLI.
+* Better error reporting for port-forward logic with namespace
+  and pod data, used across dashboard, checks, etc
+  (thanks @piyushsingariya)
+* Added support to disable the rendering of `linkerd-viz` namespace
+  resource in the viz extension (thanks @nlamirault)
+* Make service-profile generation work offline with `--ignore-cluster`
+  flag (thanks @piyushsingariya)
+* Proxy's Tap API is disabled by default and it is enabled only when
+  `LINKERD2_PROXY_TAP_SVC_NAME` configuration is set. This means that
+  `LINKERD2_PROXY_TAP_DISABLED` is no longer honored
+* Upgraded the proxy's dependencies to Tokio v1 ecosystem
+
 ## edge-21.1.1
 
 This edge release introduces a new "opaque transport" feature that allows the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,9 @@
 
 ## edge-21.1.2
 
-This edge release continues the work on de-coupling non-core Linkerd components,
-with good amount of clean up work in th CLI and proxy. This release also moves
-sub-commands that use the viz-extension i.e `dashboard`, `edges`, `routes`,
-`stat`, `tap` and `top` under the `viz` sub-command. These commands are still
+This edge release continues the work on de-coupling non-core Linkerd components.
+Commands that use the viz-extension i.e `dashboard`, `edges`, `routes`,
+`stat`, `tap` and `top` are moved to the `viz` sub-command. These commands are still
 available under root but are marked depreciated and will be removed in a
 later stable release.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,30 +3,30 @@
 
 ## edge-21.1.2
 
-This edge release continues the work on de-coupling non-core Linkerd components.
-Commands that use the viz-extension i.e `dashboard`, `edges`, `routes`,
+This edge release continues the work on decoupling non-core Linkerd components.
+Commands that use the viz-extension i.e, `dashboard`, `edges`, `routes`,
 `stat`, `tap` and `top` are moved to the `viz` sub-command. These commands are still
-available under root but are marked depreciated and will be removed in a
+available under root but are marked deprecated and will be removed in a
 later stable release.
 
 This release also features proxy's dependencies upgrade to the
 Tokio v1 ecosystem.
 
-* Moves sub-commands that use the viz-extension under `viz`
-* Ignore pods with status.phase=Succeeded when watching IP addresses
+* Moved sub-commands that use the viz-extension under `viz`
+* Started ignoring pods with status.phase=Succeeded when watching IP addresses
   in destination. This is useful for re-use of IPs of terminated pods
 * Support Bring your own Jaeger use-case by adding `collector.jaegerAddr` in
   the jaeger extension.
 * Fixed an issue with the generation of working manifests in the
   `podAntiAffinity` use-case
 * Added support for the modification of proxy resources in the viz
-  extension through `Values.yaml` in Helm and flags in CLI.
-* Better error reporting for port-forward logic with namespace
+  extension through `values.yaml` in Helm and flags in CLI.
+* Improved error reporting for port-forward logic with namespace
   and pod data, used across dashboard, checks, etc
   (thanks @piyushsingariya)
 * Added support to disable the rendering of `linkerd-viz` namespace
   resource in the viz extension (thanks @nlamirault)
-* Make service-profile generation work offline with `--ignore-cluster`
+* Made service-profile generation work offline with `--ignore-cluster`
   flag (thanks @piyushsingariya)
 * Proxy's Tap API is disabled by default and it is enabled only when
   `LINKERD2_PROXY_TAP_SVC_NAME` configuration is set. This means that


### PR DESCRIPTION
## edge-21.1.2

This edge release continues the work on decoupling non-core Linkerd components.
Commands that use the viz-extension i.e, `dashboard`, `edges`, `routes`,
`stat`, `tap` and `top` are moved to the `viz` sub-command. These commands are still
available under root but are marked deprecated and will be removed in a
later stable release.

This release also features proxy's dependencies upgrade to the
Tokio v1 ecosystem.

* Moved sub-commands that use the viz-extension under `viz`
* Started ignoring pods with status.phase=Succeeded when watching IP addresses
  in destination. This is useful for re-use of IPs of terminated pods
* Support Bring your own Jaeger use-case by adding `collector.jaegerAddr` in
  the jaeger extension.
* Fixed an issue with the generation of working manifests in the
  `podAntiAffinity` use-case
* Added support for the modification of proxy resources in the viz
  extension through `values.yaml` in Helm and flags in CLI.
* Improved error reporting for port-forward logic with namespace
  and pod data, used across dashboard, checks, etc
  (thanks @piyushsingariya)
* Added support to disable the rendering of `linkerd-viz` namespace
  resource in the viz extension (thanks @nlamirault)
* Made service-profile generation work offline with `--ignore-cluster`
  flag (thanks @piyushsingariya)
* Proxy's Tap API is disabled by default and it is enabled only when
  `LINKERD2_PROXY_TAP_SVC_NAME` configuration is set. This means that
  `LINKERD2_PROXY_TAP_DISABLED` is no longer honored
* Upgraded the proxy's dependencies to Tokio v1 ecosystem


Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

