### PR TITLE
Stop loading cli-bin in bin/image-load

### DIFF
--- a/bin/image-load
+++ b/bin/image-load
@@ -79,7 +79,7 @@ fi
 "$bin" version
 
 rm -f load_fail
-for img in proxy controller web metrics-api grafana cli-bin debug cni-plugin jaeger-webhook tap; do
+for img in proxy controller web metrics-api grafana debug cni-plugin jaeger-webhook tap; do
   printf 'Importing %s...\n' $img
   if [ $archive ]; then
     param="image-archives/$img.tar"


### PR DESCRIPTION
The CLI binaries are never used inside a cluster so there's no need to
load the cli-bin image.

Also, I always have `LINKERD_LOCAL_BUILD_CLI=1` in my environment to avoid
building that image to begin with (takes more than 80s in my machine
with warm docker dependencies), which caused `bin/image-load` to fail
when it attempted to load it.