### PR TITLE
bin/test-cleanup reordering

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -19,11 +19,11 @@ echo "cleaning up multicluster resources, if present [${k8s_context}]"
 echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
 "$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
-echo "cleaning up linkerd resources [${k8s_context}]"
-"$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
-
 echo "cleaning up the all namespaces labelled with linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete ns -l linkerd.io/is-test-data-plane
+
+echo "cleaning up linkerd resources [${k8s_context}]"
+"$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
 # Helm cleanup. Just the entries in `helm ls` as the resources should have already been cleaned up by the code above.
 releases=$(helm ls -A -q)


### PR DESCRIPTION
After #5642 `linkerd uninstall` will fail if there still are injected pods in the cluster. So uninstall should happen last.