### PR TITLE
public-api/viz split 7/8: linkerd-web updates

### DIFF
--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -68,7 +68,8 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
       - args:
-        - -api-addr=linkerd-controller-api.{{.Values.linkerdNamespace}}.svc.{{.Values.clusterDomain}}:8085
+        - -linkerd-controller-api-addr=linkerd-controller-api.{{.Values.linkerdNamespace}}.svc.{{.Values.clusterDomain}}:8085
+        - -linkerd-metrics-api-addr=linkerd-metrics-api.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:8085
         - -cluster-domain={{.Values.clusterDomain}}
         {{- if .Values.grafanaUrl }}
         - -grafana-addr={{.Values.grafanaUrl}}
@@ -79,6 +80,7 @@ spec:
         - -jaeger-addr={{.Values.jaegerUrl}}
         {{- end}}
         - -controller-namespace={{.Values.linkerdNamespace}}
+        - -viz-namespace={{.Values.namespace}}
         - -log-level={{.Values.dashboard.logLevel}}
         {{- if .Values.dashboard.enforcedHostRegexp }}
         - -enforced-host={{.Values.dashboard.enforcedHostRegexp}}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -38,7 +38,8 @@ RUN mkdir -p web
 COPY web/main.go web
 COPY web/srv web/srv
 COPY controller controller
-COPY viz/metrics-api/gen/viz viz/metrics-api/gen/viz
+COPY viz/metrics-api viz/metrics-api
+COPY viz/pkg viz/pkg
 COPY pkg pkg
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly -o web/web -ldflags "-s -w" ./web

--- a/web/main.go
+++ b/web/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/trace"
+	"github.com/linkerd/linkerd2/viz/metrics-api/client"
 	"github.com/linkerd/linkerd2/web/srv"
 	log "github.com/sirupsen/logrus"
 )
@@ -25,13 +26,15 @@ func main() {
 
 	addr := cmd.String("addr", ":8084", "address to serve on")
 	metricsAddr := cmd.String("metrics-addr", ":9994", "address to serve scrapable metrics on")
-	apiAddr := cmd.String("api-addr", "127.0.0.1:8085", "address of the linkerd-controller-api service")
+	publicAPIAddr := cmd.String("linkerd-controller-api-addr", "127.0.0.1:8085", "address of the linkerd-controller-api service")
+	vizAPIAddr := cmd.String("linkerd-metrics-api-addr", "127.0.0.1:8085", "address of the linkerd-metrics-api service")
 	grafanaAddr := cmd.String("grafana-addr", "", "address of the linkerd-grafana service")
 	jaegerAddr := cmd.String("jaeger-addr", "", "address of the jaeger service")
 	templateDir := cmd.String("template-dir", "templates", "directory to search for template files")
 	staticDir := cmd.String("static-dir", "app/dist", "directory to search for static files")
 	reload := cmd.Bool("reload", true, "reloading set to true or false")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
+	vizNamespace := cmd.String("viz-namespace", "linkerd", "namespace in which Linkerd viz is installed")
 	enforcedHost := cmd.String("enforced-host", "", "regexp describing the allowed values for the Host header; protects from DNS-rebinding attacks")
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
 	clusterDomain := cmd.String("cluster-domain", "", "kubernetes cluster domain")
@@ -41,17 +44,22 @@ func main() {
 	flags.ConfigureAndParse(cmd, os.Args[1:])
 	ctx := context.Background()
 
-	_, _, err := net.SplitHostPort(*apiAddr) // Verify apiAddr is of the form host:port.
+	_, _, err := net.SplitHostPort(*vizAPIAddr) // Verify vizAPIAddr is of the form host:port.
 	if err != nil {
-		log.Fatalf("failed to parse API server address: %s", *apiAddr)
+		log.Fatalf("failed to parse metrics API server address: %s", *vizAPIAddr)
 	}
-	client, err := public.NewInternalClient(*controllerNamespace, *apiAddr)
+	client, err := client.NewInternalClient(*vizNamespace, *vizAPIAddr)
 	if err != nil {
-		log.Fatalf("failed to construct client for viz API server URL %s", *apiAddr)
+		log.Fatalf("failed to construct client for viz API server URL %s", *vizAPIAddr)
 	}
-	publicClient, err := public.NewInternalPublicClient(*controllerNamespace, *apiAddr)
+
+	_, _, err = net.SplitHostPort(*publicAPIAddr) // Verify publicAPIAddr is of the form host:port.
 	if err != nil {
-		log.Fatalf("failed to construct client for public API server URL %s", *apiAddr)
+		log.Fatalf("failed to parse public API server address: %s", *publicAPIAddr)
+	}
+	publicClient, err := public.NewInternalPublicClient(*controllerNamespace, *publicAPIAddr)
+	if err != nil {
+		log.Fatalf("failed to construct client for public API server URL %s", *publicAPIAddr)
 	}
 
 	if *clusterDomain == "" {
@@ -77,7 +85,7 @@ func main() {
 	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
 		ControlPlaneNamespace: *controllerNamespace,
 		KubeConfig:            *kubeConfigPath,
-		APIAddr:               *apiAddr,
+		APIAddr:               *publicAPIAddr,
 	})
 
 	cm, _, err := healthcheck.FetchLinkerdConfigMap(ctx, k8sAPI, *controllerNamespace)

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -15,13 +15,14 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/gorilla/websocket"
 	"github.com/julienschmidt/httprouter"
-	"github.com/linkerd/linkerd2/controller/api/util"
+	coreUtil "github.com/linkerd/linkerd2/controller/api/util"
 	publicPb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	"github.com/linkerd/linkerd2/pkg/tap"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	vizUtil "github.com/linkerd/linkerd2/viz/metrics-api/util"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -137,8 +138,8 @@ func (h *handler) handleAPIStat(w http.ResponseWriter, req *http.Request, p http
 
 	trueStr := fmt.Sprintf("%t", true)
 
-	requestParams := util.StatsSummaryRequestParams{
-		StatsBaseRequestParams: util.StatsBaseRequestParams{
+	requestParams := vizUtil.StatsSummaryRequestParams{
+		StatsBaseRequestParams: vizUtil.StatsBaseRequestParams{
 			TimeWindow:    req.FormValue("window"),
 			ResourceName:  req.FormValue("resource_name"),
 			ResourceType:  req.FormValue("resource_type"),
@@ -160,7 +161,7 @@ func (h *handler) handleAPIStat(w http.ResponseWriter, req *http.Request, p http
 		requestParams.ResourceType = defaultResourceType
 	}
 
-	statRequest, err := util.BuildStatSummaryRequest(requestParams)
+	statRequest, err := vizUtil.BuildStatSummaryRequest(requestParams)
 	if err != nil {
 		renderJSONError(w, err, http.StatusInternalServerError)
 		return
@@ -184,8 +185,8 @@ func (h *handler) handleAPIStat(w http.ResponseWriter, req *http.Request, p http
 }
 
 func (h *handler) handleAPITopRoutes(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-	requestParams := util.TopRoutesRequestParams{
-		StatsBaseRequestParams: util.StatsBaseRequestParams{
+	requestParams := vizUtil.TopRoutesRequestParams{
+		StatsBaseRequestParams: vizUtil.StatsBaseRequestParams{
 			TimeWindow:   req.FormValue("window"),
 			ResourceName: req.FormValue("resource_name"),
 			ResourceType: req.FormValue("resource_type"),
@@ -196,7 +197,7 @@ func (h *handler) handleAPITopRoutes(w http.ResponseWriter, req *http.Request, p
 		ToNamespace: req.FormValue("to_namespace"),
 	}
 
-	topReq, err := util.BuildTopRoutesRequest(requestParams)
+	topReq, err := vizUtil.BuildTopRoutesRequest(requestParams)
 	if err != nil {
 		renderJSONError(w, err, http.StatusBadRequest)
 		return
@@ -256,14 +257,14 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 		return
 	}
 
-	var requestParams util.TapRequestParams
+	var requestParams coreUtil.TapRequestParams
 	err = json.Unmarshal(message, &requestParams)
 	if err != nil {
 		websocketError(ws, websocket.CloseInternalServerErr, err)
 		return
 	}
 
-	tapReq, err := util.BuildTapByResourceRequest(requestParams)
+	tapReq, err := coreUtil.BuildTapByResourceRequest(requestParams)
 	if err != nil {
 		websocketError(ws, websocket.CloseInternalServerErr, err)
 		return
@@ -328,12 +329,12 @@ func (h *handler) handleAPITap(w http.ResponseWriter, req *http.Request, p httpr
 }
 
 func (h *handler) handleAPIEdges(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
-	requestParams := util.EdgesRequestParams{
+	requestParams := vizUtil.EdgesRequestParams{
 		Namespace:    req.FormValue("namespace"),
 		ResourceType: req.FormValue("resource_type"),
 	}
 
-	edgesRequest, err := util.BuildEdgesRequest(requestParams)
+	edgesRequest, err := vizUtil.BuildEdgesRequest(requestParams)
 	if err != nil {
 		renderJSONError(w, err, http.StatusInternalServerError)
 		return

--- a/web/srv/api_handlers_test.go
+++ b/web/srv/api_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/public"
 	publicPb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	vizApi "github.com/linkerd/linkerd2/viz/metrics-api"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 )
 
@@ -142,7 +143,7 @@ func TestHandleApiCheck(t *testing.T) {
 }
 
 func TestHandleApiGateway(t *testing.T) {
-	mockAPIClient := &public.MockAPIClient{
+	mockAPIClient := &vizApi.MockAPIClient{
 		GatewaysResponseToReturn: &pb.GatewaysResponse{
 			Response: &pb.GatewaysResponse_Ok_{
 				Ok: &pb.GatewaysResponse_Ok{

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	profiles "github.com/linkerd/linkerd2/pkg/profiles"
+	vizPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,8 +23,8 @@ type (
 
 	handler struct {
 		render              renderTemplate
-		apiClient           public.VizAPIClient
-		publicAPIClient     public.PublicAPIClient
+		apiClient           vizPb.ApiClient
+		publicAPIClient     public.Client
 		k8sAPI              *k8s.KubernetesAPI
 		uuid                string
 		controllerNamespace string

--- a/web/srv/handlers_test.go
+++ b/web/srv/handlers_test.go
@@ -76,7 +76,7 @@ func TestHandleConfigDownload(t *testing.T) {
 
 	handler := &handler{
 		render:              server.RenderTemplate,
-		apiClient:           mockAPIClient,
+		publicAPIClient:     mockAPIClient,
 		controllerNamespace: "linkerd",
 		clusterDomain:       "mycluster.local",
 	}

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
+	vizPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
 )
@@ -93,8 +94,8 @@ func NewServer(
 	clusterDomain string,
 	reload bool,
 	reHost *regexp.Regexp,
-	apiClient public.VizAPIClient,
-	publicAPIClient public.PublicAPIClient,
+	apiClient vizPb.ApiClient,
+	publicAPIClient public.Client,
 	k8sAPI *k8s.KubernetesAPI,
 	hc healthChecker,
 ) *http.Server {


### PR DESCRIPTION
This is based on the branch `alpeb/linkerd-metrics-api-bootstrap` from #5558.

`linkerd-web` requires connecting with both the public-api and the viz api, so both addresses (and the viz namespace) are now provided as parameters to the container.

We're also updating some dependencies that still were pointing to the public-api and now should point to the viz api.

Tests are not expected to pass on this one either.
