### PR TITLE
cni: add ConfigureFirewall error propagation

### DIFF
--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -238,7 +238,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 				return err
 			}
 
-			if err := iptables.ConfigureFirewall(*firewallConfiguration); err != nil {
+			err = iptables.ConfigureFirewall(*firewallConfiguration)
+			if err != nil {
 				logEntry.Errorf("linkerd-cni: could not configure firewall: %v", err)
 				return err
 			}

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -237,7 +237,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 				logEntry.Errorf("linkerd-cni: could not create a Firewall Configuration from the options: %v", options)
 				return err
 			}
-			iptables.ConfigureFirewall(*firewallConfiguration)
+
+			if err := iptables.ConfigureFirewall(*firewallConfiguration); err != nil {
+				logEntry.Errorf("linkerd-cni: could not configure firewall: %v", err)
+				return err
+			}
 		} else {
 			if containsInitContainer {
 				logEntry.Debug("linkerd-cni: linkerd-init initContainer is present, skipping.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
This change adds error propagation for the CNI's ADD command so that any failures in the `ConfigureFirewall` function to configure the Pod's iptables can be bubbled up to be logged and handled.

Fixes #5809 

Signed-off-by: Frank Gu <frank@voiceflow.com>
