### PR TITLE
Fix for CLI printing command usage for API Errors with `linkerd viz stat`

### DIFF
--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -193,6 +193,10 @@ If no resource name is specified, displays stats about all resources of the spec
 			for num, req := range reqs {
 				go func(num int, req *pb.StatSummaryRequest) {
 					resp, err := requestStatsFromAPI(client, req)
+					if err != nil {
+						fmt.Fprint(os.Stderr, err.Error())
+						os.Exit(1)
+					}
 					rows := respToRows(resp)
 					c <- indexedResults{num, rows, err}
 				}(num, req)

--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -193,10 +193,6 @@ If no resource name is specified, displays stats about all resources of the spec
 			for num, req := range reqs {
 				go func(num int, req *pb.StatSummaryRequest) {
 					resp, err := requestStatsFromAPI(client, req)
-					if err != nil {
-						fmt.Fprint(os.Stderr, err.Error())
-						os.Exit(1)
-					}
 					rows := respToRows(resp)
 					c <- indexedResults{num, rows, err}
 				}(num, req)
@@ -206,7 +202,8 @@ If no resource name is specified, displays stats about all resources of the spec
 			i := 0
 			for res := range c {
 				if res.err != nil {
-					return res.err
+					fmt.Fprint(os.Stderr, res.err.Error())
+					os.Exit(1)
 				}
 				totalRows = append(totalRows, res.rows...)
 				if i++; i == len(reqs) {


### PR DESCRIPTION
Signed-off-by: Piyush Singariya <piyushsingariya@gmail.com>

Potential fix for #5058 

Problem: CLI prints command usage for 'linkerd viz stat' in-case of API errors
Solution: Print the error and the exit using `os.Exit(1)` to avoid Cobra printing usage