### PR TITLE
Only run deep integration test in ARM 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
       #if: startsWith(github.ref, 'refs/tags/stable')
       env:
         RUN_ARM_TEST: 1
-      run: bin/tests --images skip --skip-cluster-create "$CMD"
+      run: bin/tests --name deep --images skip --skip-cluster-create "$CMD"
     - name: CNI tests
       #if: startsWith(github.ref, 'refs/tags/stable')
       run: |


### PR DESCRIPTION
Cherry-pick of #5796 into the `release/stable-2.9` branch.

> Triggers only the deep test, which should be enough to prove the ARM-images have no issues.