### PR TITLE
Support opaque ports annotation on services

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -216,7 +216,7 @@ func (et *endpointTranslator) sendClientAdd(set watcher.AddressSet) {
 			err error
 		)
 		if address.Pod != nil {
-			opaquePorts, getErr := getOpaquePortsAnnotations(address.Pod)
+			opaquePorts, getErr := getPodOpaquePortsAnnotations(address.Pod)
 			if getErr != nil {
 				et.log.Errorf("failed getting opaque ports annotation for pod: %s", getErr)
 			}

--- a/controller/api/destination/opaque_ports_adaptor.go
+++ b/controller/api/destination/opaque_ports_adaptor.go
@@ -1,108 +1,39 @@
 package destination
 
 import (
-	"strconv"
-
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
-	"github.com/linkerd/linkerd2/controller/k8s"
-	pkgk8s "github.com/linkerd/linkerd2/pkg/k8s"
-	"github.com/linkerd/linkerd2/pkg/util"
-	logging "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 )
 
-// opaquePortsAdaptor implements EndpointUpdateListener so that it can watch
-// endpoints for services. When endpoints change, it can check for the opaque
-// ports annotation on the pods and update the list of opaque ports.
-//
-// opaquePortsAdaptor also implements ProfileUpdateListener so that it can
-// receive updates from trafficSplitAdaptor and merge the service profile by
-// adding the list of opaque ports.
-//
-// When either of these implemented interfaces has an update,
-// opaquePortsAdaptor publishes the new service profile to the
-// profileTranslator.
 type opaquePortsAdaptor struct {
 	listener    watcher.ProfileUpdateListener
-	k8sAPI      *k8s.API
-	log         *logging.Entry
 	profile     *sp.ServiceProfile
 	opaquePorts map[uint32]struct{}
 }
 
-func newOpaquePortsAdaptor(listener watcher.ProfileUpdateListener, k8sAPI *k8s.API, log *logging.Entry) *opaquePortsAdaptor {
+func newOpaquePortsAdaptor(listener watcher.ProfileUpdateListener) *opaquePortsAdaptor {
 	return &opaquePortsAdaptor{
-		listener:    listener,
-		k8sAPI:      k8sAPI,
-		log:         log,
-		opaquePorts: make(map[uint32]struct{}),
+		listener: listener,
 	}
 }
 
-func (opa *opaquePortsAdaptor) Add(set watcher.AddressSet) {
-	ports := opa.getOpaquePorts(set)
-	for port := range ports {
-		opa.opaquePorts[port] = struct{}{}
-	}
-	opa.publish()
+func (sa *opaquePortsAdaptor) Update(profile *sp.ServiceProfile) {
+	sa.profile = profile
+	sa.publish()
 }
 
-func (opa *opaquePortsAdaptor) Remove(set watcher.AddressSet) {
-	ports := opa.getOpaquePorts(set)
-	for port := range ports {
-		delete(opa.opaquePorts, port)
-	}
-	opa.publish()
+func (sa *opaquePortsAdaptor) UpdateService(ports map[uint32]struct{}) {
+	sa.opaquePorts = ports
+	sa.publish()
 }
 
-func (opa *opaquePortsAdaptor) NoEndpoints(exists bool) {
-	opa.opaquePorts = make(map[uint32]struct{})
-	opa.publish()
-}
-
-func (opa *opaquePortsAdaptor) Update(profile *sp.ServiceProfile) {
-	opa.profile = profile
-	opa.publish()
-}
-
-func (opa *opaquePortsAdaptor) getOpaquePorts(set watcher.AddressSet) map[uint32]struct{} {
-	ports := make(map[uint32]struct{})
-	for _, address := range set.Addresses {
-		pod := address.Pod
-		if pod != nil {
-			override, err := getOpaquePortsAnnotations(pod)
-			if err != nil {
-				opa.log.Errorf("Failed to get opaque ports annotation for pod %s: %s", pod, err)
-			}
-			for port := range override {
-				ports[port] = struct{}{}
-			}
-		}
-	}
-	return ports
-}
-
-func (opa *opaquePortsAdaptor) publish() {
+func (sa *opaquePortsAdaptor) publish() {
 	merged := sp.ServiceProfile{}
-	if opa.profile != nil {
-		merged = *opa.profile
+	if sa.profile != nil {
+		merged = *sa.profile
 	}
-	merged.Spec.OpaquePorts = opa.opaquePorts
-	opa.listener.Update(&merged)
-}
-
-func getOpaquePortsAnnotations(pod *corev1.Pod) (map[uint32]struct{}, error) {
-	opaquePorts := make(map[uint32]struct{})
-	annotation := pod.Annotations[pkgk8s.ProxyOpaquePortsAnnotation]
-	if annotation != "" {
-		for _, portStr := range util.ParseOpaquePorts(annotation, pod.Spec.Containers) {
-			port, err := strconv.ParseUint(portStr, 10, 32)
-			if err != nil {
-				return nil, err
-			}
-			opaquePorts[uint32(port)] = struct{}{}
-		}
+	if len(sa.opaquePorts) != 0 {
+		merged.Spec.OpaquePorts = sa.opaquePorts
 	}
-	return opaquePorts, nil
+	sa.listener.Update(&merged)
 }

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -15,6 +15,8 @@ import (
 
 const fullyQualifiedName = "name1.ns.svc.mycluster.local"
 const fullyQualifiedNameOpaque = "name3.ns.svc.mycluster.local"
+const fullyQualifiedNameOpaqueService = "name4.ns.svc.mycluster.local"
+const fullyQualifiedNameOpaqueNamespace = "name5.ns2.svc.mycluster.local"
 const clusterIP = "172.17.12.0"
 const clusterIPOpaque = "172.17.12.1"
 const podIP1 = "172.17.0.12"
@@ -196,9 +198,38 @@ spec:
         value: 0.0.0.0:4143
       name: linkerd-proxy`,
 	}
+
+	meshedOpaqueServiceResources := []string{
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: name4
+  namespace: ns
+  annotations:
+    config.linkerd.io/opaque-ports: "4242"`,
+	}
+
+	meshedOpaqueNamespaceResources := []string{
+		`
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns2
+  annotations:
+    config.linkerd.io/opaque-ports: "4242"`,
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: name5
+  namespace: ns2`,
+	}
 	res := append(meshedPodResources, clientSP...)
 	res = append(res, unmeshedPod)
 	res = append(res, meshedOpaquePodResources...)
+	res = append(res, meshedOpaqueServiceResources...)
+	res = append(res, meshedOpaqueNamespaceResources...)
 	k8sAPI, err := k8s.NewFakeAPI(res...)
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
@@ -206,6 +237,7 @@ spec:
 	log := logging.WithField("test", t.Name())
 
 	endpoints := watcher.NewEndpointsWatcher(k8sAPI, log, false)
+	opaquePorts := watcher.NewOpaquePortsWatcher(k8sAPI, log)
 	profiles := watcher.NewProfileWatcher(k8sAPI, log)
 	trafficSplits := watcher.NewTrafficSplitWatcher(k8sAPI, log)
 	ips := watcher.NewIPWatcher(k8sAPI, endpoints, log)
@@ -216,6 +248,7 @@ spec:
 
 	return &server{
 		endpoints,
+		opaquePorts,
 		profiles,
 		trafficSplits,
 		ips,
@@ -622,7 +655,7 @@ func TestGetProfiles(t *testing.T) {
 		}
 	})
 
-	t.Run("Return opaque protocol profile when using cluster IP and opaque protocol port", func(t *testing.T) {
+	t.Run("Return non-opaque protocol profile when using cluster IP and opaque protocol port", func(t *testing.T) {
 		server := makeServer(t)
 		stream := &bufferingGetProfileStream{
 			updates:          []*pb.DestinationProfile{},
@@ -647,8 +680,8 @@ func TestGetProfiles(t *testing.T) {
 		if last.FullyQualifiedName != fullyQualifiedNameOpaque {
 			t.Fatalf("Expected fully qualified name '%s', but got '%s'", fullyQualifiedNameOpaque, last.FullyQualifiedName)
 		}
-		if !last.OpaqueProtocol {
-			t.Fatalf("Expected port %d to be an opaque protocol, but it was not", opaquePort)
+		if last.OpaqueProtocol {
+			t.Fatalf("Expected port %d to not be an opaque protocol, but it was", opaquePort)
 		}
 	})
 
@@ -698,6 +731,58 @@ func TestGetProfiles(t *testing.T) {
 		}
 		if first.Endpoint.Addr.String() != epAddr.String() {
 			t.Fatalf("Expected endpoint IP port to be %d, but it was %d", epAddr.Port, first.Endpoint.Addr.Port)
+		}
+	})
+
+	t.Run("Return opaque protocol profile when using service name with opaque port annotation", func(t *testing.T) {
+		server := makeServer(t)
+		stream := &bufferingGetProfileStream{
+			updates:          []*pb.DestinationProfile{},
+			MockServerStream: util.NewMockServerStream(),
+		}
+		stream.Cancel()
+		err := server.GetProfile(&pb.GetDestination{
+			Scheme: "k8s",
+			Path:   fmt.Sprintf("%s:%d", fullyQualifiedNameOpaqueService, opaquePort),
+		}, stream)
+		if err != nil {
+			t.Fatalf("Got error: %s", err)
+		}
+		if len(stream.updates) == 0 || len(stream.updates) > 3 {
+			t.Fatalf("Expected 1 to 3 updates but got %d: %v", len(stream.updates), stream.updates)
+		}
+		last := stream.updates[len(stream.updates)-1]
+		if last.FullyQualifiedName != fullyQualifiedNameOpaqueService {
+			t.Fatalf("Expected fully qualified name '%s', but got '%s'", fullyQualifiedNameOpaqueService, last.FullyQualifiedName)
+		}
+		if !last.OpaqueProtocol {
+			t.Fatalf("Expected port %d to be an opaque protocol, but it was not", opaquePort)
+		}
+	})
+
+	t.Run("Return opaque protocol profile when using service name in namespace with opaque port annotation", func(t *testing.T) {
+		server := makeServer(t)
+		stream := &bufferingGetProfileStream{
+			updates:          []*pb.DestinationProfile{},
+			MockServerStream: util.NewMockServerStream(),
+		}
+		stream.Cancel()
+		err := server.GetProfile(&pb.GetDestination{
+			Scheme: "k8s",
+			Path:   fmt.Sprintf("%s:%d", fullyQualifiedNameOpaqueNamespace, opaquePort),
+		}, stream)
+		if err != nil {
+			t.Fatalf("Got error: %s", err)
+		}
+		if len(stream.updates) == 0 || len(stream.updates) > 3 {
+			t.Fatalf("Expected 1 to 3 updates but got %d: %v", len(stream.updates), stream.updates)
+		}
+		last := stream.updates[len(stream.updates)-1]
+		if last.FullyQualifiedName != fullyQualifiedNameOpaqueNamespace {
+			t.Fatalf("Expected fully qualified name '%s', but got '%s'", fullyQualifiedNameOpaqueNamespace, last.FullyQualifiedName)
+		}
+		if !last.OpaqueProtocol {
+			t.Fatalf("Expected port %d to be an opaque protocol, but it was not", opaquePort)
 		}
 	})
 }

--- a/controller/api/destination/watcher/opaque_ports_watcher.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher.go
@@ -1,0 +1,396 @@
+package watcher
+
+import (
+	"reflect"
+	"strconv"
+	"sync"
+
+	"github.com/linkerd/linkerd2-proxy-init/ports"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	labels "github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/util"
+	log "github.com/sirupsen/logrus"
+	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+type (
+	// OpaquePortsWatcher watches all the services and their namespaces in the
+	// cluster. If the Linkerd opaque ports annotation is added to either
+	// service or namespace, the watcher will merge the port value or ranges
+	// added—giving priority to service annotations.
+	OpaquePortsWatcher struct {
+		subscriptions map[string]*nsSubscriptions
+		k8sAPI        *k8s.API
+		log           *logging.Entry
+		sync.RWMutex
+	}
+
+	nsSubscriptions struct {
+		opaquePorts map[uint32]struct{}
+		services    map[ServiceID]*svcSubscriptions
+	}
+
+	svcSubscriptions struct {
+		opaquePorts map[uint32]struct{}
+		listeners   []OpaquePortsUpdateListener
+	}
+
+	// OpaquePortsUpdateListener is the interface that subscribers must implement.
+	OpaquePortsUpdateListener interface {
+		UpdateService(ports map[uint32]struct{})
+	}
+)
+
+// NewOpaquePortsWatcher creates a OpaquePortsWatcher and begins watching for
+// k8sAPI for service and namespace changes.
+func NewOpaquePortsWatcher(k8sAPI *k8s.API, log *logging.Entry) *OpaquePortsWatcher {
+	opw := &OpaquePortsWatcher{
+		subscriptions: make(map[string]*nsSubscriptions),
+		k8sAPI:        k8sAPI,
+		log:           log.WithField("component", "opaque-ports-watcher"),
+	}
+	k8sAPI.Svc().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    opw.addService,
+		DeleteFunc: opw.deleteService,
+		UpdateFunc: func(_, obj interface{}) { opw.addService(obj) },
+	})
+	k8sAPI.NS().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    opw.addNamespace,
+		DeleteFunc: opw.deleteNamespace,
+		UpdateFunc: func(_, obj interface{}) { opw.addNamespace(obj) },
+	})
+	return opw
+}
+
+// Subscribe subscribes a listener to a service; each time the service or
+// namespace changes, the listener will be updated if the list of opaque ports
+// changes.
+func (opw *OpaquePortsWatcher) Subscribe(id ServiceID, listener OpaquePortsUpdateListener) error {
+	opw.Lock()
+	defer opw.Unlock()
+	svc, _ := opw.k8sAPI.Svc().Lister().Services(id.Namespace).Get(id.Name)
+	if svc != nil && svc.Spec.Type == corev1.ServiceTypeExternalName {
+		return invalidService(id.String())
+	}
+	opw.log.Infof("Starting watch on service %s", id)
+	ns, ok := opw.subscriptions[id.Namespace]
+	// If there is no watched namespace for the service, create a subscription
+	// for the namespace qualified service and no opaque ports.
+	if !ok {
+		opw.subscriptions[id.Namespace] = &nsSubscriptions{
+			opaquePorts: make(map[uint32]struct{}),
+			services: map[ServiceID]*svcSubscriptions{id: {
+				opaquePorts: make(map[uint32]struct{}),
+				listeners:   []OpaquePortsUpdateListener{listener},
+			}},
+		}
+		return nil
+	}
+	ss, ok := ns.services[id]
+	// If there is no watched service, create a subscription for the service
+	// and no opaque ports.
+	if !ok {
+		ns.services[id] = &svcSubscriptions{
+			opaquePorts: make(map[uint32]struct{}),
+			listeners:   []OpaquePortsUpdateListener{listener},
+		}
+		if len(ns.opaquePorts) != 0 {
+			listener.UpdateService(ns.opaquePorts)
+		}
+		return nil
+	}
+	// There are subscriptions for this service, so add the listener to the
+	// service listeners. If there are opaque ports for the service or the
+	// namespace, update the listener with that value.
+	ss.listeners = append(ss.listeners, listener)
+	op := ss.opaquePorts
+	if len(op) == 0 {
+		op = ns.opaquePorts
+	}
+	if len(op) != 0 {
+		listener.UpdateService(op)
+	}
+	return nil
+}
+
+// Unsubscribe unsubscries a listener from service.
+func (opw *OpaquePortsWatcher) Unsubscribe(id ServiceID, listener OpaquePortsUpdateListener) {
+	opw.Lock()
+	defer opw.Unlock()
+	opw.log.Infof("Stopping watch on service %s", id)
+	ns, ok := opw.subscriptions[id.Namespace]
+	if !ok {
+		opw.log.Errorf("Cannot unsubscribe from service in unknown namespace %s", id.Namespace)
+		return
+	}
+	ss, ok := ns.services[id]
+	if !ok {
+		opw.log.Errorf("Cannot unsubscribe from unknown service %s", id)
+		return
+	}
+	for i, l := range ss.listeners {
+		if l == listener {
+			n := len(ss.listeners)
+			ss.listeners[i] = ss.listeners[n-1]
+			ss.listeners[n-1] = nil
+			ss.listeners = ss.listeners[:n-1]
+		}
+	}
+}
+
+func (opw *OpaquePortsWatcher) addService(obj interface{}) {
+	opw.Lock()
+	defer opw.Unlock()
+	svc := obj.(*corev1.Service)
+	if svc.Namespace == kubeSystem {
+		return
+	}
+	id := ServiceID{
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+	opaquePorts, err := getServiceOpaquePortsAnnotation(svc)
+	if err != nil {
+		opw.log.Errorf("failed to get %s service opaque ports annotation: %s", id, err)
+		return
+	}
+	// If the service has no opaque ports, we check the namespace. If the
+	// namespace does have the service, that means there are listeners waiting
+	// for updates; we must update them with the namespace's opaque ports.
+	if len(opaquePorts) == 0 {
+		ns, ok := opw.subscriptions[id.Namespace]
+		// If there are no namespace subscriptions or the namespace has no
+		// opaque ports, there are no listeners to update.
+		if !ok || len(ns.opaquePorts) == 0 {
+			return
+		}
+		ss, ok := ns.services[id]
+		// There are no listeners for this service.
+		if !ok {
+			return
+		}
+		for _, listener := range ss.listeners {
+			listener.UpdateService(ns.opaquePorts)
+		}
+		return
+	}
+	ns, ok := opw.subscriptions[id.Namespace]
+	// If there are no namespace subscriptions for the service's namespace,
+	// create one and add the service subscription with its opaque ports.
+	if !ok {
+		opw.subscriptions[id.Namespace] = &nsSubscriptions{
+			opaquePorts: make(map[uint32]struct{}),
+			services: map[ServiceID]*svcSubscriptions{id: {
+				opaquePorts: opaquePorts,
+				listeners:   []OpaquePortsUpdateListener{},
+			}},
+		}
+		return
+	}
+	ss, ok := ns.services[id]
+	// If there is service subscription, create one with the opaque ports.
+	if !ok {
+		ns.services[id] = &svcSubscriptions{
+			opaquePorts: opaquePorts,
+			listeners:   []OpaquePortsUpdateListener{},
+		}
+		return
+	}
+	// Do not send updates if there was no change in the opaque ports; if
+	// there was, send an update to each of the listeners.
+	if !reflect.DeepEqual(ss.opaquePorts, opaquePorts) {
+		ss.opaquePorts = opaquePorts
+		for _, listener := range ss.listeners {
+			listener.UpdateService(ss.opaquePorts)
+		}
+	}
+}
+
+func (opw *OpaquePortsWatcher) deleteService(obj interface{}) {
+	opw.Lock()
+	defer opw.Unlock()
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			opw.log.Errorf("could not get object from DeletedFinalStateUnknown %#v", obj)
+			return
+		}
+		service, ok = tombstone.Obj.(*corev1.Service)
+		if !ok {
+			opw.log.Errorf("DeletedFinalStateUnknown contained object that is not a Service %#v", obj)
+			return
+		}
+	}
+	if service.Namespace == kubeSystem {
+		return
+	}
+	id := ServiceID{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	ns, ok := opw.subscriptions[id.Namespace]
+	if !ok {
+		return
+	}
+	ss, ok := ns.services[id]
+	if !ok {
+		return
+	}
+	old := ss.opaquePorts
+	ss.opaquePorts = make(map[uint32]struct{})
+	// Do not send an update if the service already had no opaque ports
+	if len(old) == 0 {
+		return
+	}
+	// Deleting a service does not mean there are no opaque ports; if the
+	// namespace has a list, that must be sent instead.
+	if len(ns.opaquePorts) != 0 {
+		for _, listener := range ss.listeners {
+			listener.UpdateService(ns.opaquePorts)
+		}
+		return
+	}
+	for _, listener := range ss.listeners {
+		listener.UpdateService(make(map[uint32]struct{}))
+	}
+}
+
+func (opw *OpaquePortsWatcher) addNamespace(obj interface{}) {
+	opw.Lock()
+	defer opw.Unlock()
+	namespace := obj.(*corev1.Namespace)
+	opaquePorts, err := getNamespaceOpaquePortsAnnotation(namespace)
+	if err != nil {
+		opw.log.Errorf("failed to get %s namespaces opaque ports annotation: %s", namespace.Name, err)
+		return
+	}
+	// If there are no opaque ports on the namespaces, there is nothing to do.
+	if len(opaquePorts) == 0 {
+		return
+	}
+	ns, ok := opw.subscriptions[namespace.Name]
+	// If there are no namespace subscriptions, there are no listeners to
+	// update; we do set the opaque ports though.
+	if !ok {
+		opw.subscriptions[namespace.Name] = &nsSubscriptions{
+			opaquePorts: opaquePorts,
+			services:    make(map[ServiceID]*svcSubscriptions),
+		}
+	}
+	if ns == nil {
+		ns = &nsSubscriptions{}
+	}
+	ns.opaquePorts = opaquePorts
+	// For each service subscribed to in the namespace, send an update with
+	// the namespace's opaque ports only if the service does not have its own.
+	for _, svc := range ns.services {
+		if len(svc.opaquePorts) == 0 {
+			for _, listener := range svc.listeners {
+				listener.UpdateService(ns.opaquePorts)
+			}
+		}
+	}
+}
+
+func (opw *OpaquePortsWatcher) deleteNamespace(obj interface{}) {
+	opw.Lock()
+	defer opw.Unlock()
+	namespace := obj.(*corev1.Namespace)
+	ns, ok := opw.subscriptions[namespace.Name]
+	// If there are no namespace subscriptions, there are no listeners to
+	// update.
+	if !ok {
+		return
+	}
+	if ns == nil {
+		ns = &nsSubscriptions{}
+	}
+	old := ns.opaquePorts
+	ns.opaquePorts = make(map[uint32]struct{})
+	// For each service subscribed to in the namespace, send an update only if
+	// the namespace had a list of opaque ports, and the subscribed service
+	// has none.
+	//
+	// Note: At this point if the namespace is being deleted, then the
+	// services within that namespace have likely been deleted. In this case,
+	// each service will have no opaque ports, but it's still important that
+	// the updates are sent. Since the stream remains open, clients must be
+	// updated that the service is not an opaque protocol.
+	if len(old) == 0 {
+		return
+	}
+	for _, svc := range ns.services {
+		if len(svc.opaquePorts) == 0 {
+			for _, listener := range svc.listeners {
+				listener.UpdateService(ns.opaquePorts)
+			}
+		}
+	}
+}
+
+func getNamespaceOpaquePortsAnnotation(ns *corev1.Namespace) (map[uint32]struct{}, error) {
+	opaquePorts := make(map[uint32]struct{})
+	annotation := ns.GetAnnotations()[labels.ProxyOpaquePortsAnnotation]
+	if annotation != "" {
+		for _, portStr := range util.ParseOpaquePorts(annotation) {
+			port, err := strconv.ParseUint(portStr, 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			opaquePorts[uint32(port)] = struct{}{}
+		}
+	}
+	return opaquePorts, nil
+}
+
+func getServiceOpaquePortsAnnotation(svc *corev1.Service) (map[uint32]struct{}, error) {
+	opaquePorts := make(map[uint32]struct{})
+	annotation := svc.Annotations[labels.ProxyOpaquePortsAnnotation]
+	if annotation != "" {
+		for _, portStr := range parseServiceOpaquePorts(annotation, svc.Spec.Ports) {
+			port, err := strconv.ParseUint(portStr, 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			opaquePorts[uint32(port)] = struct{}{}
+		}
+	}
+	return opaquePorts, nil
+}
+
+func parseServiceOpaquePorts(annotation string, sps []corev1.ServicePort) []string {
+	portRanges := util.GetPortRanges(annotation)
+	var values []string
+	for _, portRange := range portRanges {
+		pr := portRange.GetPortRange()
+		port, named := isNamed(pr, sps)
+		if named {
+			values = append(values, strconv.Itoa(int(port)))
+		} else {
+			pr, err := ports.ParsePortRange(pr)
+			if err != nil {
+				log.Warnf("Invalid port range [%v]: %s", pr, err)
+				continue
+			}
+			for i := pr.LowerBound; i <= pr.UpperBound; i++ {
+				values = append(values, strconv.Itoa(i))
+			}
+		}
+	}
+	return values
+}
+
+// isNamed checks if a port range is actually a service named port (e.g.
+// `123-456` is a valid name, but also is a valid range); all port names must
+// be checked before making it a list.
+func isNamed(pr string, sps []corev1.ServicePort) (int32, bool) {
+	for _, sp := range sps {
+		if sp.Name == pr {
+			return sp.Port, true
+		}
+	}
+	return 0, false
+}

--- a/controller/api/destination/watcher/opaque_ports_watcher_test.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher_test.go
@@ -1,0 +1,198 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/linkerd/linkerd2/controller/k8s"
+	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	baseNamespace = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns`
+
+	baseNamespaceObject = corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+		},
+	}
+
+	opaqueNamespace = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns
+  annotations:
+    config.linkerd.io/opaque-ports: "3308"`
+
+	opaqueNamespaceObject = corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "ns",
+			Annotations: map[string]string{"config.linkerd.io/opaque-ports": "3308"},
+		},
+	}
+
+	baseService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: ns`
+
+	baseServiceObject = corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "ns",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 8080}},
+		},
+	}
+
+	opaqueService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: ns
+  annotations:
+    config.linkerd.io/opaque-ports: "3306"`
+
+	opaqueServiceObject = corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc",
+			Namespace:   "ns",
+			Annotations: map[string]string{"config.linkerd.io/opaque-ports": "3306"},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 3306}},
+		},
+	}
+)
+
+type testOpaquePortsListener struct {
+	updates []map[uint32]struct{}
+}
+
+func newTestOpaquePortsListener() *testOpaquePortsListener {
+	return &testOpaquePortsListener{
+		updates: []map[uint32]struct{}{},
+	}
+}
+
+func (bopl *testOpaquePortsListener) UpdateService(ports map[uint32]struct{}) {
+	bopl.updates = append(bopl.updates, ports)
+}
+
+// []map[uint32]struct{}{{3306: {}}}
+
+func TestOpaquePortsWatcher(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		initialState        []string
+		nsObject            interface{}
+		svcObject           interface{}
+		service             ServiceID
+		expectedOpaquePorts []map[uint32]struct{}
+	}{
+		{
+			name:         "base namespace and service",
+			initialState: []string{baseNamespace, baseService},
+			nsObject:     &baseNamespaceObject,
+			svcObject:    &baseServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// Adding and remove namespaces and services that do not have the
+			// opaque ports annotation should not result in any updates being
+			// sent.
+			expectedOpaquePorts: []map[uint32]struct{}{},
+		},
+		{
+			name:         "opaque namespace and service",
+			initialState: []string{opaqueNamespace, opaqueService},
+			nsObject:     &opaqueNamespaceObject,
+			svcObject:    &opaqueServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// 1: svc annotation 3306
+			// 2: svc deleted: update with ns annotation 3308
+			// 3. svc created: update with svc annotation 3306
+			// 4. ns deleted: continue to use svc annotation; no update
+			// 5. ns created: continue to use svc annotation; no update
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {3308: {}}, {3306: {}}},
+		},
+		{
+			name:         "opaque namespace with base service",
+			initialState: []string{opaqueNamespace, baseService},
+			nsObject:     &opaqueNamespaceObject,
+			svcObject:    &baseServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// 1: ns annotation 3308
+			// 2: svc deleted: continue to use ns annotation; no update
+			// 3. svc created: update with ns annotation 3308
+			// 4. ns deleted: update with svc annotation which is empty
+			// 5. ns created: update with ns annotation 3308
+			expectedOpaquePorts: []map[uint32]struct{}{{3308: {}}, {3308: {}}, {}, {3308: {}}},
+		},
+		{
+			name:         "base namespace with opaque service",
+			initialState: []string{baseNamespace, opaqueService},
+			nsObject:     &baseNamespaceObject,
+			svcObject:    &opaqueServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// 1: svc annotation 3306
+			// 2: svc deleted: ns annotation has no annotation; update with
+			//    svc which is now empty
+			// 3. svc created: update with svc annotation 3306
+			// 4. ns deleted: continue to use svc annotation; no update
+			// 5. ns created: continue to use svc annotation; no update
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {}, {3306: {}}},
+		},
+		{
+			name:         "base namespace and service, create opaque ones",
+			initialState: []string{baseNamespace, baseService},
+			nsObject:     &opaqueNamespaceObject,
+			svcObject:    &opaqueServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// 1: no annotations, no update
+			// 2: svc deleted: ns annotation has no annotation; update with
+			//    svc which is now empty
+			// 3. svc created: update with svc annotation 3306
+			// 4. ns deleted: continue to use svc annotation; no update
+			// 5. ns created: continue to use svc annotation; no update
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}},
+		},
+	} {
+		k8sAPI, err := k8s.NewFakeAPI(tt.initialState...)
+		if err != nil {
+			t.Fatalf("NewFakeAPI returned an error: %s", err)
+		}
+		watcher := NewOpaquePortsWatcher(k8sAPI, logging.WithField("test", t.Name()))
+		k8sAPI.Sync(nil)
+		listener := newTestOpaquePortsListener()
+		watcher.Subscribe(tt.service, listener)
+		watcher.deleteService(tt.svcObject)
+		watcher.addService(tt.svcObject)
+		watcher.deleteNamespace(tt.nsObject)
+		watcher.addNamespace(tt.nsObject)
+		testCompare(t, tt.expectedOpaquePorts, listener.updates)
+	}
+}

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -170,10 +170,15 @@ func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceLabels() map[string]s
 }
 
 func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceAnnotations(remoteService *corev1.Service) map[string]string {
-	return map[string]string{
+	annotations := map[string]string{
 		consts.RemoteResourceVersionAnnotation: remoteService.ResourceVersion, // needed to detect real changes
 		consts.RemoteServiceFqName:             fmt.Sprintf("%s.%s.svc.%s", remoteService.Name, remoteService.Namespace, rcsw.link.TargetClusterDomain),
 	}
+	value, ok := remoteService.GetAnnotations()[consts.ProxyOpaquePortsAnnotation]
+	if ok {
+		annotations[consts.ProxyOpaquePortsAnnotation] = value
+	}
+	return annotations
 }
 
 func (rcsw *RemoteClusterServiceWatcher) mirrorNamespaceIfNecessary(ctx context.Context, namespace string) error {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -826,7 +826,7 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 	}
 
 	if override, ok := annotations[k8s.ProxyOpaquePortsAnnotation]; ok {
-		opaquePortsStrs := util.ParseOpaquePorts(override, conf.pod.spec.Containers)
+		opaquePortsStrs := util.ParseContainerOpaquePorts(override, conf.pod.spec.Containers)
 		values.GetGlobal().Proxy.OpaquePorts = strings.Join(opaquePortsStrs, ",")
 	}
 

--- a/pkg/util/parsing.go
+++ b/pkg/util/parsing.go
@@ -10,32 +10,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ParseOpaquePorts parses the opaque ports annotation into a list of ports;
+// ParseContainerOpaquePorts parses the opaque ports annotation into a list of ports;
 // this includes converting port ranges into separate ports and named ports
 // into their port number equivalents.
-func ParseOpaquePorts(override string, containers []corev1.Container) []string {
-	var portRanges []*config.PortRange
-	split := strings.Split(strings.TrimSuffix(override, ","), ",")
-	portRanges = ToPortRanges(split)
-
+func ParseContainerOpaquePorts(override string, containers []corev1.Container) []string {
+	portRanges := GetPortRanges(override)
 	var values []string
 	for _, portRange := range portRanges {
 		pr := portRange.GetPortRange()
-
-		// It is valid for the format of a port name to be the same as a
-		// port range (e.g. `123-456` is a valid name, but also is a valid
-		// range). All port names must be checked before making it a list.
-		named := false
-		for _, c := range containers {
-			for _, p := range c.Ports {
-				if p.Name == pr {
-					named = true
-					values = append(values, strconv.Itoa(int(p.ContainerPort)))
-				}
-			}
-		}
-
-		if !named {
+		port, named := isNamed(pr, containers)
+		if named {
+			values = append(values, strconv.Itoa(int(port)))
+		} else {
 			pr, err := ports.ParsePortRange(pr)
 			if err != nil {
 				log.Warnf("Invalid port range [%v]: %s", pr, err)
@@ -49,10 +35,42 @@ func ParseOpaquePorts(override string, containers []corev1.Container) []string {
 	return values
 }
 
-// ToPortRanges converts a slice of strings into a slice of PortRanges.
-func ToPortRanges(portRanges []string) []*config.PortRange {
-	ports := make([]*config.PortRange, len(portRanges))
-	for i, p := range portRanges {
+// isNamed checks if a port range is actually a container named port (e.g.
+// `123-456` is a valid name, but also is a valid range); all port names must
+// be checked before making it a list.
+func isNamed(pr string, containers []corev1.Container) (int32, bool) {
+	for _, c := range containers {
+		for _, p := range c.Ports {
+			if p.Name == pr {
+				return p.ContainerPort, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// ParseOpaquePorts parses the opaque ports annotation into a list of ports
+func ParseOpaquePorts(override string) []string {
+	portRanges := GetPortRanges(override)
+	var values []string
+	for _, portRange := range portRanges {
+		pr, err := ports.ParsePortRange(portRange.GetPortRange())
+		if err != nil {
+			log.Warnf("Invalid port range [%v]: %s", pr, err)
+			continue
+		}
+		for i := pr.LowerBound; i <= pr.UpperBound; i++ {
+			values = append(values, strconv.Itoa(i))
+		}
+	}
+	return values
+}
+
+// GetPortRanges gets port ranges from an override annotation
+func GetPortRanges(override string) []*config.PortRange {
+	split := strings.Split(strings.TrimSuffix(override, ","), ",")
+	ports := make([]*config.PortRange, len(split))
+	for i, p := range split {
 		ports[i] = &config.PortRange{PortRange: p}
 	}
 	return ports

--- a/test/integration/opaqueports/testdata/opaque_ports_application.yaml
+++ b/test/integration/opaqueports/testdata/opaque_ports_application.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app
+  name: opaque-pod
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: app
+      app: opaque-pod
   template:
     metadata:
       labels:
-        app: app
+        app: opaque-pod
       annotations:
         config.linkerd.io/opaque-ports: "8080"
     spec:
@@ -21,19 +21,19 @@ spec:
         args:
         - terminus
         - "--h1-server-port=8080"
-        - "--response-text=app"
+        - "--response-text=opaque-pod"
         ports:
         - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: svc
+  name: svc-opaque-pod
   labels:
-    app: svc
+    app: svc-opaque-pod
 spec:
   selector:
-    app: app
+    app: opaque-pod
   ports:
   - name: http
     port: 8080
@@ -42,15 +42,15 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: slow-cooker
+  name: slow-cooker-opaque-pod
 spec:
   template:
     metadata:
       labels:
-        app: slow-cooker
+        app: slow-cooker-opaque-pod
     spec:
       containers:
-      - name: slow-cooker
+      - name: slow-cooker-opaque-pod
         image: buoyantio/slow_cooker:1.3.0
         command:
         - "/bin/sh"
@@ -58,7 +58,71 @@ spec:
         - "-c"
         - |
           sleep 15 # wait for pods to start
-          /slow_cooker/slow_cooker -qps 1 -metric-addr 0.0.0.0:9999 http://svc:8080
+          /slow_cooker/slow_cooker -qps 1 -metric-addr 0.0.0.0:9999 http://svc-opaque-pod:8080
+        ports:
+        - containerPort: 9999
+      restartPolicy: OnFailure
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opaque-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opaque-service
+  template:
+    metadata:
+      labels:
+        app: opaque-service
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=opaque-service"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-opaque-service
+  labels:
+    app: svc-opaque-service
+  annotations:
+    config.linkerd.io/opaque-ports: "8080"
+spec:
+  selector:
+    app: opaque-service
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: slow-cooker-opaque-service
+spec:
+  template:
+    metadata:
+      labels:
+        app: slow-cooker-opaque-service
+    spec:
+      containers:
+      - name: slow-cooker-opaque-service
+        image: buoyantio/slow_cooker:1.3.0
+        command:
+        - "/bin/sh"
+        args:
+        - "-c"
+        - |
+          sleep 15 # wait for pods to start
+          /slow_cooker/slow_cooker -qps 1 -metric-addr 0.0.0.0:9999 http://svc-opaque-service:8080
         ports:
         - containerPort: 9999
       restartPolicy: OnFailure


### PR DESCRIPTION
This change introduces an opaque ports annotation watcher that will send
destination profile updates when a service or its namespace has its opaque ports
annotation change.

The user facing change introduced by this is that the opaque ports annotation is
now required on services or namespaces when using the multicluster extension.
This is because the service mirror will create mirrored services in the source
cluster, and destination lookups in the source cluster need to discover that the
workloads in the target cluster are opaque protocols.

This also fixes an existing bug where changes to the opaque port annotations on
the namespace do not update a destination client. Updates are now merged between
namespace and service — giving priority to the annotation on a service.

### Why

Closes #5650

### How

The destination server now has a new opaque ports annotation watcher. When a
client subscribes to updates for a service name or cluster IP, the `GetProfile`
method creates a profile translator stack that passes updates through resource
adaptors such as: traffic split adaptor, service profile adaptor, and now opaque
ports adaptor.

When the annotation on a namespace or service changes, the opaque ports watcher
will merge those changes — giving priority to the service annotation. This
update is passed through to the client where the `opaque_protocol` field will
either be set to true or false.

There are a few scenarios to consider that the opaque ports watcher handles:

- If both namespace and service have the annotation, the client should get the
  update for the service annotation.

  - If the annotation is removed from the service, the client should receive an
    update with the namespace annotation.
  - If the service is deleted, the stream stays open so the client should
    receive an update with the namespace annotation.
  - If the annotation is removed from the namespace there should be no update.

- If neither the namespace or the service has the annotation, the client should
  receive an update with no opaque ports — and therefore `opaque_protocol` is
  false.

  - If either the namespace or the service has the annotation added, the client
    should receive that update.

### Testing

Unit test have been added to the watcher as well as the destination server.

An integration test has been added that tests the opaque port annotation on a
service.

For manual testing, using the destination server scripts is easiest:

```
# install Linkerd

# start the destination server
$ go run controller/cmd/main.go destination -kubeconfig ~/.kube/config

# Create a service or namespace with the annotation and inject it

# get the destination profile for that service and observe the opaque protocol field
$ go run controller/script/destination-client/main.go -method getProfile -path test-svc.default.svc.cluster.local:8080
INFO[0000] fully_qualified_name:"terminus-svc.default.svc.cluster.local" opaque_protocol:true retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} dst_overrides:{authority:"terminus-svc.default.svc.cluster.local.:8080" weight:10000} 
INFO[0000]                                              
INFO[0000] fully_qualified_name:"terminus-svc.default.svc.cluster.local" opaque_protocol:true retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} dst_overrides:{authority:"terminus-svc.default.svc.cluster.local.:8080" weight:10000} 
INFO[0000]
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
