### PR TITLE
Move CP check after the readiness check

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
         - helm-upgrade
         - multicluster
         - uninstall
-        - upgrade-edge
+        #- upgrade-edge
         - upgrade-stable
         - cni-calico-deep
     needs: [docker_build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         - helm-deep
         - helm-upgrade
         - uninstall
-        - upgrade-edge
+        #- upgrade-edge
         - upgrade-stable
         - cni-calico-deep
     needs: [docker_build]

--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"text/tabwriter"
+	"time"
 
 	destinationPb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	netPb "github.com/linkerd/linkerd2-proxy-api/go/net"
@@ -89,13 +90,14 @@ destination.`,
 				return err
 			}
 
-			endpoints, err := requestEndpointsFromAPI(api.CheckPublicAPIClientOrExit(healthcheck.Options{
+			endpoints, err := requestEndpointsFromAPI(api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
 				ControlPlaneNamespace: controlPlaneNamespace,
 				KubeConfig:            kubeconfigPath,
 				Impersonate:           impersonate,
 				ImpersonateGroup:      impersonateGroup,
 				KubeContext:           kubeContext,
 				APIAddr:               apiAddr,
+				RetryDeadline:         time.Time{},
 			}), args)
 			if err != nil {
 				fmt.Fprint(os.Stderr, fmt.Errorf("Destination API error: %s", err))

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -342,13 +342,14 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 
 func fetchConfigs(ctx context.Context) (*linkerd2.Values, error) {
 
-	api.CheckPublicAPIClientOrExit(healthcheck.Options{
+	api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
 		ControlPlaneNamespace: controlPlaneNamespace,
 		KubeConfig:            kubeconfigPath,
 		Impersonate:           impersonate,
 		ImpersonateGroup:      impersonateGroup,
 		KubeContext:           kubeContext,
 		APIAddr:               apiAddr,
+		RetryDeadline:         time.Time{},
 	})
 
 	api, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -58,7 +58,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 					ImpersonateGroup:      impersonateGroup,
 					APIAddr:               apiAddr,
 					RetryDeadline:         time.Now().Add(wait),
-				}, true)
+				})
 			}
 
 			return install(os.Stdout, options)

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -73,7 +73,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				ImpersonateGroup:      impersonateGroup,
 				APIAddr:               apiAddr,
 				RetryDeadline:         time.Now().Add(wait),
-			}, true)
+			})
 
 			values, err := buildMulticlusterInstallValues(cmd.Context(), options)
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -760,29 +760,6 @@ func (hc *HealthChecker) allCategories() []Category {
 						return checkContainerRunning(hc.controlPlanePods, "controller")
 					},
 				},
-				{
-					description: "can initialize the client",
-					hintAnchor:  "l5d-existence-client",
-					fatal:       true,
-					check: func(ctx context.Context) (err error) {
-						if hc.APIAddr != "" {
-							hc.apiClient, err = public.NewInternalClient(hc.ControlPlaneNamespace, hc.APIAddr)
-						} else {
-							hc.apiClient, err = public.NewExternalClient(ctx, hc.ControlPlaneNamespace, hc.kubeAPI)
-						}
-						return
-					},
-				},
-				{
-					description:   "can query the control plane API",
-					hintAnchor:    "l5d-existence-api",
-					retryDeadline: hc.RetryDeadline,
-					fatal:         true,
-					check: func(ctx context.Context) (err error) {
-						hc.serverVersion, err = GetServerVersion(ctx, hc.apiClient)
-						return
-					},
-				},
 			},
 		},
 		{
@@ -1212,6 +1189,29 @@ func (hc *HealthChecker) allCategories() []Category {
 							return err
 						}
 						return validateControlPlanePods(hc.controlPlanePods)
+					},
+				},
+				{
+					description: "can initialize the client",
+					hintAnchor:  "l5d-api-control-client",
+					fatal:       true,
+					check: func(ctx context.Context) (err error) {
+						if hc.APIAddr != "" {
+							hc.apiClient, err = public.NewInternalClient(hc.ControlPlaneNamespace, hc.APIAddr)
+						} else {
+							hc.apiClient, err = public.NewExternalClient(ctx, hc.ControlPlaneNamespace, hc.kubeAPI)
+						}
+						return
+					},
+				},
+				{
+					description:   "can query the control plane API",
+					hintAnchor:    "l5d-api-control-api",
+					retryDeadline: hc.RetryDeadline,
+					fatal:         true,
+					check: func(ctx context.Context) (err error) {
+						hc.serverVersion, err = GetServerVersion(ctx, hc.apiClient)
+						return
 					},
 				},
 			},

--- a/pkg/public/api.go
+++ b/pkg/public/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/linkerd/linkerd2/controller/api/public"
 	pb "github.com/linkerd/linkerd2/controller/gen/public"
@@ -21,26 +20,15 @@ func RawPublicAPIClient(ctx context.Context, kubeAPI *k8s.KubernetesAPI, control
 	return public.NewExternalClient(ctx, controlPlaneNamespace, kubeAPI)
 }
 
-// CheckPublicAPIClientOrExit builds a new Public API client and executes default status
-// checks to determine if the client can successfully perform cli commands. If the
-// checks fail, then CLI will print an error and exit.
-func CheckPublicAPIClientOrExit(hcOptions healthcheck.Options) public.Client {
-	hcOptions.RetryDeadline = time.Time{}
-	return CheckPublicAPIClientOrRetryOrExit(hcOptions, false)
-}
-
 // CheckPublicAPIClientOrRetryOrExit builds a new Public API client and executes status
 // checks to determine if the client can successfully connect to the API. If the
 // checks fail, then CLI will print an error and exit. If the hcOptions.retryDeadline
 // param is specified, then the CLI will print a message to stderr and retry.
-func CheckPublicAPIClientOrRetryOrExit(hcOptions healthcheck.Options, apiChecks bool) public.Client {
+func CheckPublicAPIClientOrRetryOrExit(hcOptions healthcheck.Options) public.Client {
 	checks := []healthcheck.CategoryID{
 		healthcheck.KubernetesAPIChecks,
 		healthcheck.LinkerdControlPlaneExistenceChecks,
-	}
-
-	if apiChecks {
-		checks = append(checks, healthcheck.LinkerdAPIChecks)
+		healthcheck.LinkerdAPIChecks,
 	}
 
 	hc := healthcheck.NewHealthChecker(checks, &hcOptions)

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -405,14 +405,8 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 			"'kubectl apply' command failed\n%s", out)
 	}
 
-	// Wait for the proxy injector to be up
-	name := "linkerd-proxy-injector"
-	ns := "linkerd"
-	o, err := TestHelper.Kubectl("", "--namespace="+ns, "rollout", "status", "--timeout=120s", "deploy/"+name)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for deploy/%s in namespace %s", name, ns),
-			"failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", name, ns, err, o)
-	}
+	TestHelper.WaitRollout(t, "linkerd-controller")
+	TestHelper.WaitRollout(t, "linkerd-proxy-injector")
 
 	if TestHelper.ExternalPrometheus() {
 
@@ -506,14 +500,7 @@ func TestInstallHelm(t *testing.T) {
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
 
-	// Wait for the proxy injector to be up
-	name := "linkerd-proxy-injector"
-	ns := "linkerd"
-	o, err := TestHelper.Kubectl("", "--namespace="+ns, "wait", "--for=condition=available", "--timeout=120s", "deploy/"+name)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for deploy/%s in namespace %s", name, ns),
-			"failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", name, ns, err, o)
-	}
+	TestHelper.WaitRollout(t, "linkerd-proxy-injector")
 
 	if TestHelper.UpgradeHelmFromVersion() == "" {
 		vizChart := TestHelper.GetLinkerdVizHelmChart()

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -405,8 +405,11 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 			"'kubectl apply' command failed\n%s", out)
 	}
 
-	TestHelper.WaitRollout(t, "linkerd-controller")
-	TestHelper.WaitRollout(t, "linkerd-proxy-injector")
+	for deploy, deploySpec := range testutil.LinkerdDeployReplicasEdge {
+		if deploySpec.Namespace == "linkerd" {
+			TestHelper.WaitRollout(t, deploy)
+		}
+	}
 
 	if TestHelper.ExternalPrometheus() {
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -342,7 +342,17 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 
 		// apply stage 1
-		out, err = TestHelper.KubectlApply(out, "")
+		// Limit the pruning only to known resources
+		// that we intend to be delete in this stage to prevent it
+		// from deleting other resources that have the
+		// label
+		out, err = TestHelper.KubectlApplyWithArgs(out, []string{
+			"--prune",
+			"-l", "linkerd.io/control-plane-ns=linkerd",
+			"--prune-whitelist", "rbac.authorization.k8s.io/v1/clusterrole",
+			"--prune-whitelist", "rbac.authorization.k8s.io/v1/clusterrolebinding",
+			"--prune-whitelist", "apiregistration.k8s.io/v1/apiservice",
+		}...)
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 				"kubectl apply command failed\n%s", out)
@@ -399,7 +409,17 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		}
 	}
 
-	out, err = TestHelper.KubectlApply(out, "")
+	// Limit the pruning only to known resources
+	// that we intend to be delete in this stage to prevent it
+	// from deleting other resources that have the
+	// label
+	out, err = TestHelper.KubectlApplyWithArgs(out, []string{
+		"--prune",
+		"-l", "linkerd.io/control-plane-ns=linkerd",
+		"--prune-whitelist", "apps/v1/deployment",
+		"--prune-whitelist", "core/v1/service",
+		"--prune-whitelist", "core/v1/configmap",
+	}...)
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 			"'kubectl apply' command failed\n%s", out)

--- a/test/integration/testdata/check.cni.golden
+++ b/test/integration/testdata/check.cni.golden
@@ -15,8 +15,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-config
 --------------
@@ -62,6 +60,8 @@ linkerd-webhooks-and-apisvc-tls
 linkerd-api
 -----------
 √ control plane pods are ready
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.cni.proxy.golden
+++ b/test/integration/testdata/check.cni.proxy.golden
@@ -15,8 +15,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-config
 --------------
@@ -66,6 +64,8 @@ linkerd-identity-data-plane
 linkerd-api
 -----------
 √ control plane pods are ready
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.golden
+++ b/test/integration/testdata/check.golden
@@ -15,8 +15,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-config
 --------------
@@ -50,6 +48,8 @@ linkerd-webhooks-and-apisvc-tls
 linkerd-api
 -----------
 √ control plane pods are ready
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -15,8 +15,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-config
 --------------
@@ -54,6 +52,8 @@ linkerd-identity-data-plane
 linkerd-api
 -----------
 √ control plane pods are ready
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-version
 ---------------

--- a/test/integration/testdata/check.proxy.golden
+++ b/test/integration/testdata/check.proxy.golden
@@ -15,8 +15,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ controller pod is running
-√ can initialize the client
-√ can query the control plane API
 
 linkerd-config
 --------------
@@ -54,6 +52,8 @@ linkerd-identity-data-plane
 linkerd-api
 -----------
 √ control plane pods are ready
+√ can initialize the client
+√ can query the control plane API
 
 linkerd-version
 ---------------

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -131,6 +131,15 @@ func (h *KubernetesHelper) KubectlApply(stdin string, namespace string) (string,
 	return h.Kubectl(stdin, args...)
 }
 
+// KubectlApplyWithArgs applies a given configuration string with the passed
+// flags
+func (h *KubernetesHelper) KubectlApplyWithArgs(stdin string, cmdArgs ...string) (string, error) {
+	args := []string{"apply"}
+	args = append(args, cmdArgs...)
+	args = append(args, "-f", "-")
+	return h.Kubectl(stdin, args...)
+}
+
 // Kubectl executes an arbitrary Kubectl command
 func (h *KubernetesHelper) Kubectl(stdin string, arg ...string) (string, error) {
 	withContext := append([]string{"--context=" + h.k8sContext}, arg...)
@@ -342,7 +351,7 @@ func (h *KubernetesHelper) URLFor(ctx context.Context, namespace, deployName str
 // WaitRollout blocks until the specified deployment has been
 // completely rolled out (and its pods are ready)
 func (h *KubernetesHelper) WaitRollout(t *testing.T, deployment string) {
-	o, err := h.Kubectl("", "--namespace=linkerd", "wait", "--for=condition=available", "--timeout=120s", "deploy/"+deployment)
+	o, err := h.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=120s", "deploy/"+deployment)
 	if err != nil {
 		AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for deploy/%s", deployment),
 			"failed to wait for condition=available for deploy/%s: %s: %s", deployment, err, o)

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -336,4 +337,14 @@ func (h *KubernetesHelper) URLFor(ctx context.Context, namespace, deployName str
 	}
 
 	return pf.URLFor(""), nil
+}
+
+// WaitRollout blocks until the specified deployment has been
+// completely rolled out (and its pods are ready)
+func (h *KubernetesHelper) WaitRollout(t *testing.T, deployment string) {
+	o, err := h.Kubectl("", "--namespace=linkerd", "wait", "--for=condition=available", "--timeout=120s", "deploy/"+deployment)
+	if err != nil {
+		AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for deploy/%s", deployment),
+			"failed to wait for condition=available for deploy/%s: %s: %s", deployment, err, o)
+	}
 }

--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -45,6 +45,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.tapInjector.crtPEM)) (empty .Values.tapInjector.crtPEM) }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -67,7 +67,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 					ImpersonateGroup:      impersonateGroup,
 					APIAddr:               apiAddr,
 					RetryDeadline:         time.Now().Add(wait),
-				}, true)
+				})
 
 			}
 			return install(os.Stdout, options, ha)

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -1038,6 +1038,8 @@ metadata:
   namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: dGVzdC10YXAtY3J0LXBlbQ==
@@ -1083,6 +1085,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector
@@ -1109,7 +1112,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
+        checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -1038,6 +1038,8 @@ metadata:
   namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: dGVzdC10YXAtY3J0LXBlbQ==
@@ -1083,6 +1085,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector
@@ -1109,7 +1112,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
+        checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -856,6 +856,8 @@ metadata:
   namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: dGVzdC10YXAtY3J0LXBlbQ==
@@ -901,6 +903,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector
@@ -927,7 +930,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
+        checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -748,6 +748,8 @@ metadata:
   namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: dGVzdC10YXAtY3J0LXBlbQ==
@@ -793,6 +795,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector
@@ -819,7 +822,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
+        checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -1050,6 +1050,8 @@ metadata:
   namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+  labels:
+    linkerd.io/extension: viz
 type: kubernetes.io/tls
 data:
   tls.crt: dGVzdC10YXAtY3J0LXBlbQ==
@@ -1095,6 +1097,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    linkerd.io/extension: viz
     component: tap-injector
   ports:
   - name: tap-injector
@@ -1121,7 +1124,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cb033e3116205dd502bee6f822717a8efe049d8ada2f02d1343a2c8b0cd3c93
+        checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz


### PR DESCRIPTION
Moved the `can initialize client` and `can query the control plane API`
checks from the `linkerd-existence` section to the `linkerd-api` because
they required the `linkerd-controller` pod to not just be "Running" but
actually be ready.

This was causing `linkerd check` to show some port-forwarding warnings
when ran right after install.

This also allowed getting rid of the `CheckPublicAPIClientOrExit` function
and directly use `CheckPublicAPIClientOrRetryOrExit` (better naming
punted for later) which was refactored so it always runs the
`linkerd-api` checks before retrieving the client.
