### PR TITLE
Return default opaque ports in the destination service

### DIFF
--- a/controller/api/destination/opaque_ports_adaptor.go
+++ b/controller/api/destination/opaque_ports_adaptor.go
@@ -36,8 +36,6 @@ func (opa *opaquePortsAdaptor) publish() {
 	if opa.profile != nil {
 		merged = *opa.profile
 	}
-	if len(opa.opaquePorts) != 0 {
-		merged.Spec.OpaquePorts = opa.opaquePorts
-	}
+	merged.Spec.OpaquePorts = opa.opaquePorts
 	opa.listener.Update(&merged)
 }

--- a/controller/api/destination/watcher/opaque_ports_watcher_test.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher_test.go
@@ -109,7 +109,7 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			// 2. svc updated: no update
 			// 3. svc deleted: no update
 			// 4. svc created: ?
-			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}},
 		},
 		{
 			name:         "namespace with opaque service",
@@ -124,7 +124,7 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			// 2: svc updated: no update
 			// 2: svc deleted: update with default ports
 			// 3. svc created: update with port 3306
-			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}, {3306: {}}},
 		},
 		{
 			name:         "namespace and service, create opaque service",
@@ -139,7 +139,7 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			// 2: svc updated: update with port 3306
 			// 3: svc deleted: update with default ports
 			// 4. svc created: update with port 3306
-			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}, {3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}, {3306: {}}},
 		},
 		{
 			name:         "namespace and opaque service, create base service",
@@ -154,7 +154,7 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			// 2. svc updated: update with default ports
 			// 3. svc deleted: no update
 			// 4. svc added: no update
-			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}},
 		},
 		{
 			name:         "namespace and explicitly not opaque service, create explicitly not opaque service",
@@ -169,7 +169,7 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			// 2. svc updated: no update
 			// 3. svc deleted: update with default ports
 			// 4. svc added: update with no ports
-			expectedOpaquePorts: []map[uint32]struct{}{{}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {}},
+			expectedOpaquePorts: []map[uint32]struct{}{{}, {11211: {}, 25: {}, 3306: {}, 443: {}, 5432: {}, 587: {}}, {}},
 		},
 	} {
 		k8sAPI, err := k8s.NewFakeAPI(tt.initialState...)

--- a/controller/api/destination/watcher/opaque_ports_watcher_test.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher_test.go
@@ -53,6 +53,24 @@ metadata:
 			Ports: []corev1.ServicePort{{Port: 3306}},
 		},
 	}
+	explicitlyNotOpaqueService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: ns
+  annotations:
+    config.linkerd.io/opaque-ports: ""`
+	explicitlyNotOpaqueServiceObject = corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "svc",
+			Namespace:   "ns",
+			Annotations: map[string]string{"config.linkerd.io/opaque-ports": ""},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 3306}},
+		},
+	}
 )
 
 type testOpaquePortsListener struct {
@@ -87,9 +105,11 @@ func TestOpaquePortsWatcher(t *testing.T) {
 				Name:      "svc",
 				Namespace: "ns",
 			},
-			// Adding and removing services that do not have the opaque ports
-			// annotation should not result in any updates being sent.
-			expectedOpaquePorts: []map[uint32]struct{}{},
+			// 1. default opaque ports
+			// 2. svc updated: no update
+			// 3. svc deleted: no update
+			// 4. svc created: ?
+			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}},
 		},
 		{
 			name:         "namespace with opaque service",
@@ -102,9 +122,9 @@ func TestOpaquePortsWatcher(t *testing.T) {
 			},
 			// 1: svc annotation 3306
 			// 2: svc updated: no update
-			// 2: svc deleted: update with no ports
+			// 2: svc deleted: update with default ports
 			// 3. svc created: update with port 3306
-			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {}, {3306: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}},
 		},
 		{
 			name:         "namespace and service, create opaque service",
@@ -115,11 +135,11 @@ func TestOpaquePortsWatcher(t *testing.T) {
 				Name:      "svc",
 				Namespace: "ns",
 			},
-			// 1: no svc annotation
+			// 1: default opaque ports
 			// 2: svc updated: update with port 3306
-			// 3: svc deleted: update with no ports
+			// 3: svc deleted: update with default ports
 			// 4. svc created: update with port 3306
-			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {}, {3306: {}}},
+			expectedOpaquePorts: []map[uint32]struct{}{{11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {3306: {}}},
 		},
 		{
 			name:         "namespace and opaque service, create base service",
@@ -131,10 +151,25 @@ func TestOpaquePortsWatcher(t *testing.T) {
 				Namespace: "ns",
 			},
 			// 1: svc annotation 3306
-			// 2. svc updated: update with no ports
+			// 2. svc updated: update with default ports
 			// 3. svc deleted: no update
 			// 4. svc added: no update
-			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {}},
+			expectedOpaquePorts: []map[uint32]struct{}{{3306: {}}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}},
+		},
+		{
+			name:         "namespace and explicitly not opaque service, create explicitly not opaque service",
+			initialState: []string{testNS, explicitlyNotOpaqueService},
+			nsObject:     &testNSObject,
+			svcObject:    &explicitlyNotOpaqueServiceObject,
+			service: ServiceID{
+				Name:      "svc",
+				Namespace: "ns",
+			},
+			// 1: svc annotation empty
+			// 2. svc updated: no update
+			// 3. svc deleted: update with default ports
+			// 4. svc added: update with no ports
+			expectedOpaquePorts: []map[uint32]struct{}{{}, {11211: {}, 25: {}, 3306: {}, 443: {}, 587: {}}, {}},
 		},
 	} {
 		k8sAPI, err := k8s.NewFakeAPI(tt.initialState...)

--- a/pkg/opaqueports/defaults.go
+++ b/pkg/opaqueports/defaults.go
@@ -1,0 +1,17 @@
+package opaqueports
+
+// DefaultOpaquePorts is the default list of opaque ports that the destination
+// server will use to determine whether a destination is an opaque protocol.
+// When a pod or service already has its own annotation, that value will have
+// priority of this.
+//
+// Note: Keep in sync with proxy.opaquePorts in values.yaml
+var DefaultOpaquePorts = make(map[uint32]struct{})
+
+func init() {
+	DefaultOpaquePorts[25] = struct{}{}
+	DefaultOpaquePorts[443] = struct{}{}
+	DefaultOpaquePorts[587] = struct{}{}
+	DefaultOpaquePorts[3306] = struct{}{}
+	DefaultOpaquePorts[11211] = struct{}{}
+}

--- a/pkg/opaqueports/defaults.go
+++ b/pkg/opaqueports/defaults.go
@@ -6,12 +6,11 @@ package opaqueports
 // priority of this.
 //
 // Note: Keep in sync with proxy.opaquePorts in values.yaml
-var DefaultOpaquePorts = make(map[uint32]struct{})
-
-func init() {
-	DefaultOpaquePorts[25] = struct{}{}
-	DefaultOpaquePorts[443] = struct{}{}
-	DefaultOpaquePorts[587] = struct{}{}
-	DefaultOpaquePorts[3306] = struct{}{}
-	DefaultOpaquePorts[11211] = struct{}{}
+var DefaultOpaquePorts = map[uint32]struct{}{
+	25:    {},
+	443:   {},
+	587:   {},
+	3306:  {},
+	5432:  {},
+	11211: {},
 }


### PR DESCRIPTION
This changes the destination service to always use a default set of opaque ports
for pods and services. This is so that after Linkerd is installed onto a
cluster, users can benefit from common opaque ports without having to annotate
the workloads that serve the applications.

After #5810 merges, the proxy containers will be have the default opaque ports
`25,443,587,3306,5432,11211`. This value on the proxy container does not affect
traffic though; it only configures the proxy.

In order for clients and servers to detect opaque protocols and determine opaque
transports, the pods and services need to have these annotations.

The ports `25,443,587,3306,5432,11211` are now handled opaquely when a pod or
service does not have the opaque ports annotation. If the annotation is present
with a different value, this is used instead of the default. If the annotation
is present but is an empty string, there are no opaque ports for the workload.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
