### PR TITLE
experiment: replace pointer types with values to avoid nil pointer segfaults

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -359,17 +359,17 @@ func fetchConfigs(ctx context.Context) (*linkerd2.Values, error) {
 func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[string]string {
 	overrideAnnotations := make(map[string]string)
 
-	proxy := values.GetGlobal().Proxy
-	baseProxy := base.GetGlobal().Proxy
+	proxy := values.Global.Proxy
+	baseProxy := base.Global.Proxy
 	if proxy.Image.Version != baseProxy.Image.Version {
 		overrideAnnotations[k8s.ProxyVersionOverrideAnnotation] = proxy.Image.Version
 	}
 
-	if values.GetGlobal().ProxyInit.IgnoreInboundPorts != base.GetGlobal().ProxyInit.IgnoreInboundPorts {
-		overrideAnnotations[k8s.ProxyIgnoreInboundPortsAnnotation] = values.GetGlobal().ProxyInit.IgnoreInboundPorts
+	if values.Global.ProxyInit.IgnoreInboundPorts != base.Global.ProxyInit.IgnoreInboundPorts {
+		overrideAnnotations[k8s.ProxyIgnoreInboundPortsAnnotation] = values.Global.ProxyInit.IgnoreInboundPorts
 	}
-	if values.GetGlobal().ProxyInit.IgnoreOutboundPorts != base.GetGlobal().ProxyInit.IgnoreOutboundPorts {
-		overrideAnnotations[k8s.ProxyIgnoreOutboundPortsAnnotation] = values.GetGlobal().ProxyInit.IgnoreOutboundPorts
+	if values.Global.ProxyInit.IgnoreOutboundPorts != base.Global.ProxyInit.IgnoreOutboundPorts {
+		overrideAnnotations[k8s.ProxyIgnoreOutboundPortsAnnotation] = values.Global.ProxyInit.IgnoreOutboundPorts
 	}
 
 	if proxy.Ports.Admin != baseProxy.Ports.Admin {
@@ -388,15 +388,15 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 	if proxy.Image.Name != baseProxy.Image.Name {
 		overrideAnnotations[k8s.ProxyImageAnnotation] = proxy.Image.Name
 	}
-	if values.GetGlobal().ProxyInit.Image.Name != base.GetGlobal().ProxyInit.Image.Name {
-		overrideAnnotations[k8s.ProxyInitImageAnnotation] = values.GetGlobal().ProxyInit.Image.Name
+	if values.Global.ProxyInit.Image.Name != base.Global.ProxyInit.Image.Name {
+		overrideAnnotations[k8s.ProxyInitImageAnnotation] = values.Global.ProxyInit.Image.Name
 	}
 	if values.DebugContainer.Image.Name != base.DebugContainer.Image.Name {
 		overrideAnnotations[k8s.DebugImageAnnotation] = values.DebugContainer.Image.Name
 	}
 
-	if values.GetGlobal().ProxyInit.Image.Version != base.GetGlobal().ProxyInit.Image.Version {
-		overrideAnnotations[k8s.ProxyInitImageVersionAnnotation] = values.GetGlobal().ProxyInit.Image.Version
+	if values.Global.ProxyInit.Image.Version != base.Global.ProxyInit.Image.Version {
+		overrideAnnotations[k8s.ProxyInitImageVersionAnnotation] = values.Global.ProxyInit.Image.Version
 	}
 
 	if values.DebugContainer.Image.Version != base.DebugContainer.Image.Version {
@@ -456,7 +456,7 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 	}
 
 	// Set fields that can't be converted into annotations
-	values.GetGlobal().Namespace = controlPlaneNamespace
+	values.Global.Namespace = controlPlaneNamespace
 
 	return overrideAnnotations
 }

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -64,8 +64,8 @@ func defaultConfig() *linkerd2.Values {
 	if err != nil {
 		log.Fatalf("Unexpected error: %v", err)
 	}
-	defaultConfig.GetGlobal().LinkerdVersion = "test-inject-control-plane-version"
-	defaultConfig.GetGlobal().Proxy.Image.Version = "test-inject-proxy-version"
+	defaultConfig.Global.LinkerdVersion = "test-inject-control-plane-version"
+	defaultConfig.Global.Proxy.Image.Version = "test-inject-proxy-version"
 	defaultConfig.DebugContainer.Image.Version = "test-inject-debug-version"
 
 	return defaultConfig
@@ -75,10 +75,10 @@ func TestUninjectAndInject(t *testing.T) {
 	defaultValues := defaultConfig()
 
 	overrideConfig := defaultConfig()
-	overrideConfig.GetGlobal().Proxy.Image.Version = "override"
+	overrideConfig.Global.Proxy.Image.Version = "override"
 
 	proxyResourceConfig := defaultConfig()
-	proxyResourceConfig.GetGlobal().Proxy.Resources = &linkerd2.Resources{
+	proxyResourceConfig.Global.Proxy.Resources = linkerd2.Resources{
 		CPU: linkerd2.Constraints{
 			Request: "110m",
 			Limit:   "160m",
@@ -90,11 +90,11 @@ func TestUninjectAndInject(t *testing.T) {
 	}
 
 	cniEnabledConfig := defaultConfig()
-	cniEnabledConfig.GetGlobal().CNIEnabled = true
+	cniEnabledConfig.Global.CNIEnabled = true
 
 	proxyIgnorePortsConfig := defaultConfig()
-	proxyIgnorePortsConfig.GetGlobal().ProxyInit.IgnoreInboundPorts = "22,8100-8102"
-	proxyIgnorePortsConfig.GetGlobal().ProxyInit.IgnoreOutboundPorts = "5432"
+	proxyIgnorePortsConfig.Global.ProxyInit.IgnoreInboundPorts = "22,8100-8102"
+	proxyIgnorePortsConfig.Global.ProxyInit.IgnoreOutboundPorts = "5432"
 
 	testCases := []testCase{
 		{
@@ -111,7 +111,7 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:    false,
 			testInjectConfig: func() *linkerd2.Values {
 				values := defaultConfig()
-				values.GetGlobal().Proxy.Ports.Admin = 1234
+				values.Global.Proxy.Ports.Admin = 1234
 				return values
 			}(),
 		},
@@ -122,7 +122,7 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:    true,
 			testInjectConfig: func() *linkerd2.Values {
 				values := defaultConfig()
-				values.GetGlobal().Proxy.Ports.Admin = 1234
+				values.Global.Proxy.Ports.Admin = 1234
 				return values
 			}(),
 		},
@@ -317,7 +317,7 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	testConfig.GetGlobal().Proxy.Image.Version = "testinjectversion"
+	testConfig.Global.Proxy.Image.Version = "testinjectversion"
 
 	errBuffer := &bytes.Buffer{}
 	outBuffer := &bytes.Buffer{}
@@ -584,23 +584,23 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.GetGlobal().ProxyInit.IgnoreInboundPorts = "8500-8505"
-	values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "3306"
-	values.GetGlobal().Proxy.Ports.Admin = 1234
-	values.GetGlobal().Proxy.Ports.Control = 4191
-	values.GetGlobal().Proxy.Ports.Inbound = 4144
-	values.GetGlobal().Proxy.Ports.Outbound = 4141
-	values.GetGlobal().Proxy.UID = 999
-	values.GetGlobal().Proxy.LogLevel = "debug"
-	values.GetGlobal().Proxy.LogFormat = "cool"
-	values.GetGlobal().Proxy.DisableIdentity = true
-	values.GetGlobal().Proxy.DisableTap = true
-	values.GetGlobal().Proxy.EnableExternalProfiles = true
-	values.GetGlobal().Proxy.Resources.CPU.Request = "10m"
-	values.GetGlobal().Proxy.Resources.CPU.Limit = "100m"
-	values.GetGlobal().Proxy.Resources.Memory.Request = "10Mi"
-	values.GetGlobal().Proxy.Resources.Memory.Limit = "50Mi"
-	values.GetGlobal().Proxy.WaitBeforeExitSeconds = 10
+	values.Global.ProxyInit.IgnoreInboundPorts = "8500-8505"
+	values.Global.ProxyInit.IgnoreOutboundPorts = "3306"
+	values.Global.Proxy.Ports.Admin = 1234
+	values.Global.Proxy.Ports.Control = 4191
+	values.Global.Proxy.Ports.Inbound = 4144
+	values.Global.Proxy.Ports.Outbound = 4141
+	values.Global.Proxy.UID = 999
+	values.Global.Proxy.LogLevel = "debug"
+	values.Global.Proxy.LogFormat = "cool"
+	values.Global.Proxy.DisableIdentity = true
+	values.Global.Proxy.DisableTap = true
+	values.Global.Proxy.EnableExternalProfiles = true
+	values.Global.Proxy.Resources.CPU.Request = "10m"
+	values.Global.Proxy.Resources.CPU.Limit = "100m"
+	values.Global.Proxy.Resources.Memory.Request = "10Mi"
+	values.Global.Proxy.Resources.Memory.Limit = "50Mi"
+	values.Global.Proxy.WaitBeforeExitSeconds = 10
 
 	expectedOverrides := map[string]string{
 		k8s.ProxyIgnoreInboundPortsAnnotation:     "8500-8505",
@@ -636,7 +636,7 @@ func TestProxyImageAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.GetGlobal().Proxy.Image = &linkerd2.Image{
+	values.Global.Proxy.Image = linkerd2.Image{
 		Name:       "my.registry/linkerd/proxy",
 		Version:    "test-proxy-version",
 		PullPolicy: "Always",
@@ -662,7 +662,7 @@ func TestProxyInitImageAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	values.GetGlobal().ProxyInit.Image = &linkerd2.Image{
+	values.Global.ProxyInit.Image = linkerd2.Image{
 		Name:    "my.registry/linkerd/proxy-init",
 		Version: "test-proxy-init-version",
 	}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -116,7 +116,7 @@ resources for the Linkerd control plane. This command should be followed by
 			}
 			if !ignoreCluster {
 				// Ensure k8s is reachable and that Linkerd is not already installed.
-				if err := errAfterRunningChecks(values.GetGlobal().CNIEnabled); err != nil {
+				if err := errAfterRunningChecks(values.Global.CNIEnabled); err != nil {
 					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 					} else {
@@ -166,7 +166,7 @@ control plane. It should be run after "linkerd install config".`,
 			if !skipChecks {
 				// check if global resources exist to determine if the `install config`
 				// stage succeeded
-				if err := errAfterRunningChecks(values.GetGlobal().CNIEnabled); err == nil {
+				if err := errAfterRunningChecks(values.Global.CNIEnabled); err == nil {
 					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
 						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
 					} else {
@@ -290,7 +290,7 @@ func install(ctx context.Context, w io.Writer, values *l5dcharts.Values, flags [
 func render(w io.Writer, values *l5dcharts.Values, stage string) error {
 
 	// Set any global flags if present, common with install and upgrade
-	values.GetGlobal().Namespace = controlPlaneNamespace
+	values.Global.Namespace = controlPlaneNamespace
 	values.Stage = stage
 
 	// Render raw values and create chart config
@@ -334,7 +334,7 @@ func render(w io.Writer, values *l5dcharts.Values, stage string) error {
 	}
 
 	if stage == "" || stage == controlPlaneStage {
-		overrides, err := renderOverrides(values, values.GetGlobal().Namespace)
+		overrides, err := renderOverrides(values, values.Global.Namespace)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/install_helm_test.go
+++ b/cli/cmd/install_helm_test.go
@@ -283,8 +283,8 @@ func readTestValues(ha bool, ignoreOutboundPorts string, ignoreInboundPorts stri
 			return nil, err
 		}
 	}
-	values.GetGlobal().ProxyInit.IgnoreOutboundPorts = ignoreOutboundPorts
-	values.GetGlobal().ProxyInit.IgnoreInboundPorts = ignoreInboundPorts
+	values.Global.ProxyInit.IgnoreOutboundPorts = ignoreOutboundPorts
+	values.Global.ProxyInit.IgnoreInboundPorts = ignoreInboundPorts
 
 	return values, nil
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -39,7 +39,7 @@ func TestRender(t *testing.T) {
 		Identity:               defaultValues.Identity,
 		NodeSelector:           defaultValues.NodeSelector,
 		Tolerations:            defaultValues.Tolerations,
-		Global: &charts.Global{
+		Global: charts.Global{
 			Namespace:                "Namespace",
 			ClusterDomain:            "cluster.local",
 			ClusterNetworks:          "ClusterNetworks",
@@ -57,19 +57,19 @@ func TestRender(t *testing.T) {
 			LinkerdNamespaceLabel:    "LinkerdNamespaceLabel",
 			ProxyContainerName:       "ProxyContainerName",
 			CNIEnabled:               false,
-			IdentityTrustDomain:      defaultValues.GetGlobal().IdentityTrustDomain,
-			IdentityTrustAnchorsPEM:  defaultValues.GetGlobal().IdentityTrustAnchorsPEM,
+			IdentityTrustDomain:      defaultValues.Global.IdentityTrustDomain,
+			IdentityTrustAnchorsPEM:  defaultValues.Global.IdentityTrustAnchorsPEM,
 			PodAnnotations:           map[string]string{},
 			PodLabels:                map[string]string{},
-			Proxy: &charts.Proxy{
-				Image: &charts.Image{
+			Proxy: charts.Proxy{
+				Image: charts.Image{
 					Name:       "ProxyImageName",
 					PullPolicy: "ImagePullPolicy",
 					Version:    "ProxyVersion",
 				},
 				LogLevel:  "warn,linkerd=info",
 				LogFormat: "plain",
-				Resources: &charts.Resources{
+				Resources: charts.Resources{
 					CPU: charts.Constraints{
 						Limit:   "cpu-limit",
 						Request: "cpu-request",
@@ -79,7 +79,7 @@ func TestRender(t *testing.T) {
 						Request: "memory-request",
 					},
 				},
-				Ports: &charts.Ports{
+				Ports: charts.Ports{
 					Admin:    4191,
 					Control:  4190,
 					Inbound:  4143,
@@ -87,14 +87,14 @@ func TestRender(t *testing.T) {
 				},
 				UID: 2102,
 			},
-			ProxyInit: &charts.ProxyInit{
-				Image: &charts.Image{
+			ProxyInit: charts.ProxyInit{
+				Image: charts.Image{
 					Name:       "ProxyInitImageName",
 					PullPolicy: "ImagePullPolicy",
 					Version:    "ProxyInitVersion",
 				},
 				IgnoreOutboundPorts: "443",
-				Resources: &charts.Resources{
+				Resources: charts.Resources{
 					CPU: charts.Constraints{
 						Limit:   "100m",
 						Request: "10m",
@@ -104,7 +104,7 @@ func TestRender(t *testing.T) {
 						Request: "10Mi",
 					},
 				},
-				XTMountPath: &charts.VolumeMountPath{
+				XTMountPath: charts.VolumeMountPath{
 					MountPath: "/run",
 					Name:      "linkerd-proxy-init-xtables-lock",
 				},
@@ -115,8 +115,8 @@ func TestRender(t *testing.T) {
 			Proxy:   "ProxyConfig",
 			Install: "InstallConfig",
 		},
-		DebugContainer: &charts.DebugContainer{
-			Image: &charts.Image{
+		DebugContainer: charts.DebugContainer{
+			Image: charts.Image{
 				Name:       "DebugImageName",
 				PullPolicy: "DebugImagePullPolicy",
 				Version:    "DebugVersion",
@@ -138,10 +138,10 @@ func TestRender(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	haWithOverridesValues.GetGlobal().HighAvailability = true
+	haWithOverridesValues.Global.HighAvailability = true
 	haWithOverridesValues.ControllerReplicas = 2
-	haWithOverridesValues.GetGlobal().Proxy.Resources.CPU.Request = "400m"
-	haWithOverridesValues.GetGlobal().Proxy.Resources.Memory.Request = "300Mi"
+	haWithOverridesValues.Global.Proxy.Resources.CPU.Request = "400m"
+	haWithOverridesValues.Global.Proxy.Resources.Memory.Request = "300Mi"
 	addFakeTLSSecrets(haWithOverridesValues)
 
 	cniEnabledValues, err := testInstallOptions()
@@ -149,15 +149,15 @@ func TestRender(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	cniEnabledValues.GetGlobal().CNIEnabled = true
+	cniEnabledValues.Global.CNIEnabled = true
 	addFakeTLSSecrets(cniEnabledValues)
 
 	withProxyIgnoresValues, err := testInstallOptions()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withProxyIgnoresValues.GetGlobal().ProxyInit.IgnoreInboundPorts = "22,8100-8102"
-	withProxyIgnoresValues.GetGlobal().ProxyInit.IgnoreOutboundPorts = "5432"
+	withProxyIgnoresValues.Global.ProxyInit.IgnoreInboundPorts = "22,8100-8102"
+	withProxyIgnoresValues.Global.ProxyInit.IgnoreOutboundPorts = "5432"
 	addFakeTLSSecrets(withProxyIgnoresValues)
 
 	withHeartBeatDisabledValues, err := testInstallOptions()
@@ -171,7 +171,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withControlPlaneTracingValues.GetGlobal().ControlPlaneTracing = true
+	withControlPlaneTracingValues.Global.ControlPlaneTracing = true
 	addFakeTLSSecrets(withControlPlaneTracingValues)
 
 	customRegistryOverride := "my.custom.registry/linkerd-io"
@@ -194,7 +194,7 @@ func TestRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
-	withCustomDestinationGetNetsValues.GetGlobal().ClusterNetworks = "10.0.0.0/8,100.64.0.0/10,172.0.0.0/8"
+	withCustomDestinationGetNetsValues.Global.ClusterNetworks = "10.0.0.0/8,100.64.0.0/10,172.0.0.0/8"
 	addFakeTLSSecrets(withCustomDestinationGetNetsValues)
 
 	testCases := []struct {
@@ -231,7 +231,7 @@ func TestValidateAndBuild_Errors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
-		values.GetGlobal().ProxyInit.IgnoreInboundPorts = "-25"
+		values.Global.ProxyInit.IgnoreInboundPorts = "-25"
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {
 			t.Fatal("expected error but got nothing")
@@ -243,7 +243,7 @@ func TestValidateAndBuild_Errors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
-		values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "-25"
+		values.Global.ProxyInit.IgnoreOutboundPorts = "-25"
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {
 			t.Fatal("expected error but got nothing")
@@ -283,7 +283,7 @@ func testInstallOptionsHA(ha bool) (*charts.Values, error) {
 	if err != nil {
 		return nil, err
 	}
-	values.GetGlobal().IdentityTrustAnchorsPEM = string(data)
+	values.Global.IdentityTrustAnchorsPEM = string(data)
 
 	return values, nil
 }
@@ -299,9 +299,9 @@ func testInstallOptionsNoCerts(ha bool) (*charts.Values, error) {
 		}
 	}
 
-	values.GetGlobal().Proxy.Image.Version = installProxyVersion
+	values.Global.Proxy.Image.Version = installProxyVersion
 	values.DebugContainer.Image.Version = installDebugVersion
-	values.GetGlobal().ControllerImageVersion = installControlPlaneVersion
+	values.Global.ControllerImageVersion = installControlPlaneVersion
 	values.HeartbeatSchedule = fakeHeartbeatSchedule()
 
 	return values, nil
@@ -313,10 +313,10 @@ func testInstallValues() (*charts.Values, error) {
 		return nil, err
 	}
 
-	values.GetGlobal().Proxy.Image.Version = installProxyVersion
+	values.Global.Proxy.Image.Version = installProxyVersion
 	values.DebugContainer.Image.Version = installDebugVersion
-	values.GetGlobal().LinkerdVersion = installControlPlaneVersion
-	values.GetGlobal().ControllerImageVersion = installControlPlaneVersion
+	values.Global.LinkerdVersion = installControlPlaneVersion
+	values.Global.ControllerImageVersion = installControlPlaneVersion
 	values.HeartbeatSchedule = fakeHeartbeatSchedule()
 
 	identityCert, err := ioutil.ReadFile(filepath.Join("testdata", "valid-crt.pem"))
@@ -334,7 +334,7 @@ func testInstallValues() (*charts.Values, error) {
 
 	values.Identity.Issuer.TLS.CrtPEM = string(identityCert)
 	values.Identity.Issuer.TLS.KeyPEM = string(identityKey)
-	values.GetGlobal().IdentityTrustAnchorsPEM = string(trustAnchorsPEM)
+	values.Global.IdentityTrustAnchorsPEM = string(trustAnchorsPEM)
 	return values, nil
 }
 
@@ -356,7 +356,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 
-		values.GetGlobal().ClusterNetworks = "wrong"
+		values.Global.ClusterNetworks = "wrong"
 		expected := "cannot parse destination get networks: invalid CIDR address: wrong"
 
 		err = validateValues(context.Background(), nil, values)
@@ -374,7 +374,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 
-		values.GetGlobal().ControllerLogLevel = "super"
+		values.Global.ControllerLogLevel = "super"
 		expected := "--controller-log-level must be one of: panic, fatal, error, warn, info, debug"
 
 		err = validateValues(context.Background(), nil, values)
@@ -410,7 +410,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			values.GetGlobal().Proxy.LogLevel = tc.input
+			values.Global.Proxy.LogLevel = tc.input
 			err := validateValues(context.Background(), nil, values)
 			if tc.valid && err != nil {
 				t.Fatalf("Error not expected: %s", err)
@@ -462,7 +462,7 @@ func TestValidate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			values.GetGlobal().IdentityTrustAnchorsPEM = string(ca)
+			values.Global.IdentityTrustAnchorsPEM = string(ca)
 
 			err = validateValues(context.Background(), nil, values)
 

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -44,7 +44,7 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 	flags := []flag.Flag{
 		flag.NewStringFlag(installUpgradeFlags, "controller-log-level", defaults.GetGlobal().ControllerLogLevel,
 			"Log level for the controller and web components", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ControllerLogLevel = value
+				values.Global.ControllerLogLevel = value
 				return nil
 			}),
 
@@ -52,7 +52,7 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 		// individual flags can override the HA defaults.
 		flag.NewBoolFlag(installUpgradeFlags, "ha", false, "Enable HA deployment config for the control plane (default false)",
 			func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().HighAvailability = value
+				values.Global.HighAvailability = value
 				if value {
 					if err := l5dcharts.MergeHAValues(values); err != nil {
 						return err
@@ -109,13 +109,13 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 
 		flag.NewBoolFlag(installUpgradeFlags, "control-plane-tracing", defaults.GetGlobal().ControlPlaneTracing,
 			"Enables Control Plane Tracing with the defaults", func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().ControlPlaneTracing = value
+				values.Global.ControlPlaneTracing = value
 				return nil
 			}),
 
 		flag.NewStringFlag(installUpgradeFlags, "control-plane-tracing-namespace", defaults.GetGlobal().ControlPlaneTracingNamespace,
 			"Send control plane traces to Linkerd-Jaeger extension in this namespace", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ControlPlaneTracingNamespace = value
+				values.Global.ControlPlaneTracingNamespace = value
 				return nil
 			}),
 
@@ -153,7 +153,7 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 					if err != nil {
 						return err
 					}
-					values.GetGlobal().IdentityTrustAnchorsPEM = string(data)
+					values.Global.IdentityTrustAnchorsPEM = string(data)
 				}
 				return nil
 			}),
@@ -161,14 +161,14 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 		flag.NewBoolFlag(installUpgradeFlags, "enable-endpoint-slices", defaults.GetGlobal().EnableEndpointSlices,
 			"Enables the usage of EndpointSlice informers and resources for destination service",
 			func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().EnableEndpointSlices = value
+				values.Global.EnableEndpointSlices = value
 				return nil
 			}),
 
 		flag.NewStringFlag(installUpgradeFlags, "control-plane-version", defaults.GetGlobal().ControllerImageVersion,
 			"Tag to be used for the control plane component images",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ControllerImageVersion = value
+				values.Global.ControllerImageVersion = value
 				return nil
 			}),
 	}
@@ -225,7 +225,7 @@ func makeAllStageFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet)
 		flag.NewBoolFlag(allStageFlags, "linkerd-cni-enabled", defaults.GetGlobal().CNIEnabled,
 			"Omit the NET_ADMIN capability in the PSP and the proxy-init container when injecting the proxy; requires the linkerd-cni plugin to already be installed",
 			func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().CNIEnabled = value
+				values.Global.CNIEnabled = value
 				return nil
 			}),
 
@@ -259,13 +259,13 @@ func makeInstallFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) 
 	flags := []flag.Flag{
 		flag.NewStringFlag(installOnlyFlags, "cluster-domain", defaults.GetGlobal().ClusterDomain,
 			"Set custom cluster domain", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ClusterDomain = value
+				values.Global.ClusterDomain = value
 				return nil
 			}),
 
 		flag.NewStringFlag(installOnlyFlags, "identity-trust-domain", defaults.GetGlobal().IdentityTrustDomain,
 			"Configures the name suffix used for identities.", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().IdentityTrustDomain = value
+				values.Global.IdentityTrustDomain = value
 				return nil
 			}),
 
@@ -293,25 +293,25 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 	flags := []flag.Flag{
 		flag.NewStringFlagP(proxyFlags, "proxy-version", "v", defaults.GetGlobal().Proxy.Image.Version, "Tag to be used for the Linkerd proxy images",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Image.Version = value
+				values.Global.Proxy.Image.Version = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-image", defaults.GetGlobal().Proxy.Image.Name, "Linkerd proxy container image name",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Image.Name = value
+				values.Global.Proxy.Image.Name = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "init-image", defaults.GetGlobal().ProxyInit.Image.Name, "Linkerd init container image name",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ProxyInit.Image.Name = value
+				values.Global.ProxyInit.Image.Name = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "init-image-version", defaults.GetGlobal().ProxyInit.Image.Version,
 			"Linkerd init container image version", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ProxyInit.Image.Version = value
+				values.Global.ProxyInit.Image.Version = value
 				return nil
 			}),
 
@@ -319,77 +319,77 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 			func(values *l5dcharts.Values, value string) error {
 				values.ControllerImage = registryOverride(values.ControllerImage, value)
 				values.DebugContainer.Image.Name = registryOverride(values.DebugContainer.Image.Name, value)
-				values.GetGlobal().Proxy.Image.Name = registryOverride(values.GetGlobal().Proxy.Image.Name, value)
-				values.GetGlobal().ProxyInit.Image.Name = registryOverride(values.GetGlobal().ProxyInit.Image.Name, value)
+				values.Global.Proxy.Image.Name = registryOverride(values.Global.Proxy.Image.Name, value)
+				values.Global.ProxyInit.Image.Name = registryOverride(values.Global.ProxyInit.Image.Name, value)
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "image-pull-policy", defaults.GetGlobal().ImagePullPolicy,
 			"Docker image pull policy", func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().ImagePullPolicy = value
-				values.GetGlobal().Proxy.Image.PullPolicy = value
-				values.GetGlobal().ProxyInit.Image.PullPolicy = value
+				values.Global.ImagePullPolicy = value
+				values.Global.Proxy.Image.PullPolicy = value
+				values.Global.ProxyInit.Image.PullPolicy = value
 				values.DebugContainer.Image.PullPolicy = value
 				return nil
 			}),
 
 		flag.NewUintFlag(proxyFlags, "inbound-port", uint(defaults.GetGlobal().Proxy.Ports.Inbound),
 			"Proxy port to use for inbound traffic", func(values *l5dcharts.Values, value uint) error {
-				values.GetGlobal().Proxy.Ports.Inbound = int32(value)
+				values.Global.Proxy.Ports.Inbound = int32(value)
 				return nil
 			}),
 
 		flag.NewUintFlag(proxyFlags, "outbound-port", uint(defaults.GetGlobal().Proxy.Ports.Outbound),
 			"Proxy port to use for outbound traffic", func(values *l5dcharts.Values, value uint) error {
-				values.GetGlobal().Proxy.Ports.Outbound = int32(value)
+				values.Global.Proxy.Ports.Outbound = int32(value)
 				return nil
 			}),
 
 		flag.NewStringSliceFlag(proxyFlags, "skip-inbound-ports", nil, "Ports and/or port ranges (inclusive) that should skip the proxy and send directly to the application",
 			func(values *l5dcharts.Values, value []string) error {
-				values.GetGlobal().ProxyInit.IgnoreInboundPorts = strings.Join(value, ",")
+				values.Global.ProxyInit.IgnoreInboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
 		flag.NewStringSliceFlag(proxyFlags, "skip-outbound-ports", nil, "Outbound ports and/or port ranges (inclusive) that should skip the proxy",
 			func(values *l5dcharts.Values, value []string) error {
-				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = strings.Join(value, ",")
+				values.Global.ProxyInit.IgnoreOutboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
 		flag.NewInt64Flag(proxyFlags, "proxy-uid", defaults.GetGlobal().Proxy.UID, "Run the proxy under this user ID",
 			func(values *l5dcharts.Values, value int64) error {
-				values.GetGlobal().Proxy.UID = value
+				values.Global.Proxy.UID = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-log-level", defaults.GetGlobal().Proxy.LogLevel, "Log level for the proxy",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.LogLevel = value
+				values.Global.Proxy.LogLevel = value
 				return nil
 			}),
 
 		flag.NewUintFlag(proxyFlags, "control-port", uint(defaults.GetGlobal().Proxy.Ports.Control), "Proxy port to use for control",
 			func(values *l5dcharts.Values, value uint) error {
-				values.GetGlobal().Proxy.Ports.Control = int32(value)
+				values.Global.Proxy.Ports.Control = int32(value)
 				return nil
 			}),
 
 		flag.NewUintFlag(proxyFlags, "admin-port", uint(defaults.GetGlobal().Proxy.Ports.Admin), "Proxy port to serve metrics on",
 			func(values *l5dcharts.Values, value uint) error {
-				values.GetGlobal().Proxy.Ports.Admin = int32(value)
+				values.Global.Proxy.Ports.Admin = int32(value)
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-cpu-request", defaults.GetGlobal().Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Resources.CPU.Request = value
+				values.Global.Proxy.Resources.CPU.Request = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory-request", defaults.GetGlobal().Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Resources.Memory.Request = value
+				values.Global.Proxy.Resources.Memory.Request = value
 				return nil
 			}),
 
@@ -403,20 +403,20 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				if err != nil {
 					return err
 				}
-				values.GetGlobal().Proxy.Cores = c
-				values.GetGlobal().Proxy.Resources.CPU.Limit = value
+				values.Global.Proxy.Cores = c
+				values.Global.Proxy.Resources.CPU.Limit = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory-limit", defaults.GetGlobal().Proxy.Resources.Memory.Limit, "Maximum amount of Memory that the proxy sidecar can use",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Resources.Memory.Limit = value
+				values.Global.Proxy.Resources.Memory.Limit = value
 				return nil
 			}),
 
 		flag.NewBoolFlag(proxyFlags, "enable-external-profiles", defaults.GetGlobal().Proxy.EnableExternalProfiles, "Enable service profiles for non-Kubernetes services",
 			func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().Proxy.EnableExternalProfiles = value
+				values.Global.Proxy.EnableExternalProfiles = value
 				return nil
 			}),
 
@@ -424,13 +424,13 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.GetGlobal().Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Resources.Memory.Request = value
+				values.Global.Proxy.Resources.Memory.Request = value
 				return nil
 			}),
 
 		flag.NewStringFlag(proxyFlags, "proxy-cpu", defaults.GetGlobal().Proxy.Resources.CPU.Request, "Amount of CPU units that the proxy sidecar requests",
 			func(values *l5dcharts.Values, value string) error {
-				values.GetGlobal().Proxy.Resources.CPU.Request = value
+				values.Global.Proxy.Resources.CPU.Request = value
 				return nil
 			}),
 	}
@@ -467,31 +467,31 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 			"The period during which the proxy sidecar must stay alive while its pod is terminating. "+
 				"Must be smaller than terminationGracePeriodSeconds for the pod (default 0)",
 			func(values *l5dcharts.Values, value int64) error {
-				values.GetGlobal().Proxy.WaitBeforeExitSeconds = uint64(value)
+				values.Global.Proxy.WaitBeforeExitSeconds = uint64(value)
 				return nil
 			}),
 
 		flag.NewBoolFlag(injectFlags, "disable-identity", defaults.GetGlobal().Proxy.DisableIdentity,
 			"Disables resources from participating in TLS identity", func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().Proxy.DisableIdentity = value
+				values.Global.Proxy.DisableIdentity = value
 				return nil
 			}),
 
 		flag.NewBoolFlag(injectFlags, "disable-tap", defaults.GetGlobal().Proxy.DisableTap,
 			"Disables resources from being tapped", func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().Proxy.DisableTap = value
+				values.Global.Proxy.DisableTap = value
 				return nil
 			}),
 
 		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.GetGlobal().Proxy.RequireIdentityOnInboundPorts, ","),
 			"Inbound ports on which the proxy should require identity", func(values *l5dcharts.Values, value []string) error {
-				values.GetGlobal().Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
+				values.Global.Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
 				return nil
 			}),
 
 		flag.NewBoolFlag(injectFlags, "ingress", defaults.GetGlobal().Proxy.IsIngress, "Enable ingress mode in the linkerd proxy",
 			func(values *l5dcharts.Values, value bool) error {
-				values.GetGlobal().Proxy.IsIngress = value
+				values.Global.Proxy.IsIngress = value
 				return nil
 			}),
 	}
@@ -502,19 +502,19 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 /* Validation */
 
 func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts.Values) error {
-	if !alphaNumDashDot.MatchString(values.GetGlobal().ControllerImageVersion) {
-		return fmt.Errorf("%s is not a valid version", values.GetGlobal().ControllerImageVersion)
+	if !alphaNumDashDot.MatchString(values.Global.ControllerImageVersion) {
+		return fmt.Errorf("%s is not a valid version", values.Global.ControllerImageVersion)
 	}
 
-	if _, err := log.ParseLevel(values.GetGlobal().ControllerLogLevel); err != nil {
+	if _, err := log.ParseLevel(values.Global.ControllerLogLevel); err != nil {
 		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
 	}
 
-	if values.GetGlobal().Proxy.LogLevel == "" {
+	if values.Global.Proxy.LogLevel == "" {
 		return errors.New("--proxy-log-level must not be empty")
 	}
 
-	if values.GetGlobal().EnableEndpointSlices && k != nil {
+	if values.Global.EnableEndpointSlices && k != nil {
 		k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 		if err != nil {
 			return err
@@ -526,8 +526,8 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		}
 	}
 
-	if errs := validation.IsDNS1123Subdomain(values.GetGlobal().IdentityTrustDomain); len(errs) > 0 {
-		return fmt.Errorf("invalid trust domain '%s': %s", values.GetGlobal().IdentityTrustDomain, errs[0])
+	if errs := validation.IsDNS1123Subdomain(values.Global.IdentityTrustDomain); len(errs) > 0 {
+		return fmt.Errorf("invalid trust domain '%s': %s", values.Global.IdentityTrustDomain, errs[0])
 	}
 
 	err := validateProxyValues(values)
@@ -559,7 +559,7 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		issuerData := issuercerts.IssuerCertData{
 			IssuerCrt:    values.Identity.Issuer.TLS.CrtPEM,
 			IssuerKey:    values.Identity.Issuer.TLS.KeyPEM,
-			TrustAnchors: values.GetGlobal().IdentityTrustAnchorsPEM,
+			TrustAnchors: values.Global.IdentityTrustAnchorsPEM,
 		}
 		_, err := issuerData.VerifyAndBuildCreds()
 		if err != nil {
@@ -571,76 +571,76 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 }
 
 func validateProxyValues(values *l5dcharts.Values) error {
-	networks := strings.Split(values.GetGlobal().ClusterNetworks, ",")
+	networks := strings.Split(values.Global.ClusterNetworks, ",")
 	for _, network := range networks {
 		if _, _, err := net.ParseCIDR(network); err != nil {
 			return fmt.Errorf("cannot parse destination get networks: %s", err)
 		}
 	}
 
-	if values.GetGlobal().Proxy.DisableIdentity && len(values.GetGlobal().Proxy.RequireIdentityOnInboundPorts) > 0 {
+	if values.Global.Proxy.DisableIdentity && len(values.Global.Proxy.RequireIdentityOnInboundPorts) > 0 {
 		return errors.New("Identity must be enabled when  --require-identity-on-inbound-ports is specified")
 	}
 
-	if values.GetGlobal().Proxy.Image.Version != "" && !alphaNumDashDot.MatchString(values.GetGlobal().Proxy.Image.Version) {
-		return fmt.Errorf("%s is not a valid version", values.GetGlobal().Proxy.Image.Version)
+	if values.Global.Proxy.Image.Version != "" && !alphaNumDashDot.MatchString(values.Global.Proxy.Image.Version) {
+		return fmt.Errorf("%s is not a valid version", values.Global.Proxy.Image.Version)
 	}
 
-	if !alphaNumDashDot.MatchString(values.GetGlobal().ProxyInit.Image.Version) {
-		return fmt.Errorf("%s is not a valid version", values.GetGlobal().ProxyInit.Image.Version)
+	if !alphaNumDashDot.MatchString(values.Global.ProxyInit.Image.Version) {
+		return fmt.Errorf("%s is not a valid version", values.Global.ProxyInit.Image.Version)
 	}
 
-	if values.GetGlobal().ImagePullPolicy != "Always" && values.GetGlobal().ImagePullPolicy != "IfNotPresent" && values.GetGlobal().ImagePullPolicy != "Never" {
+	if values.Global.ImagePullPolicy != "Always" && values.Global.ImagePullPolicy != "IfNotPresent" && values.Global.ImagePullPolicy != "Never" {
 		return fmt.Errorf("--image-pull-policy must be one of: Always, IfNotPresent, Never")
 	}
 
-	if values.GetGlobal().Proxy.Resources.CPU.Request != "" {
-		if _, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Request); err != nil {
-			return fmt.Errorf("Invalid cpu request '%s' for --proxy-cpu-request flag", values.GetGlobal().Proxy.Resources.CPU.Request)
+	if values.Global.Proxy.Resources.CPU.Request != "" {
+		if _, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Request); err != nil {
+			return fmt.Errorf("Invalid cpu request '%s' for --proxy-cpu-request flag", values.Global.Proxy.Resources.CPU.Request)
 		}
 	}
 
-	if values.GetGlobal().Proxy.Resources.Memory.Request != "" {
-		if _, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Request); err != nil {
-			return fmt.Errorf("Invalid memory request '%s' for --proxy-memory-request flag", values.GetGlobal().Proxy.Resources.Memory.Request)
+	if values.Global.Proxy.Resources.Memory.Request != "" {
+		if _, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Request); err != nil {
+			return fmt.Errorf("Invalid memory request '%s' for --proxy-memory-request flag", values.Global.Proxy.Resources.Memory.Request)
 		}
 	}
 
-	if values.GetGlobal().Proxy.Resources.CPU.Limit != "" {
-		cpuLimit, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Limit)
+	if values.Global.Proxy.Resources.CPU.Limit != "" {
+		cpuLimit, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Limit)
 		if err != nil {
-			return fmt.Errorf("Invalid cpu limit '%s' for --proxy-cpu-limit flag", values.GetGlobal().Proxy.Resources.CPU.Limit)
+			return fmt.Errorf("Invalid cpu limit '%s' for --proxy-cpu-limit flag", values.Global.Proxy.Resources.CPU.Limit)
 		}
 		// Not checking for error because option proxyCPURequest was already validated
-		if cpuRequest, _ := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.CPU.Request); cpuRequest.MilliValue() > cpuLimit.MilliValue() {
-			return fmt.Errorf("The cpu limit '%s' cannot be lower than the cpu request '%s'", values.GetGlobal().Proxy.Resources.CPU.Limit, values.GetGlobal().Proxy.Resources.CPU.Request)
+		if cpuRequest, _ := k8sResource.ParseQuantity(values.Global.Proxy.Resources.CPU.Request); cpuRequest.MilliValue() > cpuLimit.MilliValue() {
+			return fmt.Errorf("The cpu limit '%s' cannot be lower than the cpu request '%s'", values.Global.Proxy.Resources.CPU.Limit, values.Global.Proxy.Resources.CPU.Request)
 		}
 	}
 
-	if values.GetGlobal().Proxy.Resources.Memory.Limit != "" {
-		memoryLimit, err := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Limit)
+	if values.Global.Proxy.Resources.Memory.Limit != "" {
+		memoryLimit, err := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Limit)
 		if err != nil {
-			return fmt.Errorf("Invalid memory limit '%s' for --proxy-memory-limit flag", values.GetGlobal().Proxy.Resources.Memory.Limit)
+			return fmt.Errorf("Invalid memory limit '%s' for --proxy-memory-limit flag", values.Global.Proxy.Resources.Memory.Limit)
 		}
 		// Not checking for error because option proxyMemoryRequest was already validated
-		if memoryRequest, _ := k8sResource.ParseQuantity(values.GetGlobal().Proxy.Resources.Memory.Request); memoryRequest.Value() > memoryLimit.Value() {
-			return fmt.Errorf("The memory limit '%s' cannot be lower than the memory request '%s'", values.GetGlobal().Proxy.Resources.Memory.Limit, values.GetGlobal().Proxy.Resources.Memory.Request)
+		if memoryRequest, _ := k8sResource.ParseQuantity(values.Global.Proxy.Resources.Memory.Request); memoryRequest.Value() > memoryLimit.Value() {
+			return fmt.Errorf("The memory limit '%s' cannot be lower than the memory request '%s'", values.Global.Proxy.Resources.Memory.Limit, values.Global.Proxy.Resources.Memory.Request)
 		}
 	}
 
-	if !validProxyLogLevel.MatchString(values.GetGlobal().Proxy.LogLevel) {
+	if !validProxyLogLevel.MatchString(values.Global.Proxy.LogLevel) {
 		return fmt.Errorf("\"%s\" is not a valid proxy log level - for allowed syntax check https://docs.rs/env_logger/0.6.0/env_logger/#enabling-logging",
-			values.GetGlobal().Proxy.LogLevel)
+			values.Global.Proxy.LogLevel)
 	}
 
-	if values.GetGlobal().ProxyInit.IgnoreInboundPorts != "" {
-		if err := validateRangeSlice(strings.Split(values.GetGlobal().ProxyInit.IgnoreInboundPorts, ",")); err != nil {
+	if values.Global.ProxyInit.IgnoreInboundPorts != "" {
+		if err := validateRangeSlice(strings.Split(values.Global.ProxyInit.IgnoreInboundPorts, ",")); err != nil {
 			return err
 		}
 	}
 
-	if values.GetGlobal().ProxyInit.IgnoreOutboundPorts != "" {
-		if err := validateRangeSlice(strings.Split(values.GetGlobal().ProxyInit.IgnoreOutboundPorts, ",")); err != nil {
+	if values.Global.ProxyInit.IgnoreOutboundPorts != "" {
+		if err := validateRangeSlice(strings.Split(values.Global.ProxyInit.IgnoreOutboundPorts, ",")); err != nil {
 			return err
 		}
 	}
@@ -663,11 +663,11 @@ func initializeIssuerCredentials(ctx context.Context, k *k8s.KubernetesAPI, valu
 		if err != nil {
 			return err
 		}
-		values.GetGlobal().IdentityTrustAnchorsPEM = externalIssuerData.TrustAnchors
-	} else if values.Identity.Issuer.TLS.CrtPEM != "" || values.Identity.Issuer.TLS.KeyPEM != "" || values.GetGlobal().IdentityTrustAnchorsPEM != "" {
+		values.Global.IdentityTrustAnchorsPEM = externalIssuerData.TrustAnchors
+	} else if values.Identity.Issuer.TLS.CrtPEM != "" || values.Identity.Issuer.TLS.KeyPEM != "" || values.Global.IdentityTrustAnchorsPEM != "" {
 		// If any credentials have already been supplied, check that they are
 		// all present.
-		if values.GetGlobal().IdentityTrustAnchorsPEM == "" {
+		if values.Global.IdentityTrustAnchorsPEM == "" {
 			return errors.New("a trust anchors file must be specified if other credentials are provided")
 		}
 		if values.Identity.Issuer.TLS.CrtPEM == "" {
@@ -678,14 +678,14 @@ func initializeIssuerCredentials(ctx context.Context, k *k8s.KubernetesAPI, valu
 		}
 	} else {
 		// No credentials have been supplied so we will generate them.
-		root, err := tls.GenerateRootCAWithDefaults(issuerName(values.GetGlobal().IdentityTrustDomain))
+		root, err := tls.GenerateRootCAWithDefaults(issuerName(values.Global.IdentityTrustDomain))
 		if err != nil {
 			return fmt.Errorf("failed to generate root certificate for identity: %s", err)
 		}
 		values.Identity.Issuer.CrtExpiry = root.Cred.Crt.Certificate.NotAfter
 		values.Identity.Issuer.TLS.KeyPEM = root.Cred.EncodePrivateKeyPEM()
 		values.Identity.Issuer.TLS.CrtPEM = root.Cred.Crt.EncodeCertificatePEM()
-		values.GetGlobal().IdentityTrustAnchorsPEM = root.Cred.Crt.EncodeCertificatePEM()
+		values.Global.IdentityTrustAnchorsPEM = root.Cred.Crt.EncodeCertificatePEM()
 	}
 	return nil
 }

--- a/cli/cmd/upgrade_legacy.go
+++ b/cli/cmd/upgrade_legacy.go
@@ -146,7 +146,7 @@ func fetchIdentityValues(ctx context.Context, k kubernetes.Interface, idctx *pb.
 		return fmt.Errorf("could not convert issuance Lifetime protobuf Duration format into golang Duration: %s", err)
 	}
 
-	values.GetGlobal().IdentityTrustAnchorsPEM = trustAnchorsPEM
+	values.Global.IdentityTrustAnchorsPEM = trustAnchorsPEM
 	values.Identity.Issuer.Scheme = idctx.Scheme
 	values.Identity.Issuer.ClockSkewAllowance = clockSkewDuration.String()
 	values.Identity.Issuer.IssuanceLifetime = issuanceLifetimeDuration.String()

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -69,7 +69,7 @@ func TestUpgradeDefault(t *testing.T) {
 
 func TestUpgradeHA(t *testing.T) {
 	installOpts, upgradeOpts, _ := testOptions(t)
-	installOpts.GetGlobal().HighAvailability = true
+	installOpts.Global.HighAvailability = true
 	install, upgrade, err := renderInstallAndUpgrade(t, installOpts, upgradeOpts)
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +106,7 @@ func TestUpgradeExternalIssuer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	installOpts.GetGlobal().IdentityTrustAnchorsPEM = string(ca)
+	installOpts.Global.IdentityTrustAnchorsPEM = string(ca)
 	install := renderInstall(t, installOpts)
 	upgrade, err := renderUpgrade(install.String()+externalIssuerSecret(issuer), upgradeOpts)
 
@@ -133,8 +133,8 @@ func TestUpgradeIssuerWithExternalIssuerFails(t *testing.T) {
 	issuer := generateIssuerCerts(t, true)
 	defer issuer.cleanup()
 
-	installOpts.GetGlobal().IdentityTrustDomain = "cluster.local"
-	installOpts.GetGlobal().IdentityTrustDomain = issuer.ca
+	installOpts.Global.IdentityTrustDomain = "cluster.local"
+	installOpts.Global.IdentityTrustDomain = issuer.ca
 	installOpts.Identity.Issuer.Scheme = string(corev1.SecretTypeTLS)
 	installOpts.Identity.Issuer.TLS.CrtPEM = issuer.crt
 	installOpts.Identity.Issuer.TLS.KeyPEM = issuer.key
@@ -281,7 +281,7 @@ func TestUpgradeWebhookCrtsNameChange(t *testing.T) {
 
 	injectorCerts := generateCerts(t, "linkerd-proxy-injector.linkerd.svc", false)
 	defer injectorCerts.cleanup()
-	installOpts.ProxyInjector.TLS = &linkerd2.TLS{
+	installOpts.ProxyInjector.TLS = linkerd2.TLS{
 		CaBundle: injectorCerts.ca,
 		CrtPEM:   injectorCerts.crt,
 		KeyPEM:   injectorCerts.key,
@@ -289,7 +289,7 @@ func TestUpgradeWebhookCrtsNameChange(t *testing.T) {
 
 	validatorCerts := generateCerts(t, "linkerd-sp-validator.linkerd.svc", false)
 	defer validatorCerts.cleanup()
-	installOpts.ProfileValidator.TLS = &linkerd2.TLS{
+	installOpts.ProfileValidator.TLS = linkerd2.TLS{
 		CaBundle: validatorCerts.ca,
 		CrtPEM:   validatorCerts.crt,
 		KeyPEM:   validatorCerts.key,
@@ -333,7 +333,7 @@ func TestUpgradeTwoLevelWebhookCrts(t *testing.T) {
 	// This tests the case where the webhook certs are not self-signed.
 	injectorCerts := generateCerts(t, "linkerd-proxy-injector.linkerd.svc", false)
 	defer injectorCerts.cleanup()
-	installOpts.ProxyInjector.TLS = &linkerd2.TLS{
+	installOpts.ProxyInjector.TLS = linkerd2.TLS{
 		CaBundle: injectorCerts.ca,
 		CrtPEM:   injectorCerts.crt,
 		KeyPEM:   injectorCerts.key,
@@ -341,7 +341,7 @@ func TestUpgradeTwoLevelWebhookCrts(t *testing.T) {
 
 	validatorCerts := generateCerts(t, "linkerd-sp-validator.linkerd.svc", false)
 	defer validatorCerts.cleanup()
-	installOpts.ProfileValidator.TLS = &linkerd2.TLS{
+	installOpts.ProfileValidator.TLS = linkerd2.TLS{
 		CaBundle: validatorCerts.ca,
 		CrtPEM:   validatorCerts.crt,
 		KeyPEM:   validatorCerts.key,

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -36,8 +36,8 @@ func confNsDisabled() *inject.ResourceConfig {
 
 func TestGetPatch(t *testing.T) {
 
-	values.GetGlobal().Proxy.DisableIdentity = true
-	values.GetGlobal().Proxy.DisableTap = true
+	values.Global.Proxy.DisableIdentity = true
+	values.Global.Proxy.DisableTap = true
 
 	factory := fake.NewFactory(filepath.Join("fake", "data"))
 	nsEnabled, err := factory.Namespace("namespace-inject-enabled.yaml")

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -34,27 +34,27 @@ type (
 		HeartbeatSchedule      string            `json:"heartbeatSchedule"`
 		InstallNamespace       bool              `json:"installNamespace"`
 		Configs                ConfigJSONs       `json:"configs"`
-		Global                 *Global           `json:"global"`
-		Identity               *Identity         `json:"identity"`
-		DebugContainer         *DebugContainer   `json:"debugContainer"`
-		ProxyInjector          *ProxyInjector    `json:"proxyInjector"`
-		ProfileValidator       *ProfileValidator `json:"profileValidator"`
+		Global                 Global            `json:"global"`
+		Identity               Identity          `json:"identity"`
+		DebugContainer         DebugContainer    `json:"debugContainer"`
+		ProxyInjector          ProxyInjector     `json:"proxyInjector"`
+		ProfileValidator       ProfileValidator  `json:"profileValidator"`
 		NodeSelector           map[string]string `json:"nodeSelector"`
 		Tolerations            []interface{}     `json:"tolerations"`
 		Stage                  string            `json:"stage"`
 
-		DestinationResources   *Resources `json:"destinationResources"`
-		HeartbeatResources     *Resources `json:"heartbeatResources"`
-		IdentityResources      *Resources `json:"identityResources"`
-		ProxyInjectorResources *Resources `json:"proxyInjectorResources"`
-		PublicAPIResources     *Resources `json:"publicAPIResources"`
-		SPValidatorResources   *Resources `json:"spValidatorResources"`
+		DestinationResources   Resources `json:"destinationResources"`
+		HeartbeatResources     Resources `json:"heartbeatResources"`
+		IdentityResources      Resources `json:"identityResources"`
+		ProxyInjectorResources Resources `json:"proxyInjectorResources"`
+		PublicAPIResources     Resources `json:"publicAPIResources"`
+		SPValidatorResources   Resources `json:"spValidatorResources"`
 
-		DestinationProxyResources   *Resources `json:"destinationProxyResources"`
-		IdentityProxyResources      *Resources `json:"identityProxyResources"`
-		ProxyInjectorProxyResources *Resources `json:"proxyInjectorProxyResources"`
-		PublicAPIProxyResources     *Resources `json:"publicAPIProxyResources"`
-		SPValidatorProxyResources   *Resources `json:"spValidatorProxyResources"`
+		DestinationProxyResources   Resources `json:"destinationProxyResources"`
+		IdentityProxyResources      Resources `json:"identityProxyResources"`
+		ProxyInjectorProxyResources Resources `json:"proxyInjectorProxyResources"`
+		PublicAPIProxyResources     Resources `json:"publicAPIProxyResources"`
+		SPValidatorProxyResources   Resources `json:"spValidatorProxyResources"`
 	}
 
 	// Global values common across all charts
@@ -90,8 +90,8 @@ type (
 		PodAnnotations map[string]string `json:"podAnnotations"`
 		PodLabels      map[string]string `json:"podLabels"`
 
-		Proxy     *Proxy     `json:"proxy"`
-		ProxyInit *ProxyInit `json:"proxyInit"`
+		Proxy     Proxy     `json:"proxy"`
+		ProxyInit ProxyInit `json:"proxyInit"`
 	}
 
 	// ConfigJSONs is the JSON encoding of the Linkerd configuration
@@ -103,43 +103,43 @@ type (
 
 	// Proxy contains the fields to set the proxy sidecar container
 	Proxy struct {
-		Capabilities *Capabilities `json:"capabilities"`
+		Capabilities Capabilities `json:"capabilities"`
 		// This should match .Resources.CPU.Limit, but must be a whole number
-		Cores                         int64            `json:"cores,omitempty"`
-		DisableIdentity               bool             `json:"disableIdentity"`
-		DisableTap                    bool             `json:"disableTap"`
-		EnableExternalProfiles        bool             `json:"enableExternalProfiles"`
-		Image                         *Image           `json:"image"`
-		LogLevel                      string           `json:"logLevel"`
-		LogFormat                     string           `json:"logFormat"`
-		SAMountPath                   *VolumeMountPath `json:"saMountPath"`
-		Ports                         *Ports           `json:"ports"`
-		Resources                     *Resources       `json:"resources"`
-		UID                           int64            `json:"uid"`
-		WaitBeforeExitSeconds         uint64           `json:"waitBeforeExitSeconds"`
-		IsGateway                     bool             `json:"isGateway"`
-		IsIngress                     bool             `json:"isIngress"`
-		RequireIdentityOnInboundPorts string           `json:"requireIdentityOnInboundPorts"`
-		OutboundConnectTimeout        string           `json:"outboundConnectTimeout"`
-		InboundConnectTimeout         string           `json:"inboundConnectTimeout"`
-		OpaquePorts                   string           `json:"opaquePorts"`
+		Cores                         int64           `json:"cores,omitempty"`
+		DisableIdentity               bool            `json:"disableIdentity"`
+		DisableTap                    bool            `json:"disableTap"`
+		EnableExternalProfiles        bool            `json:"enableExternalProfiles"`
+		Image                         Image           `json:"image"`
+		LogLevel                      string          `json:"logLevel"`
+		LogFormat                     string          `json:"logFormat"`
+		SAMountPath                   VolumeMountPath `json:"saMountPath"`
+		Ports                         Ports           `json:"ports"`
+		Resources                     Resources       `json:"resources"`
+		UID                           int64           `json:"uid"`
+		WaitBeforeExitSeconds         uint64          `json:"waitBeforeExitSeconds"`
+		IsGateway                     bool            `json:"isGateway"`
+		IsIngress                     bool            `json:"isIngress"`
+		RequireIdentityOnInboundPorts string          `json:"requireIdentityOnInboundPorts"`
+		OutboundConnectTimeout        string          `json:"outboundConnectTimeout"`
+		InboundConnectTimeout         string          `json:"inboundConnectTimeout"`
+		OpaquePorts                   string          `json:"opaquePorts"`
 	}
 
 	// ProxyInit contains the fields to set the proxy-init container
 	ProxyInit struct {
-		Capabilities         *Capabilities    `json:"capabilities"`
-		IgnoreInboundPorts   string           `json:"ignoreInboundPorts"`
-		IgnoreOutboundPorts  string           `json:"ignoreOutboundPorts"`
-		Image                *Image           `json:"image"`
-		SAMountPath          *VolumeMountPath `json:"saMountPath"`
-		XTMountPath          *VolumeMountPath `json:"xtMountPath"`
-		Resources            *Resources       `json:"resources"`
-		CloseWaitTimeoutSecs int64            `json:"closeWaitTimeoutSecs"`
+		Capabilities         Capabilities    `json:"capabilities"`
+		IgnoreInboundPorts   string          `json:"ignoreInboundPorts"`
+		IgnoreOutboundPorts  string          `json:"ignoreOutboundPorts"`
+		Image                Image           `json:"image"`
+		SAMountPath          VolumeMountPath `json:"saMountPath"`
+		XTMountPath          VolumeMountPath `json:"xtMountPath"`
+		Resources            Resources       `json:"resources"`
+		CloseWaitTimeoutSecs int64           `json:"closeWaitTimeoutSecs"`
 	}
 
 	// DebugContainer contains the fields to set the debugging sidecar
 	DebugContainer struct {
-		Image *Image `json:"image"`
+		Image Image `json:"image"`
 	}
 
 	// Image contains the details to define a container image
@@ -186,29 +186,29 @@ type (
 	// Identity contains the fields to set the identity variables in the proxy
 	// sidecar container
 	Identity struct {
-		Issuer *Issuer `json:"issuer"`
+		Issuer Issuer `json:"issuer"`
 	}
 
 	// Issuer has the Helm variables of the identity issuer
 	Issuer struct {
-		Scheme              string     `json:"scheme"`
-		ClockSkewAllowance  string     `json:"clockSkewAllowance"`
-		IssuanceLifetime    string     `json:"issuanceLifetime"`
-		CrtExpiryAnnotation string     `json:"crtExpiryAnnotation"`
-		CrtExpiry           time.Time  `json:"crtExpiry"`
-		TLS                 *IssuerTLS `json:"tls"`
+		Scheme              string    `json:"scheme"`
+		ClockSkewAllowance  string    `json:"clockSkewAllowance"`
+		IssuanceLifetime    string    `json:"issuanceLifetime"`
+		CrtExpiryAnnotation string    `json:"crtExpiryAnnotation"`
+		CrtExpiry           time.Time `json:"crtExpiry"`
+		TLS                 IssuerTLS `json:"tls"`
 	}
 
 	// ProxyInjector has all the proxy injector's Helm variables
 	ProxyInjector struct {
-		*TLS
-		NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
+		TLS
+		NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
 	}
 
 	// ProfileValidator has all the profile validator's Helm variables
 	ProfileValidator struct {
-		*TLS
-		NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
+		TLS
+		NamespaceSelector metav1.LabelSelector `json:"namespaceSelector"`
 	}
 
 	// TLS has a pair of PEM-encoded key and certificate variables used in the
@@ -239,8 +239,6 @@ func NewValues() (*Values, error) {
 	v.Global.Proxy.Image.Version = version.Version
 	v.DebugContainer.Image.Version = version.Version
 	v.Global.CliVersion = k8s.CreatedByAnnotationValue()
-	v.ProfileValidator.TLS = &TLS{}
-	v.ProxyInjector.TLS = &TLS{}
 	v.Global.ProxyContainerName = k8s.ProxyContainerName
 
 	return v, nil
@@ -313,9 +311,6 @@ func (v *Values) String() string {
 
 // GetGlobal is a safe accessor for Global. It initializes Global on the first
 // access.
-func (v *Values) GetGlobal() *Global {
-	if v.Global == nil {
-		v.Global = &Global{}
-	}
+func (v *Values) GetGlobal() Global {
 	return v.Global
 }

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -17,7 +17,7 @@ func TestNewValues(t *testing.T) {
 
 	testVersion := "linkerd-dev"
 
-	namespaceSelector := &metav1.LabelSelector{
+	namespaceSelector := metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
 				Key:      "config.linkerd.io/admission-webhooks",
@@ -38,7 +38,7 @@ func TestNewValues(t *testing.T) {
 		DisableHeartBeat:       false,
 		HeartbeatSchedule:      "0 0 * * *",
 		InstallNamespace:       true,
-		Global: &Global{
+		Global: Global{
 			Namespace:                    "linkerd",
 			ClusterDomain:                "cluster.local",
 			ClusterNetworks:              "10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16",
@@ -63,22 +63,22 @@ func TestNewValues(t *testing.T) {
 			IdentityTrustDomain:          "cluster.local",
 			PodAnnotations:               map[string]string{},
 			PodLabels:                    map[string]string{},
-			Proxy: &Proxy{
+			Proxy: Proxy{
 				EnableExternalProfiles: false,
-				Image: &Image{
+				Image: Image{
 					Name:       "ghcr.io/linkerd/proxy",
 					PullPolicy: "IfNotPresent",
 					Version:    testVersion,
 				},
 				LogLevel:  "warn,linkerd=info",
 				LogFormat: "plain",
-				Ports: &Ports{
+				Ports: Ports{
 					Admin:    4191,
 					Control:  4190,
 					Inbound:  4143,
 					Outbound: 4140,
 				},
-				Resources: &Resources{
+				Resources: Resources{
 					CPU: Constraints{
 						Limit:   "",
 						Request: "",
@@ -93,15 +93,15 @@ func TestNewValues(t *testing.T) {
 				OutboundConnectTimeout: "1000ms",
 				InboundConnectTimeout:  "100ms",
 			},
-			ProxyInit: &ProxyInit{
+			ProxyInit: ProxyInit{
 				IgnoreInboundPorts:  "25,443,587,3306,11211",
 				IgnoreOutboundPorts: "25,443,587,3306,11211",
-				Image: &Image{
+				Image: Image{
 					Name:       "ghcr.io/linkerd/proxy-init",
 					PullPolicy: "IfNotPresent",
 					Version:    testVersion,
 				},
-				Resources: &Resources{
+				Resources: Resources{
 					CPU: Constraints{
 						Limit:   "100m",
 						Request: "10m",
@@ -111,34 +111,33 @@ func TestNewValues(t *testing.T) {
 						Request: "10Mi",
 					},
 				},
-				XTMountPath: &VolumeMountPath{
+				XTMountPath: VolumeMountPath{
 					Name:      "linkerd-proxy-init-xtables-lock",
 					MountPath: "/run",
 				},
 			},
 		},
-		Identity: &Identity{
-			Issuer: &Issuer{
+		Identity: Identity{
+			Issuer: Issuer{
 				ClockSkewAllowance:  "20s",
 				IssuanceLifetime:    "24h0m0s",
 				CrtExpiryAnnotation: "linkerd.io/identity-issuer-expiry",
-				TLS:                 &IssuerTLS{},
 				Scheme:              "linkerd.io/tls",
 			},
 		},
 		NodeSelector: map[string]string{
 			"beta.kubernetes.io/os": "linux",
 		},
-		DebugContainer: &DebugContainer{
-			Image: &Image{
+		DebugContainer: DebugContainer{
+			Image: Image{
 				Name:       "ghcr.io/linkerd/debug",
 				PullPolicy: "IfNotPresent",
 				Version:    testVersion,
 			},
 		},
 
-		ProxyInjector:    &ProxyInjector{TLS: &TLS{}, NamespaceSelector: namespaceSelector},
-		ProfileValidator: &ProfileValidator{TLS: &TLS{}, NamespaceSelector: namespaceSelector},
+		ProxyInjector:    ProxyInjector{NamespaceSelector: namespaceSelector},
+		ProfileValidator: ProfileValidator{NamespaceSelector: namespaceSelector},
 	}
 
 	// pin the versions to ensure consistent test result.
@@ -167,7 +166,7 @@ func TestNewValues(t *testing.T) {
 		expected.EnablePodAntiAffinity = true
 		expected.WebhookFailurePolicy = "Fail"
 
-		controllerResources := &Resources{
+		controllerResources := Resources{
 			CPU: Constraints{
 				Request: "100m",
 			},
@@ -182,7 +181,7 @@ func TestNewValues(t *testing.T) {
 		expected.SPValidatorResources = controllerResources
 		expected.HeartbeatResources = controllerResources
 
-		expected.IdentityResources = &Resources{
+		expected.IdentityResources = Resources{
 			CPU: Constraints{
 				Limit:   controllerResources.CPU.Limit,
 				Request: controllerResources.CPU.Request,
@@ -193,7 +192,7 @@ func TestNewValues(t *testing.T) {
 			},
 		}
 
-		expected.Global.Proxy.Resources = &Resources{
+		expected.Global.Proxy.Resources = Resources{
 			CPU: Constraints{
 				Limit:   "",
 				Request: controllerResources.CPU.Request,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,7 @@ func ToValues(configs *pb.All) *l5dcharts.Values {
 
 	// convert install flags into values
 	values := &l5dcharts.Values{
-		Global: &l5dcharts.Global{
+		Global: l5dcharts.Global{
 			CNIEnabled:              configs.GetGlobal().GetCniEnabled(),
 			Namespace:               configs.GetGlobal().GetLinkerdNamespace(),
 			IdentityTrustAnchorsPEM: configs.GetGlobal().GetIdentityContext().GetTrustAnchorsPem(),
@@ -128,19 +128,19 @@ func ToValues(configs *pb.All) *l5dcharts.Values {
 			ClusterDomain:           configs.GetGlobal().GetClusterDomain(),
 			ClusterNetworks:         configs.GetProxy().GetDestinationGetNetworks(),
 			LinkerdVersion:          configs.GetGlobal().GetVersion(),
-			Proxy: &l5dcharts.Proxy{
-				Image: &l5dcharts.Image{
+			Proxy: l5dcharts.Proxy{
+				Image: l5dcharts.Image{
 					Name:       configs.GetProxy().GetProxyImage().GetImageName(),
 					PullPolicy: configs.GetProxy().GetProxyImage().GetPullPolicy(),
 					Version:    configs.GetProxy().GetProxyVersion(),
 				},
-				Ports: &l5dcharts.Ports{
+				Ports: l5dcharts.Ports{
 					Control:  int32(configs.GetProxy().GetControlPort().GetPort()),
 					Inbound:  int32(configs.GetProxy().GetInboundPort().GetPort()),
 					Admin:    int32(configs.GetProxy().GetAdminPort().GetPort()),
 					Outbound: int32(configs.GetProxy().GetOutboundPort().GetPort()),
 				},
-				Resources: &l5dcharts.Resources{
+				Resources: l5dcharts.Resources{
 					CPU: l5dcharts.Constraints{
 						Limit:   configs.GetProxy().GetResource().GetLimitCpu(),
 						Request: configs.GetProxy().GetResource().GetRequestCpu(),
@@ -155,24 +155,24 @@ func ToValues(configs *pb.All) *l5dcharts.Values {
 				OutboundConnectTimeout: configs.GetProxy().GetOutboundConnectTimeout(),
 				InboundConnectTimeout:  configs.GetProxy().GetInboundConnectTimeout(),
 			},
-			ProxyInit: &l5dcharts.ProxyInit{
+			ProxyInit: l5dcharts.ProxyInit{
 				IgnoreInboundPorts:  toString(configs.GetProxy().GetIgnoreInboundPorts()),
 				IgnoreOutboundPorts: toString(configs.GetProxy().GetIgnoreOutboundPorts()),
-				Image: &l5dcharts.Image{
+				Image: l5dcharts.Image{
 					Name:       configs.GetProxy().GetProxyInitImage().GetImageName(),
 					PullPolicy: configs.GetProxy().GetProxyInitImage().GetPullPolicy(),
 					Version:    configs.GetProxy().GetProxyInitImageVersion(),
 				},
 			},
 		},
-		Identity: &l5dcharts.Identity{
-			Issuer: &l5dcharts.Issuer{
+		Identity: l5dcharts.Identity{
+			Issuer: l5dcharts.Issuer{
 				Scheme: configs.GetGlobal().GetIdentityContext().GetScheme(),
 			},
 		},
 		OmitWebhookSideEffects: configs.GetGlobal().GetOmitWebhookSideEffects(),
-		DebugContainer: &l5dcharts.DebugContainer{
-			Image: &l5dcharts.Image{
+		DebugContainer: l5dcharts.DebugContainer{
+			Image: l5dcharts.Image{
 				Name:       configs.GetProxy().GetDebugImage().GetImageName(),
 				PullPolicy: configs.GetProxy().GetDebugImage().GetPullPolicy(),
 				Version:    configs.GetProxy().GetDebugImageVersion(),
@@ -189,14 +189,14 @@ func ToValues(configs *pb.All) *l5dcharts.Values {
 	}
 
 	if configs.GetProxy().GetLogLevel() != nil {
-		values.GetGlobal().Proxy.LogLevel = configs.GetProxy().GetLogLevel().String()
+		values.Global.Proxy.LogLevel = configs.GetProxy().GetLogLevel().String()
 
 	}
 
 	// set HA, and Heartbeat flags as health-check needs them for old config installs
 	for _, flag := range configs.GetInstall().GetFlags() {
 		if flag.GetName() == "ha" && flag.GetValue() == "true" {
-			values.GetGlobal().HighAvailability = true
+			values.Global.HighAvailability = true
 		}
 
 		if flag.GetName() == "disable-heartbeat" && flag.GetValue() == "true" {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1502,8 +1502,8 @@ func (hc *HealthChecker) RunChecks(observer CheckObserver) bool {
 }
 
 // LinkerdConfigGlobal gets the Linkerd global configuration values.
-func (hc *HealthChecker) LinkerdConfigGlobal() *l5dcharts.Global {
-	return hc.linkerdConfig.GetGlobal()
+func (hc *HealthChecker) LinkerdConfigGlobal() l5dcharts.Global {
+	return hc.linkerdConfig.Global
 }
 
 func (hc *HealthChecker) runCheck(categoryID CategoryID, c *Checker, observer CheckObserver) bool {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2352,7 +2352,7 @@ data:
 				InstallNamespace:       true,
 				NodeSelector:           defaultValues.NodeSelector,
 				Tolerations:            defaultValues.Tolerations,
-				Global: &linkerd2.Global{
+				Global: linkerd2.Global{
 					Namespace:                "Namespace",
 					ClusterDomain:            "cluster.local",
 					ClusterNetworks:          "ClusterNetworks",
@@ -2370,15 +2370,15 @@ data:
 					ProxyContainerName:       "ProxyContainerName",
 					CNIEnabled:               false,
 					IdentityTrustDomain:      defaultValues.GetGlobal().IdentityTrustDomain,
-					Proxy: &linkerd2.Proxy{
-						Image: &linkerd2.Image{
+					Proxy: linkerd2.Proxy{
+						Image: linkerd2.Image{
 							Name:       "ProxyImageName",
 							PullPolicy: "ImagePullPolicy",
 							Version:    "ProxyVersion",
 						},
 						LogLevel:  "warn,linkerd=info",
 						LogFormat: "plain",
-						Ports: &linkerd2.Ports{
+						Ports: linkerd2.Ports{
 							Admin:    4191,
 							Control:  4190,
 							Inbound:  4143,
@@ -2386,13 +2386,13 @@ data:
 						},
 						UID: 2102,
 					},
-					ProxyInit: &linkerd2.ProxyInit{
-						Image: &linkerd2.Image{
+					ProxyInit: linkerd2.ProxyInit{
+						Image: linkerd2.Image{
 							Name:       "ProxyInitImageName",
 							PullPolicy: "ImagePullPolicy",
 							Version:    "ProxyInitVersion",
 						},
-						Resources: &linkerd2.Resources{
+						Resources: linkerd2.Resources{
 							CPU: linkerd2.Constraints{
 								Limit:   "100m",
 								Request: "10m",
@@ -2402,7 +2402,7 @@ data:
 								Request: "10Mi",
 							},
 						},
-						XTMountPath: &linkerd2.VolumeMountPath{
+						XTMountPath: linkerd2.VolumeMountPath{
 							MountPath: "/run",
 							Name:      "linkerd-proxy-init-xtables-lock",
 						},
@@ -2428,32 +2428,17 @@ data:
     {"flags":[{"name":"ha","value":"true"}]}`,
 			},
 			&linkerd2.Values{
-				Global: &linkerd2.Global{
+				Global: linkerd2.Global{
 					Namespace:        "ns",
 					CNIEnabled:       true,
 					HighAvailability: true,
-					Proxy: &linkerd2.Proxy{
+					Proxy: linkerd2.Proxy{
 						EnableExternalProfiles: true,
-						Image: &linkerd2.Image{
+						Image: linkerd2.Image{
 							Name:       "registry",
 							PullPolicy: "Always",
 						},
-						LogLevel: "",
-						Ports:    &linkerd2.Ports{},
-						Resources: &linkerd2.Resources{
-							CPU:    linkerd2.Constraints{},
-							Memory: linkerd2.Constraints{},
-						},
 					},
-					ProxyInit: &linkerd2.ProxyInit{
-						Image: &linkerd2.Image{},
-					},
-				},
-				Identity: &linkerd2.Identity{
-					Issuer: &linkerd2.Issuer{},
-				},
-				DebugContainer: &linkerd2.DebugContainer{
-					Image: &linkerd2.Image{},
 				},
 			},
 			nil,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -265,8 +265,8 @@ func (conf *ResourceConfig) GetPatch(injectProxy bool) ([]byte, error) {
 			conf.injectObjectMeta(patch)
 			conf.injectPodSpec(patch)
 		} else {
-			patch.GetGlobal().Proxy = nil
-			patch.GetGlobal().ProxyInit = nil
+			patch.Global.Proxy = l5dcharts.Proxy{}
+			patch.Global.ProxyInit = l5dcharts.ProxyInit{}
 		}
 	}
 
@@ -519,21 +519,21 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 	// enabled
 	if conf.pod.spec.Containers != nil && len(conf.pod.spec.Containers) > 0 {
 		if sc := conf.pod.spec.Containers[0].SecurityContext; sc != nil && sc.Capabilities != nil {
-			values.GetGlobal().Proxy.Capabilities = &l5dcharts.Capabilities{
+			values.Global.Proxy.Capabilities = l5dcharts.Capabilities{
 				Add:  []string{},
 				Drop: []string{},
 			}
 			for _, add := range sc.Capabilities.Add {
-				values.GetGlobal().Proxy.Capabilities.Add = append(values.GetGlobal().Proxy.Capabilities.Add, string(add))
+				values.Global.Proxy.Capabilities.Add = append(values.GetGlobal().Proxy.Capabilities.Add, string(add))
 			}
 			for _, drop := range sc.Capabilities.Drop {
-				values.GetGlobal().Proxy.Capabilities.Drop = append(values.GetGlobal().Proxy.Capabilities.Drop, string(drop))
+				values.Global.Proxy.Capabilities.Drop = append(values.GetGlobal().Proxy.Capabilities.Drop, string(drop))
 			}
 		}
 	}
 
 	if saVolumeMount != nil {
-		values.GetGlobal().Proxy.SAMountPath = &l5dcharts.VolumeMountPath{
+		values.Global.Proxy.SAMountPath = l5dcharts.VolumeMountPath{
 			Name:      saVolumeMount.Name,
 			MountPath: saVolumeMount.MountPath,
 			ReadOnly:  saVolumeMount.ReadOnly,
@@ -550,7 +550,7 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 		if debug {
 			log.Infof("inject debug container")
 			values.DebugContainer = &l5dcharts.DebugContainer{
-				Image: &l5dcharts.Image{
+				Image: l5dcharts.Image{
 					Name:       conf.values.DebugContainer.Image.Name,
 					Version:    conf.values.DebugContainer.Image.Version,
 					PullPolicy: conf.values.DebugContainer.Image.PullPolicy,
@@ -566,15 +566,15 @@ func (conf *ResourceConfig) injectPodSpec(values *patch) {
 func (conf *ResourceConfig) injectProxyInit(values *patch) {
 
 	// Fill common fields from Proxy into ProxyInit
-	values.GetGlobal().ProxyInit.Capabilities = values.GetGlobal().Proxy.Capabilities
-	values.GetGlobal().ProxyInit.SAMountPath = values.GetGlobal().Proxy.SAMountPath
+	values.Global.ProxyInit.Capabilities = values.Global.Proxy.Capabilities
+	values.Global.ProxyInit.SAMountPath = values.Global.Proxy.SAMountPath
 
 	if v := conf.pod.meta.Annotations[k8s.CloseWaitTimeoutAnnotation]; v != "" {
 		closeWait, err := time.ParseDuration(v)
 		if err != nil {
 			log.Warnf("invalid duration value used for the %s annotation: %s", k8s.CloseWaitTimeoutAnnotation, v)
 		} else {
-			values.GetGlobal().ProxyInit.CloseWaitTimeoutSecs = int64(closeWait.Seconds())
+			values.Global.ProxyInit.CloseWaitTimeoutSecs = int64(closeWait.Seconds())
 		}
 	}
 
@@ -601,7 +601,7 @@ func (conf *ResourceConfig) injectObjectMeta(values *patch) {
 
 	values.Annotations[k8s.ProxyVersionAnnotation] = values.GetGlobal().Proxy.Image.Version
 
-	if values.Identity == nil || values.GetGlobal().Proxy.DisableIdentity {
+	if values.GetGlobal().Proxy.DisableIdentity {
 		values.Annotations[k8s.IdentityModeAnnotation] = k8s.IdentityModeDisabled
 	} else {
 		values.Annotations[k8s.IdentityModeAnnotation] = k8s.IdentityModeDefault
@@ -644,78 +644,78 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 
 	if override, ok := annotations[k8s.ProxyInjectAnnotation]; ok {
 		if override == k8s.ProxyInjectIngress {
-			values.GetGlobal().Proxy.IsIngress = true
+			values.Global.Proxy.IsIngress = true
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyImageAnnotation]; ok {
-		values.GetGlobal().Proxy.Image.Name = override
+		values.Global.Proxy.Image.Name = override
 	}
 
 	if override, ok := annotations[k8s.ProxyVersionOverrideAnnotation]; ok {
-		values.GetGlobal().Proxy.Image.Version = override
+		values.Global.Proxy.Image.Version = override
 	}
 
 	if override, ok := annotations[k8s.ProxyImagePullPolicyAnnotation]; ok {
-		values.GetGlobal().Proxy.Image.PullPolicy = override
+		values.Global.Proxy.Image.PullPolicy = override
 	}
 
 	if override, ok := annotations[k8s.ProxyInitImageVersionAnnotation]; ok {
-		values.GetGlobal().ProxyInit.Image.Version = override
+		values.Global.ProxyInit.Image.Version = override
 	}
 
 	if override, ok := annotations[k8s.ProxyControlPortAnnotation]; ok {
 		controlPort, err := strconv.ParseInt(override, 10, 32)
 		if err == nil {
-			values.GetGlobal().Proxy.Ports.Control = int32(controlPort)
+			values.Global.Proxy.Ports.Control = int32(controlPort)
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyInboundPortAnnotation]; ok {
 		inboundPort, err := strconv.ParseInt(override, 10, 32)
 		if err == nil {
-			values.GetGlobal().Proxy.Ports.Inbound = int32(inboundPort)
+			values.Global.Proxy.Ports.Inbound = int32(inboundPort)
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyAdminPortAnnotation]; ok {
 		adminPort, err := strconv.ParseInt(override, 10, 32)
 		if err == nil {
-			values.GetGlobal().Proxy.Ports.Admin = int32(adminPort)
+			values.Global.Proxy.Ports.Admin = int32(adminPort)
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyOutboundPortAnnotation]; ok {
 		outboundPort, err := strconv.ParseInt(override, 10, 32)
 		if err == nil {
-			values.GetGlobal().Proxy.Ports.Outbound = int32(outboundPort)
+			values.Global.Proxy.Ports.Outbound = int32(outboundPort)
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyLogLevelAnnotation]; ok {
-		values.GetGlobal().Proxy.LogLevel = override
+		values.Global.Proxy.LogLevel = override
 	}
 
 	if override, ok := annotations[k8s.ProxyLogFormatAnnotation]; ok {
-		values.GetGlobal().Proxy.LogFormat = override
+		values.Global.Proxy.LogFormat = override
 	}
 
 	if override, ok := annotations[k8s.ProxyDisableIdentityAnnotation]; ok {
 		value, err := strconv.ParseBool(override)
 		if err == nil {
-			values.GetGlobal().Proxy.DisableIdentity = value
+			values.Global.Proxy.DisableIdentity = value
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyDisableTapAnnotation]; ok {
 		value, err := strconv.ParseBool(override)
 		if err == nil {
-			values.GetGlobal().Proxy.DisableTap = value
+			values.Global.Proxy.DisableTap = value
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyRequireIdentityOnInboundPortsAnnotation]; ok {
-		values.GetGlobal().Proxy.RequireIdentityOnInboundPorts = override
+		values.Global.Proxy.RequireIdentityOnInboundPorts = override
 	}
 
 	if override, ok := annotations[k8s.ProxyOutboundConnectTimeout]; ok {
@@ -723,7 +723,7 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("unrecognized proxy-outbound-connect-timeout duration value found on pod annotation: %s", err.Error())
 		} else {
-			values.GetGlobal().Proxy.OutboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
+			values.Global.Proxy.OutboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
 		}
 	}
 
@@ -732,14 +732,14 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("unrecognized proxy-inbound-connect-timeout duration value found on pod annotation: %s", err.Error())
 		} else {
-			values.GetGlobal().Proxy.InboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
+			values.Global.Proxy.InboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyEnableGatewayAnnotation]; ok {
 		value, err := strconv.ParseBool(override)
 		if err == nil {
-			values.GetGlobal().Proxy.IsGateway = value
+			values.Global.Proxy.IsGateway = value
 		}
 	}
 
@@ -749,7 +749,7 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 			log.Warnf("unrecognized value used for the %s annotation, uint64 is expected: %s",
 				k8s.ProxyWaitBeforeExitSecondsAnnotation, override)
 		} else {
-			values.GetGlobal().Proxy.WaitBeforeExitSeconds = waitBeforeExitSeconds
+			values.Global.Proxy.WaitBeforeExitSeconds = waitBeforeExitSeconds
 		}
 	}
 
@@ -758,7 +758,7 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("%s (%s)", err, k8s.ProxyCPURequestAnnotation)
 		} else {
-			values.GetGlobal().Proxy.Resources.CPU.Request = override
+			values.Global.Proxy.Resources.CPU.Request = override
 		}
 	}
 
@@ -767,7 +767,7 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("%s (%s)", err, k8s.ProxyMemoryRequestAnnotation)
 		} else {
-			values.GetGlobal().Proxy.Resources.Memory.Request = override
+			values.Global.Proxy.Resources.Memory.Request = override
 		}
 	}
 
@@ -776,13 +776,13 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("%s (%s)", err, k8s.ProxyCPULimitAnnotation)
 		} else {
-			values.GetGlobal().Proxy.Resources.CPU.Limit = override
+			values.Global.Proxy.Resources.CPU.Limit = override
 
 			n, err := ToWholeCPUCores(q)
 			if err != nil {
 				log.Warnf("%s (%s)", err, k8s.ProxyCPULimitAnnotation)
 			}
-			values.GetGlobal().Proxy.Cores = n
+			values.Global.Proxy.Cores = n
 		}
 	}
 
@@ -791,43 +791,43 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		if err != nil {
 			log.Warnf("%s (%s)", err, k8s.ProxyMemoryLimitAnnotation)
 		} else {
-			values.GetGlobal().Proxy.Resources.Memory.Limit = override
+			values.Global.Proxy.Resources.Memory.Limit = override
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyUIDAnnotation]; ok {
 		v, err := strconv.ParseInt(override, 10, 64)
 		if err == nil {
-			values.GetGlobal().Proxy.UID = v
+			values.Global.Proxy.UID = v
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyEnableExternalProfilesAnnotation]; ok {
 		value, err := strconv.ParseBool(override)
 		if err == nil {
-			values.GetGlobal().Proxy.EnableExternalProfiles = value
+			values.Global.Proxy.EnableExternalProfiles = value
 		}
 	}
 
 	if override, ok := annotations[k8s.ProxyInitImageAnnotation]; ok {
-		values.GetGlobal().ProxyInit.Image.Name = override
+		values.Global.ProxyInit.Image.Name = override
 	}
 
 	if override, ok := annotations[k8s.ProxyImagePullPolicyAnnotation]; ok {
-		values.GetGlobal().ProxyInit.Image.PullPolicy = override
+		values.Global.ProxyInit.Image.PullPolicy = override
 	}
 
 	if override, ok := annotations[k8s.ProxyIgnoreInboundPortsAnnotation]; ok {
-		values.GetGlobal().ProxyInit.IgnoreInboundPorts = override
+		values.Global.ProxyInit.IgnoreInboundPorts = override
 	}
 
 	if override, ok := annotations[k8s.ProxyIgnoreOutboundPortsAnnotation]; ok {
-		values.GetGlobal().ProxyInit.IgnoreOutboundPorts = override
+		values.Global.ProxyInit.IgnoreOutboundPorts = override
 	}
 
 	if override, ok := annotations[k8s.ProxyOpaquePortsAnnotation]; ok {
 		opaquePortsStrs := util.ParseOpaquePorts(override, conf.pod.spec.Containers)
-		values.GetGlobal().Proxy.OpaquePorts = strings.Join(opaquePortsStrs, ",")
+		values.Global.Proxy.OpaquePorts = strings.Join(opaquePortsStrs, ",")
 	}
 
 	if override, ok := annotations[k8s.DebugImageAnnotation]; ok {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -72,19 +72,19 @@ func TestGetOverriddenValues(t *testing.T) {
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues()
 
-				values.GetGlobal().Proxy.Cores = 2
-				values.GetGlobal().Proxy.DisableIdentity = true
-				values.GetGlobal().Proxy.Image.Name = "ghcr.io/linkerd/proxy"
-				values.GetGlobal().Proxy.Image.PullPolicy = pullPolicy
-				values.GetGlobal().Proxy.Image.Version = proxyVersionOverride
-				values.GetGlobal().Proxy.Ports.Control = 4000
-				values.GetGlobal().Proxy.Ports.Inbound = 5000
-				values.GetGlobal().Proxy.Ports.Admin = 5001
-				values.GetGlobal().Proxy.Ports.Outbound = 5002
-				values.GetGlobal().Proxy.WaitBeforeExitSeconds = 123
-				values.GetGlobal().Proxy.LogLevel = "debug,linkerd=debug"
-				values.GetGlobal().Proxy.LogFormat = "json"
-				values.GetGlobal().Proxy.Resources = &l5dcharts.Resources{
+				values.Global.Proxy.Cores = 2
+				values.Global.Proxy.DisableIdentity = true
+				values.Global.Proxy.Image.Name = "ghcr.io/linkerd/proxy"
+				values.Global.Proxy.Image.PullPolicy = pullPolicy
+				values.Global.Proxy.Image.Version = proxyVersionOverride
+				values.Global.Proxy.Ports.Control = 4000
+				values.Global.Proxy.Ports.Inbound = 5000
+				values.Global.Proxy.Ports.Admin = 5001
+				values.Global.Proxy.Ports.Outbound = 5002
+				values.Global.Proxy.WaitBeforeExitSeconds = 123
+				values.Global.Proxy.LogLevel = "debug,linkerd=debug"
+				values.Global.Proxy.LogFormat = "json"
+				values.Global.Proxy.Resources = l5dcharts.Resources{
 					CPU: l5dcharts.Constraints{
 						Limit:   "1.5",
 						Request: "0.15",
@@ -94,16 +94,16 @@ func TestGetOverriddenValues(t *testing.T) {
 						Request: "120",
 					},
 				}
-				values.GetGlobal().Proxy.UID = 8500
-				values.GetGlobal().ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
-				values.GetGlobal().ProxyInit.Image.PullPolicy = pullPolicy
-				values.GetGlobal().ProxyInit.Image.Version = version.ProxyInitVersion
-				values.GetGlobal().ProxyInit.IgnoreInboundPorts = "4222,6222"
-				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "8079,8080"
-				values.GetGlobal().Proxy.RequireIdentityOnInboundPorts = "8888,9999"
-				values.GetGlobal().Proxy.OutboundConnectTimeout = "6000ms"
-				values.GetGlobal().Proxy.InboundConnectTimeout = "600ms"
-				values.GetGlobal().Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.Global.Proxy.UID = 8500
+				values.Global.ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
+				values.Global.ProxyInit.Image.PullPolicy = pullPolicy
+				values.Global.ProxyInit.Image.Version = version.ProxyInitVersion
+				values.Global.ProxyInit.IgnoreInboundPorts = "4222,6222"
+				values.Global.ProxyInit.IgnoreOutboundPorts = "8079,8080"
+				values.Global.Proxy.RequireIdentityOnInboundPorts = "8888,9999"
+				values.Global.Proxy.OutboundConnectTimeout = "6000ms"
+				values.Global.Proxy.InboundConnectTimeout = "600ms"
+				values.Global.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				return values
 			},
 		},
@@ -154,19 +154,19 @@ func TestGetOverriddenValues(t *testing.T) {
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues()
 
-				values.GetGlobal().Proxy.Cores = 2
-				values.GetGlobal().Proxy.DisableIdentity = true
-				values.GetGlobal().Proxy.Image.Name = "ghcr.io/linkerd/proxy"
-				values.GetGlobal().Proxy.Image.PullPolicy = pullPolicy
-				values.GetGlobal().Proxy.Image.Version = proxyVersionOverride
-				values.GetGlobal().Proxy.Ports.Control = 4000
-				values.GetGlobal().Proxy.Ports.Inbound = 5000
-				values.GetGlobal().Proxy.Ports.Admin = 5001
-				values.GetGlobal().Proxy.Ports.Outbound = 5002
-				values.GetGlobal().Proxy.WaitBeforeExitSeconds = 123
-				values.GetGlobal().Proxy.LogLevel = "debug,linkerd=debug"
-				values.GetGlobal().Proxy.LogFormat = "json"
-				values.GetGlobal().Proxy.Resources = &l5dcharts.Resources{
+				values.Global.Proxy.Cores = 2
+				values.Global.Proxy.DisableIdentity = true
+				values.Global.Proxy.Image.Name = "ghcr.io/linkerd/proxy"
+				values.Global.Proxy.Image.PullPolicy = pullPolicy
+				values.Global.Proxy.Image.Version = proxyVersionOverride
+				values.Global.Proxy.Ports.Control = 4000
+				values.Global.Proxy.Ports.Inbound = 5000
+				values.Global.Proxy.Ports.Admin = 5001
+				values.Global.Proxy.Ports.Outbound = 5002
+				values.Global.Proxy.WaitBeforeExitSeconds = 123
+				values.Global.Proxy.LogLevel = "debug,linkerd=debug"
+				values.Global.Proxy.LogFormat = "json"
+				values.Global.Proxy.Resources = l5dcharts.Resources{
 					CPU: l5dcharts.Constraints{
 						Limit:   "1.5",
 						Request: "0.15",
@@ -176,15 +176,15 @@ func TestGetOverriddenValues(t *testing.T) {
 						Request: "120",
 					},
 				}
-				values.GetGlobal().Proxy.UID = 8500
-				values.GetGlobal().ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
-				values.GetGlobal().ProxyInit.Image.PullPolicy = pullPolicy
-				values.GetGlobal().ProxyInit.Image.Version = version.ProxyInitVersion
-				values.GetGlobal().ProxyInit.IgnoreInboundPorts = "4222,6222"
-				values.GetGlobal().ProxyInit.IgnoreOutboundPorts = "8079,8080"
-				values.GetGlobal().Proxy.OutboundConnectTimeout = "6000ms"
-				values.GetGlobal().Proxy.InboundConnectTimeout = "600ms"
-				values.GetGlobal().Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.Global.Proxy.UID = 8500
+				values.Global.ProxyInit.Image.Name = "ghcr.io/linkerd/proxy-init"
+				values.Global.ProxyInit.Image.PullPolicy = pullPolicy
+				values.Global.ProxyInit.Image.Version = version.ProxyInitVersion
+				values.Global.ProxyInit.IgnoreInboundPorts = "4222,6222"
+				values.Global.ProxyInit.IgnoreOutboundPorts = "8079,8080"
+				values.Global.Proxy.OutboundConnectTimeout = "6000ms"
+				values.Global.Proxy.InboundConnectTimeout = "600ms"
+				values.Global.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				return values
 			},
 		},
@@ -218,8 +218,8 @@ func TestGetOverriddenValues(t *testing.T) {
 			},
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues()
-				values.GetGlobal().Proxy.OutboundConnectTimeout = "6005ms"
-				values.GetGlobal().Proxy.InboundConnectTimeout = "2005ms"
+				values.Global.Proxy.OutboundConnectTimeout = "6005ms"
+				values.Global.Proxy.InboundConnectTimeout = "2005ms"
 				return values
 			},
 		},
@@ -248,7 +248,7 @@ func TestGetOverriddenValues(t *testing.T) {
 			},
 			expected: func() *l5dcharts.Values {
 				values, _ := l5dcharts.NewValues()
-				values.GetGlobal().Proxy.OpaquePorts = "3306"
+				values.Global.Proxy.OpaquePorts = "3306"
 				return values
 			},
 		},


### PR DESCRIPTION
This commit replaces pointer types with value types in Values.go to avoid
segfaults. This change should not be as easy and should need some more
changes in the templates where these values are used but hoping
it might work and avoid us adding getters which seems
a bit complex to add for every field.

If this wont work or is too complex. Lets go with Getters.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
