### PR TITLE
Hide the "Gateway" sidebar link

### DIFF
--- a/viz/charts/linkerd-viz/templates/web-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/web-rbac.yaml
@@ -106,6 +106,34 @@ subjects:
   name: linkerd-web
   namespace: {{.Values.namespace}}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-{{.Values.namespace}}-web-api
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: web
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-{{.Values.namespace}}-web-api
+  labels:
+    {{.Values.extensionAnnotation}}: linkerd-viz
+    component: web
+roleRef:
+  kind: ClusterRole
+  name: linkerd-{{.Values.namespace}}-web-api
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: linkerd-web
+  namespace: {{.Values.namespace}}
+---
 {{- end}}
 kind: ServiceAccount
 apiVersion: v1

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -347,6 +347,34 @@ subjects:
   name: linkerd-web
   namespace: linkerd-viz
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+roleRef:
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-web-api
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: linkerd-web
+  namespace: linkerd-viz
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -443,7 +471,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -584,7 +612,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /api/health
@@ -832,7 +860,7 @@ spec:
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
         image: prom/prometheus:v2.19.3
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -936,7 +964,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -1096,7 +1124,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -1196,7 +1224,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -471,7 +471,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -612,7 +612,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /api/health
@@ -860,7 +860,7 @@ spec:
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
         image: prom/prometheus:v2.19.3
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -964,7 +964,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -1124,7 +1124,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -1224,7 +1224,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -334,6 +334,34 @@ subjects:
   name: linkerd-web
   namespace: linkerd-viz
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+roleRef:
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-web-api
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: linkerd-web
+  namespace: linkerd-viz
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -479,7 +507,6 @@ data:
       static_configs:
       - targets: ['localhost:9090']
 
-    
 
     #  Required for: https://grafana.com/grafana/dashboards/315
     - job_name: 'kubernetes-nodes-cadvisor'

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -507,6 +507,7 @@ data:
       static_configs:
       - targets: ['localhost:9090']
 
+    
 
     #  Required for: https://grafana.com/grafana/dashboards/315
     - job_name: 'kubernetes-nodes-cadvisor'

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -307,6 +307,34 @@ subjects:
   name: linkerd-web
   namespace: linkerd-viz
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+roleRef:
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-web-api
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: linkerd-web
+  namespace: linkerd-viz
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -400,7 +428,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=external-prom.com
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -541,7 +569,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /api/health
@@ -646,7 +674,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -806,7 +834,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -906,7 +934,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -428,7 +428,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=external-prom.com
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -569,7 +569,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /api/health
@@ -674,7 +674,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -834,7 +834,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -934,7 +934,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -347,6 +347,34 @@ subjects:
   name: linkerd-web
   namespace: linkerd-viz
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-linkerd-viz-web-api
+  labels:
+    linkerd.io/extension: linkerd-viz
+    component: web
+roleRef:
+  kind: ClusterRole
+  name: linkerd-linkerd-viz-web-api
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: linkerd-web
+  namespace: linkerd-viz
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -443,7 +471,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -588,7 +616,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /api/health
@@ -840,7 +868,7 @@ spec:
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
         image: prom/prometheus:v2.19.3
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -948,7 +976,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -1108,7 +1136,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping
@@ -1212,7 +1240,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy: 
+        imagePullPolicy:
         livenessProbe:
           httpGet:
             path: /ping

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -471,7 +471,7 @@ spec:
         - -cluster-domain=cluster.local
         - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
         image: ghcr.io/linkerd/metrics-api:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -616,7 +616,7 @@ spec:
         - name: GODEBUG
           value: netdns=go
         image: ghcr.io/linkerd/grafana:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /api/health
@@ -868,7 +868,7 @@ spec:
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
         image: prom/prometheus:v2.19.3
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /-/healthy
@@ -976,7 +976,7 @@ spec:
         - -log-level=info
         - -identity-trust-domain=cluster.local
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -1136,7 +1136,7 @@ spec:
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping
@@ -1240,7 +1240,7 @@ spec:
         - -log-level=info
         - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: ghcr.io/linkerd/web:dev-undefined
-        imagePullPolicy:
+        imagePullPolicy: 
         livenessProbe:
           httpGet:
             path: /ping

--- a/web/app/js/components/Gateway.jsx
+++ b/web/app/js/components/Gateway.jsx
@@ -8,7 +8,6 @@ import React from 'react';
 import Spinner from './util/Spinner.jsx';
 import { Trans } from '@lingui/macro';
 import Typography from '@material-ui/core/Typography';
-import _find from 'lodash/find';
 import _isEmpty from 'lodash/isEmpty';
 import { processGatewayResults } from './util/MetricUtils.jsx';
 import { withContext } from './util/AppContext.jsx';
@@ -87,12 +86,11 @@ class Gateways extends React.Component {
   }
 
   checkMulticlusterExtension() {
-    this.api.setCurrentRequests([this.api.fetchExtensions()]);
+    this.api.setCurrentRequests([this.api.fetchExtension(multiclusterExtensionName)]);
 
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
-      .then(([extList]) => {
-        const mcExists = _find(extList, e => e.extensionName === multiclusterExtensionName);
-        this.setState({ multiclusterExists: mcExists || false });
+      .then(([extension]) => {
+        this.setState({ multiclusterExists: !_isEmpty(extension) });
       })
       .catch(this.handleApiError);
   }

--- a/web/app/js/components/Gateway.jsx
+++ b/web/app/js/components/Gateway.jsx
@@ -120,7 +120,7 @@ class Gateways extends React.Component {
             {(noMetrics && !multiclusterExists) &&
             <Card>
               <CardContent>
-                <Typography>To view gateway stats for your mesh, install the linkerd multicluster extension by running:</Typography>
+                <Typography><Trans>installMulticlusterMsg</Trans></Typography>
                 <br />
                 <code>linkerd multicluster install | kubectl apply -f -</code>
               </CardContent>

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -25,7 +25,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import { Trans } from '@lingui/macro';
 import Typography from '@material-ui/core/Typography';
 import Version from './Version.jsx';
-import _find from 'lodash/find';
+import _isEmpty from 'lodash/isEmpty';
 import _maxBy from 'lodash/maxBy';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { faCloud } from '@fortawesome/free-solid-svg-icons/faCloud';
@@ -323,12 +323,10 @@ class NavigationBase extends React.Component {
   }
 
   checkMulticlusterExtension() {
-    this.api.setCurrentRequests([this.api.fetchExtensions()]);
-
+    this.api.setCurrentRequests([this.api.fetchExtension(multiclusterExtensionName)]);
     this.serverPromise = Promise.all(this.api.getCurrentPromises())
-      .then(([extList]) => {
-        const mcExists = _find(extList, e => e.extensionName === multiclusterExtensionName);
-        this.setState({ showGatewayLink: mcExists || false });
+      .then(([extension]) => {
+        this.setState({ showGatewayLink: !_isEmpty(extension) });
       })
       .catch(this.handleApiError);
   }

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -61,7 +61,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   const servicesPath = '/api/services';
   const edgesPath = '/api/edges';
   const gatewaysPath = '/api/gateways';
-  const l5dExtensionsPath = '/api/extensions';
+  const l5dExtensionsPath = '/api/extension';
 
   const validMetricsWindows = {
     '10s': '10 minutes',
@@ -146,8 +146,8 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     return apiFetch('/api/check');
   };
 
-  const fetchExtensions = () => {
-    return apiFetch(l5dExtensionsPath);
+  const fetchExtension = name => {
+    return apiFetch(`${l5dExtensionsPath}?extension_name=${name}`);
   };
 
   const fetchResourceDefinition = (namespace, resourceType, resourceName) => {
@@ -260,7 +260,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     fetchServices,
     fetchEdges,
     fetchGateways,
-    fetchExtensions,
+    fetchExtension,
     fetchCheck,
     fetchResourceDefinition,
     getMetricsWindow,

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -61,6 +61,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   const servicesPath = '/api/services';
   const edgesPath = '/api/edges';
   const gatewaysPath = '/api/gateways';
+  const l5dExtensionsPath = '/api/extensions';
 
   const validMetricsWindows = {
     '10s': '10 minutes',
@@ -143,6 +144,10 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
 
   const fetchCheck = () => {
     return apiFetch('/api/check');
+  };
+
+  const fetchExtensions = () => {
+    return apiFetch(l5dExtensionsPath);
   };
 
   const fetchResourceDefinition = (namespace, resourceType, resourceName) => {
@@ -255,6 +260,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
     fetchServices,
     fetchEdges,
     fetchGateways,
+    fetchExtensions,
     fetchCheck,
     fetchResourceDefinition,
     getMetricsWindow,

--- a/web/app/js/locales/en/messages.json
+++ b/web/app/js/locales/en/messages.json
@@ -104,6 +104,7 @@
   "formToNamespaceHelpText": "Namespace of target resource",
   "formToResource": "To Resource",
   "formToResourceHelpText": "Target resource",
+  "installMulticlusterMsg": "To view gateway stats for your mesh, install the linkerd multicluster extension by running",
   "labelError": "Error",
   "labelSuccess": "Success",
   "menuItemCommunity": "Community",

--- a/web/app/js/locales/es/messages.json
+++ b/web/app/js/locales/es/messages.json
@@ -104,6 +104,7 @@
   "formToNamespaceHelpText": "Namespace del recurso de destino",
   "formToResource": "Al Recurso",
   "formToResourceHelpText": "Recurso destino",
+  "installMulticlusterMsg": "Para ver las estadísticas de la puerta de enlace para su malla, instale la extensión de multicluster linkerd ejecutando",
   "labelError": "Error",
   "labelSuccess": "Éxito",
   "menuItemCommunity": "Comunidad",

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -441,6 +441,28 @@ func (h *handler) handleAPIResourceDefinition(w http.ResponseWriter, req *http.R
 	w.Write(resourceDefinition)
 }
 
+func (h *handler) handleGetExtensions(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	ctx := req.Context()
+	linkerdExtensionLabel := "linkerd.io/extension"
+	nsList, err := h.k8sAPI.CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: linkerdExtensionLabel,
+	})
+	if err != nil {
+		renderJSONError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	resp := []map[string]interface{}{}
+	for _, ns := range nsList.Items {
+		resp = append(resp, map[string]interface{}{
+			"extensionName": ns.GetLabels()[linkerdExtensionLabel],
+			"namespace": ns.Name,
+		})
+	}
+
+	renderJSON(w, resp)
+}
+
 func (h *handler) handleAPIGateways(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	window := req.FormValue("window")
 	if window == "" {

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -456,7 +456,7 @@ func (h *handler) handleGetExtensions(w http.ResponseWriter, req *http.Request, 
 	for _, ns := range nsList.Items {
 		resp = append(resp, map[string]interface{}{
 			"extensionName": ns.GetLabels()[linkerdExtensionLabel],
-			"namespace": ns.Name,
+			"namespace":     ns.Name,
 		})
 	}
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -198,7 +198,7 @@ func NewServer(
 	server.router.GET("/api/check", handler.handleAPICheck)
 	server.router.GET("/api/resource-definition", handler.handleAPIResourceDefinition)
 	server.router.GET("/api/gateways", handler.handleAPIGateways)
-	server.router.GET("/api/extensions", handler.handleGetExtensions)
+	server.router.GET("/api/extension", handler.handleGetExtension)
 
 	// grafana proxy
 	server.handleAllOperationsForPath("/grafana/*grafanapath", handler.handleGrafana)

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -198,6 +198,7 @@ func NewServer(
 	server.router.GET("/api/check", handler.handleAPICheck)
 	server.router.GET("/api/resource-definition", handler.handleAPIResourceDefinition)
 	server.router.GET("/api/gateways", handler.handleAPIGateways)
+	server.router.GET("/api/extensions", handler.handleGetExtensions)
 
 	// grafana proxy
 	server.handleAllOperationsForPath("/grafana/*grafanapath", handler.handleGrafana)


### PR DESCRIPTION
This commit hides the "Gateway" sidebar link in the dashboard if the
`linkerd-extension` is not installed. If a user happens to navigate to
the Gateway page anyway, we display a CTA (Call to Action) that informs
the user that they would need to run the multicluster install command.

This change includes a new endpoint in the dashboard server; `GET
/api/extensions`. This endpoint returns a list of all currently
installed `linkerd.io/extension` and the corresponding namespace each
extension is installed in. The dashboard uses this endpoint to detect
whether it needs to hide the navigation link and whether to display the
CTA.
<img width="297" alt="Screen Shot 2021-01-26 at 4 15 36 PM" src="https://user-images.githubusercontent.com/2197104/105913001-dc237380-5ff1-11eb-8042-930c7badcde9.png">
<img width="1196" alt="Screen Shot 2021-01-26 at 4 15 53 PM" src="https://user-images.githubusercontent.com/2197104/105913003-dd54a080-5ff1-11eb-8ae7-b4466a2d0f14.png">


Fixes #5330

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>