### PR TITLE
Fix sp-validator not setting requestUID

### DIFF
--- a/controller/sp-validator/webhook.go
+++ b/controller/sp-validator/webhook.go
@@ -15,7 +15,10 @@ import (
 func AdmitSP(
 	_ context.Context, _ *k8s.API, request *admissionv1beta1.AdmissionRequest, _ record.EventRecorder,
 ) (*admissionv1beta1.AdmissionResponse, error) {
-	admissionResponse := &admissionv1beta1.AdmissionResponse{Allowed: true}
+	admissionResponse := &admissionv1beta1.AdmissionResponse{
+		UID:     request.UID,
+		Allowed: true,
+	}
 	if err := profiles.Validate(request.Object.Raw); err != nil {
 		admissionResponse.Allowed = false
 		admissionResponse.Result = &metav1.Status{Message: err.Error(), Code: 400}


### PR DESCRIPTION
This change fixes an issue where the `linkerd-sp-validator` does not set
the `request.UID` for an `admissionResponse`. This causes an issue that
prevents service profiles from being added or updated.

Fixes #5862