### PR TITLE
viz: only tap pods that have tap explicitly enabled

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 # TODO: remove when tap code gets moved to /viz
 COPY viz/metrics-api/gen/viz viz/metrics-api/gen/viz
+# TODO: remove when tap code gets moved to /viz
+COPY viz/pkg/labels viz/pkg/labels
 COPY pkg pkg
 COPY controller controller
 COPY charts/patch charts/patch

--- a/controller/tap-injector/patch.go
+++ b/controller/tap-injector/patch.go
@@ -3,6 +3,11 @@ package tapinjector
 const tpl = `[
   {
     "op": "add",
+    "path": "/metadata/annotations/{{.Annotation}}",
+    "value": "true"
+  },
+  {
+    "op": "add",
     "path": "/spec/containers/{{.ProxyIndex}}/env/-",
     "value": {
       "name": "LINKERD2_PROXY_TAP_SVC_NAME",

--- a/controller/tap-injector/webhook.go
+++ b/controller/tap-injector/webhook.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"html/template"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/controller/webhook"
 	labels "github.com/linkerd/linkerd2/pkg/k8s"
+	vizLabels "github.com/linkerd/linkerd2/viz/pkg/labels"
 	"github.com/prometheus/common/log"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +19,7 @@ import (
 
 // Params holds the values used in the patch template.
 type Params struct {
+	Annotation      string
 	ProxyIndex      int
 	ProxyTapSvcName string
 }
@@ -40,14 +43,19 @@ func Mutate(tapSvcName string) webhook.Handler {
 		if err := yaml.Unmarshal(request.Object.Raw, &pod); err != nil {
 			return nil, err
 		}
+		// annotation is used in the patch as a JSON pointer, so '/' must be
+		// encoded as '~1' as stated in
+		// https://tools.ietf.org/html/rfc6901#section-3
+		annotation := strings.Replace(vizLabels.VizTapEnabled, "/", "~1", -1)
 		params := Params{
+			Annotation:      annotation,
 			ProxyIndex:      webhook.GetProxyContainerIndex(pod.Spec.Containers),
 			ProxyTapSvcName: tapSvcName,
 		}
 		if params.ProxyIndex < 0 {
 			return admissionResponse, nil
 		}
-		if alreadyMutated(pod.Spec.Containers[params.ProxyIndex]) {
+		if _, contains := pod.GetAnnotations()[vizLabels.VizTapEnabled]; contains {
 			return admissionResponse, nil
 		}
 		namespace, err := k8sAPI.NS().Lister().Get(request.Namespace)
@@ -71,13 +79,4 @@ func Mutate(tapSvcName string) webhook.Handler {
 		admissionResponse.PatchType = &patchType
 		return admissionResponse, nil
 	}
-}
-
-func alreadyMutated(container corev1.Container) bool {
-	for _, envVar := range container.Env {
-		if envVar.Name == "LINKERD2_PROXY_TAP_SVC_NAME" {
-			return true
-		}
-	}
-	return false
 }

--- a/test/integration/tap/tap_test.go
+++ b/test/integration/tap/tap_test.go
@@ -144,10 +144,13 @@ func TestCliTap(t *testing.T) {
 			if stderr == "" {
 				testutil.Fatal(t, "expected an error, got none")
 			}
-			expectedErr := "Error: all pods found for deployment/t4 have tapping disabled"
-			if errs := strings.Split(stderr, "\n"); errs[0] != expectedErr {
+			expectedErr := `Error: no pods to tap for deployment/t4
+pods found with tap disabled via the config.linkerd.io/disable-tap annotation`
+			split := strings.Split(stderr, "\n")
+			actualErr := strings.Join(split[:2], "\n")
+			if actualErr != expectedErr {
 				testutil.AnnotatedFatalf(t, "unexpected error",
-					"expected [%s], got: %s", expectedErr, errs[0])
+					"expected [%s], got: %s", expectedErr, actualErr)
 			}
 		})
 

--- a/viz/pkg/labels/labels.go
+++ b/viz/pkg/labels/labels.go
@@ -1,0 +1,29 @@
+package labels
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// VizAnnotationsPrefix is the prefix of all viz-related annotations
+	VizAnnotationsPrefix = "viz.linkerd.io"
+
+	// VizTapEnabled is set by the tap-injector component when tap has been
+	// enabled on a pod.
+	VizTapEnabled = VizAnnotationsPrefix + "/tap-enabled"
+)
+
+// IsTapEnabled returns true if a pod has an annotation indicating that tap
+// is enabled.
+func IsTapEnabled(pod *corev1.Pod) bool {
+	valStr := pod.GetAnnotations()[VizTapEnabled]
+	if valStr != "" {
+		valBool, err := strconv.ParseBool(valStr)
+		if err == nil && valBool {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this changes

This allows the tap controller to inform `tap` users when pods either have tap
disabled or tap is not enabled yet.

## Why

When a user taps a resource that has not been admitted by the Viz extension's
`tap-injector`, tap is not explicitly disabled but it is also not enabled.
Therefore, the `tap` command hangs and provides no feedback to the user.

Closes #5544

## How

A new `viz.linkerd.io/tap-enabled` annotation is introduced which is
automatically added by the Viz extension's `tap-injector`. This annotation is
added to a pod when it is able to be tapped; this means that the pod and the
pod's namespace do not have the `config.linkerd.io/disable-tap` annotation
added.

When a user attempts to tap a resource, the tap controller now looks for this
new annotation; if the annotation is present on the pod then that pod is
tappable.

If the annotation is not present or tap is explicitly disabled, an error is
returned.

## UI changes

Multiple errors can now occur when trying to tap a resource:

1. There are no pods for the resource.
2. There are pods for the resource, but tap is disabled via pod or namespace
   annotation.
3. There are pods for the resource, but tap is not yet enabled because the
   `tap-injector` did not admit the resource.

Errors are now handled as shown below:

Tap is disabled:

```
❯ bin/linkerd viz tap deploy/test
Error: no pods to tap for deployment/test
pods found with tap disabled via the config.linkerd.io/disable-tap annotation
```

Tap is not enabled:

```
❯ bin/linkerd viz tap deploy/test
Error: no pods to tap for deployment/test
pods found with tap not enabled; try restarting resource so that it can be injected
```

There are a mix of pods with tap disabled or tap not enabled:

```
❯ bin/linkerd viz tap deploy/test
Error: no pods to tap for deployment/test
pods found with tap disabled via the config.linkerd.io/disable-tap annotation
pods found with tap not enabled; try restarting resource so that it can be injected
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
