### PR TITLE
cli: make `linkerd uninstall` fail when injected pods are present

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -40,8 +39,8 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 					return err
 				}
 				for _, pod := range podsList.Items {
-					// Skip core control-plane and extension namespaces when checking for proxies
-					if !strings.HasPrefix(pod.Namespace, "linkerd") && healthcheck.ContainsProxy(pod) {
+					// Skip core control-plane namespace
+					if pod.Namespace != controlPlaneNamespace && healthcheck.ContainsProxy(pod) {
 						return fmt.Errorf("Please uninject proxy containers before uninstalling the control-plane")
 					}
 				}
@@ -51,7 +50,7 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 		},
 	}
 
-	cmd.Flags().BoolVarP(&force, "force", "f", force, "Enable this to perform a forced uninstall")
+	cmd.Flags().BoolVarP(&force, "force", "f", force, "Force uninstall even if there exist non-control-plane injected pods")
 	return cmd
 }
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2571,14 +2571,15 @@ func CheckPodsRunning(pods []corev1.Pod, podsNotFoundMsg string) error {
 // CheckIfDataPlanePodsExist checks if the proxy is present in the given pods
 func CheckIfDataPlanePodsExist(pods []corev1.Pod) error {
 	for _, pod := range pods {
-		if !containsProxy(pod) {
+		if !ContainsProxy(pod) {
 			return fmt.Errorf("could not find proxy container for %s pod", pod.Name)
 		}
 	}
 	return nil
 }
 
-func containsProxy(pod corev1.Pod) bool {
+// ContainsProxy checks if the given pod contains a linkerd proxy container
+func ContainsProxy(pod corev1.Pod) bool {
 	for _, containerSpec := range pod.Spec.Containers {
 		if containerSpec.Name == k8s.ProxyContainerName {
 			return true

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2571,15 +2571,14 @@ func CheckPodsRunning(pods []corev1.Pod, podsNotFoundMsg string) error {
 // CheckIfDataPlanePodsExist checks if the proxy is present in the given pods
 func CheckIfDataPlanePodsExist(pods []corev1.Pod) error {
 	for _, pod := range pods {
-		if !ContainsProxy(pod) {
+		if !containsProxy(pod) {
 			return fmt.Errorf("could not find proxy container for %s pod", pod.Name)
 		}
 	}
 	return nil
 }
 
-// ContainsProxy checks if the given pod contains a linkerd proxy container
-func ContainsProxy(pod corev1.Pod) bool {
+func containsProxy(pod corev1.Pod) bool {
 	for _, containerSpec := range pod.Spec.Containers {
 		if containerSpec.Name == k8s.ProxyContainerName {
 			return true

--- a/test/integration/uninstall/uninstall_test.go
+++ b/test/integration/uninstall/uninstall_test.go
@@ -91,8 +91,24 @@ func TestResourcesPostInstall(t *testing.T) {
 }
 
 func TestUninstall(t *testing.T) {
+	var (
+		vizCmd = []string{"viz", "uninstall"}
+	)
+
+	// Uninstall Linkerd Viz Extension
+	out, err := TestHelper.LinkerdRun(vizCmd...)
+	if err != nil {
+		testutil.AnnotatedFatal(t, "'linkerd viz uninstall' command failed", err)
+	}
+
+	out, err = TestHelper.KubectlApply(out, "")
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
+			"'kubectl apply' command failed\n%s", out)
+	}
+
 	args := []string{"uninstall"}
-	out, err := TestHelper.LinkerdRun(args...)
+	out, err = TestHelper.LinkerdRun(args...)
 	if err != nil {
 		testutil.AnnotatedFatal(t, "'linkerd install' command failed", err)
 	}

--- a/test/integration/uninstall/uninstall_test.go
+++ b/test/integration/uninstall/uninstall_test.go
@@ -101,13 +101,14 @@ func TestUninstall(t *testing.T) {
 		testutil.AnnotatedFatal(t, "'linkerd viz uninstall' command failed", err)
 	}
 
-	out, err = TestHelper.KubectlApply(out, "")
+	args := []string{"delete", "-f", "-"}
+	out, err = TestHelper.Kubectl(out, args...)
 	if err != nil {
-		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
-			"'kubectl apply' command failed\n%s", out)
+		testutil.AnnotatedFatalf(t, "'kubectl delete' command failed",
+			"'kubectl delete' command failed\n%s", out)
 	}
 
-	args := []string{"uninstall"}
+	args = []string{"uninstall"}
 	out, err = TestHelper.LinkerdRun(args...)
 	if err != nil {
 		testutil.AnnotatedFatal(t, "'linkerd install' command failed", err)
@@ -116,8 +117,8 @@ func TestUninstall(t *testing.T) {
 	args = []string{"delete", "-f", "-"}
 	out, err = TestHelper.Kubectl(out, args...)
 	if err != nil {
-		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
-			"'kubectl apply' command failed\n%s", out)
+		testutil.AnnotatedFatalf(t, "'kubectl delete' command failed",
+			"'kubectl delete' command failed\n%s", out)
 	}
 }
 

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -34,13 +34,8 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	vizNs, err := k8sAPI.GetNamespaceWithExtensionLabel(ctx, ExtensionName)
-	if err != nil {
-		return err
-	}
-
 	resources, err := resource.FetchKubernetesResources(ctx, k8sAPI,
-		metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, vizNs.Name)},
+		metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, ExtensionName)},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #5622

This PR updates the `linkerd uninstall` cmd to check if there
are any injected pods and fails if there are any. This also
provides `--force` flag to skip this check.

pods from the control-plane namespace are skipped
so as to not error out for control-plane pods.

This PR also fixes `viz uninstall` and updates the
uninstall integration test to use it.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
