### PR TITLE
Full SHA for github action

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -69,7 +69,7 @@ jobs:
       uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
     - name: Chocolatey - lint
       # devblackops/github-action-psscriptanalyzer@v2.3.0
-      uses: devblackops/github-action-psscriptanalyzer@819c15c
+      uses: devblackops/github-action-psscriptanalyzer@819c15c7d02dec0611fe3ded6f8e259b0b925754
       env:
         # https://github.com/devblackops/github-action-psscriptanalyzer/pull/3/files
         INPUT_FAILONWARNING: 1


### PR DESCRIPTION
It appears that today the full-sha requirement on github actions is started to get enforced, and we had missed just one, for devblackops/github-action-psscriptanalyzer.

* Required for CI to pass *
