### PR TITLE
Fix 'linkerd install' current installs detection

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -270,13 +270,15 @@ func install(ctx context.Context, w io.Writer, values *l5dcharts.Values, flags [
 		if err != nil {
 			return err
 		}
-		stored, err := loadStoredValues(ctx, k8sAPI)
-		if err != nil {
-			return err
-		}
-		if stored != nil {
-			fmt.Fprintf(os.Stderr, errMsgLinkerdConfigResourceConflict, controlPlaneNamespace, "Secret/linkerd-config-overrides already exists")
+
+		// We just want to check if `linkerd-configmap` exists
+		_, err := k8sAPI.CoreV1().ConfigMaps(controlPlaneNamespace).Get(ctx, k8s.ConfigConfigMapName, metav1.GetOptions{})
+		if err == nil {
+			fmt.Fprintf(os.Stderr, errMsgLinkerdConfigResourceConflict, controlPlaneNamespace, "ConfigMap/linkerd-config already exists")
 			os.Exit(1)
+		}
+		if !kerrors.IsNotFound(err) {
+			return err
 		}
 	}
 


### PR DESCRIPTION
This change back-ports #5783 to the release/stable-2.9 branch.

`linkerd install` was checking for the existence of the
`linkerd-config-overrides` secret which hasn't been available till
recent versions. Changed this to check for the usual `linkerd-config`
ConfigMap. Uses a straight k8s API call for simplicity.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
