### PR TITLE
Update Ubuntu version in GitHub Actions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,7 +12,7 @@ env:
   DOCKER_BUILDKIT: 1
 jobs:
   docker_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Keep in sync with release.yaml matrix build
@@ -111,7 +111,7 @@ jobs:
         - cni-calico-deep
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   DOCKER_BUILDKIT: 1
 jobs:
   docker_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Keep in sync with integration_tests.yaml matrix build
@@ -110,7 +110,7 @@ jobs:
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
   arm64_integration_tests:
     name: ARM64 integration tests
     timeout-minutes: 60
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [docker_build]
     steps:
     - name: Checkout code
@@ -220,7 +220,7 @@ jobs:
     name: Create GH release
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [choco_pack]
     steps:
     - name: Checkout code
@@ -267,7 +267,7 @@ jobs:
     name: Linkerd website publish
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [gh_release]
     steps:
     - name: Create linkerd/website repository dispatch event
@@ -281,7 +281,7 @@ jobs:
     name: Linkerd website publish check
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [website_publish]
     steps:
     - name: Checkout code
@@ -311,7 +311,7 @@ jobs:
   chart_deploy:
     name: Helm chart deploy
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [gh_release]
     steps:
     - name: Checkout code

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -11,7 +11,7 @@ jobs:
   go_lint:
     name: Go lint
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: golang:1.13.4
     steps:
@@ -23,7 +23,7 @@ jobs:
   go_format:
     name: Go format
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: golang:1.13.4
     steps:
@@ -35,7 +35,7 @@ jobs:
   proto_diff:
     name: Proto diff
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: golang:1.13.4
     steps:
@@ -49,7 +49,7 @@ jobs:
   shellcheck:
     name: shellcheck
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
   psscript-analyzer:
     name: PSScriptAnalyzer
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
   markdown_lint:
     name: Markdown lint
     timeout-minutes: 10
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -88,7 +88,7 @@ jobs:
       run: bin/markdownlint-all
   chart_docs_diff:
     name: Chart readme diff check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
   go_unit_tests:
     name: Go unit tests
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: golang:1.14.2
     steps:
@@ -26,7 +26,7 @@ jobs:
   js_unit_tests:
     name: JS unit tests
     timeout-minutes: 30
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: node:14-stretch
     steps:


### PR DESCRIPTION
Our GitHub Actions depend on ubuntu-18.04, which is nearly 3 years old.

This change updates our actions to depend on the latest OS version
supported by GitHub, ubuntu-20.04 (Focal Fossa).