### PR TITLE
jaeger: combine pod running checks

### DIFF
--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -93,48 +93,24 @@ func jaegerCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
 			}))
 
 	checkers = append(checkers,
-		*healthcheck.NewChecker("collector pod is running").
-			WithHintAnchor("l5d-jaeger-collector-running").
+		*healthcheck.NewChecker("jaeger extension pods are running").
+			WithHintAnchor("l5d-jaeger-pods-running").
 			Fatal().
 			WithRetryDeadline(hc.RetryDeadline).
 			SurfaceErrorOnRetry().
 			WithCheck(func(ctx context.Context) error {
-				// Check for Collector pod
-				podList, err := hc.KubeAPIClient().CoreV1().Pods(jaegerNamespace).List(ctx, metav1.ListOptions{LabelSelector: "component=collector"})
+				pods, err := hc.KubeAPIClient().GetPodsByNamespace(ctx, jaegerNamespace)
 				if err != nil {
 					return err
 				}
-				return healthcheck.CheckPodsRunning(podList.Items, fmt.Sprintf("No collector pods found in the %s namespace", jaegerNamespace))
-			}))
 
-	checkers = append(checkers,
-		*healthcheck.NewChecker("jaeger pod is running").
-			WithHintAnchor("l5d-jaeger-jaeger-running").
-			Fatal().
-			WithRetryDeadline(hc.RetryDeadline).
-			SurfaceErrorOnRetry().
-			WithCheck(func(ctx context.Context) error {
-				// Check for Jaeger pod
-				podList, err := hc.KubeAPIClient().CoreV1().Pods(jaegerNamespace).List(ctx, metav1.ListOptions{LabelSelector: "component=jaeger"})
+				// Check for relevant pods to be present
+				err = healthcheck.CheckForPods(pods, []string{"collector", "jaeger", "jaeger-injector"})
 				if err != nil {
 					return err
 				}
-				return healthcheck.CheckPodsRunning(podList.Items, fmt.Sprintf("No jaeger pods found in the %s namespace", jaegerNamespace))
-			}))
 
-	checkers = append(checkers,
-		*healthcheck.NewChecker("jaeger injector pod is running").
-			WithHintAnchor("l5d-jaeger-jaeger-running").
-			Fatal().
-			WithRetryDeadline(hc.RetryDeadline).
-			SurfaceErrorOnRetry().
-			WithCheck(func(ctx context.Context) error {
-				// Check for Jaeger Injector pod
-				podList, err := hc.KubeAPIClient().CoreV1().Pods(jaegerNamespace).List(ctx, metav1.ListOptions{LabelSelector: "component=jaeger-injector"})
-				if err != nil {
-					return err
-				}
-				return healthcheck.CheckPodsRunning(podList.Items, fmt.Sprintf("No jaeger injector pods found in the %s namespace", jaegerNamespace))
+				return healthcheck.CheckPodsRunning(pods, "")
 			}))
 
 	return healthcheck.NewCategory(linkerdJaegerExtensionCheck, checkers, true)

--- a/test/integration/tracing/testdata/check.jaeger.golden
+++ b/test/integration/tracing/testdata/check.jaeger.golden
@@ -4,8 +4,6 @@ linkerd-jaeger
 √ collector and jaeger service account exists
 √ collector config map exists
 √ jaeger extension pods are injected
-√ collector pod is running
-√ jaeger pod is running
-√ jaeger injector pod is running
+√ jaeger extension pods are running
 
 Status check results are √


### PR DESCRIPTION
This PR combines the induvidual checks that check for each deployment
in running into a single check which checks for `running` status
for all the known deployments in the jaeger extension namespace.

This follows the same pattern as other extensions.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
