### PR TITLE
viz: update viz self-check hintanchor

### DIFF
--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -212,7 +212,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 				return
 			}),
 		*healthcheck.NewChecker("viz extension self-check").
-			WithHintAnchor("l5d-api-control-api").
+			WithHintAnchor("l5d-viz-metrics-api").
 			Fatal().
 			// to avoid confusing users with a prometheus readiness error, we only show
 			// "waiting for check to complete" while things converge. If after the timeout


### PR DESCRIPTION
This PR updates the viz self-checks hint anchor to be the
right one.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
