### PR TITLE
Fix unit tests for duration parsing

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-18.04
     container:
-      image: golang:1.14.2
+      image: golang:1.15.7
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -352,7 +352,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration foo"),
+			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration \"foo\""),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/viz/metrics-api/util/api_utils_test.go
+++ b/viz/metrics-api/util/api_utils_test.go
@@ -65,8 +65,8 @@ func TestBuildStatSummaryRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {
@@ -138,8 +138,8 @@ func TestBuildTopRoutesRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {


### PR DESCRIPTION
Go unit tests have been consistently failing for me due to missing quotations on
values. This is happening on Debian Linux; why this hasn't occurred in CI yet
could be an OS difference.

Escaping quotations around these values is not unique to these tests. We do this
in all the tests that test valid duration values.

Failures that always happen:

```
❯ go test ./...
...
--- FAIL: TestValidate (0.01s)
    --- FAIL: TestValidate/19 (0.00s)
        profiles_test.go:418: Unexpected error (Expected: ServiceProfile "name.ns.svc.cluster.local" RetryBudget: time: invalid duration foo, Got: ServiceProfile "name.ns.svc.cluster.local" RetryBudget: time: invalid duration "foo")
FAIL
FAIL    github.com/linkerd/linkerd2/pkg/profiles        0.088s
...
--- FAIL: TestBuildStatSummaryRequest (0.00s)
    --- FAIL: TestBuildStatSummaryRequest/Rejects_invalid_time_windows (0.00s)
        api_utils_test.go:84: BuildStatSummaryRequest(1) should have returned: time: missing unit in duration 1 but got unexpected message: time: missing unit in duration "1"
--- FAIL: TestBuildTopRoutesRequest (0.00s)
    --- FAIL: TestBuildTopRoutesRequest/Rejects_invalid_time_windows (0.00s)
        api_utils_test.go:158: BuildTopRoutesRequest(1) should have returned: time: missing unit in duration 1 but got unexpected message: time: missing unit in duration "1"
FAIL
FAIL    github.com/linkerd/linkerd2/viz/metrics-api/util        0.022s
...
FAIL
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>