### PR TITLE
Rename multicluster annotation prefix and move when possible

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -1466,10 +1466,10 @@ metadata:
   name: name1-remote
   namespace: ns
   annotations:
-    mirror.linkerd.io/remote-gateway-identity: "gateway-identity-1"
-    mirror.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
+    multicluster.linkerd.io/remote-gateway-identity: "gateway-identity-1"
+    multicluster.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
   labels:
-    mirror.linkerd.io/mirrored-service: "true"
+    multicluster.linkerd.io/mirrored-service: "true"
 subsets:
 - addresses:
   - ip: 172.17.0.12
@@ -1503,9 +1503,9 @@ metadata:
   name: name1-remote
   namespace: ns
   annotations:
-    mirror.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
+    multicluster.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
   labels:
-    mirror.linkerd.io/mirrored-service: "true"
+    multicluster.linkerd.io/mirrored-service: "true"
 subsets:
 - addresses:
   - ip: 172.17.0.12
@@ -1540,10 +1540,10 @@ metadata:
   name: name1-remote
   namespace: ns
   annotations:
-    mirror.linkerd.io/remote-gateway-identity: "gateway-identity-1"
-    mirror.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
+    multicluster.linkerd.io/remote-gateway-identity: "gateway-identity-1"
+    multicluster.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
   labels:
-    mirror.linkerd.io/mirrored-service: "true"
+    multicluster.linkerd.io/mirrored-service: "true"
 subsets:
 - addresses:
   - ip: 172.17.0.12
@@ -1577,10 +1577,10 @@ metadata:
   name: name1-remote
   namespace: ns
   annotations:
-    mirror.linkerd.io/remote-gateway-identity: ""
-    mirror.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
+    multicluster.linkerd.io/remote-gateway-identity: ""
+    multicluster.linkerd.io/remote-svc-fq-name: "name1-remote-fq"
   labels:
-    mirror.linkerd.io/mirrored-service: "true"
+    multicluster.linkerd.io/mirrored-service: "true"
 subsets:
 - addresses:
   - ip: 172.17.0.12
@@ -1722,10 +1722,10 @@ metadata:
   name: remote-service
   namespace: ns
   annotations:
-    mirror.linkerd.io/remote-gateway-identity: "gateway-identity-1"
-    mirror.linkerd.io/remote-svc-fq-name: "remote-service.svc.default.cluster.local"
+    multicluster.linkerd.io/remote-gateway-identity: "gateway-identity-1"
+    multicluster.linkerd.io/remote-svc-fq-name: "remote-service.svc.default.cluster.local"
   labels:
-    mirror.linkerd.io/mirrored-service: "true"
+    multicluster.linkerd.io/mirrored-service: "true"
 subsets:
 - addresses:
   - ip: 1.2.3.4

--- a/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
@@ -5,8 +5,8 @@ metadata:
   name: probe-gateway-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}
   labels:
-    mirror.linkerd.io/mirrored-gateway: "true"
-    mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+    multicluster.linkerd.io/mirrored-gateway: "true"
+    multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 spec:
   ports:
   - name: mc-probe

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -5,7 +5,7 @@ metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
     {{.Values.controllerComponentLabel}}: service-mirror
-    mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+    multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
 - apiGroups: [""]
   resources: ["endpoints", "services"]
@@ -20,7 +20,7 @@ metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
     {{.Values.controllerComponentLabel}}: service-mirror
-    mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+    multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -37,7 +37,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
       {{.Values.controllerComponentLabel}}: service-mirror
-      mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+      multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -54,7 +54,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
       {{.Values.controllerComponentLabel}}: service-mirror
-      mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+      multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -71,14 +71,14 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     {{.Values.controllerComponentLabel}}: service-mirror
-    mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+    multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     {{.Values.controllerComponentLabel}}: service-mirror
-    mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+    multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   namespace: {{.Values.namespace}}
 spec:
@@ -86,14 +86,14 @@ spec:
   selector:
     matchLabels:
       {{.Values.controllerComponentLabel}}: linkerd-service-mirror
-      mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+      multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   template:
     metadata:
       annotations:
         linkerd.io/inject: enabled
       labels:
         {{.Values.controllerComponentLabel}}: linkerd-service-mirror
-        mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+        multicluster.linkerd.io/cluster-name: {{.Values.targetClusterName}}
     spec:
       containers:
       - args:

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -120,10 +120,10 @@ metadata:
   labels:
     linkerd.io/extension: linkerd-multicluster
   annotations:
-    mirror.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
-    mirror.linkerd.io/probe-period: "{{.Values.gatewayProbeSeconds}}"
-    mirror.linkerd.io/probe-path: {{.Values.gatewayProbePath}}
-    mirror.linkerd.io/multicluster-gateway: "true"
+    multicluster.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
+    multicluster.linkerd.io/probe-period: "{{.Values.gatewayProbeSeconds}}"
+    multicluster.linkerd.io/probe-path: {{.Values.gatewayProbePath}}
+    multicluster.linkerd.io/multicluster-gateway: "true"
     {{.Values.controllerComponentLabel}}: gateway
     {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
     {{- with .Values.gatewayServiceAnnotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/multicluster/cmd/gateways.go
+++ b/multicluster/cmd/gateways.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/linkerd/linkerd2/cli/table"
+	labels "github.com/linkerd/linkerd2/multicluster/pkg"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	vizCmd "github.com/linkerd/linkerd2/viz/cmd"
 	"github.com/linkerd/linkerd2/viz/metrics-api/client"
@@ -163,9 +164,9 @@ func gatewaysRowToTableRow(row *pb.GatewaysTable_Row) []string {
 
 func extractGatewayPort(gateway *corev1.Service) (uint32, error) {
 	for _, port := range gateway.Spec.Ports {
-		if port.Name == k8s.GatewayPortName {
+		if port.Name == labels.GatewayPortName {
 			return uint32(port.Port), nil
 		}
 	}
-	return 0, fmt.Errorf("gateway service %s has no gateway port named %s", gateway.Name, k8s.GatewayPortName)
+	return 0, fmt.Errorf("gateway service %s has no gateway port named %s", gateway.Name, labels.GatewayPortName)
 }

--- a/multicluster/pkg/labels.go
+++ b/multicluster/pkg/labels.go
@@ -1,0 +1,21 @@
+package pkg
+
+const (
+	// MulticlusterAnnotationsPrefix is the prefix of all multicluster-related annotations
+	MulticlusterAnnotationsPrefix = "multicluster.linkerd.io"
+
+	// RemoteResourceVersionAnnotation is the last observed remote resource
+	// version of a mirrored resource. Useful when doing updates
+	RemoteResourceVersionAnnotation = MulticlusterAnnotationsPrefix + "/remote-resource-version"
+
+	// RemoteGatewayResourceVersionAnnotation is the last observed remote resource
+	// version of the gateway for a particular mirrored service. It is used
+	// in cases we detect a change in a remote gateway
+	RemoteGatewayResourceVersionAnnotation = MulticlusterAnnotationsPrefix + "/remote-gateway-resource-version"
+
+	// GatewayPortName is the name of the incoming port of the gateway
+	GatewayPortName = "mc-gateway"
+
+	// ServiceMirrorLabel is the value used in the controller component label
+	ServiceMirrorLabel = "servicemirror"
+)

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	labels "github.com/linkerd/linkerd2/multicluster/pkg"
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/multicluster"
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,7 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	k8sLabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -171,7 +172,7 @@ func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceLabels() map[string]s
 
 func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceAnnotations(remoteService *corev1.Service) map[string]string {
 	return map[string]string{
-		consts.RemoteResourceVersionAnnotation: remoteService.ResourceVersion, // needed to detect real changes
+		labels.RemoteResourceVersionAnnotation: remoteService.ResourceVersion, // needed to detect real changes
 		consts.RemoteServiceFqName:             fmt.Sprintf("%s.%s.svc.%s", remoteService.Name, remoteService.Namespace, rcsw.link.TargetClusterDomain),
 	}
 }
@@ -227,7 +228,7 @@ func (rcsw *RemoteClusterServiceWatcher) cleanupOrphanedServices(ctx context.Con
 		consts.RemoteClusterNameLabel: rcsw.link.TargetClusterName,
 	}
 
-	servicesOnLocalCluster, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+	servicesOnLocalCluster, err := rcsw.localAPIClient.Svc().Lister().List(k8sLabels.Set(matchLabels).AsSelector())
 	if err != nil {
 		innerErr := fmt.Errorf("failed to list services while cleaning up mirror services: %s", err)
 		if kerrors.IsNotFound(err) {
@@ -268,7 +269,7 @@ func (rcsw *RemoteClusterServiceWatcher) cleanupOrphanedServices(ctx context.Con
 func (rcsw *RemoteClusterServiceWatcher) cleanupMirroredResources(ctx context.Context) error {
 	matchLabels := rcsw.getMirroredServiceLabels()
 
-	services, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+	services, err := rcsw.localAPIClient.Svc().Lister().List(k8sLabels.Set(matchLabels).AsSelector())
 	if err != nil {
 		innerErr := fmt.Errorf("could not retrieve mirrored services that need cleaning up: %s", err)
 		if kerrors.IsNotFound(err) {
@@ -290,7 +291,7 @@ func (rcsw *RemoteClusterServiceWatcher) cleanupMirroredResources(ctx context.Co
 		}
 	}
 
-	endpoints, err := rcsw.localAPIClient.Endpoint().Lister().List(labels.Set(matchLabels).AsSelector())
+	endpoints, err := rcsw.localAPIClient.Endpoint().Lister().List(k8sLabels.Set(matchLabels).AsSelector())
 	if err != nil {
 		innerErr := fmt.Errorf("could not retrieve Endpoints that need cleaning up: %s", err)
 		if kerrors.IsNotFound(err) {
@@ -467,7 +468,7 @@ func (rcsw *RemoteClusterServiceWatcher) isExportedService(service *corev1.Servi
 		rcsw.log.Errorf("Invalid service selector: %s", err)
 		return false
 	}
-	return selector.Matches(labels.Set(service.Labels))
+	return selector.Matches(k8sLabels.Set(service.Labels))
 }
 
 // this method is common to both CREATE and UPDATE because if we have been
@@ -488,7 +489,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateService(service *corev1.S
 			return RetryableError{[]error{err}}
 		}
 		// if we have the local service present, we need to issue an update
-		lastMirroredRemoteVersion, ok := localService.Annotations[consts.RemoteResourceVersionAnnotation]
+		lastMirroredRemoteVersion, ok := localService.Annotations[labels.RemoteResourceVersionAnnotation]
 		if ok && lastMirroredRemoteVersion != service.ResourceVersion {
 			endpoints, err := rcsw.localAPIClient.Endpoint().Lister().Endpoints(service.Namespace).Get(localName)
 			if err == nil {
@@ -525,7 +526,7 @@ func (rcsw *RemoteClusterServiceWatcher) getMirrorServices() ([]*corev1.Service,
 		consts.RemoteClusterNameLabel: rcsw.link.TargetClusterName,
 	}
 
-	services, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+	services, err := rcsw.localAPIClient.Svc().Lister().List(k8sLabels.Set(matchLabels).AsSelector())
 	if err != nil {
 		return nil, err
 	}

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	labels "github.com/linkerd/linkerd2/multicluster/pkg"
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/multicluster"
 	logging "github.com/sirupsen/logrus"
@@ -468,7 +469,7 @@ func remoteServiceAsYaml(name, namespace, resourceVersion string, ports []corev1
 
 func mirrorService(name, namespace, resourceVersion string, ports []corev1.ServicePort) *corev1.Service {
 	annotations := make(map[string]string)
-	annotations[consts.RemoteResourceVersionAnnotation] = resourceVersion
+	annotations[labels.RemoteResourceVersionAnnotation] = resourceVersion
 	annotations[consts.RemoteServiceFqName] = fmt.Sprintf("%s.%s.svc.cluster.local", strings.Replace(name, "-remote", "", 1), namespace)
 
 	return &corev1.Service{

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -376,7 +376,7 @@ const (
 
 	// DefaultExportedServiceSelector is the default label selector for exported
 	// services.
-	DefaultExportedServiceSelector = MulticlusterAnnotationsPrefix + "/exported"
+	DefaultExportedServiceSelector = MulticlusterAnnotationsPrefix + "/export"
 
 	// MirroredResourceLabel indicates that this resource is the result
 	// of a mirroring operation (can be a namespace or a service)

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -363,69 +363,54 @@ const (
 	IdentityServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 	/*
-	 * Service mirror constants
+	 * Multicluster labels
 	 */
 
-	// SvcMirrorPrefix is the prefix common to all labels and annotations
-	// and types used by the service mirror component
-	SvcMirrorPrefix = "mirror.linkerd.io"
+	// MulticlusterAnnotationsPrefix is the prefix common to all labels and
+	// annotations and types used by the service mirror component
+	MulticlusterAnnotationsPrefix = "multicluster.linkerd.io"
 
 	// MirrorSecretType is the type of secret that is supposed to contain
 	// the access information for remote clusters.
-	MirrorSecretType = SvcMirrorPrefix + "/remote-kubeconfig"
+	MirrorSecretType = MulticlusterAnnotationsPrefix + "/remote-kubeconfig"
 
 	// DefaultExportedServiceSelector is the default label selector for exported
 	// services.
-	DefaultExportedServiceSelector = SvcMirrorPrefix + "/exported"
+	DefaultExportedServiceSelector = MulticlusterAnnotationsPrefix + "/exported"
 
 	// MirroredResourceLabel indicates that this resource is the result
 	// of a mirroring operation (can be a namespace or a service)
-	MirroredResourceLabel = SvcMirrorPrefix + "/mirrored-service"
+	MirroredResourceLabel = MulticlusterAnnotationsPrefix + "/mirrored-service"
 
 	// MirroredGatewayLabel indicates that this is a mirrored gateway
-	MirroredGatewayLabel = SvcMirrorPrefix + "/mirrored-gateway"
+	MirroredGatewayLabel = MulticlusterAnnotationsPrefix + "/mirrored-gateway"
 
 	// RemoteClusterNameLabel put on a local mirrored service, it
 	// allows us to associate a mirrored service with a remote cluster
-	RemoteClusterNameLabel = SvcMirrorPrefix + "/cluster-name"
-
-	// RemoteResourceVersionAnnotation is the last observed remote resource
-	// version of a mirrored resource. Useful when doing updates
-	RemoteResourceVersionAnnotation = SvcMirrorPrefix + "/remote-resource-version"
+	RemoteClusterNameLabel = MulticlusterAnnotationsPrefix + "/cluster-name"
 
 	// RemoteServiceFqName is the fully qualified name of the mirrored service
 	// on the remote cluster
-	RemoteServiceFqName = SvcMirrorPrefix + "/remote-svc-fq-name"
-
-	// RemoteGatewayResourceVersionAnnotation is the last observed remote resource
-	// version of the gateway for a particular mirrored service. It is used
-	// in cases we detect a change in a remote gateway
-	RemoteGatewayResourceVersionAnnotation = SvcMirrorPrefix + "/remote-gateway-resource-version"
+	RemoteServiceFqName = MulticlusterAnnotationsPrefix + "/remote-svc-fq-name"
 
 	// RemoteGatewayIdentity follows the same kind of logic as RemoteGatewayNameLabel
-	RemoteGatewayIdentity = SvcMirrorPrefix + "/remote-gateway-identity"
+	RemoteGatewayIdentity = MulticlusterAnnotationsPrefix + "/remote-gateway-identity"
 
 	// GatewayIdentity can be found on the remote gateway service
-	GatewayIdentity = SvcMirrorPrefix + "/gateway-identity"
+	GatewayIdentity = MulticlusterAnnotationsPrefix + "/gateway-identity"
 
 	// GatewayProbePeriod the interval at which the health of the gateway should be probed
-	GatewayProbePeriod = SvcMirrorPrefix + "/probe-period"
+	GatewayProbePeriod = MulticlusterAnnotationsPrefix + "/probe-period"
 
 	// GatewayProbePath the path at which the health of the gateway should be probed
-	GatewayProbePath = SvcMirrorPrefix + "/probe-path"
+	GatewayProbePath = MulticlusterAnnotationsPrefix + "/probe-path"
 
 	// ConfigKeyName is the key in the secret that stores the kubeconfig needed to connect
 	// to a remote cluster
 	ConfigKeyName = "kubeconfig"
 
-	// GatewayPortName is the name of the incoming port of the gateway
-	GatewayPortName = "mc-gateway"
-
 	// ProbePortName is the name of the probe port of the gateway
 	ProbePortName = "mc-probe"
-
-	// ServiceMirrorLabel is the value used in the controller component label
-	ServiceMirrorLabel = "servicemirror"
 )
 
 // CreatedByAnnotationValue returns the value associated with

--- a/test/integration/multicluster/target1/testdata/emojivoto-no-bot.yml
+++ b/test/integration/multicluster/target1/testdata/emojivoto-no-bot.yml
@@ -54,7 +54,7 @@ metadata:
   name: web-svc
   namespace: emojivoto
   labels:
-    mirror.linkerd.io/exported: "true"
+    multicluster.linkerd.io/exported: "true"
 spec:
   ports:
   - name: http

--- a/test/integration/multicluster/target1/testdata/emojivoto-no-bot.yml
+++ b/test/integration/multicluster/target1/testdata/emojivoto-no-bot.yml
@@ -54,7 +54,7 @@ metadata:
   name: web-svc
   namespace: emojivoto
   labels:
-    multicluster.linkerd.io/exported: "true"
+    multicluster.linkerd.io/export: "true"
 spec:
   ports:
   - name: http


### PR DESCRIPTION
This renames the multicluster annotation prefix from `mirror.linkerd.io` to
`multicluster.linkerd.io` in order to reflect other extension naming patterns.

Additionally, it moves labels only used in the Multicluster extension into their
own labels file—again to reflect other extensions.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
