### PR TITLE
tests: enable external-prometheus-deep with cleanup logic

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -7,7 +7,7 @@ set +e
 ##### Test setup helpers #####
 
 export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
-export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_test_names[*]}")
+export all_test_names=(cluster-domain cni-calico-deep external-prometheus-deep multicluster "${default_test_names[*]}")
 
 tests_usage() {
   progname="${0##*/}"

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -6,8 +6,8 @@ set +e
 
 ##### Test setup helpers #####
 
-export default_test_names=(deep external-issuer helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
-export all_test_names=(cluster-domain cni-calico-deep external-prometheus-deep multicluster "${default_test_names[*]}")
+export default_test_names=(deep external-issuer external-prometheus-deep helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
+export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_test_names[*]}")
 
 tests_usage() {
   progname="${0##*/}"

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -374,7 +374,7 @@ install_version() {
 
     #Now we need to install the app that will be used to verify that upgrade does not break anything
     kubectl --context="$context" create namespace "$test_app_namespace" > /dev/null 2>&1
-    kubectl --context="$context" label namespaces "$test_app_namespace" 'linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
+    kubectl --context="$context" label namespaces "$test_app_namespace" 'test.linkerd.io/is-test-data-plane'='true' > /dev/null 2>&1
     (
         set -x
         "$linkerd_path" inject "$test_directory/testdata/upgrade_test.yaml" | kubectl --context="$context" apply --namespace="$test_app_namespace" -f - 2>&1

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -22,6 +22,9 @@ echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
 echo "cleaning up the all namespaces labelled with linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete ns -l linkerd.io/is-test-data-plane
 
+echo "cleaning up ohter cluster-scoped resources labelled with linkerd.io/is-test-data-plane"
+kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings -l linkerd.io/is-test-data-planee
+
 echo "cleaning up linkerd resources [${k8s_context}]"
 "$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -22,7 +22,7 @@ echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
 echo "cleaning up the all namespaces labelled with linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete ns -l linkerd.io/is-test-data-plane
 
-echo "cleaning up ohter cluster-scoped resources labelled with linkerd.io/is-test-data-plane"
+echo "cleaning up cluster-scoped resources labelled with linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings -l linkerd.io/is-test-data-planee
 
 echo "cleaning up linkerd resources [${k8s_context}]"

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -19,11 +19,11 @@ echo "cleaning up multicluster resources, if present [${k8s_context}]"
 echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
 "$linkerd_path" jaeger uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
 
-echo "cleaning up the all namespaces labelled with linkerd.io/is-test-data-plane"
-kubectl --context="$k8s_context" delete ns -l linkerd.io/is-test-data-plane
+echo "cleaning up the all namespaces labelled with test.linkerd.io/is-test-data-plane"
+kubectl --context="$k8s_context" delete ns -l test.linkerd.io/is-test-data-plane
 
-echo "cleaning up cluster-scoped resources labelled with linkerd.io/is-test-data-plane"
-kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings -l linkerd.io/is-test-data-planee
+echo "cleaning up cluster-scoped resources labelled with test.linkerd.io/is-test-data-plane"
+kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings -l test.linkerd.io/is-test-data-plane
 
 echo "cleaning up linkerd resources [${k8s_context}]"
 "$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -

--- a/test/integration/edges/testdata/external_prometheus/direct_edges.golden
+++ b/test/integration/edges/testdata/external_prometheus/direct_edges.golden
@@ -1,19 +1,19 @@
 \[
   \{
     "src": "prometheus",
-    "src_namespace": "default",
+    "src_namespace": "external\-prometheus",
     "dst": "slow-cooker",
     "dst_namespace": "{{.Ns}}",
-    "client_id": "prometheus.default",
+    "client_id": "prometheus.external\-prometheus",
     "server_id": "default.{{.Ns}}",
     "no_tls_reason": ""
   \},
   \{
     "src": "prometheus",
-    "src_namespace": "default",
+    "src_namespace": "external\-prometheus",
     "dst": "terminus",
     "dst_namespace": "{{.Ns}}",
-    "client_id": "prometheus.default",
+    "client_id": "prometheus.external\-prometheus",
     "server_id": "default.{{.Ns}}",
     "no_tls_reason": ""
   \},

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -38,7 +38,7 @@ func TestGoodEndpoints(t *testing.T) {
 	if !TestHelper.ExternalPrometheus() {
 		cmd = append(cmd, fmt.Sprintf("linkerd-prometheus.%s.svc.cluster.local:9090", vizNs))
 	} else {
-		cmd = append(cmd, "prometheus.default.svc.cluster.local:9090")
+		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
 		testDataPath += "/external_prometheus"
 	}
 

--- a/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
@@ -1,10 +1,10 @@
 \[
   \{
-    "namespace": "default",
+    "namespace": "external\-prometheus",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 9090,
     "pod": "prometheus\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "prometheus.default"
+    "service": "prometheus.external\-prometheus"
   \},
   \{
     "namespace": "{{.Ns}}",

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -429,7 +429,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 
 		// Update args to use external proemtheus
-		vizArgs = append(vizArgs, "--set", "prometheusUrl=http://prometheus.default.svc.cluster.local:9090", "--set", "prometheus.enabled=false")
+		vizArgs = append(vizArgs, "--set", "prometheusUrl=http://prometheus.external-prometheus.svc.cluster.local:9090", "--set", "prometheus.enabled=false")
 	}
 
 	// Install Linkerd Viz Extension

--- a/test/integration/stat/stat_test.go
+++ b/test/integration/stat/stat_test.go
@@ -49,7 +49,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 
 	// Retrieve Prometheus pod details
 	if TestHelper.ExternalPrometheus() {
-		prometheusNamespace = "default"
+		prometheusNamespace = "external-prometheus"
 		prometheusDeployment = "prometheus"
 	} else {
 		prometheusNamespace = TestHelper.GetVizNamespace()

--- a/test/integration/testdata/external_prometheus.yaml
+++ b/test/integration/testdata/external_prometheus.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: external-prometheus
-  annotations:
-    linkerd.io/is-test-data-plane: true
+  labels:
+    linkerd.io/is-test-data-plane: "true"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/integration/testdata/external_prometheus.yaml
+++ b/test/integration/testdata/external_prometheus.yaml
@@ -3,14 +3,14 @@ kind: Namespace
 metadata:
   name: external-prometheus
   labels:
-    linkerd.io/is-test-data-plane: "true"
+    test.linkerd.io/is-test-data-plane: "true"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus
   labels:
-    linkerd.io/is-test-data-plane: "true"
+    test.linkerd.io/is-test-data-plane: "true"
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -21,7 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus
   labels:
-    linkerd.io/is-test-data-plane: "true"
+    test.linkerd.io/is-test-data-plane: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/integration/testdata/external_prometheus.yaml
+++ b/test/integration/testdata/external_prometheus.yaml
@@ -9,6 +9,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus
+  labels:
+    linkerd.io/is-test-data-plane: "true"
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/proxy", "pods"]
@@ -18,6 +20,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: prometheus
+  labels:
+    linkerd.io/is-test-data-plane: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/integration/testdata/external_prometheus.yaml
+++ b/test/integration/testdata/external_prometheus.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-prometheus
+  annotations:
+    linkerd.io/is-test-data-plane: true
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -18,19 +25,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: default
+  namespace: external-prometheus
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: default
+  namespace: external-prometheus
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: default
+  namespace: external-prometheus
 data:
   prometheus.yml: |-
     global:
@@ -168,7 +175,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: default
+  namespace: external-prometheus
 spec:
   type: ClusterIP
   selector:
@@ -182,7 +189,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus
-  namespace: default
+  namespace: external-prometheus
 spec:
   replicas: 1
   selector:

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -113,9 +113,9 @@ func (h *KubernetesHelper) CreateControlPlaneNamespaceIfNotExists(ctx context.Co
 }
 
 // CreateDataPlaneNamespaceIfNotExists creates a dataplane namespace if it does not already exist,
-// with a linkerd.io/is-test-data-plane label for easier cleanup afterwards
+// with a test.linkerd.io/is-test-data-plane label for easier cleanup afterwards
 func (h *KubernetesHelper) CreateDataPlaneNamespaceIfNotExists(ctx context.Context, namespace string, annotations map[string]string) error {
-	return h.createNamespaceIfNotExists(ctx, namespace, annotations, map[string]string{"linkerd.io/is-test-data-plane": "true"})
+	return h.createNamespaceIfNotExists(ctx, namespace, annotations, map[string]string{"test.linkerd.io/is-test-data-plane": "true"})
 }
 
 // KubectlApply applies a given configuration string in a namespace. If the


### PR DESCRIPTION
This PR enables the temporarily disabled external-prometheus-deep
integration test. This also fixes the clean up issue by essentially
moving the external-prometheus resources into `external-prometheus`
which has the relevant annotation required to be deleted by
`bin/test-cleanup`

This PR also updates the test resource label to be `test.linkerd.io/is-test-data-plane` from
`linkerd.io/is-test-data-plane` to prevent `linkerd inject` from removing it.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
