### PR TITLE
Fix spelling issue w/ sidecarContainers key in linkerd-viz helm chart

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -137,7 +137,7 @@ Kubernetes: `>=1.13.0-0`
 | prometheus.resources.memory.request | string | `nil` | Amount of memory that the prometheus container requests |
 | prometheus.ruleConfigMapMounts | string | `nil` | Alerting/recording rule ConfigMap mounts (sub-path names must end in ´_rules.yml´ or ´_rules.yaml´) |
 | prometheus.scrapeConfigs | string | `nil` | A scrapeConfigs section specifies a set of targets and parameters describing how to scrape them. |
-| prometheus.sideCarContainers | string | `nil` | A sidecarContainers section specifies a list of secondary containers to run in the prometheus pod e.g. to export data to non-prometheus systems |
+| prometheus.sidecarContainers | string | `nil` | A sidecarContainers section specifies a list of secondary containers to run in the prometheus pod e.g. to export data to non-prometheus systems |
 | prometheusUrl | string | `""` | url of external prometheus instance |
 | proxyInjectAnnotation | string | `"linkerd.io/inject"` |  |
 | tap.UID | int | `2103` |  |

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -338,7 +338,7 @@ prometheus:
 
   # -- A sidecarContainers section specifies a list of secondary containers to run
   # in the prometheus pod e.g. to export data to non-prometheus systems
-  sideCarContainers:
+  sidecarContainers:
   # Ex:
   # - name: sidecar
   #   image: gcr.io/myproject/stackdriver-prometheus-sidecar


### PR DESCRIPTION
Problem:

The name of the `sidecarContainers` chart value key is misspelled
`sideCarContainers` in the default values file and the README: anyone
who uses the misspelled key will be confused and unhappy to see that
their sidecar container is not added to the pod because the Helm
template is looking for `.Values.prometheus.sidecarContainer`

Solution:

Change the first `c` character to lower-case as the template expects. :)

Signed-off-by: Nathan J. Mehl <n@oden.io>
