### PR TITLE
Helpful error when attempting `linkerd upgrade` on Helm installation

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -251,9 +251,9 @@ func upgrade(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, stage
 			return bytes.Buffer{}, err
 		}
 	}
-	// if there is still no linkerd-config-overrides secret, Linkerd has been installed using
-	// Helm installation, where linkerd-config-overrides secret doesn't exist
-	// User must be notified to upgrade Linkerd using Helm
+	// if we fails to fetch linkerd-config-overrides secret;
+	// Linkerd maybe installed using Helm installation,
+	// where linkerd-config-overrides secret doesn't exist
 	if values == nil {
 		err := errors.New("failed to fetch current install configuration; if Linkerd was installed with Helm, users need to upgrade with Helm.")
 		return bytes.Buffer{}, err

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -251,6 +251,13 @@ func upgrade(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, stage
 			return bytes.Buffer{}, err
 		}
 	}
+	// if there is still no linkerd-config-overrides secret, Linkerd has been installed using
+	// Helm installation, where linkerd-config-overrides secret doesn't exist
+	// User must be notified to upgrade Linkerd using Helm
+	if values == nil {
+		err := errors.New("Linkerd was installed with Helm Installation, upgrade Linkerd with Helm")
+		return bytes.Buffer{}, err
+	}
 
 	err = flag.ApplySetFlags(values, flags)
 	if err != nil {

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -255,7 +255,7 @@ func upgrade(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, stage
 	// Helm installation, where linkerd-config-overrides secret doesn't exist
 	// User must be notified to upgrade Linkerd using Helm
 	if values == nil {
-		err := errors.New("Linkerd was installed with Helm Installation, upgrade Linkerd with Helm")
+		err := errors.New("failed to fetch current install configuration; if Linkerd was installed with Helm, users need to upgrade with Helm.")
 		return bytes.Buffer{}, err
 	}
 

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -255,7 +255,7 @@ func upgrade(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, stage
 	// Linkerd maybe installed using Helm installation,
 	// where linkerd-config-overrides secret doesn't exist
 	if values == nil {
-		err := errors.New("failed to fetch current install configuration; if Linkerd was installed with Helm, users need to upgrade with Helm.")
+		err := errors.New("failed to fetch current install configuration; if linkerd was installed with helm, users need to upgrade with helm")
 		return bytes.Buffer{}, err
 	}
 

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -251,7 +251,7 @@ func upgrade(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, stage
 			return bytes.Buffer{}, err
 		}
 	}
-	// if we fails to fetch linkerd-config-overrides secret;
+	// if we fail to fetch linkerd-config-overrides secret;
 	// Linkerd maybe installed using Helm installation,
 	// where linkerd-config-overrides secret doesn't exist
 	if values == nil {


### PR DESCRIPTION
**Problem**
Not possible to upgrade Linkerd using cli if Linkerd was installed with Helm
when attempting `linkerd upgrade` with Helm installation it outputs a confusing error

**Solution**
When attempting `linkerd upgrade` CLI looks for `linkerd-stored-overrides` secret using `loadStoredValues()` https://github.com/linkerd/linkerd2/blob/main/cli/cmd/upgrade.go#L241
If it is not found Linkerd assume it to be a previous version before the introduction of `linkerd-stored-overrides` and tries to lookup for default values from the Legacy linked-config config map with `loadStoredValuesLegacy()` https://github.com/linkerd/linkerd2/blob/main/cli/cmd/upgrade.go#L249

If linkerd has been installed using Helm the `linkerd-stored-overrides` do not exist in the first place. And the error we're seeing now it being output by `validateValues()` https://github.com/linkerd/linkerd2/blob/main/cli/cmd/upgrade.go#L268 where the values are validated

> bin/linkerd upgrade
> Error: failed to validate issuer credentials: failed to read CA: not PEM-encoded

So after looking up values in the legacy if still, no values exist we return a new error notifying the user to upgrade Linkerd using **Helm**

Fixes #5518 