### PR TITLE
Increase min k8s version to 1.16

### DIFF
--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
   up your pod's network so  incoming and outgoing traffic is proxied through the
   data plane.
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
 version: 0.1.0

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -12,7 +12,7 @@ data plane.
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd2/Chart.yaml
+++ b/charts/linkerd2/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 name: "linkerd2"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -11,7 +11,7 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -114,7 +114,7 @@ respective readme.md
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd2/README.md.gotmpl
+++ b/charts/linkerd2/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -11,7 +11,7 @@ OpenCensus and Jaeger.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd/linkerd-jaeger
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/linkerd-jaeger/README.md.gotmpl
+++ b/jaeger/charts/linkerd-jaeger/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/multicluster/charts/linkerd-multicluster-link/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   `cluster-credentials` secret and the Link CR, which are not found in this
   chart. Therefore this chart is not a replacement for that command, and
   shouldn't be used as-is unless you really know what you're doing ;-)
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd-multicluster-link"
 version: 0.1.0

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -15,7 +15,7 @@ shouldn't be used as-is unless you really know what you're doing ;-)
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 ## Values
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -11,7 +11,7 @@ linking to remote clusters
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd/linkerd-multicluster
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 ## Values
 

--- a/multicluster/charts/linkerd-multicluster/README.md.gotmpl
+++ b/multicluster/charts/linkerd-multicluster/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -24,7 +24,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-var minAPIVersion = [3]int{1, 13, 0}
+var minAPIVersion = [3]int{1, 16, 0}
 
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
 // TODO: support ServiceProfile ClientSet. A prerequisite is moving the

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.13.0-0"
+kubeVersion: ">=1.16.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -11,7 +11,7 @@ components for Linkerd.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd/linkerd-viz
 
 ## Requirements
 
-Kubernetes: `>=1.13.0-0`
+Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/viz/charts/linkerd-viz/README.md.gotmpl
+++ b/viz/charts/linkerd-viz/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.13+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.16+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd


### PR DESCRIPTION
... in order to support the bumped CRD and webhook config versions made
in #5603. In #5688 we asked if there were any concerns. None so far.