### PR TITLE
Move @siggy to emeritus maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@ The Linkerd maintainers are:
 * Oliver Gould <ver@buoyant.io> @olix0r (super-maintainer)
 * Alejandro Pedraza <alejandro@buoyant.io> @alpeb
 * Alex Leong <alex@buoyant.io> @adleong
-* Andrew Seigner <siggy@buoyant.io> @siggy
 * Eliza Weisman <eliza@buoyant.io> @hawkw
 * Hema Lee <Hemalekha.Lee@nordstrom.com> @hemakl
 * Kevin Leimkuhler <kevinl@buoyant.io> @kleimkuhler
@@ -15,6 +14,7 @@ The Linkerd maintainers are:
 
 Former maintainers include:
 
+* Andrew Seigner <siggy@buoyant.io> @siggy
 * Kevin Ingleman <ki@buoyant.io> @klingerf
 * Risha Mars <mars@buoyant.io> @rmars
 


### PR DESCRIPTION
Emeritus (adj): having retired but allowed to retain their title as an
honor

Signed-off-by: Andrew Seigner <siggy@buoyant.io>
