### PR TITLE
Add tracing enabled annotation

### DIFF
--- a/controller/tap-injector/patch.go
+++ b/controller/tap-injector/patch.go
@@ -3,7 +3,7 @@ package tapinjector
 const tpl = `[
   {
     "op": "add",
-    "path": "/metadata/annotations/{{.Annotation}}",
+    "path": "/metadata/annotations/viz.linkerd.io~1tap-enabled",
     "value": "true"
   },
   {

--- a/controller/tap-injector/webhook.go
+++ b/controller/tap-injector/webhook.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"html/template"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -19,7 +18,6 @@ import (
 
 // Params holds the values used in the patch template.
 type Params struct {
-	Annotation      string
 	ProxyIndex      int
 	ProxyTapSvcName string
 }
@@ -43,12 +41,7 @@ func Mutate(tapSvcName string) webhook.Handler {
 		if err := yaml.Unmarshal(request.Object.Raw, &pod); err != nil {
 			return nil, err
 		}
-		// annotation is used in the patch as a JSON pointer, so '/' must be
-		// encoded as '~1' as stated in
-		// https://tools.ietf.org/html/rfc6901#section-3
-		annotation := strings.Replace(vizLabels.VizTapEnabled, "/", "~1", -1)
 		params := Params{
-			Annotation:      annotation,
 			ProxyIndex:      webhook.GetProxyContainerIndex(pod.Spec.Containers),
 			ProxyTapSvcName: tapSvcName,
 		}

--- a/controller/tap-injector/webhook.go
+++ b/controller/tap-injector/webhook.go
@@ -52,10 +52,7 @@ func Mutate(tapSvcName string) webhook.Handler {
 			ProxyIndex:      webhook.GetProxyContainerIndex(pod.Spec.Containers),
 			ProxyTapSvcName: tapSvcName,
 		}
-		if params.ProxyIndex < 0 {
-			return admissionResponse, nil
-		}
-		if _, contains := pod.GetAnnotations()[vizLabels.VizTapEnabled]; contains {
+		if params.ProxyIndex < 0 || vizLabels.IsTapEnabled(pod) {
 			return admissionResponse, nil
 		}
 		namespace, err := k8sAPI.NS().Lister().Get(request.Namespace)

--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -3,7 +3,7 @@ package mutator
 const tpl = `[
   {
     "op": "add",
-    "path": "/metadata/annotations/{{.Annotation}}",
+    "path": "/metadata/annotations/jaeger.linkerd.io~1tracing-enabled",
     "value": "true"
   },
   {

--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -3,6 +3,11 @@ package mutator
 const tpl = `[
   {
     "op": "add",
+    "path": "/metadata/annotations/{{.Annotation}}",
+    "value": "true"
+  },
+  {
+    "op": "add",
     "path": "/spec/containers/{{.ProxyIndex}}/env/-",
     "value": {
       "name": "LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH",

--- a/jaeger/injector/mutator/webhook.go
+++ b/jaeger/injector/mutator/webhook.go
@@ -26,7 +26,6 @@ const (
 
 // Params holds the values used in the patch template
 type Params struct {
-	Annotation          string
 	ProxyIndex          int
 	CollectorSvcAddr    string
 	CollectorSvcAccount string
@@ -56,13 +55,7 @@ func Mutate(collectorSvcAddr, collectorSvcAccount string) webhook.Handler {
 		if err := yaml.Unmarshal(request.Object.Raw, &pod); err != nil {
 			return nil, err
 		}
-
-		// annotation is used in the patch as a JSON pointer, so '/' must be
-		// encoded as '~1' as stated in
-		// https://tools.ietf.org/html/rfc6901#section-3
-		annotation := strings.Replace(labels.JaegerTracingEnabled, "/", "~1", -1)
 		params := Params{
-			Annotation:          annotation,
 			ProxyIndex:          webhook.GetProxyContainerIndex(pod.Spec.Containers),
 			CollectorSvcAddr:    collectorSvcAddr,
 			CollectorSvcAccount: collectorSvcAccount,

--- a/jaeger/injector/mutator/webhook.go
+++ b/jaeger/injector/mutator/webhook.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/controller/webhook"
-	labels "github.com/linkerd/linkerd2/pkg/k8s"
+	labels "github.com/linkerd/linkerd2/jaeger/pkg"
+	l5dLables "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/prometheus/common/log"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,13 +19,14 @@ import (
 )
 
 const (
-	collectorSvcAddrAnnotation    = labels.ProxyConfigAnnotationsPrefix + "/trace-collector"
-	collectorSvcAccountAnnotation = labels.ProxyConfigAnnotationsPrefixAlpha +
+	collectorSvcAddrAnnotation    = l5dLables.ProxyConfigAnnotationsPrefix + "/trace-collector"
+	collectorSvcAccountAnnotation = l5dLables.ProxyConfigAnnotationsPrefixAlpha +
 		"/trace-collector-service-account"
 )
 
 // Params holds the values used in the patch template
 type Params struct {
+	Annotation          string
 	ProxyIndex          int
 	CollectorSvcAddr    string
 	CollectorSvcAccount string
@@ -55,12 +57,17 @@ func Mutate(collectorSvcAddr, collectorSvcAccount string) webhook.Handler {
 			return nil, err
 		}
 
+		// annotation is used in the patch as a JSON pointer, so '/' must be
+		// encoded as '~1' as stated in
+		// https://tools.ietf.org/html/rfc6901#section-3
+		annotation := strings.Replace(labels.JaegerTracingEnabled, "/", "~1", -1)
 		params := Params{
+			Annotation:          annotation,
 			ProxyIndex:          webhook.GetProxyContainerIndex(pod.Spec.Containers),
 			CollectorSvcAddr:    collectorSvcAddr,
 			CollectorSvcAccount: collectorSvcAccount,
 		}
-		if params.ProxyIndex < 0 || alreadyMutated(pod, params.ProxyIndex) {
+		if params.ProxyIndex < 0 || labels.IsTracingEnabled(pod) {
 			return admissionResponse, nil
 		}
 
@@ -86,27 +93,6 @@ func Mutate(collectorSvcAddr, collectorSvcAccount string) webhook.Handler {
 
 		return admissionResponse, nil
 	}
-}
-
-func alreadyMutated(pod *corev1.Pod, proxyIndex int) bool {
-	for _, v := range pod.Spec.Volumes {
-		if v.DownwardAPI != nil && v.Name == "podinfo" {
-			return true
-		}
-	}
-	for _, mount := range pod.Spec.Containers[proxyIndex].VolumeMounts {
-		if mount.Name == "podinfo" && mount.MountPath == "var/run/linkerd/podinfo" {
-			return true
-		}
-	}
-	for _, env := range pod.Spec.Containers[proxyIndex].Env {
-		if env.Name == "LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH" ||
-			env.Name == "LINKERD2_PROXY_TRACE_COLLECTOR_SVC_ADDR" ||
-			env.Name == "LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME" {
-			return true
-		}
-	}
-	return false
 }
 
 func applyOverrides(ns *corev1.Namespace, pod *corev1.Pod, params *Params) {

--- a/jaeger/pkg/labels.go
+++ b/jaeger/pkg/labels.go
@@ -1,0 +1,29 @@
+package pkg
+
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// JaegerAnnotationsPrefix is the prefix of all jaeger-related annotations
+	JaegerAnnotationsPrefix = "jaeger.linkerd.io"
+
+	// JaegerTracingEnabled is set by the jaeger-injector component when
+	// tracing has been enabled on a pod.
+	JaegerTracingEnabled = JaegerAnnotationsPrefix + "/tracing-enabled"
+)
+
+// IsTracingEnabled returns true if a pod has an annotation indicating that
+// tracing is enabled.
+func IsTracingEnabled(pod *corev1.Pod) bool {
+	valStr := pod.GetAnnotations()[JaegerTracingEnabled]
+	if valStr != "" {
+		valBool, err := strconv.ParseBool(valStr)
+		if err == nil && valBool {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This change adds the `jaeger.linkerd.io/tracing-enabled` annotation which is
automatically added by the Jaeger extension's `jaeger-injector`.

All pods that receive this annotation have also had the required environment
variables and volume/volume mounts add by the injector.

The purpose of this annotation is that it will allow `jaeger check` to check for
the presence of this annotation instead of needing to look at the proxy
containers directly. If this annotation is not present on pods, `jaeger check`
can warn users that tracing is not configured for those pods. This is similar to
`viz check` warning users that tap is not configured—recenlty added in #5602.

Closes #5632

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
