### PR TITLE
Flag -L in 'viz install' should be synced to its Helm value

### DIFF
--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -117,6 +117,12 @@ func install(w io.Writer, options values.Options, ha bool) error {
 		return err
 	}
 
+	// if using -L to specify a non-standard CP namespace, make sure
+	// the linkerdNamespace Helm value is synced
+	if controlPlaneNamespace != "linkerd" {
+		valuesOverrides["linkerdNamespace"] = controlPlaneNamespace
+	}
+
 	if ha {
 		valuesOverrides, err = charts.OverrideFromFile(valuesOverrides, static.Templates, vizChartName, "values-ha.yaml")
 		if err != nil {

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -119,7 +119,7 @@ func install(w io.Writer, options values.Options, ha bool) error {
 
 	// if using -L to specify a non-standard CP namespace, make sure
 	// the linkerdNamespace Helm value is synced
-	if controlPlaneNamespace != defaultLinkerdNamespace
+	if controlPlaneNamespace != defaultLinkerdNamespace {
 		valuesOverrides["linkerdNamespace"] = controlPlaneNamespace
 	}
 

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -119,7 +119,7 @@ func install(w io.Writer, options values.Options, ha bool) error {
 
 	// if using -L to specify a non-standard CP namespace, make sure
 	// the linkerdNamespace Helm value is synced
-	if controlPlaneNamespace != "linkerd" {
+	if controlPlaneNamespace != defaultLinkerdNamespace
 		valuesOverrides["linkerdNamespace"] = controlPlaneNamespace
 	}
 


### PR DESCRIPTION
Fixes #5676

if passing -L to `linkerd viz install` to specify a non-standard CP namespace, make sure the `linkerdNamespace` Helm value is synced, otherwise the default `linkerd` is used.