### PR TITLE
Add --skip-cluster-delete flag to bin/tests

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -36,8 +36,9 @@ Examples:
 
 Available Commands:
     --name: the argument to this option is the specific test to run
-    --skip-cluster-create: skip k3d cluster creation step and run tests in an existing cluster.
-    --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)."
+    --skip-cluster-create: skip k3d cluster creation step and run tests in an existing cluster
+    --skip-cluster-delete: if the tests succeed, don't delete the created resources nor the cluster
+    --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)"
 }
 
 cleanup_usage() {
@@ -59,6 +60,7 @@ handle_tests_input() {
   export images="docker"
   export test_name=''
   export skip_cluster_create=''
+  export skip_cluster_delete=''
   export linkerd_path=""
 
   while  [ "$#" -ne 0 ]; do
@@ -96,6 +98,10 @@ handle_tests_input() {
         skip_cluster_create=1
         shift
         ;;
+      --skip-cluster-delete)
+        skip_cluster_delete=1
+        shift
+        ;;
       *)
         if echo "$1" | grep -q '^-.*' ; then
           echo "Unexpected flag: $1" >&2
@@ -117,6 +123,12 @@ handle_tests_input() {
 
   if [ -z "$linkerd_path" ]; then
     echo "Error: path to linkerd binary is required" >&2
+    tests_usage "$0" >&2
+    exit 64
+  fi
+
+  if [ -z "$test_name" ] && [ -n "$skip_cluster_delete" ]; then
+    echo "Error: must provide --name when using --skip-cluster-delete" >&2
     tests_usage "$0" >&2
     exit 64
   fi
@@ -223,11 +235,13 @@ setup_cluster() {
 }
 
 finish() {
-  local name=$1
-  if [ -z "$skip_cluster_create" ]; then
-    delete_cluster "$name"
-  else
-    cleanup_cluster
+  if [ -z "$skip_cluster_delete" ]; then
+    local name=$1
+    if [ -z "$skip_cluster_create" ]; then
+      delete_cluster "$name"
+    else
+      cleanup_cluster
+    fi
   fi
 }
 


### PR DESCRIPTION
... to avoid tearing down resources and the cluster itself (or clusters) after a given test finishes. This allows for example when running the multicluster test, leaving both clusters around for further inspection:
```bash
bin/tests --name multicluster --skip-cluster-delete `pwd`/target/cli/linux-amd64/linkerd
```