### PR TITLE
Add the 'tapInjector.logLevel' value.

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -164,6 +164,7 @@ Kubernetes: `>=1.13.0-0`
 | tapInjector.image.registry | string | `"ghcr.io/linkerd"` | Docker registry for the tapInjector instance |
 | tapInjector.image.tag | string | `"linkerdVersionValue"` | Docker image tag for the tapInjector instance |
 | tapInjector.keyPEM | string | `""` | Certificate key for the tapInjector. If not provided then Helm will generate one. |
+| tapInjector.logLevel | string | defaultLogLevel | log level of the tapInjector |
 | tapInjector.namespaceSelector | string | `nil` |  |
 | tapInjector.objectSelector | string | `nil` |  |
 | tapInjector.proxy | string | `nil` |  |

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -71,6 +71,7 @@ spec:
       - args:
         - injector
         - -tap-service-name=linkerd-tap.{{.Values.namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -log-level={{.Values.tapInjector.logLevel | default .Values.defaultLogLevel}}
         image: {{.Values.tapInjector.image.registry}}/{{.Values.tapInjector.image.name}}:{{.Values.tapInjector.image.tag}}
         imagePullPolicy: {{.Values.tapInjector.image.pullPolicy}}
         livenessProbe:

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -145,6 +145,9 @@ tap:
 tapInjector:
   # -- Number of replicas of tapInjector
   replicas: 1
+  # -- log level of the tapInjector
+  # @default -- defaultLogLevel
+  logLevel: ""
   image:
     # -- Docker registry for the tapInjector instance
     registry: *registry

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -1094,6 +1094,7 @@ spec:
       - args:
         - injector
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
         imagePullPolicy: 
         livenessProbe:

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -803,6 +803,7 @@ spec:
       - args:
         - injector
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
         imagePullPolicy: 
         livenessProbe:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -1106,6 +1106,7 @@ spec:
       - args:
         - injector
         - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -log-level=info
         image: ghcr.io/linkerd/tap:dev-undefined
         imagePullPolicy: 
         livenessProbe:


### PR DESCRIPTION
Fixes #5686

Test:
```bash
$ linkerd viz install --set tapInjector.logLevel=debug | k apply -f -

// and then when creating a pod we can see debug log entries such as:

time="2021-02-10T16:19:28Z" level=debug msg="admission request: &AdmissionRequest{UID:c5e95e8d-...
```