### PR TITLE
image-load: Parallelize image loading in k3d

### DIFF
--- a/bin/image-load
+++ b/bin/image-load
@@ -78,26 +78,33 @@ fi
 # the parallel executions below attempt doing so
 "$bin" version
 
-rm -f load_fail
-for img in proxy controller web metrics-api grafana cli-bin debug cni-plugin jaeger-webhook tap; do
-  printf 'Importing %s...\n' $img
-  if [ $archive ]; then
-    param="image-archives/$img.tar"
-  else
-    param="$DOCKER_REGISTRY/$img:$TAG"
-  fi
+if [ -n "$kind" ]; then
+  rm -f load_fail
+  for img in proxy controller web metrics-api grafana cli-bin debug cni-plugin jaeger-webhook tap; do
+    printf 'Importing %s...\n' $img
+    if [ $archive ]; then
+      param="image-archives/$img.tar"
+    else
+      param="$DOCKER_REGISTRY/$img:$TAG"
+    fi
 
-  if [ -n "$kind" ]; then
     "$bin" "${image_sub_cmd[@]}" "${param[@]}" || touch load_fail &
-  else
-    # "k3d image import" commands don't behave well when parallelized
-    "$bin" "${image_sub_cmd[@]}" "${param[@]}"
-  fi
-done
+  done
 
-wait < <(jobs -p)
-if [ -f load_fail ]; then
-  echo "Loading docker images into the cluster failed."
-  rm load_fail
-  exit 1
+  wait < <(jobs -p)
+  if [ -f load_fail ]; then
+    echo "Loading docker images into the cluster failed."
+    rm load_fail
+    exit 1
+  fi
+else
+  images=()
+  for img in proxy controller web metrics-api grafana cli-bin debug cni-plugin jaeger-webhook tap; do
+    if [ $archive ]; then
+      images+=("image-archives/$img.tar")
+    else
+      images+=("$DOCKER_REGISTRY/$img:$TAG")
+    fi
+  done
+  "$bin" "${image_sub_cmd[@]}" "${images[@]}"
 fi

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -62,15 +62,13 @@ func TestTracing(t *testing.T) {
 	}
 
 	// wait for the jaeger extension
-	checkCmd := []string{"jaeger", "check", "--wait=0"}
-	golden := "check.jaeger.golden"
 	timeout := time.Minute
 	err = TestHelper.RetryFor(timeout, func() error {
-		out, err := TestHelper.LinkerdRun(checkCmd...)
+		out, stderr, err := TestHelper.PipeToLinkerdRun("", "jaeger", "check", "--wait=0")
 		if err != nil {
-			return fmt.Errorf("'linkerd jaeger check' command failed\n%s", err)
+			return fmt.Errorf("'linkerd jaeger check' command failed\n%s\n%s", err, stderr)
 		}
-		err = TestHelper.ValidateOutput(out, golden)
+		err = TestHelper.ValidateOutput(out, "check.jaeger.golden")
 		if err != nil {
 			return fmt.Errorf("received unexpected output\n%s", err.Error())
 		}

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -62,7 +62,7 @@ func TestTracing(t *testing.T) {
 	}
 
 	// wait for the jaeger extension
-	timeout := time.Minute
+	timeout := 3 * time.Minute
 	err = TestHelper.RetryFor(timeout, func() error {
 		out, stderr, err := TestHelper.PipeToLinkerdRun("", "jaeger", "check", "--wait=0")
 		if err != nil {


### PR DESCRIPTION
The `image-load` script invokes `k3d image load` once for reach image.
This is unnecessary, as k3d accepts a list of images on the
command-line.

This change updates the image-load script to load all images in a single
command. Anecdotally, this seems much faster.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
