### PR TITLE
Report better errors for pods with tap disabled

### DIFF
--- a/test/integration/tap/tap_test.go
+++ b/test/integration/tap/tap_test.go
@@ -144,8 +144,8 @@ func TestCliTap(t *testing.T) {
 			if stderr == "" {
 				testutil.Fatal(t, "expected an error, got none")
 			}
-			expectedErr := `Error: no pods to tap for deployment/t4
-pods found with tap disabled via the viz.linkerd.io/disable-tap annotation`
+			expectedErr := `no pods to tap for deployment/t4
+1 pods found with tap disabled via the viz.linkerd.io/disable-tap annotation:`
 			split := strings.Split(stderr, "\n")
 			actualErr := strings.Join(split[:2], "\n")
 			if actualErr != expectedErr {

--- a/test/integration/testdata/check.viz.proxy.golden
+++ b/test/integration/testdata/check.viz.proxy.golden
@@ -16,6 +16,5 @@ linkerd-viz-data-plane
 ----------------------
 √ data plane namespace exists
 √ data plane proxy metrics are present in Prometheus
-√ data-plane pods have tap enabled
 
 Status check results are √

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -210,15 +210,23 @@ func NewCmdTap() *cobra.Command {
 
 			req, err := pkg.BuildTapByResourceRequest(requestParams)
 			if err != nil {
-				return err
+				fmt.Fprint(os.Stderr, err.Error())
+				os.Exit(1)
 			}
 
 			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
-				return err
+				fmt.Fprint(os.Stderr, err.Error())
+				os.Exit(1)
 			}
 
-			return requestTapByResourceFromAPI(cmd.Context(), os.Stdout, k8sAPI, req, options)
+			err = requestTapByResourceFromAPI(cmd.Context(), os.Stdout, k8sAPI, req, options)
+			if err != nil {
+				fmt.Fprint(os.Stderr, err.Error())
+				os.Exit(1)
+			}
+
+			return nil
 		},
 	}
 

--- a/viz/main.go
+++ b/viz/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/linkerd/linkerd2/viz/cmd"
+)
+
+func main() {
+	if err := cmd.NewCmdViz().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/viz/tap/api/grpc_server_test.go
+++ b/viz/tap/api/grpc_server_test.go
@@ -91,7 +91,7 @@ status:
 			},
 		},
 		{
-			err: status.Errorf(codes.NotFound, "no pods to tap for pod/emojivoto-not-meshed"),
+			err: status.Errorf(codes.NotFound, "no pods to tap for pod/emojivoto-not-meshed\n"),
 			k8sRes: []string{`
 apiVersion: v1
 kind: Pod
@@ -157,7 +157,7 @@ status:
 			},
 		},
 		{
-			err: status.Errorf(codes.NotFound, "no pods to tap for pod/emojivoto-meshed"),
+			err: status.Errorf(codes.NotFound, "no pods to tap for pod/emojivoto-meshed\n"),
 			k8sRes: []string{`
 apiVersion: v1
 kind: Pod
@@ -186,7 +186,10 @@ status:
 		},
 		{
 			err: status.Errorf(codes.NotFound, `no pods to tap for pod/emojivoto-meshed-tap-disabled
-pods found with tap disabled via the viz.linkerd.io/disable-tap annotation`),
+1 pods found with tap disabled via the viz.linkerd.io/disable-tap annotation:
+	* emojivoto-meshed-tap-disabled
+remove this annotation to make these pods valid tap targets
+`),
 			k8sRes: []string{`
 apiVersion: v1
 kind: Pod
@@ -221,7 +224,10 @@ status:
 		},
 		{
 			err: status.Errorf(codes.NotFound, `no pods to tap for pod/emojivoto-meshed-tap-not-enabled
-pods found with tap not enabled; try restarting resource so that it can be injected`),
+1 pods found with tap not enabled:
+	* emojivoto-meshed-tap-not-enabled
+restart these pods to enable tap and make them valid tap targets
+`),
 			k8sRes: []string{`
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/discussions/5777

When a user runs `linkerd viz check --proxy`, it will print a warning if there are any proxies which cannot be tapped.  This is a normal state of affairs after freshly installing the linkerd-viz extensions because any existing pods will need to be restarted before they can be tapped.  The check warning may lead users to falsely believe that something has gone wrong with their installation.

We remove this specific check from `linkerd viz check --proxy`.  To replace it, we improve the error output when attempting to tap a resource which is not tappable.  This gives the user actionable feedback when the tap command fails.

Old:

```console
> linkerd viz tap -n emojivoto deploy/vote-bot
no pods to tap for deployment/vote-bot
```

New:

```console
> linkerd viz tap -n emojivoto deploy/vote-bot
no pods to tap for deployment/vote-bot
1 pods found with tap not enabled:
	* vote-bot-64dd87cb87-7mcv4
restart these pods to enable tap and make them valid tap targets
```

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
