### PR TITLE
Add back ignore ports fields in values.yaml

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -26,6 +26,8 @@ Kubernetes: `>=1.16.0-0`
 | cniPluginVersion | string | `"linkerdVersionValue"` | Tag for the CNI container Docker image |
 | destCNIBinDir | string | `"/opt/cni/bin"` | Directory on the host where the CNI configuration will be placed |
 | destCNINetDir | string | `"/etc/cni/net.d"` | Directory on the host where the CNI plugin binaries reside |
+| ignoreInboundPorts | string | `""` | Default set of inbound ports to skip via itpables |
+| ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via itpables |
 | imagePullSecrets | string | `nil` |  |
 | inboundProxyPort | int | `4143` | Inbound port for the proxy container |
 | installNamespace | bool | `true` | Whether to create the CNI plugin plane namespace or not |

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -6,6 +6,10 @@ installNamespace: true
 inboundProxyPort: 4143
 # -- Outbound port for the proxy container
 outboundProxyPort: 4140
+# -- Default set of inbound ports to skip via itpables
+ignoreInboundPorts: ""
+# -- Default set of outbound ports to skip via itpables
+ignoreOutboundPorts: ""
 # -- Docker image for the CNI plugin
 cniPluginImage:   "cr.l5d.io/linkerd/cni-plugin"
 # -- Tag for the CNI container Docker image

--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -188,6 +188,8 @@ Kubernetes: `>=1.16.0-0`
 | proxy.uid | int | `2102` | User id under which the proxy runs |
 | proxy.waitBeforeExitSeconds | int | `0` | If set the proxy sidecar will stay alive for at least the given period before receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`. See [Lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) for more info on container lifecycle hooks. |
 | proxyInit.closeWaitTimeoutSecs | int | `0` |  |
+| proxyInit.ignoreInboundPorts | string | `""` | Default set of inbound ports to skip via itpables |
+| proxyInit.ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via itpables |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container Docker image |
 | proxyInit.image.version | string | `"v1.3.9"` | Tag for the proxy-init container Docker image |

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -108,6 +108,10 @@ proxy:
 
 # proxy-init configuration
 proxyInit:
+  # -- Default set of inbound ports to skip via itpables
+  ignoreInboundPorts: ""
+  # -- Default set of outbound ports to skip via itpables
+  ignoreOutboundPorts: ""
   image:
     # -- Docker image for the proxy-init container
     name: cr.l5d.io/linkerd/proxy-init


### PR DESCRIPTION
Add back configurations to `values.yaml` files after being removed in #5810

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
