### PR TITLE
Add watch to jaeger-injector

### DIFF
--- a/jaeger/charts/jaeger/templates/rbac.yaml
+++ b/jaeger/charts/jaeger/templates/rbac.yaml
@@ -33,7 +33,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What this changes

This fixes an issue in the Jaeger extension's `jaeger-injector` component that
causes an injection error in situations with high pod or namespace churn.

Because it cannot watch namespaces, it relies only off of `get` and this appears
to fall behind at a certain point. This surfaces as an error.

For example, in the `inject` test about half way through it errors with the
error:

```
=== RUN   TestInjectAutoPod
    inject_test.go:430: failed to create pod/inject-pod-test-terminus in namespace linkerd-inject-pod-test for exit status 1: Error from server: error when creating "STDIN": admission webhook "jaeger-injector.linkerd.io" denied the request: namespace "linkerd-inject-pod-test" not found
--- FAIL: TestInjectAutoPod (0.22s)
FAIL
```

Looking at the `jaeger-injector` logs, most of it's messages are about the test
namespaces not being created:

```
..
time="2021-01-15T15:34:12Z" level=info msg="received admission review request b2f36a9c-3f88-4abe-bcaa-f63c61cd24c0"
time="2021-01-15T15:34:12Z" level=info msg="received admission review request 9f5b229b-1c60-4b24-a020-b66cd201171e"
time="2021-01-15T15:34:12Z" level=error msg="failed to run webhook handler. Reason: namespace \"linkerd-inj-auto-params-test\" not found"
time="2021-01-15T15:34:12Z" level=info msg="received admission review request ae00d63a-1585-46ba-9a75-1f93d40766a8"
time="2021-01-15T15:34:12Z" level=info msg="received admission review request 998721eb-5625-4be8-9166-9db834c58f10"
time="2021-01-15T15:34:12Z" level=error msg="failed to run webhook handler. Reason: namespace \"linkerd-inj-auto-params-test\" not found"
time="2021-01-15T15:34:12Z" level=info msg="received admission review request 52e4e603-89b1-492b-a69b-dc8ff67d5f26"
time="2021-01-15T15:34:12Z" level=info msg="received admission review request 27558a16-5120-4aeb-a0bd-f22a1666b2b1"
time="2021-01-15T15:34:12Z" level=error msg="failed to run webhook handler. Reason: namespace \"linkerd-inj-auto-params-test\" not found"
..
```

Adding the `watch` verb to it's cluster role fixes this and these errors no
longer occur.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
