### PR TITLE
Multicluster: Uninstall multicluster without Linkerd control plane

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{.Values.gatewayName}}-config
   labels:
     {{.Values.controllerComponentLabel}}: gateway
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
   namespace: {{.Values.namespace}}
@@ -58,6 +59,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     {{.Values.controllerComponentLabel}}: gateway
     app: {{.Values.gatewayName}}
+    linkerd.io/extension: linkerd-multicluster
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
 spec:
@@ -115,6 +117,8 @@ kind: Service
 metadata:
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     mirror.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
     mirror.linkerd.io/probe-period: "{{.Values.gatewayProbeSeconds}}"
@@ -143,4 +147,6 @@ apiVersion: v1
 metadata:
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-multicluster
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
@@ -6,6 +6,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: links.multicluster.linkerd.io
+  labels:
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:

--- a/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
@@ -10,6 +10,8 @@ kind: ClusterRole
 metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     {{$.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" $.Values.linkerdVersion) $.Values.cliVersion}}
 rules:
@@ -26,6 +28,8 @@ kind: ServiceAccount
 metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     {{$.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" $.Values.linkerdVersion) $.Values.cliVersion}}
 ---
@@ -34,6 +38,8 @@ kind: ClusterRoleBinding
 metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
+  labels:
+    linkerd.io/extension: linkerd-multicluster
   annotations:
     {{$.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" $.Values.linkerdVersion) $.Values.cliVersion}}
 roleRef:

--- a/multicluster/cmd/uninstall.go
+++ b/multicluster/cmd/uninstall.go
@@ -7,18 +7,13 @@ import (
 	"os"
 	"strings"
 
-	// "github.com/linkerd/linkerd2/multicluster/static"
-	// "github.com/linkerd/linkerd2/pkg/charts"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/k8s/resource"
 	mc "github.com/linkerd/linkerd2/pkg/multicluster"
 	"github.com/spf13/cobra"
 
-	// chartloader "helm.sh/helm/v3/pkg/chart/loader"
-	// "helm.sh/helm/v3/pkg/chartutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	// "sigs.k8s.io/yaml"
 )
 
 func newMulticlusterUninstallCommand() *cobra.Command {

--- a/multicluster/cmd/uninstall.go
+++ b/multicluster/cmd/uninstall.go
@@ -1,20 +1,24 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/linkerd/linkerd2/multicluster/static"
-	"github.com/linkerd/linkerd2/pkg/charts"
+	// "github.com/linkerd/linkerd2/multicluster/static"
+	// "github.com/linkerd/linkerd2/pkg/charts"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/k8s/resource"
 	mc "github.com/linkerd/linkerd2/pkg/multicluster"
 	"github.com/spf13/cobra"
-	chartloader "helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/chartutil"
+
+	// chartloader "helm.sh/helm/v3/pkg/chart/loader"
+	// "helm.sh/helm/v3/pkg/chartutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/yaml"
+	// "sigs.k8s.io/yaml"
 )
 
 func newMulticlusterUninstallCommand() *cobra.Command {
@@ -42,12 +46,12 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 				config.CurrentContext = kubeContext
 			}
 
-			k, err := k8s.NewAPI(kubeconfigPath, config.CurrentContext, impersonate, impersonateGroup, 0)
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, config.CurrentContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}
 
-			links, err := mc.GetLinks(cmd.Context(), k.DynamicClient)
+			links, err := mc.GetLinks(cmd.Context(), k8sAPI.DynamicClient)
 			if err != nil {
 				return err
 			}
@@ -60,46 +64,28 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 				return errors.New(strings.Join(err, "\n"))
 			}
 
-			values, err := buildMulticlusterInstallValues(cmd.Context(), options)
-
-			if err != nil {
-				return err
-			}
-
-			// Render raw values and create chart config
-			rawValues, err := yaml.Marshal(values)
-			if err != nil {
-				return err
-			}
-
-			files := []*chartloader.BufferedFile{
-				{Name: chartutil.ChartfileName},
-				{Name: "templates/namespace.yaml"},
-				{Name: "templates/gateway.yaml"},
-				{Name: "templates/remote-access-service-mirror-rbac.yaml"},
-				{Name: "templates/link-crd.yaml"},
-			}
-
-			chart := &charts.Chart{
-				Name:      helmMulticlusterDefaultChartName,
-				Dir:       helmMulticlusterDefaultChartName,
-				Namespace: controlPlaneNamespace,
-				RawValues: rawValues,
-				Files:     files,
-				Fs:        static.Templates,
-			}
-			buf, err := chart.RenderNoPartials()
-			if err != nil {
-				return err
-			}
-			stdout.Write(buf.Bytes())
-			stdout.Write([]byte("---\n"))
-
-			return nil
+			return uninstallRunE(cmd.Context(), k8sAPI)
 		},
 	}
 
 	cmd.Flags().StringVar(&options.namespace, "namespace", options.namespace, "The namespace in which the multicluster add-on is to be installed. Must not be the control plane namespace. ")
 
 	return cmd
+}
+
+func uninstallRunE(ctx context.Context, k8sAPI *k8s.KubernetesAPI) error {
+
+	resources, err := resource.FetchKubernetesResources(ctx, k8sAPI,
+		metav1.ListOptions{LabelSelector: "linkerd.io/extension=linkerd-multicluster"},
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range resources {
+		if err := r.RenderResource(os.Stdout); err != nil {
+			return fmt.Errorf("error rendering Kubernetes resource: %v", err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Piyush Singariya <piyushsingariya@gmail.com>

Problem
If the main Linkerd control plane has been uninstalled, it is no longer possible to uninstall the multicluster extension.
```
$ bin/linkerd mc uninstall | k delete -f -
Error: you need Linkerd to be installed in order to install multicluster addons
Usage:
  linkerd multicluster uninstall [flags]
```
Solution
Fetch resources with the label `linkerd.io/extension: linkerd-multicluster` and delete them

Fixes #5624