### PR TITLE
docker: Avoid specifying TARGETARCH for await

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=$BUILDPLATFORM docker.io/curlimages/curl:7.75.0  as await
 WORKDIR /tmp
-ARG TARGETARCH=amd64
 ARG LINKERD_AWAIT_VERSION=v0.2.1
+ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies

--- a/jaeger/injector/Dockerfile
+++ b/jaeger/injector/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=$BUILDPLATFORM docker.io/curlimages/curl:7.75.0  as await
 WORKDIR /tmp
-ARG TARGETARCH=amd64
 ARG LINKERD_AWAIT_VERSION=v0.2.1
+ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=$BUILDPLATFORM docker.io/curlimages/curl:7.75.0  as await
 WORKDIR /tmp
-ARG TARGETARCH=amd64
 ARG LINKERD_AWAIT_VERSION=v0.2.1
+ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=$BUILDPLATFORM docker.io/curlimages/curl:7.75.0  as await
 WORKDIR /tmp
-ARG TARGETARCH=amd64
 ARG LINKERD_AWAIT_VERSION=v0.2.1
+ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,8 +2,8 @@ ARG BUILDPLATFORM=linux/amd64
 
 FROM --platform=$BUILDPLATFORM docker.io/curlimages/curl:7.75.0  as await
 WORKDIR /tmp
-ARG TARGETARCH=amd64
 ARG LINKERD_AWAIT_VERSION=v0.2.1
+ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies


### PR DESCRIPTION
When introducing the `linkerd-await` helper, we provided a default value
for `TARGETARCH`. This appears to interfere with multi-arch image
builds, causing ARM builds to fetch amd64 binaries.

Unsetting this default appears to fix this issue.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
