### PR TITLE
Only support docker buildx

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,6 @@ on:
     - main
 env:
   GH_ANNOTATION: true
-  DOCKER_BUILDKIT: 1
 jobs:
   docker_build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     - "*"
 env:
   GH_ANNOTATION: true
-  DOCKER_BUILDKIT: 1
 jobs:
   docker_build:
     runs-on: ubuntu-20.04

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+docker buildx &> /dev/null || { echo 'Please install docker buildx before proceeding'; exit 1; }
+
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
 # shellcheck source=_log.sh
@@ -11,13 +13,10 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 # docker registry in, for instance, CI.
 export DOCKER_REGISTRY=${DOCKER_REGISTRY:-cr.l5d.io/linkerd}
 
-# When set, use `docker buildx` and use the github actions cache to store/retrieve images
-export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-}
-
-# buildx cache directory. Needed if DOCKER_BUILDKIT is used
+# buildx cache directory
 export DOCKER_BUILDKIT_CACHE=${DOCKER_BUILDKIT_CACHE:-}
 
-# When set together with DOCKER_BUILDKIT, it will build the multi-arch images. Currently DOCKER_PUSH is also required
+# build the multi-arch images. Currently DOCKER_PUSH is also required
 export DOCKER_MULTIARCH=${DOCKER_MULTIARCH:-}
 
 # When set together with DOCKER_MULTIARCH, it will push the multi-arch images to the registry
@@ -48,40 +47,32 @@ docker_build() {
     shift
 
     rootdir=$( cd "$bindir"/.. && pwd )
+    cache_params=""
 
-    if [ -n "$DOCKER_BUILDKIT" ]; then
-      cache_params=""
-      if [ -n "$DOCKER_BUILDKIT_CACHE" ]; then
-        cache_params="--cache-from type=local,src=${DOCKER_BUILDKIT_CACHE} --cache-to type=local,dest=${DOCKER_BUILDKIT_CACHE},mode=max"
-      fi
-
-      output_params="--load"
-      if [ -n "$DOCKER_MULTIARCH" ]; then
-        output_params="--platform $SUPPORTED_ARCHS"
-        if [ -n "$DOCKER_PUSH" ]; then
-          output_params+=" --push"
-        else
-          echo "Error: env DOCKER_PUSH=1 is missing"
-          echo "When building the multi-arch images it is required to push the images to the registry"
-          echo "See https://github.com/docker/buildx/issues/59 for more details"
-          exit 1
-        fi
-      fi
-
-      log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
-      # shellcheck disable=SC2086
-      docker buildx build "$rootdir" $cache_params \
-          $output_params \
-          -t "$repo:$tag" \
-          -f "$file" \
-          "$@"
-    else
-      log_debug "  :; docker build $rootdir -t $repo:$tag -f $file $*"
-      docker build "$rootdir" \
-          -t "$repo:$tag" \
-          -f "$file" \
-          "$@"
+    if [ -n "$DOCKER_BUILDKIT_CACHE" ]; then
+      cache_params="--cache-from type=local,src=${DOCKER_BUILDKIT_CACHE} --cache-to type=local,dest=${DOCKER_BUILDKIT_CACHE},mode=max"
     fi
+
+    output_params="--load"
+    if [ -n "$DOCKER_MULTIARCH" ]; then
+      output_params="--platform $SUPPORTED_ARCHS"
+      if [ -n "$DOCKER_PUSH" ]; then
+        output_params+=" --push"
+      else
+        echo "Error: env DOCKER_PUSH=1 is missing"
+        echo "When building the multi-arch images it is required to push the images to the registry"
+        echo "See https://github.com/docker/buildx/issues/59 for more details"
+        exit 1
+      fi
+    fi
+
+    log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
+    # shellcheck disable=SC2086
+    docker buildx build "$rootdir" $cache_params \
+        $output_params \
+        -t "$repo:$tag" \
+        -f "$file" \
+        "$@"
 
     echo "$repo:$tag"
 }


### PR DESCRIPTION
With #5835 adding `linkerd-await` in most Dockerfiles we require
`TARGETARCH` to be set by the system, which is only available in the
BuildKit backend. Thus we drop support for plain vanilla docker and
remove all references to `DOCKER_BUILDKIT`. The developer docs are being
updated accordingly in #5869
