### PR TITLE
Remove linkerd prefix from extension resources

### DIFF
--- a/charts/linkerd2/templates/heartbeat.yaml
+++ b/charts/linkerd2/templates/heartbeat.yaml
@@ -46,7 +46,7 @@ spec:
             - "-controller-namespace={{.Values.namespace}}"
             - "-log-level={{.Values.controllerLogLevel}}"
             - "-log-format={{.Values.controllerLogFormat}}"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.{{.Values.clusterDomain}}:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.{{.Values.clusterDomain}}:9090"
             {{- if .Values.heartbeatResources -}}
             {{- include "partials.resources" .Values.heartbeatResources | nindent 12 }}
             {{- end }}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1825,7 +1825,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=l5d"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -2008,7 +2008,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             resources:
               limits:
                 memory: "250Mi"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -2008,7 +2008,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             resources:
               limits:
                 memory: "250Mi"

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1799,7 +1799,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1985,7 +1985,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             resources:
               limits:
                 memory: "250Mi"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -2005,7 +2005,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             resources:
               limits:
                 memory: "250Mi"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1985,7 +1985,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             resources:
               limits:
                 memory: "250Mi"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1705,7 +1705,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=ControllerLogLevel"
             - "-log-format=ControllerLogFormat"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1822,7 +1822,7 @@ spec:
             - "-controller-namespace=linkerd"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1808,7 +1808,7 @@ spec:
             - "-controller-namespace=l5d"
             - "-log-level=info"
             - "-log-format=plain"
-            - "-prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.example.com:9090"
+            - "-prometheus-url=http://prometheus.linkerd-viz.svc.example.com:9090"
             securityContext:
               runAsUser: 2103
 ---

--- a/controller/heartbeat/heartbeat_test.go
+++ b/controller/heartbeat/heartbeat_test.go
@@ -72,10 +72,10 @@ metadata:
     linkerd.io/extension: viz`,
 			},
 			url.Values{
-				"k8s-version":     []string{"v0.0.0-master+$Format:%h$"},
-				"install-time":    []string{"1550234096"},
-				"uuid":            []string{"fake-uuid"},
-				"ext-viz": []string{"1"},
+				"k8s-version":  []string{"v0.0.0-master+$Format:%h$"},
+				"install-time": []string{"1550234096"},
+				"uuid":         []string{"fake-uuid"},
+				"ext-viz":      []string{"1"},
 			},
 		},
 	}

--- a/controller/heartbeat/heartbeat_test.go
+++ b/controller/heartbeat/heartbeat_test.go
@@ -69,13 +69,13 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz`,
+    linkerd.io/extension: viz`,
 			},
 			url.Values{
 				"k8s-version":     []string{"v0.0.0-master+$Format:%h$"},
 				"install-time":    []string{"1550234096"},
 				"uuid":            []string{"fake-uuid"},
-				"ext-linkerd-viz": []string{"1"},
+				"ext-viz": []string{"1"},
 			},
 		},
 	}

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -75,8 +75,6 @@ Kubernetes: `>=1.16.0-0`
 | collector.image.pullPolicy | string | `"Always"` |  |
 | collector.image.version | string | `"0.1.11"` |  |
 | collector.jaegerAddr | string | `nil` | address of the jaeger backend to send traces to |
-| createdByAnnotation | string | `"linkerd.io/created-by"` |  |
-| extensionAnnotation | string | `"linkerd.io/extension"` |  |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
 | jaeger.image.version | string | `"1.19.2"` |  |

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -75,6 +75,8 @@ Kubernetes: `>=1.16.0-0`
 | collector.image.pullPolicy | string | `"Always"` |  |
 | collector.image.version | string | `"0.1.11"` |  |
 | collector.jaegerAddr | string | `nil` | address of the jaeger backend to send traces to |
+| createdByAnnotation | string | `"linkerd.io/created-by"` |  |
+| extensionAnnotation | string | `"linkerd.io/extension"` |  |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
 | jaeger.image.version | string | `"1.19.2"` |  |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
     app.kubernetes.io/name: jaeger-injector
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -17,14 +17,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: jaeger
+      linkerd.io/extension: jaeger
       component: jaeger-injector
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/rbac.yaml") . | sha256sum }}
       labels:
-        {{.Values.extensionAnnotation}}: jaeger
+        linkerd.io/extension: jaeger
         component: jaeger-injector
     spec:
       containers:
@@ -66,14 +66,12 @@ metadata:
   name: jaeger-injector
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
     component: jaeger-injector
-  annotations:
-    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
     component: jaeger-injector
   ports:
   - name: jaeger-injector

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -6,8 +6,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    {{.Values.extensionAnnotation}}: jaeger
     app.kubernetes.io/name: jaeger-injector
     app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: jaeger-injector
   name: jaeger-injector
   namespace: {{.Values.namespace}}
@@ -15,12 +17,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      {{.Values.extensionAnnotation}}: jaeger
       component: jaeger-injector
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/rbac.yaml") . | sha256sum }}
       labels:
+        {{.Values.extensionAnnotation}}: jaeger
         component: jaeger-injector
     spec:
       containers:
@@ -62,13 +66,16 @@ metadata:
   name: jaeger-injector
   namespace: {{.Values.namespace}}
   labels:
+    {{.Values.extensionAnnotation}}: jaeger
     component: jaeger-injector
+  annotations:
+    {{.Values.createdByAnnotation}}: {{default (printf "linkerd/helm %s" .Values.linkerdVersion) .Values.cliVersion}}
 spec:
   type: ClusterIP
   selector:
+    {{.Values.extensionAnnotation}}: jaeger
     component: jaeger-injector
   ports:
   - name: jaeger-injector
     port: 443
     targetPort: jaeger-injector
-

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -9,7 +9,7 @@ metadata:
     linkerd.io/extension: jaeger
     app.kubernetes.io/name: jaeger-injector
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.webhook.image.version .Values.cliVersion}}
     component: jaeger-injector
   name: jaeger-injector
   namespace: {{.Values.namespace}}

--- a/jaeger/charts/linkerd-jaeger/templates/namespace.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace.yaml
@@ -4,6 +4,6 @@ apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
   annotations:
     linkerd.io/inject: enabled

--- a/jaeger/charts/linkerd-jaeger/templates/namespace.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace.yaml
@@ -4,6 +4,6 @@ apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-jaeger
+    {{.Values.extensionAnnotation}}: jaeger
   annotations:
     linkerd.io/inject: enabled

--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-jaeger-injector
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -37,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-jaeger-injector
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
 subjects:
 - kind: ServiceAccount
   name: jaeger-injector
@@ -73,7 +73,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-jaeger-injector-webhook-config
   labels:
-    {{.Values.extensionAnnotation}}: jaeger
+    linkerd.io/extension: jaeger
 webhooks:
 - name: jaeger-injector.linkerd.io
   {{- if .Values.webhook.namespaceSelector }}

--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -26,7 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-jaeger-injector
   labels:
-    linkerd.io/extension: linkerd-jaeger
+    {{.Values.extensionAnnotation}}: jaeger
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -37,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-jaeger-injector
   labels:
-    linkerd.io/extension: linkerd-jaeger
+    {{.Values.extensionAnnotation}}: jaeger
 subjects:
 - kind: ServiceAccount
   name: jaeger-injector
@@ -73,7 +73,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-jaeger-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-jaeger
+    {{.Values.extensionAnnotation}}: jaeger
 webhooks:
 - name: jaeger-injector.linkerd.io
   {{- if .Values.webhook.namespaceSelector }}
@@ -102,4 +102,3 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   sideEffects: None
-

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -2,8 +2,6 @@
 
 namespace: linkerd-jaeger
 
-createdByAnnotation: linkerd.io/created-by
-extensionAnnotation: linkerd.io/extension
 collector:
   image: 
     name: omnition/opencensus-collector

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -2,6 +2,8 @@
 
 namespace: linkerd-jaeger
 
+createdByAnnotation: linkerd.io/created-by
+extensionAnnotation: linkerd.io/extension
 collector:
   image: 
     name: omnition/opencensus-collector
@@ -48,8 +50,6 @@ webhook:
     #- key: runlevel
     #  operator: NotIn
     #  values: ["0","1"]
-
   objectSelector:
     #matchLabels:
     #  foo: bar
-

--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -18,10 +18,10 @@ import (
 const (
 
 	// JaegerExtensionName is the name of jaeger extension
-	JaegerExtensionName = "linkerd-jaeger"
+	JaegerExtensionName = "jaeger"
 
 	// linkerdJaegerExtensionCheck adds checks related to the jaeger extension
-	linkerdJaegerExtensionCheck healthcheck.CategoryID = JaegerExtensionName
+	linkerdJaegerExtensionCheck healthcheck.CategoryID = "linkerd-jaeger"
 
 	// linkerdJaegerExtensionDataPlaneCheck adds checks related to the jaeger extension
 	linkerdJaegerExtensionDataPlaneCheck healthcheck.CategoryID = JaegerExtensionName + "-data-plane"

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -35,7 +35,7 @@ func uninstallRunE(ctx context.Context) error {
 	}
 
 	resources, err := resource.FetchKubernetesResources(ctx, k8sAPI,
-		metav1.ListOptions{LabelSelector: "linkerd.io/extension=linkerd-jaeger"},
+		metav1.ListOptions{LabelSelector: "linkerd.io/extension=jaeger"},
 	)
 	if err != nil {
 		return err

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{.Values.gatewayName}}-config
   labels:
     linkerd.io/control-plane-component: gateway
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     {{ include "partials.annotations.created-by" . }}
   namespace: {{.Values.namespace}}
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     linkerd.io/control-plane-component: gateway
     app: {{.Values.gatewayName}}
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
 spec:
@@ -118,7 +118,7 @@ metadata:
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     mirror.linkerd.io/gateway-identity: {{.Values.gatewayName}}.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
     mirror.linkerd.io/probe-period: "{{.Values.gatewayProbeSeconds}}"
@@ -148,5 +148,5 @@ metadata:
   name: {{.Values.gatewayName}}
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
@@ -7,7 +7,7 @@ kind: CustomResourceDefinition
 metadata:
   name: links.multicluster.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:

--- a/multicluster/charts/linkerd-multicluster/templates/namespace.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace.yaml
@@ -4,5 +4,5 @@ apiVersion: v1
 metadata:
   name: {{ .Values.namespace }}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     {{ include "partials.annotations.created-by" $ }}
 rules:
@@ -29,7 +29,7 @@ metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     {{ include "partials.annotations.created-by" $ }}
 ---
@@ -39,7 +39,7 @@ metadata:
   name: {{.}}
   namespace: {{$.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-multicluster
+    linkerd.io/extension: multicluster
   annotations:
     {{ include "partials.annotations.created-by" $ }}
 roleRef:

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -26,10 +26,10 @@ import (
 
 const (
 	// MulticlusterExtensionName is the name of the multicluster extension
-	MulticlusterExtensionName = "linkerd-multicluster"
+	MulticlusterExtensionName = "multicluster"
 
 	// linkerdMulticlusterExtensionCheck adds checks related to the multicluster extension
-	linkerdMulticlusterExtensionCheck healthcheck.CategoryID = MulticlusterExtensionName
+	linkerdMulticlusterExtensionCheck healthcheck.CategoryID = "linkerd-multicluster"
 
 	linkerdServiceMirrorServiceAccountName = "linkerd-service-mirror-%s"
 	linkerdServiceMirrorComponentName      = "service-mirror"

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -352,7 +352,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration foo"),
+			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration \"foo\""),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -352,7 +352,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration \"foo\""),
+			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration foo"),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/test/integration/edges/testdata/direct_edges.golden
+++ b/test/integration/edges/testdata/direct_edges.golden
@@ -9,20 +9,20 @@
     "no_tls_reason": ""
   \},
   \{
-    "src": "linkerd-prometheus",
+    "src": "prometheus",
     "src_namespace": "{{.VizNs}}",
     "dst": "slow-cooker",
     "dst_namespace": "{{.Ns}}",
-    "client_id": "linkerd-prometheus.{{.VizNs}}",
+    "client_id": "prometheus.{{.VizNs}}",
     "server_id": "default.{{.Ns}}",
     "no_tls_reason": ""
   \},
   \{
-    "src": "linkerd-prometheus",
+    "src": "prometheus",
     "src_namespace": "{{.VizNs}}",
     "dst": "terminus",
     "dst_namespace": "{{.Ns}}",
-    "client_id": "linkerd-prometheus.{{.VizNs}}",
+    "client_id": "prometheus.{{.VizNs}}",
     "server_id": "default.{{.Ns}}",
     "no_tls_reason": ""
   \}

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -27,16 +27,16 @@ func TestGoodEndpoints(t *testing.T) {
 		"endpoints",
 		fmt.Sprintf("linkerd-controller-api.%s.svc.cluster.local:8085", ns),
 		fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", ns),
-		fmt.Sprintf("linkerd-grafana.%s.svc.cluster.local:3000", vizNs),
+		fmt.Sprintf("grafana.%s.svc.cluster.local:3000", vizNs),
 		fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", ns),
 		fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", ns),
 		fmt.Sprintf("linkerd-sp-validator.%s.svc.cluster.local:443", ns),
-		fmt.Sprintf("linkerd-tap.%s.svc.cluster.local:8088", vizNs),
-		fmt.Sprintf("linkerd-web.%s.svc.cluster.local:8084", vizNs),
+		fmt.Sprintf("tap.%s.svc.cluster.local:8088", vizNs),
+		fmt.Sprintf("web.%s.svc.cluster.local:8084", vizNs),
 	}
 
 	if !TestHelper.ExternalPrometheus() {
-		cmd = append(cmd, fmt.Sprintf("linkerd-prometheus.%s.svc.cluster.local:9090", vizNs))
+		cmd = append(cmd, fmt.Sprintf("prometheus.%s.svc.cluster.local:9090", vizNs))
 	} else {
 		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
 		testDataPath += "/external_prometheus"

--- a/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
@@ -45,21 +45,21 @@
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 3000,
-    "pod": "linkerd\-grafana\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-grafana\.{{.VizNs}}"
+    "pod": "grafana\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "grafana\.{{.VizNs}}"
   \},
   \{
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8088,
-    "pod": "linkerd\-tap\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-tap\.{{.VizNs}}"
+    "pod": "tap\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "tap\.{{.VizNs}}"
   \},
   \{
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8084,
-    "pod": "linkerd\-web\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-web\.{{.VizNs}}"
+    "pod": "web\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "web\.{{.VizNs}}"
   \}
 \]

--- a/test/integration/endpoints/testdata/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/linkerd_endpoints.golden
@@ -38,28 +38,28 @@
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 3000,
-    "pod": "linkerd\-grafana\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-grafana\.{{.VizNs}}"
+    "pod": "grafana\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "grafana\.{{.VizNs}}"
   \},
   \{
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 9090,
-    "pod": "linkerd\-prometheus-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-prometheus\.{{.VizNs}}"
+    "pod": "prometheus-[a-f0-9]+\-[a-z0-9]+",
+    "service": "prometheus\.{{.VizNs}}"
   \},
   \{
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8088,
-    "pod": "linkerd\-tap\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-tap\.{{.VizNs}}"
+    "pod": "tap\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "tap\.{{.VizNs}}"
   \},
   \{
     "namespace": "{{.VizNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8084,
-    "pod": "linkerd\-web\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "linkerd\-web\.{{.VizNs}}"
+    "pod": "web\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "web\.{{.VizNs}}"
   \}
 \]

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -35,7 +35,7 @@ var (
 	linkerdSvcStable = []testutil.Service{
 		{Namespace: "linkerd", Name: "linkerd-controller-api"},
 		{Namespace: "linkerd", Name: "linkerd-dst"},
-		{Namespace: "linkerd", Name: "grafana"},
+		{Namespace: "linkerd", Name: "linkerd-grafana"},
 		{Namespace: "linkerd", Name: "linkerd-identity"},
 		{Namespace: "linkerd", Name: "linkerd-prometheus"},
 		{Namespace: "linkerd", Name: "linkerd-web"},

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -35,7 +35,7 @@ var (
 	linkerdSvcStable = []testutil.Service{
 		{Namespace: "linkerd", Name: "linkerd-controller-api"},
 		{Namespace: "linkerd", Name: "linkerd-dst"},
-		{Namespace: "linkerd", Name: "linkerd-grafana"},
+		{Namespace: "linkerd", Name: "grafana"},
 		{Namespace: "linkerd", Name: "linkerd-identity"},
 		{Namespace: "linkerd", Name: "linkerd-prometheus"},
 		{Namespace: "linkerd", Name: "linkerd-web"},
@@ -47,10 +47,10 @@ var (
 	linkerdSvcEdge = []testutil.Service{
 		{Namespace: "linkerd", Name: "linkerd-controller-api"},
 		{Namespace: "linkerd", Name: "linkerd-dst"},
-		{Namespace: "linkerd-viz", Name: "linkerd-grafana"},
+		{Namespace: "linkerd-viz", Name: "grafana"},
 		{Namespace: "linkerd", Name: "linkerd-identity"},
-		{Namespace: "linkerd-viz", Name: "linkerd-web"},
-		{Namespace: "linkerd-viz", Name: "linkerd-tap"},
+		{Namespace: "linkerd-viz", Name: "web"},
+		{Namespace: "linkerd-viz", Name: "tap"},
 		{Namespace: "linkerd", Name: "linkerd-dst-headless"},
 		{Namespace: "linkerd", Name: "linkerd-identity-headless"},
 	}
@@ -539,8 +539,8 @@ func TestControlPlaneResourcesPostInstall(t *testing.T) {
 	expectedServices := linkerdSvcEdge
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
-		expectedServices = append(expectedServices, testutil.Service{Namespace: "linkerd-viz", Name: "linkerd-prometheus"})
-		expectedDeployments["linkerd-prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedServices = append(expectedServices, testutil.Service{Namespace: "linkerd-viz", Name: "prometheus"})
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
 	}
 
 	// Upgrade Case
@@ -1052,7 +1052,7 @@ func TestCheckProxy(t *testing.T) {
 func TestRestarts(t *testing.T) {
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
-		expectedDeployments["linkerd-prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
 	}
 	for deploy, spec := range expectedDeployments {
 		if err := TestHelper.CheckPods(context.Background(), spec.Namespace, deploy, spec.Replicas); err != nil {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -84,8 +84,8 @@ var (
 	//skippedInboundPorts lists some ports to be marked as skipped, which will
 	// be verified in test/integration/inject
 	skippedInboundPorts       = "1234,5678"
-	multiclusterExtensionName = "linkerd-multicluster"
-	vizExtensionName          = "linkerd-viz"
+	multiclusterExtensionName = "multicluster"
+	vizExtensionName          = "viz"
 )
 
 //////////////////////

--- a/test/integration/stat/stat_test.go
+++ b/test/integration/stat/stat_test.go
@@ -37,7 +37,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 	ctx := context.Background()
 	var prometheusPod, prometheusAuthority, prometheusNamespace, prometheusDeployment, metricsPod string
 	// Get Metrics Pod
-	pods, err := TestHelper.GetPodNamesForDeployment(ctx, TestHelper.GetVizNamespace(), "linkerd-metrics-api")
+	pods, err := TestHelper.GetPodNamesForDeployment(ctx, TestHelper.GetVizNamespace(), "metrics-api")
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "failed to get pods for metrics-api",
 			"failed to get pods for metrics-api: %s", err)
@@ -53,7 +53,7 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		prometheusDeployment = "prometheus"
 	} else {
 		prometheusNamespace = TestHelper.GetVizNamespace()
-		prometheusDeployment = "linkerd-prometheus"
+		prometheusDeployment = "prometheus"
 	}
 
 	pods, err = TestHelper.GetPodNamesForDeployment(ctx, prometheusNamespace, prometheusDeployment)
@@ -98,13 +98,13 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 		{
 			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace(), "--to", fmt.Sprintf("po/%s", prometheusPod), "--to-namespace", prometheusNamespace},
 			expectedRows: map[string]string{
-				"linkerd-metrics-api": "1/1",
+				"metrics-api": "1/1",
 			},
 		},
 		{
 			args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace(), "--to", fmt.Sprintf("svc/%s", prometheusDeployment), "--to-namespace", prometheusNamespace},
 			expectedRows: map[string]string{
-				"linkerd-metrics-api": "1/1",
+				"metrics-api": "1/1",
 			},
 		},
 		{
@@ -131,12 +131,12 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 			{
 				args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace()},
 				expectedRows: map[string]string{
-					"linkerd-metrics-api": "1/1",
-					"linkerd-grafana":     "1/1",
-					"linkerd-prometheus":  "1/1",
-					"linkerd-tap":         "1/1",
-					"linkerd-web":         "1/1",
-					"tap-injector":        "1/1",
+					"metrics-api":  "1/1",
+					"grafana":      "1/1",
+					"prometheus":   "1/1",
+					"tap":          "1/1",
+					"web":          "1/1",
+					"tap-injector": "1/1",
 				},
 			},
 			{
@@ -146,9 +146,9 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 				},
 			},
 			{
-				args: []string{"viz", "stat", "svc", "linkerd-prometheus", "-n", TestHelper.GetVizNamespace(), "--from", "deploy/linkerd-metrics-api", "--from-namespace", TestHelper.GetVizNamespace()},
+				args: []string{"viz", "stat", "svc", "prometheus", "-n", TestHelper.GetVizNamespace(), "--from", "deploy/metrics-api", "--from-namespace", TestHelper.GetVizNamespace()},
 				expectedRows: map[string]string{
-					"linkerd-prometheus": "1/1",
+					"prometheus": "1/1",
 				},
 			},
 		}...,
@@ -162,11 +162,11 @@ func TestCliStatForLinkerdNamespace(t *testing.T) {
 			{
 				args: []string{"viz", "stat", "deploy", "-n", TestHelper.GetVizNamespace()},
 				expectedRows: map[string]string{
-					"linkerd-metrics-api": "1/1",
-					"linkerd-grafana":     "1/1",
-					"linkerd-tap":         "1/1",
-					"linkerd-web":         "1/1",
-					"tap-injector":        "1/1",
+					"metrics-api":  "1/1",
+					"grafana":      "1/1",
+					"tap":          "1/1",
+					"web":          "1/1",
+					"tap-injector": "1/1",
 				},
 			},
 			{

--- a/test/integration/uninstall/uninstall_test.go
+++ b/test/integration/uninstall/uninstall_test.go
@@ -73,7 +73,7 @@ func TestResourcesPostInstall(t *testing.T) {
 
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
-		expectedDeployments["linkerd-prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
 	}
 	// Upgrade Case
 	if TestHelper.UpgradeHelmFromVersion() != "" {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -85,11 +85,11 @@ var LinkerdDeployReplicasStable = map[string]DeploySpec{
 var LinkerdDeployReplicasEdge = map[string]DeploySpec{
 	"linkerd-controller":     {"linkerd", 1, []string{"public-api"}},
 	"linkerd-destination":    {"linkerd", 1, []string{"destination"}},
-	"linkerd-tap":            {"linkerd-viz", 1, []string{"tap"}},
-	"linkerd-grafana":        {"linkerd-viz", 1, []string{}},
+	"tap":                    {"linkerd-viz", 1, []string{"tap"}},
+	"grafana":                {"linkerd-viz", 1, []string{}},
 	"linkerd-identity":       {"linkerd", 1, []string{"identity"}},
 	"linkerd-sp-validator":   {"linkerd", 1, []string{"sp-validator"}},
-	"linkerd-web":            {"linkerd-viz", 1, []string{"web"}},
+	"web":                    {"linkerd-viz", 1, []string{"web"}},
 	"linkerd-proxy-injector": {"linkerd", 1, []string{"proxy-injector"}},
 }
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -91,7 +91,6 @@ Kubernetes: `>=1.16.0-0`
 | defaultRegistry | string | `"cr.l5d.io/linkerd"` | Docker registry for all viz components |
 | defaultUID | int | `2103` | UID for all the viz components |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
-| extensionAnnotation | string | `"linkerd.io/extension"` |  |
 | grafana.enabled | bool | `true` | toggle field to enable or disable grafana |
 | grafana.image.name | string | `"grafana"` | Docker image name for the grafana instance |
 | grafana.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the grafana instance |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -91,6 +91,7 @@ Kubernetes: `>=1.16.0-0`
 | defaultRegistry | string | `"cr.l5d.io/linkerd"` | Docker registry for all viz components |
 | defaultUID | int | `2103` | UID for all the viz components |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
+| extensionAnnotation | string | `"linkerd.io/extension"` |  |
 | grafana.enabled | bool | `true` | toggle field to enable or disable grafana |
 | grafana.image.name | string | `"grafana"` | Docker image name for the grafana instance |
 | grafana.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the grafana instance |

--- a/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
@@ -6,10 +6,10 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: grafana
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: grafana
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -6,17 +6,17 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-grafana-config
+  name: grafana-config
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: grafana
     namespace: {{.Values.namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
   grafana.ini: |-
-    instance_name = linkerd-grafana
+    instance_name = grafana
     [server]
     root_url = %(protocol)s://%(domain)s:/grafana/
     [auth]
@@ -40,7 +40,7 @@ data:
       {{- if .Values.prometheusUrl }}
       url: {{.Values.prometheusUrl}}
       {{- else }}
-      url: http://linkerd-prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
+      url: http://prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
       {{- end }}
       isDefault: true
       jsonData:
@@ -64,10 +64,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: grafana
     namespace: {{.Values.namespace}}
   annotations:
@@ -75,7 +75,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: grafana
   ports:
   - name: http
@@ -88,19 +88,19 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: grafana
     namespace: {{.Values.namespace}}
-  name: linkerd-grafana
+  name: grafana
   namespace: {{.Values.namespace}}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      {{.Values.extensionAnnotation}}: viz
       component: grafana
       namespace: {{.Values.namespace}}
   template:
@@ -112,7 +112,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: grafana
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -155,7 +155,7 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: true
-      serviceAccountName: linkerd-grafana
+      serviceAccountName: grafana
       volumes:
       - emptyDir: {}
         name: data
@@ -167,6 +167,6 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: linkerd-grafana-config
+          name: grafana-config
         name: grafana-config
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -9,7 +9,7 @@ metadata:
   name: grafana-config
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: {{.Values.namespace}}
   annotations:
@@ -67,7 +67,7 @@ metadata:
   name: grafana
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: {{.Values.namespace}}
   annotations:
@@ -75,7 +75,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: grafana
   ports:
   - name: http
@@ -88,7 +88,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -100,7 +100,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: viz
+      linkerd.io/extension: viz
       component: grafana
       namespace: {{.Values.namespace}}
   template:
@@ -112,7 +112,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: grafana
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -91,7 +91,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: grafana
     namespace: {{.Values.namespace}}
   name: grafana

--- a/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -31,7 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,15 +39,15 @@ roleRef:
   name: linkerd-{{.Values.namespace}}-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: {{.Values.namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: metrics-api
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-metrics-api
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -31,7 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-metrics-api
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48,6 +48,6 @@ metadata:
   name: metrics-api
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: metrics-api
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -5,17 +5,17 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: metrics-api
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: metrics-api
   ports:
   - name: http
@@ -28,18 +28,18 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: {{.Values.namespace}}
 spec:
   replicas: {{.Values.metricsAPI.replicas}}
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      {{.Values.extensionAnnotation}}: viz
       component: metrics-api
   template:
     metadata:
@@ -53,7 +53,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: metrics-api
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
@@ -73,7 +73,7 @@ spec:
         {{- if .Values.prometheusUrl }}
         - -prometheus-url={{.Values.prometheusUrl}}
         {{- else if .Values.prometheus.enabled }}
-        - -prometheus-url=http://linkerd-prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
+        - -prometheus-url=http://prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
         {{- else }}
         {{ fail "Please enable `linkerd-prometheus` or provide `prometheusUrl` for the viz extension to function properly"}}
         {{- end }}
@@ -100,4 +100,4 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.metricsAPI.UID | default .Values.defaultUID}}
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -8,14 +8,14 @@ metadata:
   name: metrics-api
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -28,7 +28,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -39,7 +39,7 @@ spec:
   replicas: {{.Values.metricsAPI.replicas}}
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -53,7 +53,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: metrics-api
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -31,7 +31,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: metrics-api
   name: metrics-api
   namespace: {{.Values.namespace}}

--- a/viz/charts/linkerd-viz/templates/namespace.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
   annotations:
     {{- if .Values.prometheusUrl }}
     viz.linkerd.io/external-prometheus: {{.Values.prometheusUrl}}

--- a/viz/charts/linkerd-viz/templates/namespace.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 metadata:
   name: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
   annotations:
     {{- if .Values.prometheusUrl }}
     viz.linkerd.io/external-prometheus: {{.Values.prometheusUrl}}

--- a/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28,16 +28,16 @@ roleRef:
   name: linkerd-{{.Values.namespace}}-prometheus
 subjects:
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-prometheus
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-prometheus
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -37,7 +37,7 @@ metadata:
   name: prometheus
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
   name: prometheus-config
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: {{.Values.namespace}}
   annotations:
@@ -177,7 +177,7 @@ metadata:
   name: prometheus
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: {{.Values.namespace}}
   annotations:
@@ -185,7 +185,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -198,7 +198,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -214,7 +214,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: viz
+      linkerd.io/extension: viz
       component: prometheus
       namespace: {{.Values.namespace}}
   template:
@@ -226,7 +226,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{  . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: prometheus
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -307,7 +307,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -6,10 +6,10 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus-config
+  name: prometheus-config
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
     namespace: {{.Values.namespace}}
   annotations:
@@ -174,10 +174,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
     namespace: {{.Values.namespace}}
   annotations:
@@ -185,7 +185,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -198,13 +198,13 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: prometheus
     namespace: {{.Values.namespace}}
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
 spec:
   replicas: 1
@@ -214,7 +214,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      {{.Values.extensionAnnotation}}: viz
       component: prometheus
       namespace: {{.Values.namespace}}
   template:
@@ -226,7 +226,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{  . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: prometheus
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -284,7 +284,7 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
-      serviceAccountName: linkerd-prometheus
+      serviceAccountName: prometheus
       volumes:
     {{- range .Values.prometheus.ruleConfigMapMounts }}
       - name: {{ .name }}
@@ -294,12 +294,12 @@ spec:
       - name: data
     {{- if .Values.prometheus.persistence }}
         persistentVolumeClaim:
-          claimName: linkerd-prometheus
+          claimName: prometheus
     {{- else }}
         emptyDir: {}
     {{- end }}
       - configMap:
-          name: linkerd-prometheus-config
+          name: prometheus-config
         name: prometheus-config
 {{- if .Values.prometheus.persistence }}
 ---
@@ -307,12 +307,12 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: prometheus
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
 spec:
   accessModes:

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -201,7 +201,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: prometheus
     namespace: {{.Values.namespace}}
   name: prometheus
@@ -310,7 +310,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion}}
     component: prometheus
   name: prometheus
   namespace: {{.Values.namespace}}

--- a/viz/charts/linkerd-viz/templates/psp.yaml
+++ b/viz/charts/linkerd-viz/templates/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: viz-psp
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     namespace: {{.Values.namespace}}
 roleRef:
   kind: Role

--- a/viz/charts/linkerd-viz/templates/psp.yaml
+++ b/viz/charts/linkerd-viz/templates/psp.yaml
@@ -2,29 +2,29 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     namespace: {{.Values.namespace}}
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 {{ if .Values.grafana.enabled -}}
 - kind: ServiceAccount
-  name: linkerd-grafana
+  name: grafana
   namespace: {{.Values.namespace}}
 {{ end -}}
 {{ if .Values.prometheus.enabled -}}
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: {{.Values.namespace}}
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -56,7 +56,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   {{- if .Values.tapInjector.namespaceSelector }}

--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -18,7 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -56,7 +56,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
 webhooks:
 - name: tap-injector.linkerd.io
   {{- if .Values.tapInjector.namespaceSelector }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -8,7 +8,7 @@ metadata:
   name: tap-injector
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     {{ include "partials.annotations.created-by" . }}
@@ -27,7 +27,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -55,7 +55,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: tap-injector
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -8,7 +8,7 @@ metadata:
   name: tap-injector
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap-injector
   annotations:
     {{ include "partials.annotations.created-by" . }}
@@ -27,7 +27,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -55,7 +55,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: tap-injector
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
@@ -70,7 +70,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.{{.Values.namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.{{.Values.namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level={{.Values.tapInjector.logLevel | default .Values.defaultLogLevel}}
         image: {{.Values.tapInjector.image.registry | default .Values.defaultRegistry}}/{{.Values.tapInjector.image.name}}:{{.Values.tapInjector.image.tag | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.tapInjector.image.pullPolicy | default .Values.defaultImagePullPolicy}}

--- a/viz/charts/linkerd-viz/templates/tap-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap-admin
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -37,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-tap-auth-delegator
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -70,7 +70,7 @@ metadata:
   name: tap
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
@@ -81,7 +81,7 @@ metadata:
   name: linkerd-{{.Values.namespace}}-tap-auth-reader
   namespace: kube-system
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
     namespace: {{.Values.namespace}}
 roleRef:
@@ -102,7 +102,7 @@ metadata:
   name: tap-k8s-tls
   namespace: {{ .Values.namespace }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
     namespace: {{.Values.namespace}}
   annotations:
@@ -118,7 +118,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io

--- a/viz/charts/linkerd-viz/templates/tap-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -37,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,7 +45,7 @@ roleRef:
   name: linkerd-{{.Values.namespace}}-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -53,7 +53,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -61,16 +61,16 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
@@ -81,7 +81,7 @@ metadata:
   name: linkerd-{{.Values.namespace}}-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
     namespace: {{.Values.namespace}}
 roleRef:
@@ -90,19 +90,19 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
 ---
-{{- $host := printf "linkerd-tap.%s.svc" .Values.namespace }}
+{{- $host := printf "tap.%s.svc" .Values.namespace }}
 {{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.tap.externalSecret) }}
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: {{ .Values.namespace }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
     namespace: {{.Values.namespace}}
   annotations:
@@ -118,7 +118,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -126,7 +126,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: {{.Values.namespace}}
 {{- if and (.Values.tap.externalSecret) (empty .Values.tap.caBundle) }}
   {{- fail "If tap.externalSecret is true then you need to provide tap.caBundle" }}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -5,10 +5,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
     namespace: {{.Values.namespace}}
   annotations:
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: tap
   ports:
   - name: grpc
@@ -32,19 +32,19 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: tap
     namespace: {{.Values.namespace}}
-  name: linkerd-tap
+  name: tap
   namespace: {{.Values.namespace}}
 spec:
   replicas: {{.Values.tap.replicas}}
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      {{.Values.extensionAnnotation}}: viz
       component: tap
       namespace: {{.Values.namespace}}
   {{- if .Values.enablePodAntiAffinity }}
@@ -64,7 +64,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: tap
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -112,9 +112,8 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
-
+          secretName: tap-k8s-tls

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -8,7 +8,7 @@ metadata:
   name: tap
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
     namespace: {{.Values.namespace}}
   annotations:
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -32,7 +32,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -44,7 +44,7 @@ spec:
   replicas: {{.Values.tap.replicas}}
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: viz
+      linkerd.io/extension: viz
       component: tap
       namespace: {{.Values.namespace}}
   {{- if .Values.enablePodAntiAffinity }}
@@ -64,7 +64,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: tap
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -35,7 +35,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: tap
     namespace: {{.Values.namespace}}
   name: tap

--- a/viz/charts/linkerd-viz/templates/web-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/web-rbac.yaml
@@ -5,10 +5,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: {{.Values.linkerdNamespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
     namespace: {{.Values.linkerdNamespace}}
 rules:
@@ -31,19 +31,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: {{.Values.linkerdNamespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
     namespace: {{.Values.linkerdNamespace}}
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 ---
 {{- if not .Values.dashboard.restrictPrivileges }}
@@ -52,7 +52,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-{{.Values.namespace}}-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -79,7 +79,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -87,7 +87,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 ---
 kind: ClusterRoleBinding
@@ -95,7 +95,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -103,7 +103,7 @@ roleRef:
   name: linkerd-{{.Values.namespace}}-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -111,7 +111,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-{{.Values.namespace}}-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -123,7 +123,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -131,17 +131,17 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 ---
 {{- end}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/web-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/web-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
   name: web
   namespace: {{.Values.linkerdNamespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
     namespace: {{.Values.linkerdNamespace}}
 rules:
@@ -34,7 +34,7 @@ metadata:
   name: web
   namespace: {{.Values.linkerdNamespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
     namespace: {{.Values.linkerdNamespace}}
 roleRef:
@@ -52,7 +52,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-{{.Values.namespace}}-web-check
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -79,7 +79,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-web-check
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -95,7 +95,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-{{.Values.namespace}}-web-admin
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111,7 +111,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-{{.Values.namespace}}-web-api
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -123,7 +123,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-{{.Values.namespace}}-web-api
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -141,7 +141,7 @@ metadata:
   name: web
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
     namespace: {{.Values.namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -5,10 +5,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
     namespace: {{.Values.namespace}}
   annotations:
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     component: web
   ports:
   - name: http
@@ -32,19 +32,19 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    linkerd.io/extension: linkerd-viz
+    {{.Values.extensionAnnotation}}: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     component: web
     namespace: {{.Values.namespace}}
-  name: linkerd-web
+  name: web
   namespace: {{.Values.namespace}}
 spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      {{.Values.extensionAnnotation}}: viz
       component: web
       namespace: {{.Values.namespace}}
   template:
@@ -56,7 +56,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        linkerd.io/extension: linkerd-viz
+        {{.Values.extensionAnnotation}}: viz
         component: web
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -68,12 +68,12 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.{{.Values.linkerdNamespace}}.svc.{{.Values.clusterDomain}}:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:8085
+        - -linkerd-metrics-api-addr=metrics-api.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:8085
         - -cluster-domain={{.Values.clusterDomain}}
         {{- if .Values.grafanaUrl }}
         - -grafana-addr={{.Values.grafanaUrl}}
         {{- else if .Values.grafana.enabled }}
-        - -grafana-addr=linkerd-grafana.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:3000
+        - -grafana-addr=grafana.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:3000
         {{- end}}
         {{- if .Values.jaegerUrl }}
         - -jaeger-addr={{.Values.jaegerUrl}}
@@ -84,8 +84,8 @@ spec:
         {{- if .Values.dashboard.enforcedHostRegexp }}
         - -enforced-host={{.Values.dashboard.enforcedHostRegexp}}
         {{- else -}}
-        {{- $hostFull := replace "." "\\." (printf "linkerd-web.%s.svc.%s" .Values.namespace .Values.clusterDomain) }}
-        {{- $hostAbbrev := replace "." "\\." (printf "linkerd-web.%s.svc" .Values.namespace) }}
+        {{- $hostFull := replace "." "\\." (printf "web.%s.svc.%s" .Values.namespace .Values.clusterDomain) }}
+        {{- $hostAbbrev := replace "." "\\." (printf "web.%s.svc" .Values.namespace) }}
         - -enforced-host=^(localhost|127\.0\.0\.1|{{ $hostFull }}|{{ $hostAbbrev }}|\[::1\])(:\d+)?$
         {{- end}}
         image: {{.Values.dashboard.image.registry | default .Values.defaultRegistry}}/{{.Values.dashboard.image.name}}:{{.Values.dashboard.image.tag | default .Values.linkerdVersion}}
@@ -111,4 +111,4 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.dashboard.UID | default .Values.defaultUID}}
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -8,7 +8,7 @@ metadata:
   name: web
   namespace: {{.Values.namespace}}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
     namespace: {{.Values.namespace}}
   annotations:
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -32,7 +32,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    {{.Values.extensionAnnotation}}: viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
@@ -44,7 +44,7 @@ spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
     matchLabels:
-      {{.Values.extensionAnnotation}}: viz
+      linkerd.io/extension: viz
       component: web
       namespace: {{.Values.namespace}}
   template:
@@ -56,7 +56,7 @@ spec:
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
-        {{.Values.extensionAnnotation}}: viz
+        linkerd.io/extension: viz
         component: web
         namespace: {{.Values.namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -35,7 +35,7 @@ metadata:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
-    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: web
     namespace: {{.Values.namespace}}
   name: web

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -12,8 +12,6 @@ clusterDomain: cluster.local
 # @default -- clusterDomain
 identityTrustDomain: ""
 
-extensionAnnotation: linkerd.io/extension
-
 # -- Docker registry for all viz components
 defaultRegistry: cr.l5d.io/linkerd
 # -- Docker imagePullPolicy for all viz components

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -12,6 +12,8 @@ clusterDomain: cluster.local
 # @default -- clusterDomain
 identityTrustDomain: ""
 
+extensionAnnotation: linkerd.io/extension
+
 # -- Docker registry for all viz components
 defaultRegistry: cr.l5d.io/linkerd
 # -- Docker imagePullPolicy for all viz components

--- a/viz/cmd/dashboard.go
+++ b/viz/cmd/dashboard.go
@@ -93,7 +93,6 @@ func NewCmdDashboard() *cobra.Command {
 				RetryDeadline:         time.Now().Add(options.wait),
 			}, true)
 
-			fmt.Println("we've hit this")
 			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err

--- a/viz/cmd/dashboard.go
+++ b/viz/cmd/dashboard.go
@@ -26,7 +26,7 @@ const (
 	showURL = "url"
 
 	// webDeployment is the name of the web deployment in cli/install/template.go
-	webDeployment = "linkerd-web"
+	webDeployment = "web"
 
 	// webPort is the http port from the web pod spec in cli/install/template.go
 	webPort = 8084
@@ -93,6 +93,7 @@ func NewCmdDashboard() *cobra.Command {
 				RetryDeadline:         time.Now().Add(options.wait),
 			}, true)
 
+			fmt.Println("we've hit this")
 			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err

--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// ExtensionName is the value that the viz extension resources should be labeled with
-	ExtensionName = "linkerd-viz"
+	ExtensionName = "viz"
 
 	vizChartName            = "linkerd-viz"
 	defaultLinkerdNamespace = "linkerd"

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -7,7 +7,7 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
   annotations:
     linkerd.io/inject: enabled
 ---
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -43,7 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,16 +51,16 @@ roleRef:
   name: linkerd-linkerd-viz-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 ---
 ###
@@ -69,10 +69,10 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
 ---
@@ -84,7 +84,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -96,7 +96,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -104,16 +104,16 @@ roleRef:
   name: linkerd-linkerd-viz-prometheus
 subjects:
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
 ---
@@ -125,7 +125,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -143,7 +143,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -155,7 +155,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -171,7 +171,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,7 +188,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 ---
@@ -198,7 +198,7 @@ metadata:
   name: linkerd-linkerd-viz-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 roleRef:
@@ -213,10 +213,10 @@ subjects:
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -231,7 +231,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -249,10 +249,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 rules:
@@ -273,19 +273,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -293,7 +293,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -320,7 +320,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -328,7 +328,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ClusterRoleBinding
@@ -336,7 +336,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -344,7 +344,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -352,7 +352,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -364,7 +364,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -372,26 +372,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     namespace: linkerd-viz
 roleRef:
   kind: Role
@@ -402,13 +402,13 @@ subjects:
   name: linkerd-tap
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 ###
@@ -417,17 +417,17 @@ subjects:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -440,18 +440,18 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -459,7 +459,7 @@ spec:
         checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -469,7 +469,7 @@ spec:
         - -controller-namespace=linkerd
         - -log-level=info
         - -cluster-domain=cluster.local
-        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -491,7 +491,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api
 ---
 ###
 ### Grafana
@@ -499,17 +499,17 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-grafana-config
+  name: grafana-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 data:
   grafana.ini: |-
-    instance_name = linkerd-grafana
+    instance_name = grafana
     [server]
     root_url = %(protocol)s://%(domain)s:/grafana/
     [auth]
@@ -530,7 +530,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+      url: http://prometheus.linkerd-viz.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -553,10 +553,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
@@ -564,7 +564,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
   ports:
   - name: http
@@ -577,19 +577,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: grafana
     namespace: linkerd-viz
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -597,7 +597,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -635,7 +635,7 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: true
-      serviceAccountName: linkerd-grafana
+      serviceAccountName: grafana
       volumes:
       - emptyDir: {}
         name: data
@@ -647,7 +647,7 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: linkerd-grafana-config
+          name: grafana-config
         name: grafana-config
 ---
 ###
@@ -656,10 +656,10 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus-config
+  name: prometheus-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -801,10 +801,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -812,7 +812,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -825,19 +825,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: prometheus
     namespace: linkerd-viz
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -845,7 +845,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -889,12 +889,12 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
-      serviceAccountName: linkerd-prometheus
+      serviceAccountName: prometheus
       volumes:
       - name: data
         emptyDir: {}
       - configMap:
-          name: linkerd-prometheus-config
+          name: prometheus-config
         name: prometheus-config
 ---
 ###
@@ -906,7 +906,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -914,7 +914,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -930,7 +930,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
@@ -942,7 +942,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
@@ -951,7 +951,7 @@ spec:
         checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -994,7 +994,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
+          secretName: tap-k8s-tls
 
 ---
 ###
@@ -1005,7 +1005,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -1016,7 +1016,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -1049,7 +1049,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   clientConfig:
@@ -1077,7 +1077,7 @@ metadata:
   name: tap-injector
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
@@ -1096,7 +1096,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -1113,7 +1113,7 @@ spec:
         checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -1160,10 +1160,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
   annotations:
@@ -1171,7 +1171,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -1187,19 +1187,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: web
     namespace: linkerd-viz
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1207,7 +1207,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -1216,13 +1216,13 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
-        - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
+        - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
-        - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
+        - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1244,4 +1244,4 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -163,7 +163,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -179,13 +179,13 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -207,7 +207,7 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: Secret
@@ -239,7 +239,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: linkerd-viz
   caBundle: dGVzdC10YXAtY2EtYnVuZGxl
 ---
@@ -395,11 +395,11 @@ metadata:
     namespace: linkerd-viz
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: web
@@ -451,15 +451,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
       annotations:
-        checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
+        checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -589,7 +589,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -597,7 +597,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -837,7 +837,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -845,7 +845,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -903,7 +903,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -936,22 +936,22 @@ metadata:
     app.kubernetes.io/version: dev-undefined
     component: tap
     namespace: linkerd-viz
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
     metadata:
       annotations:
-        checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
+        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -990,12 +990,11 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-
 ---
 ###
 ### Tap Injector RBAC
@@ -1110,10 +1109,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
+        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -1121,7 +1120,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1199,7 +1198,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1207,7 +1206,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -395,7 +395,7 @@ metadata:
     namespace: linkerd-viz
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
@@ -456,10 +456,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
+        checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -589,7 +589,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -597,7 +597,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -837,7 +837,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -845,7 +845,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -942,16 +942,16 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
     metadata:
       annotations:
-        checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
+        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -995,7 +995,6 @@ spec:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-
 ---
 ###
 ### Tap Injector RBAC
@@ -1110,10 +1109,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
+        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -1199,7 +1198,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1207,7 +1206,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -1216,7 +1215,7 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
         - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -7,7 +7,7 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
   annotations:
     linkerd.io/inject: enabled
 ---
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -43,7 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,16 +51,16 @@ roleRef:
   name: linkerd-linkerd-viz-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 ---
 ###
@@ -69,10 +69,10 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
 ---
@@ -84,7 +84,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -96,7 +96,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -104,16 +104,16 @@ roleRef:
   name: linkerd-linkerd-viz-prometheus
 subjects:
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
 ---
@@ -125,7 +125,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -143,7 +143,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -155,7 +155,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -163,7 +163,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -171,7 +171,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -179,16 +179,16 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 ---
@@ -198,7 +198,7 @@ metadata:
   name: linkerd-linkerd-viz-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 roleRef:
@@ -207,16 +207,16 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -231,7 +231,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -239,7 +239,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: linkerd-viz
   caBundle: dGVzdC10YXAtY2EtYnVuZGxl
 ---
@@ -249,10 +249,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 rules:
@@ -273,19 +273,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -293,7 +293,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -320,7 +320,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -328,7 +328,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ClusterRoleBinding
@@ -336,7 +336,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -344,7 +344,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -352,7 +352,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -364,7 +364,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -372,26 +372,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     namespace: linkerd-viz
 roleRef:
   kind: Role
@@ -399,16 +399,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 ###
@@ -417,17 +417,17 @@ subjects:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -440,18 +440,18 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -459,7 +459,7 @@ spec:
         checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -469,7 +469,7 @@ spec:
         - -controller-namespace=linkerd
         - -log-level=debug
         - -cluster-domain=cluster.local
-        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: gcr.io/linkerd/metrics-api:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -491,7 +491,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 1234
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api
 ---
 ###
 ### Grafana
@@ -499,17 +499,17 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-grafana-config
+  name: grafana-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 data:
   grafana.ini: |-
-    instance_name = linkerd-grafana
+    instance_name = grafana
     [server]
     root_url = %(protocol)s://%(domain)s:/grafana/
     [auth]
@@ -530,7 +530,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+      url: http://prometheus.linkerd-viz.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -553,10 +553,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
@@ -564,7 +564,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
   ports:
   - name: http
@@ -577,19 +577,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: grafana
     namespace: linkerd-viz
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -597,7 +597,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -635,7 +635,7 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: true
-      serviceAccountName: linkerd-grafana
+      serviceAccountName: grafana
       volumes:
       - emptyDir: {}
         name: data
@@ -647,7 +647,7 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: linkerd-grafana-config
+          name: grafana-config
         name: grafana-config
 ---
 ###
@@ -656,10 +656,10 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus-config
+  name: prometheus-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -801,10 +801,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -812,7 +812,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -825,19 +825,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: prometheus
     namespace: linkerd-viz
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -845,7 +845,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -889,12 +889,12 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
-      serviceAccountName: linkerd-prometheus
+      serviceAccountName: prometheus
       volumes:
       - name: data
         emptyDir: {}
       - configMap:
-          name: linkerd-prometheus-config
+          name: prometheus-config
         name: prometheus-config
 ---
 ###
@@ -903,10 +903,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -914,7 +914,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -930,19 +930,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: tap
     namespace: linkerd-viz
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
@@ -951,7 +951,7 @@ spec:
         checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -990,11 +990,11 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
+          secretName: tap-k8s-tls
 
 ---
 ###
@@ -1005,7 +1005,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -1016,7 +1016,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -1049,7 +1049,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   clientConfig:
@@ -1077,7 +1077,7 @@ metadata:
   name: tap-injector
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
@@ -1096,7 +1096,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -1113,7 +1113,7 @@ spec:
         checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -1121,7 +1121,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=debug
         image: gcr.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1160,10 +1160,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
   annotations:
@@ -1171,7 +1171,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -1187,19 +1187,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: web
     namespace: linkerd-viz
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1207,7 +1207,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -1216,13 +1216,13 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
-        - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
+        - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=debug
-        - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
+        - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: gcr.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1244,4 +1244,4 @@ spec:
         resources:
         securityContext:
           runAsUser: 1234
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -150,7 +150,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -166,13 +166,13 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -194,7 +194,7 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: Secret
@@ -226,7 +226,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: linkerd-viz
   caBundle: dGVzdC10YXAtY2EtYnVuZGxl
 ---
@@ -382,11 +382,11 @@ metadata:
     namespace: linkerd-viz
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: web
@@ -435,15 +435,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
       annotations:
-        checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
+        checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -655,7 +655,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -663,7 +663,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -721,7 +721,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -754,22 +754,22 @@ metadata:
     app.kubernetes.io/version: dev-undefined
     component: tap
     namespace: linkerd-viz
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
     metadata:
       annotations:
-        checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
+        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -808,12 +808,11 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-
 ---
 ###
 ### Tap Injector RBAC
@@ -928,10 +927,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
+        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -939,7 +938,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1017,7 +1016,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1025,7 +1024,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -7,7 +7,7 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
   annotations:
     linkerd.io/inject: enabled
 ---
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -43,7 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,16 +51,16 @@ roleRef:
   name: linkerd-linkerd-viz-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 ---
 ###
@@ -71,7 +71,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -83,7 +83,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -91,16 +91,16 @@ roleRef:
   name: linkerd-linkerd-viz-prometheus
 subjects:
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
 ---
@@ -112,7 +112,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -130,7 +130,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -142,7 +142,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -158,7 +158,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -175,7 +175,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 ---
@@ -185,7 +185,7 @@ metadata:
   name: linkerd-linkerd-viz-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 roleRef:
@@ -200,10 +200,10 @@ subjects:
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -218,7 +218,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -236,10 +236,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 rules:
@@ -260,19 +260,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -280,7 +280,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -307,7 +307,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -315,7 +315,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ClusterRoleBinding
@@ -323,7 +323,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -331,7 +331,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -339,7 +339,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -351,7 +351,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -359,26 +359,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     namespace: linkerd-viz
 roleRef:
   kind: Role
@@ -389,10 +389,10 @@ subjects:
   name: linkerd-tap
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 ###
@@ -401,17 +401,17 @@ subjects:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -424,18 +424,18 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -443,7 +443,7 @@ spec:
         checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -453,7 +453,7 @@ spec:
         - -controller-namespace=linkerd
         - -log-level=info
         - -cluster-domain=cluster.local
-        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -475,7 +475,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api
 ---
 ###
 ### Prometheus
@@ -483,10 +483,10 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus-config
+  name: prometheus-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -619,10 +619,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -630,7 +630,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -643,19 +643,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: prometheus
     namespace: linkerd-viz
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -663,7 +663,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -707,12 +707,12 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
-      serviceAccountName: linkerd-prometheus
+      serviceAccountName: prometheus
       volumes:
       - name: data
         emptyDir: {}
       - configMap:
-          name: linkerd-prometheus-config
+          name: prometheus-config
         name: prometheus-config
 ---
 ###
@@ -724,7 +724,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -732,7 +732,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -748,7 +748,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
@@ -760,7 +760,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
@@ -769,7 +769,7 @@ spec:
         checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -812,7 +812,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
+          secretName: tap-k8s-tls
 
 ---
 ###
@@ -823,7 +823,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -834,7 +834,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -867,7 +867,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   clientConfig:
@@ -895,7 +895,7 @@ metadata:
   name: tap-injector
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
@@ -914,7 +914,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -931,7 +931,7 @@ spec:
         checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -978,10 +978,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
   annotations:
@@ -989,7 +989,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -1005,19 +1005,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: web
     namespace: linkerd-viz
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1025,7 +1025,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -1034,13 +1034,13 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
         - -grafana-addr=external-grafana.com
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
-        - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
+        - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1062,4 +1062,4 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -7,7 +7,7 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
   annotations:
     viz.linkerd.io/external-prometheus: external-prom.com
     linkerd.io/inject: enabled
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -44,7 +44,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52,16 +52,16 @@ roleRef:
   name: linkerd-linkerd-viz-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 ---
 ###
@@ -70,10 +70,10 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
 ---
@@ -85,7 +85,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -103,7 +103,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -115,7 +115,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -131,7 +131,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,7 +148,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 ---
@@ -158,7 +158,7 @@ metadata:
   name: linkerd-linkerd-viz-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 roleRef:
@@ -173,10 +173,10 @@ subjects:
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -191,7 +191,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -209,10 +209,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 rules:
@@ -233,19 +233,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -253,7 +253,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -280,7 +280,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -288,7 +288,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ClusterRoleBinding
@@ -296,7 +296,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -304,7 +304,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -312,7 +312,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -324,7 +324,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -332,26 +332,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     namespace: linkerd-viz
 roleRef:
   kind: Role
@@ -362,10 +362,10 @@ subjects:
   name: linkerd-tap
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 ---
 ###
@@ -374,17 +374,17 @@ subjects:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -397,18 +397,18 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -416,7 +416,7 @@ spec:
         checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -448,7 +448,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api
 ---
 ###
 ### Grafana
@@ -456,17 +456,17 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-grafana-config
+  name: grafana-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 data:
   grafana.ini: |-
-    instance_name = linkerd-grafana
+    instance_name = grafana
     [server]
     root_url = %(protocol)s://%(domain)s:/grafana/
     [auth]
@@ -510,10 +510,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
@@ -521,7 +521,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
   ports:
   - name: http
@@ -534,19 +534,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: grafana
     namespace: linkerd-viz
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -554,7 +554,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -592,7 +592,7 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: true
-      serviceAccountName: linkerd-grafana
+      serviceAccountName: grafana
       volumes:
       - emptyDir: {}
         name: data
@@ -604,7 +604,7 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: linkerd-grafana-config
+          name: grafana-config
         name: grafana-config
 ---
 ###
@@ -616,7 +616,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -624,7 +624,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -640,7 +640,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
@@ -652,7 +652,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
@@ -661,7 +661,7 @@ spec:
         checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -704,7 +704,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
+          secretName: tap-k8s-tls
 
 ---
 ###
@@ -715,7 +715,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -726,7 +726,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -759,7 +759,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   clientConfig:
@@ -787,7 +787,7 @@ metadata:
   name: tap-injector
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
@@ -806,7 +806,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -823,7 +823,7 @@ spec:
         checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -870,10 +870,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
   annotations:
@@ -881,7 +881,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -897,19 +897,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: web
     namespace: linkerd-viz
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+     linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -917,7 +917,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+       linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -926,13 +926,13 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
-        - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
+        - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
-        - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
+        - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -954,4 +954,4 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -123,7 +123,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -139,13 +139,13 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -167,7 +167,7 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: Secret
@@ -199,7 +199,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: linkerd-viz
   caBundle: dGVzdC10YXAtY2EtYnVuZGxl
 ---
@@ -355,11 +355,11 @@ metadata:
     namespace: linkerd-viz
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: web
@@ -408,15 +408,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
       annotations:
-        checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
+        checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -546,7 +546,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -554,7 +554,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -613,7 +613,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -646,22 +646,22 @@ metadata:
     app.kubernetes.io/version: dev-undefined
     component: tap
     namespace: linkerd-viz
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
     metadata:
       annotations:
-        checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
+        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -700,12 +700,11 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-
 ---
 ###
 ### Tap Injector RBAC
@@ -820,10 +819,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
+        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -831,7 +830,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -909,7 +908,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-     linkerd.io/extension: viz
+      linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -917,7 +916,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-       linkerd.io/extension: viz
+        linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -7,7 +7,7 @@ apiVersion: v1
 metadata:
   name: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
   annotations:
     linkerd.io/inject: enabled
 ---
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 rules:
 - apiGroups: ["extensions", "apps"]
@@ -43,7 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-metrics-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51,16 +51,16 @@ roleRef:
   name: linkerd-linkerd-viz-metrics-api
 subjects:
 - kind: ServiceAccount
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
 ---
 ###
@@ -69,10 +69,10 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
 ---
@@ -84,7 +84,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 rules:
 - apiGroups: [""]
@@ -96,7 +96,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-prometheus
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -104,16 +104,16 @@ roleRef:
   name: linkerd-linkerd-viz-prometheus
 subjects:
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
 ---
@@ -125,7 +125,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: [""]
@@ -143,7 +143,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 rules:
 - apiGroups: ["tap.linkerd.io"]
@@ -155,7 +155,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-tap
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -171,7 +171,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-tap-auth-delegator
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,7 +188,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 ---
@@ -198,7 +198,7 @@ metadata:
   name: linkerd-linkerd-viz-tap-auth-reader
   namespace: kube-system
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
 roleRef:
@@ -213,10 +213,10 @@ subjects:
 kind: Secret
 apiVersion: v1
 metadata:
-  name: linkerd-tap-k8s-tls
+  name: tap-k8s-tls
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -231,7 +231,7 @@ kind: APIService
 metadata:
   name: v1alpha1.tap.linkerd.io
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
 spec:
   group: tap.linkerd.io
@@ -249,10 +249,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 rules:
@@ -273,19 +273,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd
 roleRef:
   kind: Role
-  name: linkerd-web
+  name: web
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -293,7 +293,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
@@ -320,7 +320,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-check
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -328,7 +328,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ClusterRoleBinding
@@ -336,7 +336,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-linkerd-viz-web-admin
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -344,7 +344,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap-admin
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -352,7 +352,7 @@ kind: ClusterRole
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 rules:
 - apiGroups: [""]
@@ -364,7 +364,7 @@ kind: ClusterRoleBinding
 metadata:
   name: linkerd-linkerd-viz-web-api
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
@@ -372,26 +372,26 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-viz-psp
+  name: viz-psp
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     namespace: linkerd-viz
 roleRef:
   kind: Role
@@ -402,13 +402,13 @@ subjects:
   name: linkerd-tap
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 - kind: ServiceAccount
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 ---
 ###
@@ -417,17 +417,17 @@ subjects:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: metrics-api
   ports:
   - name: http
@@ -440,18 +440,18 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: metrics-api
-  name: linkerd-metrics-api
+  name: metrics-api
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: metrics-api
   template:
     metadata:
@@ -459,7 +459,7 @@ spec:
         checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: metrics-api
     spec:
       nodeSelector:
@@ -469,7 +469,7 @@ spec:
         - -controller-namespace=linkerd
         - -log-level=info
         - -cluster-domain=cluster.local
-        - -prometheus-url=http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+        - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -491,7 +491,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-metrics-api
+      serviceAccountName: metrics-api
 ---
 ###
 ### Grafana
@@ -499,17 +499,17 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-grafana-config
+  name: grafana-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 data:
   grafana.ini: |-
-    instance_name = linkerd-grafana
+    instance_name = grafana
     [server]
     root_url = %(protocol)s://%(domain)s:/grafana/
     [auth]
@@ -530,7 +530,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://linkerd-prometheus.linkerd-viz.svc.cluster.local:9090
+      url: http://prometheus.linkerd-viz.svc.cluster.local:9090
       isDefault: true
       jsonData:
         timeInterval: "5s"
@@ -553,10 +553,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
     namespace: linkerd-viz
   annotations:
@@ -564,7 +564,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: grafana
   ports:
   - name: http
@@ -577,19 +577,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: grafana
     namespace: linkerd-viz
-  name: linkerd-grafana
+  name: grafana
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: grafana
       namespace: linkerd-viz
   template:
@@ -601,7 +601,7 @@ spec:
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: grafana
         namespace: linkerd-viz
     spec:
@@ -639,7 +639,7 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: true
-      serviceAccountName: linkerd-grafana
+      serviceAccountName: grafana
       volumes:
       - emptyDir: {}
         name: data
@@ -651,7 +651,7 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: linkerd-grafana-config
+          name: grafana-config
         name: grafana-config
 ---
 ###
@@ -660,10 +660,10 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus-config
+  name: prometheus-config
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -805,10 +805,10 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
     namespace: linkerd-viz
   annotations:
@@ -816,7 +816,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: prometheus
   ports:
   - name: admin-http
@@ -829,19 +829,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: prometheus
     namespace: linkerd-viz
-  name: linkerd-prometheus
+  name: prometheus
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: prometheus
       namespace: linkerd-viz
   template:
@@ -853,7 +853,7 @@ spec:
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: prometheus
         namespace: linkerd-viz
     spec:
@@ -897,12 +897,12 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
-      serviceAccountName: linkerd-prometheus
+      serviceAccountName: prometheus
       volumes:
       - name: data
         emptyDir: {}
       - configMap:
-          name: linkerd-prometheus-config
+          name: prometheus-config
         name: prometheus-config
 ---
 ###
@@ -914,7 +914,7 @@ metadata:
   name: linkerd-tap
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
     namespace: linkerd-viz
   annotations:
@@ -922,7 +922,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap
   ports:
   - name: grpc
@@ -938,7 +938,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
@@ -950,7 +950,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: tap
       namespace: linkerd-viz
   template:
@@ -963,7 +963,7 @@ spec:
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: tap
         namespace: linkerd-viz
     spec:
@@ -1006,7 +1006,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: linkerd-tap-k8s-tls
+          secretName: tap-k8s-tls
 
 ---
 ###
@@ -1017,7 +1017,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -1028,7 +1028,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-tap-injector
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 subjects:
 - kind: ServiceAccount
   name: tap-injector
@@ -1061,7 +1061,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: linkerd-tap-injector-webhook-config
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
 webhooks:
 - name: tap-injector.linkerd.io
   clientConfig:
@@ -1089,7 +1089,7 @@ metadata:
   name: tap-injector
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
@@ -1108,7 +1108,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
@@ -1125,7 +1125,7 @@ spec:
         checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: tap-injector
     spec:
       nodeSelector:
@@ -1172,10 +1172,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
     namespace: linkerd-viz
   annotations:
@@ -1183,7 +1183,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     component: web
   ports:
   - name: http
@@ -1199,19 +1199,19 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
   labels:
-    linkerd.io/extension: linkerd-viz
+    linkerd.io/extension: viz
     app.kubernetes.io/name: web
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: dev-undefined
     component: web
     namespace: linkerd-viz
-  name: linkerd-web
+  name: web
   namespace: linkerd-viz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: linkerd-viz
+      linkerd.io/extension: viz
       component: web
       namespace: linkerd-viz
   template:
@@ -1223,7 +1223,7 @@ spec:
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
       labels:
-        linkerd.io/extension: linkerd-viz
+        linkerd.io/extension: viz
         component: web
         namespace: linkerd-viz
     spec:
@@ -1232,13 +1232,13 @@ spec:
       containers:
       - args:
         - -linkerd-controller-api-addr=linkerd-controller-api.linkerd.svc.cluster.local:8085
-        - -linkerd-metrics-api-addr=linkerd-metrics-api.linkerd-viz.svc.cluster.local:8085
+        - -linkerd-metrics-api-addr=metrics-api.linkerd-viz.svc.cluster.local:8085
         - -cluster-domain=cluster.local
-        - -grafana-addr=linkerd-grafana.linkerd-viz.svc.cluster.local:3000
+        - -grafana-addr=grafana.linkerd-viz.svc.cluster.local:3000
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
-        - -enforced-host=^(localhost|127\.0\.0\.1|linkerd-web\.linkerd-viz\.svc\.cluster\.local|linkerd-web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
+        - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1260,4 +1260,4 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
-      serviceAccountName: linkerd-web
+      serviceAccountName: web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -163,7 +163,7 @@ roleRef:
   name: linkerd-linkerd-viz-tap
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -179,13 +179,13 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -207,7 +207,7 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 ---
 kind: Secret
@@ -239,7 +239,7 @@ spec:
   groupPriorityMinimum: 1000
   versionPriority: 100
   service:
-    name: linkerd-tap
+    name: tap
     namespace: linkerd-viz
   caBundle: dGVzdC10YXAtY2EtYnVuZGxl
 ---
@@ -395,11 +395,11 @@ metadata:
     namespace: linkerd-viz
 roleRef:
   kind: Role
-  name: linkerd-psp
+  name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: web
@@ -456,7 +456,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6827b2203b1cd90692d9dd6a973a2162e574dc9fd7b5b9e346ceac7e287204a6
+        checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz
@@ -911,7 +911,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
@@ -944,7 +944,7 @@ metadata:
     app.kubernetes.io/version: dev-undefined
     component: tap
     namespace: linkerd-viz
-  name: linkerd-tap
+  name: tap
   namespace: linkerd-viz
 spec:
   replicas: 1
@@ -956,7 +956,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bbc82b03e8c9fdc549e1ef5d3f795c07c21fb3b4c089351186f170b722689d86
+        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
         linkerd.io/created-by: linkerd/helm dev-undefined
         config.linkerd.io/proxy-cpu-request: "500m"
         config.linkerd.io/proxy-cpu-limit: "100m"
@@ -1002,12 +1002,11 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
-      serviceAccountName: linkerd-tap
+      serviceAccountName: tap
       volumes:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-
 ---
 ###
 ### Tap Injector RBAC
@@ -1122,7 +1121,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0120b5feafdef04a057ab39fd63ed315ebbcc2bfc0b0657e3007fa34ffb8b7e2
+        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz
@@ -1133,7 +1132,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=linkerd-tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level=info
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/metrics-api/client/client.go
+++ b/viz/metrics-api/client/client.go
@@ -28,7 +28,7 @@ const (
 	APIPrefix = "api/" + apiVersion + "/"
 
 	apiPort       = 8085
-	apiDeployment = "linkerd-metrics-api"
+	apiDeployment = "metrics-api"
 )
 
 type grpcOverHTTPClient struct {

--- a/viz/metrics-api/util/api_utils_test.go
+++ b/viz/metrics-api/util/api_utils_test.go
@@ -65,8 +65,8 @@ func TestBuildStatSummaryRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration \"1\"",
-			"s": "time: invalid duration \"s\"",
+			"1": "time: missing unit in duration 1",
+			"s": "time: invalid duration s",
 		}
 
 		for timeWindow, msg := range expectations {
@@ -138,8 +138,8 @@ func TestBuildTopRoutesRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration \"1\"",
-			"s": "time: invalid duration \"s\"",
+			"1": "time: missing unit in duration 1",
+			"s": "time: invalid duration s",
 		}
 
 		for timeWindow, msg := range expectations {

--- a/viz/metrics-api/util/api_utils_test.go
+++ b/viz/metrics-api/util/api_utils_test.go
@@ -65,8 +65,8 @@ func TestBuildStatSummaryRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {
@@ -138,8 +138,8 @@ func TestBuildTopRoutesRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// VizExtensionName is the name of the viz extension
-	VizExtensionName = "linkerd-viz"
+	VizExtensionName = "viz"
 
 	// LinkerdVizExtensionCheck adds checks related to the Linkerd Viz extension
 	LinkerdVizExtensionCheck healthcheck.CategoryID = "linkerd-viz"
@@ -28,7 +28,7 @@ const (
 	// LinkerdVizExtensionDataPlaneCheck adds checks related to dataplane for the linkerd-viz extension
 	LinkerdVizExtensionDataPlaneCheck healthcheck.CategoryID = "linkerd-viz-data-plane"
 
-	tapTLSSecretName    = "linkerd-tap-k8s-tls"
+	tapTLSSecretName    = "tap-k8s-tls"
 	tapOldTLSSecretName = "linkerd-tap-tls"
 
 	// linkerdTapAPIServiceName is the name of the tap api service
@@ -74,7 +74,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 			WithHintAnchor("l5d-viz-ns-exists").
 			Fatal().
 			WithCheck(func(ctx context.Context) error {
-				vizNs, err := hc.KubeAPIClient().GetNamespaceWithExtensionLabel(ctx, "linkerd-viz")
+				vizNs, err := hc.KubeAPIClient().GetNamespaceWithExtensionLabel(ctx, "viz")
 				if err != nil {
 					return err
 				}
@@ -113,7 +113,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 					return err
 				}
 
-				identityName := fmt.Sprintf("linkerd-tap.%s.svc", hc.vizNamespace)
+				identityName := fmt.Sprintf("tap.%s.svc", hc.vizNamespace)
 				return hc.CheckCertAndAnchors(cert, anchors, identityName)
 			}),
 		*healthcheck.NewChecker("tap API server cert is valid for at least 60 days").
@@ -158,7 +158,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 				}
 
 				// Check for relevant pods to be present
-				err = healthcheck.CheckForPods(pods, []string{"linkerd-web", "linkerd-tap", "linkerd-metrics-api", "tap-injector"})
+				err = healthcheck.CheckForPods(pods, []string{"web", "tap", "metrics-api", "tap-injector"})
 				if err != nil {
 					return err
 				}
@@ -170,7 +170,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 			Warning().
 			WithCheck(func(ctx context.Context) error {
 				if hc.externalPrometheusURL != "" {
-					return &healthcheck.SkipError{Reason: "linkerd-prometheus is disabled"}
+					return &healthcheck.SkipError{Reason: "prometheus is disabled"}
 				}
 
 				// Check for ClusterRoles
@@ -186,7 +186,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 				}
 
 				// Check for ConfigMap
-				err = healthcheck.CheckConfigMaps(ctx, hc.KubeAPIClient(), hc.vizNamespace, true, []string{"linkerd-prometheus-config"}, "")
+				err = healthcheck.CheckConfigMaps(ctx, hc.KubeAPIClient(), hc.vizNamespace, true, []string{"prometheus-config"}, "")
 				if err != nil {
 					return err
 				}
@@ -197,7 +197,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 					return err
 				}
 
-				err = healthcheck.CheckForPods(pods, []string{"linkerd-prometheus"})
+				err = healthcheck.CheckForPods(pods, []string{"prometheus"})
 				if err != nil {
 					return err
 				}

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -44,7 +44,7 @@ import { withStyles } from '@material-ui/core/styles';
 import yellow from '@material-ui/core/colors/yellow';
 
 const jsonFeedUrl = 'https://linkerd.io/dashboard/index.json';
-const multiclusterExtensionName = 'linkerd-multicluster';
+const multiclusterExtensionName = 'multicluster';
 const localStorageKey = 'linkerd-updates-last-clicked';
 const minBrowserWidth = 960;
 

--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -58,13 +58,13 @@ const getPodClassification = pod => {
 
 const componentsToDeployNames = {
   Destination: 'linkerd-controller',
-  Grafana: 'linkerd-grafana',
+  Grafana: 'grafana',
   Identity: 'linkerd-identity',
-  Prometheus: 'linkerd-prometheus',
+  Prometheus: 'prometheus',
   'Public API': 'linkerd-controller',
   'Service Profile Validator': 'linkerd-sp-validator',
   Tap: 'linkerd-tap',
-  'Web UI': 'linkerd-web',
+  'Web UI': 'web',
 };
 
 class ServiceMesh extends React.Component {

--- a/web/main.go
+++ b/web/main.go
@@ -98,7 +98,7 @@ func main() {
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	if *traceCollector != "" {
-		if err := trace.InitializeTracing("linkerd-web", *traceCollector); err != nil {
+		if err := trace.InitializeTracing("web", *traceCollector); err != nil {
 			log.Warnf("failed to initialize tracing: %s", err)
 		}
 	}


### PR DESCRIPTION
This change removes the `linkerd-` prefix on all non-cluster resources
in the jaeger and viz linkerd extensions. Removing the prefix makes all
linkerd extensions consistent in their naming.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>