### PR TITLE
helm chart changes to run proxy-init container as non root

### DIFF
--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{.Values.global.controllerNamespaceLabel}}: {{.Values.global.namespace}}
 spec:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
   readOnlyRootFilesystem: true
   {{- if empty .Values.global.cniEnabled }}
   allowedCapabilities:
@@ -25,11 +25,7 @@ spec:
   seLinux:
     rule: RunAsAny
   runAsUser:
-    {{- if .Values.global.cniEnabled }}
     rule: MustRunAsNonRoot
-    {{- else }}
-    rule: RunAsAny
-    {{- end }}
   supplementalGroups:
     rule: MustRunAs
     ranges:

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -146,6 +146,8 @@ global:
     xtMountPath:
       mountPath: /run
       name: linkerd-proxy-init-xtables-lock
+    runAsNonRoot: false
+    runAsUser: 0
 
   # -- Annotation label for the proxy create. Do not edit.
   createdByAnnotation: linkerd.io/created-by

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -40,8 +40,8 @@ securityContext:
   privileged: false
   {{- end }}
   readOnlyRootFilesystem: true
-  runAsNonRoot: {{.Values.global.proxyInit.runAsNonRoot}}
-  runAsUser: {{.Values.global.proxyInit.runAsUser}}
+  runAsNonRoot: true
+  runAsUser: 76543
 terminationMessagePolicy: FallbackToLogsOnError
 {{- if or (not .Values.global.cniEnabled) .Values.global.proxyInit.saMountPath }}
 volumeMounts:

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -21,11 +21,7 @@ imagePullPolicy: {{.Values.global.proxyInit.image.pullPolicy}}
 name: linkerd-init
 {{ include "partials.resources" .Values.global.proxyInit.resources }}
 securityContext:
-  {{- if .Values.global.proxyInit.closeWaitTimeoutSecs }}
   allowPrivilegeEscalation: true
-  {{- else }}
-  allowPrivilegeEscalation: false
-  {{- end }}
   capabilities:
     add:
     - NET_ADMIN
@@ -44,8 +40,8 @@ securityContext:
   privileged: false
   {{- end }}
   readOnlyRootFilesystem: true
-  runAsNonRoot: false
-  runAsUser: 0
+  runAsNonRoot: {{.Values.global.proxyInit.runAsNonRoot}}
+  runAsUser: {{.Values.global.proxyInit.runAsUser}}
 terminationMessagePolicy: FallbackToLogsOnError
 {{- if or (not .Values.global.cniEnabled) .Values.global.proxyInit.saMountPath }}
 volumeMounts:
@@ -58,5 +54,5 @@ volumeMounts:
 - mountPath: {{.Values.global.proxyInit.saMountPath.mountPath}}
   name: {{.Values.global.proxyInit.saMountPath.name}}
   readOnly: {{.Values.global.proxyInit.saMountPath.readOnly}}
-{{- end -}}  
+{{- end -}}
 {{- end -}}

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -135,6 +135,8 @@ type (
 		XTMountPath          *VolumeMountPath `json:"xtMountPath"`
 		Resources            *Resources       `json:"resources"`
 		CloseWaitTimeoutSecs int64            `json:"closeWaitTimeoutSecs"`
+		RunAsNonRoot         bool             `json:"runAsNonRoot"`
+		RunAsUser            int64            `json:"runAsUser"`
 	}
 
 	// DebugContainer contains the fields to set the debugging sidecar


### PR DESCRIPTION
Signed-off-by: Pankaj Tolani <pankaj.tolani@gmail.com>

So the idea is to be able to run proxy-init container iptables changes as non root with NET_RAW and NET_ADMIN capabilities. This will allow for workloads to run with a more constrained and secure PSP. Changes to the proxy-init container image are outlined here. 

Now, controller/proxy-injector binary has an embedded copy of the helm chart which gets rendered at runtime to define the securityContext for the proxy-init initContainer. This change allows for configuring the runAsNonRoot and runAsUser fields of the securityContext. 