### PR TITLE
public-api/viz split 6/8: linkerd-metrics-api bootstrap files

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -21,3 +21,5 @@ else
 fi
 "$bindir"/docker-build-grafana
 "$bindir"/docker-build-jaeger-webhook
+"$bindir"/docker-build-metrics-api
+

--- a/bin/docker-build-metrics-api
+++ b/bin/docker-build-metrics-api
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for ${0##*/}, given: $*" >&2
+    exit 64
+fi
+
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+
+# shellcheck source=_docker.sh
+. "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
+. "$bindir"/_tag.sh
+
+dockerfile=$rootdir/viz/metrics-api/Dockerfile
+tag=$(head_root_tag)
+docker_build metrics-api "$tag" "$dockerfile"
+

--- a/bin/image-load
+++ b/bin/image-load
@@ -10,7 +10,7 @@ while :
 do
   case $1 in
     -h|--help)
-      echo "Load into KinD/k3d the images for Linkerd's proxy, controller, web, grafana, cli-bin, debug and cni-plugin."
+      echo "Load into KinD/k3d the images for Linkerd's proxy, controller, metrics-api, web, grafana, cli-bin, debug and cni-plugin."
       echo ""
       echo "Usage:"
       echo "    bin/image-load [--kind] [--k3d] [--archive]"
@@ -79,7 +79,7 @@ fi
 "$bin" version
 
 rm -f load_fail
-for img in proxy controller web grafana cli-bin debug cni-plugin jaeger-webhook; do
+for img in proxy controller web metrics-api grafana cli-bin debug cni-plugin jaeger-webhook; do
   printf 'Importing %s...\n' $img
   if [ $archive ]; then
     param="image-archives/$img.tar"

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -13,7 +13,7 @@ RUN ./bin/install-deps $TARGETARCH
 FROM go-deps as golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
-# TODO: remove when viz API code gets moved to /viz
+# TODO: remove when tap code gets moved to /viz
 COPY viz/metrics-api/gen/viz viz/metrics-api/gen/viz
 COPY pkg pkg
 COPY controller controller

--- a/test/integration/stat/stat_test.go
+++ b/test/integration/stat/stat_test.go
@@ -46,15 +46,15 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	}
 	prometheusPod := pods[0]
 
-	pods, err = TestHelper.GetPodNamesForDeployment(ctx, TestHelper.GetLinkerdNamespace(), "linkerd-controller")
+	pods, err = TestHelper.GetPodNamesForDeployment(ctx, TestHelper.GetVizNamespace(), "linkerd-metrics-api")
 	if err != nil {
-		testutil.AnnotatedFatalf(t, "failed to get pods for controller",
-			"failed to get pods for controller: %s", err)
+		testutil.AnnotatedFatalf(t, "failed to get pods for metrics-api",
+			"failed to get pods for metrics-api: %s", err)
 	}
 	if len(pods) != 1 {
-		testutil.Fatalf(t, "expected 1 pod for controller, got %d", len(pods))
+		testutil.Fatalf(t, "expected 1 pod for metrics-api, got %d", len(pods))
 	}
-	controllerPod := pods[0]
+	metricsPod := pods[0]
 
 	prometheusAuthority := "linkerd-prometheus." + TestHelper.GetVizNamespace() + ".svc.cluster.local:9090"
 
@@ -76,35 +76,36 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		{
 			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
-				"linkerd-grafana":    "1/1",
-				"linkerd-prometheus": "1/1",
-				"linkerd-tap":        "1/1",
-				"linkerd-web":        "1/1",
+				"linkerd-metrics-api": "1/1",
+				"linkerd-grafana":     "1/1",
+				"linkerd-prometheus":  "1/1",
+				"linkerd-tap":         "1/1",
+				"linkerd-web":         "1/1",
 			},
 		},
 		{
-			args: []string{"viz", "stat", fmt.Sprintf("po/%s", prometheusPod), "-n", TestHelper.GetVizNamespace(), "--from", fmt.Sprintf("po/%s", controllerPod), "--from-namespace", TestHelper.GetLinkerdNamespace()},
+			args: []string{"viz", "stat", fmt.Sprintf("po/%s", prometheusPod), "-n", TestHelper.GetVizNamespace(), "--from", fmt.Sprintf("po/%s", metricsPod), "--from-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
 				prometheusPod: "1/1",
 			},
 			status: "Running",
 		},
 		{
-			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetLinkerdNamespace(), "--to", fmt.Sprintf("po/%s", prometheusPod), "--to-namespace", TestHelper.GetVizNamespace()},
+			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace(), "--to", fmt.Sprintf("po/%s", prometheusPod), "--to-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
-				"linkerd-controller": "1/1",
+				"linkerd-metrics-api": "1/1",
 			},
 		},
 		{
-			args: []string{"viz", "stat", "svc", "linkerd-prometheus", "-n", TestHelper.GetVizNamespace(), "--from", "deploy/linkerd-controller", "--from-namespace", TestHelper.GetLinkerdNamespace()},
+			args: []string{"viz", "stat", "svc", "linkerd-prometheus", "-n", TestHelper.GetVizNamespace(), "--from", "deploy/linkerd-metrics-api", "--from-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
 				"linkerd-prometheus": "1/1",
 			},
 		},
 		{
-			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetLinkerdNamespace(), "--to", "svc/linkerd-prometheus", "--to-namespace", TestHelper.GetVizNamespace()},
+			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace(), "--to", "svc/linkerd-prometheus", "--to-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
-				"linkerd-controller": "1/1",
+				"linkerd-metrics-api": "1/1",
 			},
 		},
 		{
@@ -116,18 +117,18 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		{
 			args: []string{"viz", "stat", "ns", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
-				TestHelper.GetVizNamespace(): "4/4",
+				TestHelper.GetVizNamespace(): "5/5",
 			},
 		},
 		{
-			args: []string{"viz", "stat", "po", "-n", TestHelper.GetLinkerdNamespace(), "--to", fmt.Sprintf("au/%s", prometheusAuthority), "--to-namespace", TestHelper.GetVizNamespace()},
+			args: []string{"viz", "stat", "po", "-n", TestHelper.GetVizNamespace(), "--to", fmt.Sprintf("au/%s", prometheusAuthority), "--to-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
-				controllerPod: "1/1",
+				metricsPod: "1/1",
 			},
 			status: "Running",
 		},
 		{
-			args: []string{"viz", "stat", "au", "-n", TestHelper.GetLinkerdNamespace(), "--to", fmt.Sprintf("po/%s", prometheusPod), "--to-namespace", TestHelper.GetVizNamespace()},
+			args: []string{"viz", "stat", "au", "-n", TestHelper.GetVizNamespace(), "--to", fmt.Sprintf("po/%s", prometheusPod), "--to-namespace", TestHelper.GetVizNamespace()},
 			expectedRows: map[string]string{
 				prometheusAuthority: "-",
 			},

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -13,6 +13,59 @@ metadata:
     linkerd.io/inject: enabled
 ---
 ###
+### Metrics API RBAC
+###
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-viz-metrics-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["cronjobs", "jobs"]
+  verbs: ["list" , "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["linkerd.io"]
+  resources: ["serviceprofiles"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["split.smi-spec.io"]
+  resources: ["trafficsplits"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-viz-metrics-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-metrics-api
+subjects:
+- kind: ServiceAccount
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+---
+###
 ### Grafana RBAC
 ###
 ---
@@ -335,6 +388,92 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-prometheus
   namespace: linkerd-viz
+---
+###
+### Metrics API
+###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  type: ClusterIP
+  selector:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+  ports:
+  - name: http
+    port: 8085
+    targetPort: 8085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: linkerd-viz
+    app.kubernetes.io/name: metrics-api
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: dev-undefined
+    component: metrics-api
+    namespace: linkerd-viz
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: linkerd-viz
+      component: metrics-api
+      namespace: linkerd-viz
+  template:
+    metadata:
+      annotations:
+        checksum/config: b9049bed0ca52f3d63f34e03d87cfdd38bd81f6066310d0bf64d2d3f380d5733
+        linkerd.io/created-by: linkerd/helm dev-undefined
+      labels:
+        linkerd.io/extension: linkerd-viz
+        component: metrics-api
+        namespace: linkerd-viz
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - args:
+        - -controller-namespace=linkerd
+        - -log-level=info
+        - -cluster-domain=cluster.local
+        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+        image: ghcr.io/linkerd/metrics-api:dev-undefined
+        imagePullPolicy: 
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
+        name: metrics-api
+        ports:
+        - containerPort: 8085
+          name: http
+        - containerPort: 9995
+          name: admin-http
+        readinessProbe:
+          failureThreshold: 7
+          httpGet:
+            path: /ready
+            port: 9995
+        resources:
+        securityContext:
+          runAsUser: 2103
+      serviceAccountName: linkerd-metrics-api
 ---
 ###
 ### Grafana
@@ -904,10 +1043,12 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - args:
-        - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
+        - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
         - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
+        - -viz-namespace=linkerd-viz
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -13,6 +13,59 @@ metadata:
     linkerd.io/inject: enabled
 ---
 ###
+### Metrics API RBAC
+###
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-viz-metrics-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+rules:
+- apiGroups: ["extensions", "apps"]
+  resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["extensions", "batch"]
+  resources: ["cronjobs", "jobs"]
+  verbs: ["list" , "get", "watch"]
+- apiGroups: [""]
+  resources: ["pods", "endpoints", "services", "replicationcontrollers", "namespaces"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["linkerd.io"]
+  resources: ["serviceprofiles"]
+  verbs: ["list", "get", "watch"]
+- apiGroups: ["split.smi-spec.io"]
+  resources: ["trafficsplits"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-linkerd-viz-metrics-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-metrics-api
+subjects:
+- kind: ServiceAccount
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+---
+###
 ### Grafana RBAC
 ###
 ---
@@ -290,6 +343,92 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-grafana
   namespace: linkerd-viz
+---
+###
+### Metrics API
+###
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  type: ClusterIP
+  selector:
+    linkerd.io/extension: linkerd-viz
+    component: metrics-api
+  ports:
+  - name: http
+    port: 8085
+    targetPort: 8085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: linkerd-viz
+    app.kubernetes.io/name: metrics-api
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: dev-undefined
+    component: metrics-api
+    namespace: linkerd-viz
+  name: linkerd-metrics-api
+  namespace: linkerd-viz
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: linkerd-viz
+      component: metrics-api
+      namespace: linkerd-viz
+  template:
+    metadata:
+      annotations:
+        checksum/config: b9049bed0ca52f3d63f34e03d87cfdd38bd81f6066310d0bf64d2d3f380d5733
+        linkerd.io/created-by: linkerd/helm dev-undefined
+      labels:
+        linkerd.io/extension: linkerd-viz
+        component: metrics-api
+        namespace: linkerd-viz
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      containers:
+      - args:
+        - -controller-namespace=linkerd
+        - -log-level=info
+        - -cluster-domain=cluster.local
+        - -prometheus-url=external-prom.com
+        image: ghcr.io/linkerd/metrics-api:dev-undefined
+        imagePullPolicy: 
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: 9995
+          initialDelaySeconds: 10
+        name: metrics-api
+        ports:
+        - containerPort: 8085
+          name: http
+        - containerPort: 9995
+          name: admin-http
+        readinessProbe:
+          failureThreshold: 7
+          httpGet:
+            path: /ready
+            port: 9995
+        resources:
+        securityContext:
+          runAsUser: 2103
+      serviceAccountName: linkerd-metrics-api
 ---
 ###
 ### Grafana
@@ -612,10 +751,12 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - args:
-        - -api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
+        - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
         - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
+        - -viz-namespace=linkerd-viz
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -1,0 +1,29 @@
+ARG BUILDPLATFORM=linux/amd64
+
+# Precompile key slow-to-build dependencies
+FROM --platform=$BUILDPLATFORM golang:1.14.2-alpine as go-deps
+WORKDIR /linkerd-build
+COPY go.mod go.sum ./
+COPY bin/install-deps bin/
+RUN go mod download
+ARG TARGETARCH
+RUN ./bin/install-deps $TARGETARCH
+
+## compile metrics-apiservice
+FROM go-deps as golang
+WORKDIR /linkerd-build
+COPY pkg pkg
+COPY controller controller
+COPY viz/metrics-api viz/metrics-api
+COPY viz/pkg viz/pkg
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/metrics-api -tags prod -mod=readonly -ldflags "-s -w" ./viz/metrics-api/cmd
+
+## package runtime
+FROM scratch
+ENV PATH=$PATH:/go/bin
+COPY LICENSE /linkerd/LICENSE
+COPY --from=golang /out/metrics-api /go/bin/metrics-api
+
+ENTRYPOINT ["/go/bin/metrics-api"]

--- a/viz/metrics-api/cmd/main.go
+++ b/viz/metrics-api/cmd/main.go
@@ -1,45 +1,40 @@
-package publicapi
+package main
 
 import (
 	"context"
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
-	"github.com/linkerd/linkerd2/controller/api/destination"
-	"github.com/linkerd/linkerd2/controller/api/public"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/admin"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/trace"
+	api "github.com/linkerd/linkerd2/viz/metrics-api"
+	promApi "github.com/prometheus/client_golang/api"
 	log "github.com/sirupsen/logrus"
 )
 
-// Main executes the public-api subcommand
-func Main(args []string) {
-	cmd := flag.NewFlagSet("public-api", flag.ExitOnError)
+func main() {
+	cmd := flag.NewFlagSet("metrics-api", flag.ExitOnError)
 
 	addr := cmd.String("addr", ":8085", "address to serve on")
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
+	prometheusURL := cmd.String("prometheus-url", "", "prometheus url")
 	metricsAddr := cmd.String("metrics-addr", ":9995", "address to serve scrapable metrics on")
-	destinationAPIAddr := cmd.String("destination-addr", "127.0.0.1:8086", "address of destination service")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	ignoredNamespaces := cmd.String("ignore-namespaces", "kube-system", "comma separated list of namespaces to not list pods from")
 	clusterDomain := cmd.String("cluster-domain", "cluster.local", "kubernetes cluster domain")
 
 	traceCollector := flags.AddTraceFlags(cmd)
 
-	flags.ConfigureAndParse(cmd, args)
+	flags.ConfigureAndParse(cmd, os.Args[1:])
 	ctx := context.Background()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-
-	destinationClient, destinationConn, err := destination.NewClient(*destinationAPIAddr)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	defer destinationConn.Close()
 
 	k8sAPI, err := k8s.InitializeAPI(
 		ctx,
@@ -51,6 +46,15 @@ func Main(args []string) {
 		log.Fatalf("Failed to initialize K8s API: %s", err)
 	}
 
+	var prometheusClient promApi.Client
+	if *prometheusURL != "" {
+		prometheusClient, err = promApi.NewClient(promApi.Config{Address: *prometheusURL})
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
+	log.Infof("prometheusClient: %#v", prometheusClient)
 	log.Info("Using cluster domain: ", *clusterDomain)
 
 	if *traceCollector != "" {
@@ -59,12 +63,13 @@ func Main(args []string) {
 		}
 	}
 
-	server := public.NewServer(
+	server := api.NewServer(
 		*addr,
-		destinationClient,
+		prometheusClient,
 		k8sAPI,
 		*controllerNamespace,
 		*clusterDomain,
+		strings.Split(*ignoredNamespaces, ","),
 	)
 
 	k8sAPI.Sync(nil) // blocks until caches are synced


### PR DESCRIPTION
This is based on the branch `alpeb/grpc-viz` from #5557.

Here we complete the work started in #5554 ("Chart templates for new viz linkerd-metrics-api pod") by providing the Dockerfile, `main.go` command and the `bin/` scripts for building the new `linkerd-metrics-api` pod under the `linkerd-viz` namespace.

At the same time, we strip out of the public-api's `main.go` file the prometheus parameters and other no longer relevant bits.

Finally, updated tests related to linkerd-metrics-api.

Tests are not expected to pass on this one either.