### PR TITLE
Drop tcp_duration_* labels

### DIFF
--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -149,6 +149,11 @@ data:
       # Copy tmp labels into real labels
       - action: labelmap
         regex: __tmp_pod_label_(.+)
+      metric_relabel_configs:
+      # Drop tcp_connection_duration stats i.e. bucket,sum,count
+      - source_labels: [__name__]
+        regex: 'tcp_connection_duration_ms_(.+)'
+        action: drop
 
     {{- if .Values.prometheus.scrapeConfigs }}
     {{- toYaml .Values.prometheus.scrapeConfigs | trim | nindent 4 }}

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -797,6 +797,11 @@ data:
       # Copy tmp labels into real labels
       - action: labelmap
         regex: __tmp_pod_label_(.+)
+      metric_relabel_configs:
+      # Drop tcp_connection_duration stats i.e. bucket,sum,count
+      - source_labels: [__name__]
+        regex: 'tcp_connection_duration_ms_(.+)'
+        action: drop
 ---
 kind: Service
 apiVersion: v1

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -797,6 +797,11 @@ data:
       # Copy tmp labels into real labels
       - action: labelmap
         regex: __tmp_pod_label_(.+)
+      metric_relabel_configs:
+      # Drop tcp_connection_duration stats i.e. bucket,sum,count
+      - source_labels: [__name__]
+        regex: 'tcp_connection_duration_ms_(.+)'
+        action: drop
 ---
 kind: Service
 apiVersion: v1

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -615,6 +615,11 @@ data:
       # Copy tmp labels into real labels
       - action: labelmap
         regex: __tmp_pod_label_(.+)
+      metric_relabel_configs:
+      # Drop tcp_connection_duration stats i.e. bucket,sum,count
+      - source_labels: [__name__]
+        regex: 'tcp_connection_duration_ms_(.+)'
+        action: drop
 ---
 kind: Service
 apiVersion: v1

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -801,6 +801,11 @@ data:
       # Copy tmp labels into real labels
       - action: labelmap
         regex: __tmp_pod_label_(.+)
+      metric_relabel_configs:
+      # Drop tcp_connection_duration stats i.e. bucket,sum,count
+      - source_labels: [__name__]
+        regex: 'tcp_connection_duration_ms_(.+)'
+        action: drop
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
This change drops `tcp_connection_duration_` metrics to reduce the
cardinality in tcp metrics. It adds a `metrics_relabel_config` to
the linkerd prometheus-viz.

Fixes #5818

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>