### PR TITLE
Use a shared informer when getting node topology

### DIFF
--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -1,7 +1,6 @@
 package destination
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -142,13 +141,12 @@ metadata:
 
 	mockGetServer := &mockDestinationGetServer{updatesReceived: []*pb.Update{}}
 	translator := newEndpointTranslator(
-		context.Background(),
 		"linkerd",
 		"trust.domain",
 		true,
 		"service-name.service-ns",
 		"test-123",
-		k8sAPI.Client,
+		k8sAPI.Node(),
 		mockGetServer,
 		logging.WithField("test", t.Name()),
 	)

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 )
 
 type (
@@ -25,6 +26,7 @@ type (
 		profiles      *watcher.ProfileWatcher
 		trafficSplits *watcher.TrafficSplitWatcher
 		ips           *watcher.IPWatcher
+		nodes         coreinformers.NodeInformer
 
 		enableH2Upgrade     bool
 		controllerNS        string
@@ -73,6 +75,7 @@ func NewServer(
 		profiles,
 		trafficSplits,
 		ips,
+		k8sAPI.Node(),
 		enableH2Upgrade,
 		controllerNS,
 		identityTrustDomain,
@@ -103,13 +106,12 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 	}
 
 	translator := newEndpointTranslator(
-		stream.Context(),
 		s.controllerNS,
 		s.identityTrustDomain,
 		s.enableH2Upgrade,
 		dest.GetPath(),
 		token.NodeName,
-		s.k8sAPI.Client,
+		s.nodes,
 		stream,
 		log,
 	)

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -219,6 +219,7 @@ spec:
 		profiles,
 		trafficSplits,
 		ips,
+		k8sAPI.Node(),
 		true,
 		"linkerd",
 		"trust.domain",

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -84,14 +84,14 @@ func Main(args []string) {
 			ctx,
 			*kubeConfigPath,
 			true,
-			k8s.Endpoint, k8s.ES, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job, k8s.NS,
+			k8s.Endpoint, k8s.ES, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job, k8s.NS, k8s.Node,
 		)
 	} else {
 		k8sAPI, err = k8s.InitializeAPI(
 			ctx,
 			*kubeConfigPath,
 			true,
-			k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job, k8s.NS,
+			k8s.Endpoint, k8s.Pod, k8s.RS, k8s.Svc, k8s.SP, k8s.TS, k8s.Job, k8s.NS, k8s.Node,
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
Getting information about node topology queries the k8s api directly.
In an environment with high traffic and high number of pods, the
k8s api server can become overwhelmed or start throttling requests.

This MR introduces a node informer to resolve the bottleneck and
fetch node information asynchronously.

Fixes #5684
