### PR TITLE
edge-21.3.1 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ CLI commands, among other improvements.
 
 * Fixed Helm install/upgrade, which was failing when not explicitly setting
   `proxy.image.version`
-* Added the command `linkerd viz list` to list mesh pods and indicate which can
+* Added the command `linkerd viz list` to list meshed pods and indicate which can
   be tapped, which need to be restarted before they can be tapped, and which
   have tap disabled
 * Similarly, added the command `linkerd jaeger list` to list meshed pods and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ CLI commands, among other improvements.
 * Similarly, added the command `linkerd jaeger list` to list meshed pods and
   indicate which will participate in tracing
 * Added the `--opaque-ports` flag to `linkerd inject` to specify the list of
-  opaque ports when injection pods (and services)
+  opaque ports when injecting pods (and services)
 * Simplified the output of `linkerd jaeger check`, combining the checks for the
   status of each component into a single check
 * Had the destination component receive the `opaquePorts` config set during

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,8 @@ CLI commands, among other improvements.
   opaque ports when injecting pods (and services)
 * Simplified the output of `linkerd jaeger check`, combining the checks for the
   status of each component into a single check
-* Had the destination component receive the `opaquePorts` config set during
-  install so it's properly reflected during injection and discovery
+* Changed the destination component to receive the list of default opaque ports
+  set during install so that it's properly reflected during discovery
 * Moved the level of the proxy server's I/O-related "Connection closed" messages
   from info to debug, which were not providing actionable information
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Changes
 
+## edge-21.3.1
+
+This edge release is another release candidate, bringing us closer to
+`stable-2.10.0`! It fixes the Helm install/upgrade procedure and ships some new
+CLI commands, among other improvements.
+
+* Fixed Helm install/upgrade, which was failing when not explicitly setting
+  `proxy.image.version`
+* Added the command `linkerd viz list` to list mesh pods and indicate which can
+  be tapped, which need to be restarted before they can be tapped, and which
+  have tap disabled
+* Similarly, added the command `linkerd jaeger list` to list meshed pods and
+  indicate which will participate in tracing
+* Added the `--opaque-ports` flag to `linkerd inject` to specify the list of
+  opaque ports when injection pods (and services)
+* Simplified the output of `linkerd jaeger check`, combining the checks for the
+  status of each component into a single check
+* Had the destination component receive the `opaquePorts` config set during
+  install so it's properly reflected during injection and discovery
+* Moved the level of the proxy server's I/O errors from info to debug, which
+  were not providing actionable information
+
 ## edge-21.2.4
 
 This edge is a release candidate for `stable-2.10.0`! It wraps up the functional

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ CLI commands, among other improvements.
 
 * Fixed Helm install/upgrade, which was failing when not explicitly setting
   `proxy.image.version`
+* Added a warning in the dashboard when viewing tap streams from resources that
+  don't have tap enabled
 * Added the command `linkerd viz list` to list meshed pods and indicate which can
   be tapped, which need to be restarted before they can be tapped, and which
   have tap disabled

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,8 @@ CLI commands, among other improvements.
   status of each component into a single check
 * Had the destination component receive the `opaquePorts` config set during
   install so it's properly reflected during injection and discovery
-* Moved the level of the proxy server's I/O errors from info to debug, which
-  were not providing actionable information
+* Moved the level of the proxy server's I/O-related "Connection closed" messages
+  from info to debug, which were not providing actionable information
 
 ## edge-21.2.4
 


### PR DESCRIPTION
## edge-21.3.1

This edge release is another release candidate, bringing us closer to
`stable-2.10.0`! It fixes the Helm install/upgrade procedure and ships some new
CLI commands, among other improvements.

* Fixed Helm install/upgrade, which was failing when not explicitly setting
  `proxy.image.version`
* Added a warning in the dashboard when viewing tap streams from resources that
  don't have tap enabled
* Added the command `linkerd viz list` to list meshed pods and indicate which can
  be tapped, which need to be restarted before they can be tapped, and which
  have tap disabled
* Similarly, added the command `linkerd jaeger list` to list meshed pods and
  indicate which will participate in tracing
* Added the `--opaque-ports` flag to `linkerd inject` to specify the list of
  opaque ports when injecting pods (and services)
* Simplified the output of `linkerd jaeger check`, combining the checks for the
  status of each component into a single check
* Changed the destination component to receive the list of default opaque ports
  set during install so that it's properly reflected during discovery
* Moved the level of the proxy server's I/O-related "Connection closed" messages
  from info to debug, which were not providing actionable information