### PR TITLE
Tweak error message in web script

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -36,7 +36,7 @@ check-for-linkerd() {
   fi
 
   if [[ -z "${grafana_pod// }" ]]; then
-    err 'Controller is not running. Have you installed Linkerd?'
+    err 'Grafana is not running. Have you installed Linkerd-Viz?'
     exit 1
   fi
 }


### PR DESCRIPTION
The `bin/web run` script sets up a local environment for linkerd
dashboard development. This script port-forwards an existing linkerd
controller and a grafana instance in a local kubernetes cluster. When
running the command with just the linkerd control plane  and no
linkerd viz extension the error message is shown below.
```
'Controller is not running. Have you installed Linkerd?'
```

This error message is a little misleading because the controller is
installed after running `linkerd install`. The issue here is
that the script errors out with an incorrect message when 
it can't find a Grafana pod in the Linkerd Viz namespace. The 
error message should instead notify the developer that
Linkerd Viz is not installed.

This change modifies the error message so it is more clear.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>