### PR TITLE
 Fix for CLI printing command usage for API Errors for multiple commands

### DIFF
--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -98,7 +98,8 @@ destination.`,
 				APIAddr:               apiAddr,
 			}), args)
 			if err != nil {
-				return fmt.Errorf("Destination API error: %s", err)
+				fmt.Fprint(os.Stderr, fmt.Errorf("Destination API error: %s", err))
+				os.Exit(1)
 			}
 
 			output := renderEndpoints(endpoints, options)

--- a/multicluster/cmd/gateways.go
+++ b/multicluster/cmd/gateways.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/linkerd/linkerd2/cli/table"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -56,7 +57,8 @@ func newGatewaysCommand() *cobra.Command {
 
 			resp, err := requestGatewaysFromAPI(client, req)
 			if err != nil {
-				return err
+				fmt.Fprint(os.Stderr, err.Error())
+				os.Exit(1)
 			}
 
 			renderGateways(resp.GetOk().GatewaysTable.Rows, stdout)

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -77,7 +77,7 @@ func TestBadEndpoints(t *testing.T) {
 	if len(stderrOut) == 0 {
 		testutil.AnnotatedFatalf(t, "unexpected output", "unexpected output: %s", stderr)
 	}
-	if stderrOut[0] != "Error: Destination API error: Invalid authority: foo" {
+	if stderrOut[0] != "Destination API error: Invalid authority: foo" {
 		testutil.AnnotatedErrorf(t, "unexpected error string", "unexpected error string: %s", stderrOut[0])
 	}
 }

--- a/viz/cmd/edges.go
+++ b/viz/cmd/edges.go
@@ -119,7 +119,8 @@ func NewCmdEdges() *cobra.Command {
 			i := 0
 			for res := range c {
 				if res.err != nil {
-					return res.err
+					fmt.Fprint(os.Stderr, res.err.Error())
+					os.Exit(1)
 				}
 				totalRows = append(totalRows, res.rows...)
 				if i++; i == len(reqs) {

--- a/viz/cmd/routes.go
+++ b/viz/cmd/routes.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -87,7 +88,8 @@ This command will only display traffic which is sent to a service that has a Ser
 				options,
 			)
 			if err != nil {
-				return err
+				fmt.Fprint(os.Stderr, err.Error())
+				os.Exit(1)
 			}
 
 			_, err = fmt.Print(output)


### PR DESCRIPTION
Signed-off-by: Piyush Singariya piyushsingariya@gmail.com

Related to #5058

Problem: CLI prints command usage for multiple commands in-case of API errors
Solution: Print the error and the exit using os.Exit(1) to avoid Cobra printing usage