### PR TITLE
Extra privs required for CR linkerd-linkerd-viz-tap-admin

### DIFF
--- a/viz/charts/linkerd-viz/templates/tap-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-rbac.yaml
@@ -28,6 +28,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -146,6 +146,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]
@@ -948,7 +951,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
+        checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -146,6 +146,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]
@@ -948,7 +951,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
+        checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -133,6 +133,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]
@@ -766,7 +769,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
+        checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -106,6 +106,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]
@@ -658,7 +661,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
+        checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
       labels:
         linkerd.io/extension: viz

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -146,6 +146,9 @@ metadata:
     linkerd.io/extension: viz
     component: tap
 rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list"]
 - apiGroups: ["tap.linkerd.io"]
   resources: ["*"]
   verbs: ["watch"]
@@ -956,7 +959,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f24ffe166f8d03a8eb039ecc551f3de9ea0ddcf1cf80a69966ce3713f043b23
+        checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
         config.linkerd.io/proxy-cpu-request: "500m"
         config.linkerd.io/proxy-cpu-limit: "100m"


### PR DESCRIPTION
@dadjeibaah [pointed out](https://github.com/linkerd/website/pull/972#discussion_r588584786) while reviewing the [Enabling Tap access](https://linkerd.io/2/tasks/securing-your-cluster/#enabling-tap-access) doc that granting the `linkerd-linkerd-viz-tap` ClusterRole to a user is no longer enough for tapping, as namespace listing is now also required:

```console
$ linkerd viz tap -n linkerd deploy/linkerd-controller --as $(whoami)

Cannot connect to Linkerd Viz: namespaces is forbidden: User "dennis"   cannot list resource "namespaces" in API group "" at the cluster scope
Validate the install with: linkerd viz check
```

Adding the Namespace List privilege to that CR solves the issue.