### PR TITLE
helm: add NOTES.txt for extension charts

### DIFF
--- a/charts/linkerd2/templates/NOTES.txt
+++ b/charts/linkerd2/templates/NOTES.txt
@@ -8,6 +8,10 @@ Alternatively, you can download the CLI directly via the Linkerd releases page:
 
   https://github.com/linkerd/linkerd2/releases/
 
+To make sure everything works as expected, Run the following:
+
+  linkerd check
+
 Linkerd Viz extension can be installed by running:
 
   linkerd viz install | kubectl apply -f -

--- a/charts/linkerd2/templates/NOTES.txt
+++ b/charts/linkerd2/templates/NOTES.txt
@@ -8,7 +8,7 @@ Alternatively, you can download the CLI directly via the Linkerd releases page:
 
   https://github.com/linkerd/linkerd2/releases/
 
-To make sure everything works as expected, Run the following:
+To make sure everything works as expected, run the following:
 
   linkerd check
 

--- a/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
+++ b/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
@@ -1,4 +1,4 @@
-The Linkerd control plane was successfully installed 🎉
+The Linkerd Jaeger extension was successfully installed 🎉
 
 To help you manage your Linkerd service mesh you can install the Linkerd CLI by running:
 
@@ -8,8 +8,8 @@ Alternatively, you can download the CLI directly via the Linkerd releases page:
 
   https://github.com/linkerd/linkerd2/releases/
 
-Linkerd Viz extension can be installed by running:
+To view the jaeger dashboard, Run the following:
 
-  linkerd viz install | kubectl apply -f -
+  linkerd jaeger dashboard
 
 Looking for more? Visit https://linkerd.io/2/getting-started/

--- a/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
+++ b/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
@@ -1,10 +1,10 @@
 The Linkerd Jaeger extension was successfully installed 🎉
 
-To make sure everything works as expected, Run the following:
+To make sure everything works as expected, run the following:
 
   linkerd jaeger check
 
-To view the jaeger dashboard, Run the following:
+To view the Jaeger dashboard, run the following:
 
   linkerd jaeger dashboard
 

--- a/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
+++ b/jaeger/charts/linkerd-jaeger/templates/NOTES.txt
@@ -1,12 +1,8 @@
 The Linkerd Jaeger extension was successfully installed 🎉
 
-To help you manage your Linkerd service mesh you can install the Linkerd CLI by running:
+To make sure everything works as expected, Run the following:
 
-  curl -sL https://run.linkerd.io/install | sh
-
-Alternatively, you can download the CLI directly via the Linkerd releases page:
-
-  https://github.com/linkerd/linkerd2/releases/
+  linkerd jaeger check
 
 To view the jaeger dashboard, Run the following:
 

--- a/multicluster/charts/linkerd-multicluster/NOTES.txt
+++ b/multicluster/charts/linkerd-multicluster/NOTES.txt
@@ -1,6 +1,6 @@
 The Linkerd Multicluster extension was successfully installed 🎉
 
-To make sure everything works as expected, Run the following:
+To make sure everything works as expected, run the following:
 
   linkerd multicluster check
 

--- a/multicluster/charts/linkerd-multicluster/NOTES.txt
+++ b/multicluster/charts/linkerd-multicluster/NOTES.txt
@@ -1,0 +1,7 @@
+The Linkerd Multicluster extension was successfully installed 🎉
+
+To make sure everything works as expected, Run the following:
+
+  linkerd multicluster check
+
+Looking for more? Visit https://linkerd.io/2/features/multicluster/

--- a/viz/charts/linkerd-viz/templates/NOTES.txt
+++ b/viz/charts/linkerd-viz/templates/NOTES.txt
@@ -1,10 +1,10 @@
 The Linkerd Viz extension was successfully installed 🎉
 
-To make sure everything works as expected, Run the following:
+To make sure everything works as expected, run the following:
 
   linkerd viz check
 
-To view the linkerd dashboard, Run the following:
+To view the linkerd dashboard, run the following:
 
   linkerd viz dashboard
 

--- a/viz/charts/linkerd-viz/templates/NOTES.txt
+++ b/viz/charts/linkerd-viz/templates/NOTES.txt
@@ -1,4 +1,4 @@
-The Linkerd control plane was successfully installed 🎉
+The Linkerd Viz extension was successfully installed 🎉
 
 To help you manage your Linkerd service mesh you can install the Linkerd CLI by running:
 
@@ -8,8 +8,8 @@ Alternatively, you can download the CLI directly via the Linkerd releases page:
 
   https://github.com/linkerd/linkerd2/releases/
 
-Linkerd Viz extension can be installed by running:
+To view the linkerd dashboard, Run the following:
 
-  linkerd viz install | kubectl apply -f -
+  linkerd viz dashboard
 
 Looking for more? Visit https://linkerd.io/2/getting-started/

--- a/viz/charts/linkerd-viz/templates/NOTES.txt
+++ b/viz/charts/linkerd-viz/templates/NOTES.txt
@@ -1,12 +1,8 @@
 The Linkerd Viz extension was successfully installed 🎉
 
-To help you manage your Linkerd service mesh you can install the Linkerd CLI by running:
+To make sure everything works as expected, Run the following:
 
-  curl -sL https://run.linkerd.io/install | sh
-
-Alternatively, you can download the CLI directly via the Linkerd releases page:
-
-  https://github.com/linkerd/linkerd2/releases/
+  linkerd viz check
 
 To view the linkerd dashboard, Run the following:
 


### PR DESCRIPTION
Currently, There is no `Notes` that get printed out after installatio
is performed through helm for extensions, like we do for the core
chart. This updates the viz and jaeger charts to include that
along with instructions to view the dashbaord.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
