### PR TITLE
Add changes for edge-21.2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## edge-21.2.2
 
+* **Breaking change**: Removed the `Global` field from the Linkerd Helm chart
+  now that it is unused because of the extension model; users doing upgrades
+  with Helm passing customized `values.yaml` will have to take this change into
+  account.
 * Added the `repair` command which will repopulate resources needed for properly
   upgrading a Linkerd installation
 * Fixed the spelling of the `sidecarContainers` key in the Viz extension Helm
@@ -15,9 +19,6 @@
 * Changed the `check` command to include each installed extension's `check`
   output; this allows users to check for proper configuration and installation
   of Linkerd without running a command for each extension
-* Removed the `Global` field from the Linkerd Helm chart now that it is unused
-  because of the extension model; this is not a breaking change and cleanup will
-  occur automatically during upgrade.
 * Added proxy support for TCP traffic to the multicluster gateways which
   completes preparation for supporting opaque traffic in multicluster
   installations; the next edge will support this end-to-end

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## edge-21.2.2
 
+This edge release continues to prepare support for multicluster opaque ports.
+
+Additionally, it contains a breaking change for Helm users upgrading with a
+customized `values.yaml`. If upgrading without this customization, there is no
+action to take.
+
 * **Breaking change**: Removed the `Global` field from the Linkerd Helm chart
   now that it is unused because of the extension model; users doing upgrades
   with Helm passing customized `values.yaml` will have to take this change into

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,16 @@
 
 ## edge-21.2.2
 
-This edge release continues to prepare support for multicluster opaque ports.
+This edge release introduces a new `repair` command which will repopulate
+resources needed for upgrading from a `2.9.x` installation. There will be an
+error message during the upgrade process indicating that this command should be
+run so that users do not need to guess.
 
-Additionally, it contains a breaking change for Helm users upgrading with a
-customized `values.yaml`. If upgrading without this customization, there is no
-action to take.
+It also continues to prepare support for multicluster opaque ports.
+
+Lastly, it contains a breaking change for Helm users upgrading with a customized
+`values.yaml`. If upgrading without this customization, there is no action to
+take.
 
 * **Breaking change**: Removed the `Global` field from the Linkerd Helm chart
   now that it is unused because of the extension model; users doing upgrades

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Changes
 
+## edge-21.2.2
+
+* Added the `repair` command which will repopulate resources needed for properly
+  upgrading a Linkerd installation
+* Fixed the spelling of the `sidecarContainers` key in the Viz extension Helm
+  chart to match that of the template (thanks @n-oden!)
+* Added the `tapInjector.logLevel` key to the Viz extension helm chart so that
+  the log level of the component can be configured
+* Removed the `--disable-tap` flag from the `inject` command now that tap is no
+  longer part of the core installation (thanks @mayankshah1607!)
+* Changed proxy configuration to use fully-qualified DNS names to avoid extra
+  search paths in DNS resolutions
+* Changed the `check` command to include each installed extension's `check`
+  output; this allows users to check for proper configuration and installation
+  of Linkerd without running a command for each extension
+* Removed the `Global` field from the Linkerd Helm chart now that it is unused
+  because of the extension model; this is not a breaking change and cleanup will
+  occur automatically during upgrade.
+* Added proxy support for TCP traffic to the multicluster gateways which
+  completes preparation for supporting opaque traffic in multicluster
+  installations; the next edge will support this end-to-end
+
 ## edge-21.2.1
 
 This edge release continues improving the proxy's diagnostics and also avoids

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,13 @@
 
 ## edge-21.2.2
 
-This edge release introduces a new `repair` command which will repopulate
-resources needed for upgrading from a `2.9.x` installation. There will be an
-error message during the upgrade process indicating that this command should be
-run so that users do not need to guess.
+This edge release introduces support for multicluster TCP. It prepares support
+for multicluster opaque ports, which will follow-up in a future release.
 
-It also continues to prepare support for multicluster opaque ports.
+The `repair` command was added which will repopulate resources needed for
+upgrading from a `2.9.x` installation. There will be an error message during the
+upgrade process indicating that this command should be run so that users do not
+need to guess.
 
 Lastly, it contains a breaking change for Helm users upgrading with a customized
 `values.yaml`. If upgrading without this customization, there is no action to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,9 +31,7 @@ take.
 * Changed the `check` command to include each installed extension's `check`
   output; this allows users to check for proper configuration and installation
   of Linkerd without running a command for each extension
-* Added proxy support for TCP traffic to the multicluster gateways which
-  completes preparation for supporting opaque traffic in multicluster
-  installations; the next edge will support this end-to-end
+* Added proxy support for TCP traffic to the multicluster gateways
 
 ## edge-21.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,22 +2,20 @@
 
 ## edge-21.2.2
 
-This edge release introduces support for multicluster TCP. It prepares support
-for multicluster opaque ports, which will follow-up in a future release.
+This edge release introduces support for multicluster TCP!
 
 The `repair` command was added which will repopulate resources needed for
 upgrading from a `2.9.x` installation. There will be an error message during the
 upgrade process indicating that this command should be run so that users do not
 need to guess.
 
-Lastly, it contains a breaking change for Helm users upgrading with a customized
-`values.yaml`. If upgrading without this customization, there is no action to
-take.
+Lastly, it contains a breaking change for Helm users. The `global` field has
+been removed from the Helm chart now that it is no longer needed. Users will
+need to pass in the identity certificates again—along with any other
+customizations, no longer rooted at `global`.
 
 * **Breaking change**: Removed the `Global` field from the Linkerd Helm chart
-  now that it is unused because of the extension model; users doing upgrades
-  with Helm passing customized `values.yaml` will have to take this change into
-  account.
+  now that it is unused because of the extension model
 * Added the `repair` command which will repopulate resources needed for properly
   upgrading a Linkerd installation
 * Fixed the spelling of the `sidecarContainers` key in the Viz extension Helm


### PR DESCRIPTION
## edge-21.2.2

This edge release introduces support for multicluster TCP!

The `repair` command was added which will repopulate resources needed for
upgrading from a `2.9.x` installation. There will be an error message during the
upgrade process indicating that this command should be run so that users do not
need to guess.

Lastly, it contains a breaking change for Helm users. The `global` field has
been removed from the Helm chart now that it is no longer needed. Users will
need to pass in the identity certificates again—along with any other
customizations, no longer rooted at `global`.

* **Breaking change**: Removed the `Global` field from the Linkerd Helm chart
  now that it is unused because of the extension model
* Added the `repair` command which will repopulate resources needed for properly
  upgrading a Linkerd installation
* Fixed the spelling of the `sidecarContainers` key in the Viz extension Helm
  chart to match that of the template (thanks @n-oden!)
* Added the `tapInjector.logLevel` key to the Viz extension helm chart so that
  the log level of the component can be configured
* Removed the `--disable-tap` flag from the `inject` command now that tap is no
  longer part of the core installation (thanks @mayankshah1607!)
* Changed proxy configuration to use fully-qualified DNS names to avoid extra
  search paths in DNS resolutions
* Changed the `check` command to include each installed extension's `check`
  output; this allows users to check for proper configuration and installation
  of Linkerd without running a command for each extension
* Added proxy support for TCP traffic to the multicluster gateways
