### PR TITLE
checks: Fix more trust hint anchors

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1132,7 +1132,7 @@ func (hc *HealthChecker) allCategories() []Category {
 				{
 					description: "proxy-injector cert is valid for at least 60 days",
 					warning:     true,
-					hintAnchor:  "l5d-webhook-cert-not-expiring-soon",
+					hintAnchor:  "l5d-proxy-injector-webhook-cert-not-expiring-soon",
 					check: func(ctx context.Context) error {
 						cert, err := hc.FetchCredsFromSecret(ctx, hc.ControlPlaneNamespace, proxyInjectorTLSSecretName)
 						if kerrors.IsNotFound(err) {
@@ -1168,7 +1168,7 @@ func (hc *HealthChecker) allCategories() []Category {
 				{
 					description: "sp-validator cert is valid for at least 60 days",
 					warning:     true,
-					hintAnchor:  "l5d-webhook-cert-not-expiring-soon",
+					hintAnchor:  "l5d-sp-validator-webhook-cert-not-expiring-soon",
 					check: func(ctx context.Context) error {
 						cert, err := hc.FetchCredsFromSecret(ctx, hc.ControlPlaneNamespace, spValidatorTLSSecretName)
 						if kerrors.IsNotFound(err) {

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -117,7 +117,7 @@ func (hc *HealthChecker) VizCategory() healthcheck.Category {
 				return hc.CheckCertAndAnchors(cert, anchors, identityName)
 			}),
 		*healthcheck.NewChecker("tap API server cert is valid for at least 60 days").
-			WithHintAnchor("l5d-webhook-cert-not-expiring-soon").
+			WithHintAnchor("l5d-tap-cert-not-expiring-soon").
 			Warning().
 			WithCheck(func(ctx context.Context) error {
 				cert, err := hc.FetchCredsFromSecret(ctx, hc.vizNamespace, tapTLSSecretName)


### PR DESCRIPTION
This PR updates hint anchors to the correct fields matching
with the anchors in `linkerd2/troubleshooting`.

The plan is to keep this PR updated with the changes being
done in https://github.com/linkerd/website/pull/947
and merge only after that PR is merged.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
