### PR TITLE
build: Remove the DOCKER_TRACE environment variable

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -121,7 +121,7 @@ Started](https://linkerd.io/2/getting-started/)
 bin/k3d cluster create
 
 # build all docker images
-DOCKER_TRACE=1 bin/docker-build
+bin/docker-build
 
 # load all the images into k3d
 bin/image-load --k3d
@@ -431,7 +431,7 @@ The `bin/docker-build-proxy` script builds the proxy by pulling a pre-published
 proxy binary:
 
 ```bash
-DOCKER_TRACE=1 bin/docker-build-proxy
+bin/docker-build-proxy
 ```
 
 ### Multi-architecture builds

--- a/TEST.md
+++ b/TEST.md
@@ -167,7 +167,7 @@ You can also test a locally-built version of the `linkerd` CLI.
 First build all of the Linkerd images by running:
 
 ```bash
-DOCKER_TRACE=1 bin/docker-build
+bin/docker-build
 ```
 
 That command also copies the corresponding `linkerd` binaries into the

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -11,9 +11,6 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 # docker registry in, for instance, CI.
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io/linkerd}
 
-# When set, causes docker's build output to be emitted to stderr.
-export DOCKER_TRACE=${DOCKER_TRACE:-}
-
 # When set, use `docker buildx` and use the github actions cache to store/retrieve images
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-}
 
@@ -50,11 +47,6 @@ docker_build() {
     file=$1
     shift
 
-    output=/dev/null
-    if [ -n "$DOCKER_TRACE" ]; then
-        output=/dev/stderr
-    fi
-
     rootdir=$( cd "$bindir"/.. && pwd )
 
     if [ -n "$DOCKER_BUILDKIT" ]; then
@@ -82,15 +74,13 @@ docker_build() {
           $output_params \
           -t "$repo:$tag" \
           -f "$file" \
-          "$@" \
-          > "$output"
+          "$@"
     else
       log_debug "  :; docker build $rootdir -t $repo:$tag -f $file $*"
       docker build "$rootdir" \
           -t "$repo:$tag" \
           -f "$file" \
-          "$@" \
-          > "$output"
+          "$@"
     fi
 
     echo "$repo:$tag"

--- a/bin/docker-test-proxy
+++ b/bin/docker-test-proxy
@@ -2,21 +2,13 @@
 
 set -eu
 
-# When set, causes docker's build output to be emitted to stderr.
-export DOCKER_TRACE=${DOCKER_TRACE:-}
 export RUST_LOG=${RUST_LOG:-}
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
 
-if [ -n "$DOCKER_TRACE" ]; then
-	output=/dev/stderr
-else
-	output=/dev/null
-fi
-
 docker build -f "$rootdir/proxy/Dockerfile" . \
     --target build \
     -t proxy-build \
-    --build-arg=PROXY_UNOPTIMIZED=1 > $output
+    --build-arg=PROXY_UNOPTIMIZED=1
 docker run --rm -it proxy-build env RUST_LOG="$RUST_LOG" cargo test "$@"


### PR DESCRIPTION
Our build scripts hide docker's output by default and only pass through
output when DOCKER_TRACE is set. Practically everyone else tends to use
DOCKER_TRACE=1 persistently. And, recently, GitHub Actions stopped
working with `/dev/stderr`

This change removes the DOCKER_TRACE environment variable so that output
is always emitted as it would when invoking docker directly.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
