### PR TITLE
public-api/viz split 2/8: chart templates for new viz linkerd-metrics-api pod

### DIFF
--- a/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
@@ -1,0 +1,54 @@
+---
+###
+### Metrics API RBAC
+###
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Values.namespace}}-metrics-api
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: metrics-api
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["cronjobs", "jobs"]
+  verbs: ["list" , "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["linkerd.io"]
+  resources: ["serviceprofiles"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["split.smi-spec.io"]
+  resources: ["trafficsplits"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-{{.Values.namespace}}-metrics-api
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: metrics-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-{{.Values.namespace}}-metrics-api
+subjects:
+- kind: ServiceAccount
+  name: linkerd-metrics-api
+  namespace: {{.Values.namespace}}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: {{.Values.namespace}}
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: metrics-api
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -34,7 +34,6 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: metrics-api
-    namespace: {{.Values.namespace}}
   name: linkerd-metrics-api
   namespace: {{.Values.namespace}}
 spec:
@@ -43,7 +42,6 @@ spec:
     matchLabels:
       {{.Values.extensionAnnotation}}: linkerd-viz
       component: metrics-api
-      namespace: {{.Values.namespace}}
   template:
     metadata:
       annotations:
@@ -58,7 +56,6 @@ spec:
       labels:
         {{.Values.extensionAnnotation}}: linkerd-viz
         component: metrics-api
-        namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- if .Values.tolerations -}}
@@ -79,7 +76,7 @@ spec:
         {{- else }}
         - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.{{.Values.clusterDomain}}:9090
         {{- end }}
-        image: {{.Values.metricsAPI.image.registry}}/{{.Values.metricsAPI.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.metricsAPI.image.tag}}
+        image: {{.Values.metricsAPI.image.registry}}/{{.Values.metricsAPI.image.name}}:{{.Values.metricsAPI.image.tag}}
         imagePullPolicy: {{.Values.metricsAPI.pullPolicy}}
         livenessProbe:
           httpGet:

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -1,0 +1,105 @@
+---
+###
+### Metrics API
+###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: {{.Values.namespace}}
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: metrics-api
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
+spec:
+  type: ClusterIP
+  selector:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: metrics-api
+  ports:
+  - name: http
+    port: 8085
+    targetPort: 8085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    app.kubernetes.io/name: metrics-api
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    component: metrics-api
+    namespace: {{.Values.namespace}}
+  name: linkerd-metrics-api
+  namespace: {{.Values.namespace}}
+spec:
+  replicas: {{.Values.metricsAPI.replicas}}
+  selector:
+    matchLabels:
+      {{.Values.extensionAnnotation}}: linkerd-viz
+      component: metrics-api
+      namespace: {{.Values.namespace}}
+  template:
+    metadata:
+      annotations:
+        {{- if empty .Values.cliVersion }}
+        checksum/config: {{ include (print $.Template.BasePath "/metrics-api-rbac.yaml") . | sha256sum }}
+        {{- end }}
+        {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
+        {{- with .Values.metricsAPI.proxy }}
+        {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+      labels:
+        {{.Values.extensionAnnotation}}: linkerd-viz
+        component: metrics-api
+        namespace: {{.Values.namespace}}
+        {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+    spec:
+      {{- if .Values.tolerations -}}
+      {{- include "linkerd.tolerations" . | nindent 6 }}
+      {{- end -}}
+      {{- include "linkerd.node-selector" . | nindent 6 }}
+      {{- if .Values.enablePodAntiAffinity -}}
+      {{- $local := dict "component" "metrics-api" "label" "component" -}}
+      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
+      {{- end }}
+      containers:
+      - args:
+        - -controller-namespace={{.Values.linkerdNamespace}}
+        - -log-level={{.Values.metricsAPI.logLevel}}
+        - -cluster-domain={{.Values.clusterDomain}}
+        {{- if .Values.prometheusUrl }}
+        - -prometheus-url={{.Values.prometheusUrl}}
+        {{- else }}
+        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.{{.Values.clusterDomain}}:9090
+        {{- end }}
+        image: {{.Values.metricsAPI.image.registry}}/{{.Values.metricsAPI.image.name}}:{{ default (default .Values.linkerdVersion .Values.controllerImageVersion) .Values.metricsAPI.image.tag}}
+        imagePullPolicy: {{.Values.metricsAPI.pullPolicy}}
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
+        name: metrics-api
+        ports:
+        - containerPort: 8085
+          name: http
+        - containerPort: 9995
+          name: admin-http
+        readinessProbe:
+          failureThreshold: 7
+          httpGet:
+            path: /ready
+            port: 9995
+        {{- if .Values.metricsAPI.resources -}}
+        {{- include "partials.resources" .Values.metricsAPI.resources | nindent 8 }}
+        {{- end }}
+        securityContext:
+          runAsUser: {{.Values.metricsAPI.UID}}
+      serviceAccountName: linkerd-metrics-api

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -58,6 +58,41 @@ imagePullSecrets: []
 # Set this to `jaeger.linkerd-jaeger.svc.<clusterDomain>` if you plan to use jaeger extension
 # jaegerUrl:
 
+# metrics API configuration
+metricsAPI:
+  # -- number of replicas of the metrics-api component
+  replicas: 1
+  # -- log level of the metrics-api component
+  logLevel: *log_level
+  image:
+    # -- Docker registry for the metrics-api component
+    registry: ghcr.io/linkerd
+    # -- Docker image name for the metrics-api component
+    name: metrics-api
+    # -- Docker image tag for the metrics-api component
+    tag: *linkerd_version
+    # -- Pull policy for the metrics-api component
+    pullPolicy: Always
+
+  resources:
+    cpu:
+      # -- Maximum amount of CPU units that the metrics-api container can use
+      limit:
+      # -- Amount of CPU units that the metrics-api container requests
+      request:
+    memory:
+      # -- Maximum amount of memory that metrics-api container can use
+      limit:
+      # -- Amount of memory that the metrics-api container requests
+      request:
+
+  proxy:
+    # -- If set, overrides default proxy resources for the proxy injected
+    # into the metrics-api component
+    # resources:
+
+  UID: *uid
+
 # tap configuration
 tap:
   replicas: 1
@@ -185,7 +220,7 @@ prometheus:
     name: prometheus
     # -- Docker image tag for the prometheus instance
     tag: v2.19.3
-    # == Pull policy for the prometheus instance
+    # -- Pull policy for the prometheus instance
     pullPolicy: Always
 
   # -- Command line options for Prometheus binary

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -24,11 +24,13 @@ import (
 var (
 	templatesVIz = []string{
 		"templates/namespace.yaml",
+		"templates/metrics-api-rbac.yaml",
 		"templates/grafana-rbac.yaml",
 		"templates/prometheus-rbac.yaml",
 		"templates/tap-rbac.yaml",
 		"templates/web-rbac.yaml",
 		"templates/psp.yaml",
+		"templates/metrics-api.yaml",
 		"templates/grafana.yaml",
 		"templates/prometheus.yaml",
 		"templates/tap.yaml",


### PR DESCRIPTION
This is based on the branch `alpeb/api-move` from #5553

The underlying go code supporting the service will be pushed in a followup PR, so tests are not expected to pass on this one.