### PR TITLE
cli: make jaeger and multicluster installs wait for core cp

### DIFF
--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -2,17 +2,17 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path"
+	"time"
 
 	"github.com/linkerd/linkerd2/jaeger/static"
 	"github.com/linkerd/linkerd2/pkg/charts"
 	partials "github.com/linkerd/linkerd2/pkg/charts/static"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
-	"github.com/linkerd/linkerd2/pkg/k8s"
+	api "github.com/linkerd/linkerd2/pkg/public"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -31,6 +31,7 @@ var (
 
 func newCmdInstall() *cobra.Command {
 	var skipChecks bool
+	var wait time.Duration
 	var options values.Options
 
 	cmd := &cobra.Command{
@@ -48,30 +49,24 @@ A full list of configurable values can be found at https://www.github.com/linker
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {
-				// Ensure there is a Linkerd installation.
-				kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
-				if err != nil {
-					return err
-				}
-
-				exists, err := healthcheck.CheckIfLinkerdExists(cmd.Context(), kubeAPI, controlPlaneNamespace)
-				if err != nil {
-					return fmt.Errorf("could not check for Linkerd existence: %s", err)
-				}
-
-				if !exists {
-					return fmt.Errorf("could not find a Linkerd installation")
-				}
+				// Wait for the core control-plane to be up and running
+				api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					KubeContext:           kubeContext,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					APIAddr:               apiAddr,
+					RetryDeadline:         time.Now().Add(wait),
+				}, true)
 			}
 
 			return install(os.Stdout, options)
 		},
 	}
 
-	cmd.Flags().BoolVar(
-		&skipChecks, "skip-checks", false,
-		`Skip checks for namespace existence`,
-	)
+	cmd.Flags().BoolVar(&skipChecks, "skip-checks", false, `Skip checks for linkerd core control-plane existence`)
+	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for core control-plane components to be available")
 
 	flags.AddValueOptionsFlags(cmd.Flags(), &options)
 

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -12,7 +11,6 @@ import (
 	partials "github.com/linkerd/linkerd2/pkg/charts/static"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
-	"github.com/linkerd/linkerd2/pkg/k8s"
 	api "github.com/linkerd/linkerd2/pkg/public"
 	"github.com/linkerd/linkerd2/viz/static"
 	"github.com/spf13/cobra"
@@ -60,22 +58,7 @@ A full list of configurable values can be found at https://www.github.com/linker
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !skipChecks {
-				// Ensure there is a Linkerd installation.
-				kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
-				if err != nil {
-					return err
-				}
-
-				exists, err := healthcheck.CheckIfLinkerdExists(cmd.Context(), kubeAPI, controlPlaneNamespace)
-				if err != nil {
-					return fmt.Errorf("could not check for Linkerd existence: %s", err)
-				}
-
-				if !exists {
-					return fmt.Errorf("could not find a Linkerd installation")
-				}
-
-				// Wait for the core extension to be up and running
+				// Wait for the core control-plane to be up and running
 				api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
 					ControlPlaneNamespace: controlPlaneNamespace,
 					KubeConfig:            kubeconfigPath,
@@ -93,7 +76,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 
 	cmd.Flags().BoolVar(
 		&skipChecks, "skip-checks", false,
-		`Skip checks for namespace existence`,
+		`Skip checks for linkerd core control-plane existence`,
 	)
 
 	cmd.Flags().BoolVar(

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -74,18 +74,9 @@ A full list of configurable values can be found at https://www.github.com/linker
 		},
 	}
 
-	cmd.Flags().BoolVar(
-		&skipChecks, "skip-checks", false,
-		`Skip checks for linkerd core control-plane existence`,
-	)
-
-	cmd.Flags().BoolVar(
-		&ha, "ha", false,
-		`Install Viz Extension in High Availability mode.`,
-	)
-	cmd.Flags().DurationVar(
-		&wait, "wait", 300*time.Second,
-		"Wait for core control-plane components to be available")
+	cmd.Flags().BoolVar(&skipChecks, "skip-checks", false, `Skip checks for linkerd core control-plane existence`)
+	cmd.Flags().BoolVar(&ha, "ha", false, `Install Viz Extension in High Availability mode.`)
+	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for core control-plane components to be available")
 
 	flags.AddValueOptionsFlags(cmd.Flags(), &options)
 


### PR DESCRIPTION
This PR updates the jaeger and multicluster installs to wait
for the core control-plane to be up before moving to the rendering
logic. This prevents these components from being installed before
the injector is up and running correctly.

`--skip-checks` has been added to jaeger to skip these checks. The
same has not been added to `multicluster` as the install fails when
there is no core cp is present.

This PR also cleans up extra core cp check that we have for `viz install`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
