### PR TITLE
viz: support type name in tap request path

### DIFF
--- a/viz/tap/api/handlers.go
+++ b/viz/tap/api/handlers.go
@@ -98,7 +98,7 @@ func initRouter(h *handler) *httprouter.Router {
 	return router
 }
 
-// createRoutes returns of list of routes that the API server should serve
+// createRoutes returns a list of routes that the API server should serve
 // depending on the type of resource given. If the resource type is anything
 // except namespace, two routes are returned: one for the resource type and
 // one for a specific resource of that type.
@@ -126,9 +126,7 @@ func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprout
 	path := strings.Split(req.URL.Path, "/")
 	if len(path) == 8 {
 		resource = path[5]
-	} else if len(path) == 10 {
-		resource = path[8]
-	} else if len(path) == 12 {
+	} else if len(path) == 10 || len(path) == 12 {
 		resource = path[8]
 	} else {
 		err := fmt.Errorf("invalid path: %s", req.URL.Path)

--- a/viz/tap/api/handlers.go
+++ b/viz/tap/api/handlers.go
@@ -116,8 +116,8 @@ func createRoutes(res resource) []string {
 }
 
 // POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/tap
-// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/type/:type/tap
-// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/type/:type/name/:name/tap
+// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/type/{resource-type}/tap
+// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/type/{resource-type}/name/:name/tap
 func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 	namespace := p.ByName("namespace")
 	name := p.ByName("name")

--- a/viz/tap/pkg/protohttp.go
+++ b/viz/tap/pkg/protohttp.go
@@ -11,18 +11,23 @@ import (
 // with the Kubernetes tap.linkerd.io APIService.
 func TapReqToURL(req *tapPb.TapByResourceRequest) string {
 	res := req.GetTarget().GetResource()
-
-	// non-namespaced
+	// Create HTTP path used for tapping a namespace
 	if res.GetType() == k8s.Namespace {
 		return fmt.Sprintf(
 			"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/tap",
 			res.GetName(),
 		)
 	}
-
-	// namespaced
+	// Create HTTP path used for tapping a resource type within a namespace.
+	if res.GetName() == "" {
+		return fmt.Sprintf(
+			"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/type/%s/tap",
+			res.GetNamespace(), res.GetType()+"s",
+		)
+	}
+	// Create HTTP path used for tapping a specific resource within a namespace.
 	return fmt.Sprintf(
-		"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/%s/%s/tap",
+		"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/type/%s/name/%s/tap",
 		res.GetNamespace(), res.GetType()+"s", res.GetName(),
 	)
 }

--- a/viz/tap/pkg/protohttp_test.go
+++ b/viz/tap/pkg/protohttp_test.go
@@ -15,7 +15,7 @@ func TestTapReqToURL(t *testing.T) {
 	}{
 		{
 			req: &tapPb.TapByResourceRequest{},
-			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces//s//tap",
+			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces//type/s/tap",
 		},
 		{
 			req: &tapPb.TapByResourceRequest{
@@ -38,7 +38,7 @@ func TestTapReqToURL(t *testing.T) {
 					},
 				},
 			},
-			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/test-ns/test-types/test-name/tap",
+			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/test-ns/type/test-types/name/test-name/tap",
 		},
 	}
 	for i, exp := range expectations {


### PR DESCRIPTION
This changes tap requests to not have consecutive `/`s in the URL. This fixes
issues seen on k3d, and more generally creates a more explicit tap request URL.

Closes #5219

The failure  happens when there are consecutive `/`s in the URL. This occurs if
there is no specific resource specified—only the type.

For example when tapping deployments, the URL is:

```
/apis/tap.linkerd.io/v1alpha1/watch/namespaces/default/deployments//tap
```

After this change, the URL will be:

```
/apis/tap.linkerd.io/v1alpha1/watch/namespaces/linkerd/type/pods/tap
```

And tapping a specific resource will be:

```
/apis/tap.linkerd.io/v1alpha1/watch/namespaces/linkerd/type/deployments/name/deploy-x/tap
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
