### PR TITLE
Remove namespace inheritance of opaque ports annotation

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -210,7 +210,6 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 					Namespace: pod.Namespace,
 					Name:      pod.Name,
 				}
-				err := watcher.SetPodOpaquePortAnnotation(s.k8sAPI, pod, pod.Namespace)
 				if err != nil {
 					log.Errorf("failed to set opaque port annotation on pod: %s", err)
 				}

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -805,7 +805,6 @@ func (pp *portPublisher) endpointsToAddresses(endpoints *corev1.Endpoints) Addre
 					pp.log.Errorf("Unable to create new address:%v", err)
 					continue
 				}
-				err = SetPodOpaquePortAnnotation(pp.k8sAPI, address.Pod, endpoints.Namespace)
 				if err != nil {
 					pp.log.Errorf("failed to set opaque port annotation on pod: %s", err)
 				}
@@ -1090,23 +1089,4 @@ func isValidSlice(es *discovery.EndpointSlice) bool {
 	}
 
 	return true
-}
-
-// SetPodOpaquePortAnnotation ensures that if there is no opaque port
-// annotation on the pod, then it inherits the annotation from the namespace.
-// If there is also no annotation on the namespace, then it remains unset.
-func SetPodOpaquePortAnnotation(k8sAPI *k8s.API, pod *corev1.Pod, ns string) error {
-	if _, ok := pod.Annotations[consts.ProxyOpaquePortsAnnotation]; !ok {
-		ns, err := k8sAPI.NS().Lister().Get(ns)
-		if err != nil {
-			return fmt.Errorf("failed to get namespace annotation: %s", err)
-		}
-		if annotation, ok := ns.Annotations[consts.ProxyOpaquePortsAnnotation]; ok {
-			if pod.Annotations == nil {
-				pod.Annotations = make(map[string]string)
-			}
-			pod.Annotations[consts.ProxyOpaquePortsAnnotation] = annotation
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
This change removes the namespace inheritance of the opaque ports annotation.
Now when setting opaque port related fields in destination profile responses, we
only look at the pod annotations.

This prepares for #5736 where the proxy-injector will add the annotation from
the namespace if the pod does not have it already.

Closes #5735

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
