### PR TITLE
Reenable disabled integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -148,5 +148,11 @@ jobs:
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Run integration tests
+      if: !endsWith(matrix.integration_test, 'deep')
       run: |
         bin/tests --images archive --name ${{ matrix.integration_test }} "$HOME/.linkerd"
+    - name: Run integration tests (deep)
+      if: endsWith(matrix.integration_test, 'deep')
+      run: |
+        # deep tests consume a lot of disk
+        bin/tests --images archive --cleanup-docker --name ${{ matrix.integration_test }} "$HOME/.linkerd"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
         - helm-upgrade
         - multicluster
         - uninstall
-        #- upgrade-edge
+        - upgrade-edge
         - upgrade-stable
         - cni-calico-deep
     needs: [docker_build]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -148,11 +148,11 @@ jobs:
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Run integration tests
-      if: !endsWith(matrix.integration_test, 'deep')
+      if: ${{ !endsWith(matrix.integration_test, 'deep') }}
       run: |
         bin/tests --images archive --name ${{ matrix.integration_test }} "$HOME/.linkerd"
     - name: Run integration tests (deep)
-      if: endsWith(matrix.integration_test, 'deep')
+      if: ${{ endsWith(matrix.integration_test, 'deep') }}
       run: |
         # deep tests consume a lot of disk
         bin/tests --images archive --cleanup-docker --name ${{ matrix.integration_test }} "$HOME/.linkerd"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         - helm-deep
         - helm-upgrade
         - uninstall
-        #- upgrade-edge
+        - upgrade-edge
         - upgrade-stable
         - cni-calico-deep
     needs: [docker_build]

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -38,7 +38,8 @@ Available Commands:
     --name: the argument to this option is the specific test to run
     --skip-cluster-create: skip k3d cluster creation step and run tests in an existing cluster
     --skip-cluster-delete: if the tests succeed, don't delete the created resources nor the cluster
-    --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)"
+    --images: by default load images into the cluster from the local docker cache (docker), or from tar files located under the 'image-archives' directory (archive), or completely skip image loading (skip)
+    --cleanup-docker: delete the 'images-archive' directory and prune the docker cache"
 }
 
 cleanup_usage() {
@@ -61,6 +62,7 @@ handle_tests_input() {
   export test_name=''
   export skip_cluster_create=''
   export skip_cluster_delete=''
+  export cleanup_docker=''
   export linkerd_path=""
 
   while  [ "$#" -ne 0 ]; do
@@ -100,6 +102,10 @@ handle_tests_input() {
         ;;
       --skip-cluster-delete)
         skip_cluster_delete=1
+        shift
+        ;;
+      --cleanup-docker)
+        cleanup_docker=1
         shift
         ;;
       *)
@@ -230,6 +236,10 @@ setup_cluster() {
   if [ -z "$skip_cluster_create" ]; then
     create_cluster "$@"
     image_load "$name"
+    if [ -n "$cleanup_docker"]; then
+      rm -rf image-archives
+      docker system prune --force --all
+    fi
   fi
   check_cluster
 }

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -236,7 +236,7 @@ setup_cluster() {
   if [ -z "$skip_cluster_create" ]; then
     create_cluster "$@"
     image_load "$name"
-    if [ -n "$cleanup_docker"]; then
+    if [ -n "$cleanup_docker" ]; then
       rm -rf image-archives
       docker system prune --force --all
     fi

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -42,8 +42,6 @@ func TestMain(m *testing.M) {
 //////////////////////
 
 func TestTracing(t *testing.T) {
-	t.Skip(`Temporarily skipped while we figure why it keeps on failing, only in CI ¯\_(ツ)_/¯`)
-
 	ctx := context.Background()
 	if os.Getenv("RUN_ARM_TEST") != "" {
 		t.Skip("Skipped. Jaeger & Open Census images does not support ARM yet")


### PR DESCRIPTION
Reenabled the `upgrade-test` and `cni-calico-deep` tracing integration tests. The former was disabled because in edge-21.2.4 the viz install wasn't waiting for the core components to be ready, and the latter was disabled because the `jaeger-webhook` image couldn't be loaded.

The reason simply was disk pressure, as evidenced by the k8s events. The fix consisted on adding a `--cleanup-docker` option to `bin/tests` which deletes the `image-archives` dir and the docker cache after the images have been loaded into k3d. That option is enacted only in the `integration_tests.yml` workflow in the deep tests, which are the ones pulling the most images.

The `release.yml` workflow doesn't require it since it pulls the images directly from the public registry.
