### PR TITLE
Update debian base images to buster-20210208-slim (#5750)

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM debian:buster-20200514-slim
+FROM debian:buster-20210208-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     dnsutils \

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,4 +1,4 @@
-ARG RUNTIME_IMAGE=debian:buster-20200514-slim
+ARG RUNTIME_IMAGE=debian:buster-20210208-slim
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -18,7 +18,7 @@ COPY cni-plugin cni-plugin
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /go/bin/linkerd-cni -v -mod=readonly ./cni-plugin/
 
-FROM debian:buster-20200514-slim
+FROM debian:buster-20210208-slim
 WORKDIR /linkerd
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -43,7 +43,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly -o web/web -ldflags "-s -w" ./web
 
 ## package it all up
-FROM debian:buster-20200514-slim
+FROM debian:buster-20210208-slim
 WORKDIR /linkerd
 
 COPY LICENSE .


### PR DESCRIPTION
This change updates all of our debian images to use the
`buster-20210208-slim` tag.

This change back-ports a2dca0c7 to the release/stable-2.9 branch

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
