### PR TITLE
Fix parsing of ignoreInboundPorts field

### DIFF
--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -7,7 +7,7 @@ args:
 - --proxy-uid
 - {{.Values.proxy.uid | quote}}
 - --inbound-ports-to-ignore
-- "{{.Values.proxy.ports.control}},{{.Values.proxy.ports.admin}}{{ternary (printf ",%s" .Values.proxyInit.ignoreInboundPorts) "" (not (empty .Values.proxyInit.ignoreInboundPorts)) }}"
+- "{{.Values.proxy.ports.control}},{{.Values.proxy.ports.admin}}{{ternary (printf ",%s" (.Values.proxyInit.ignoreInboundPorts | toString)) "" (not (empty .Values.proxyInit.ignoreInboundPorts)) }}"
 {{- if .Values.proxyInit.ignoreOutboundPorts }}
 - --outbound-ports-to-ignore
 - {{.Values.proxyInit.ignoreOutboundPorts | quote}}
@@ -58,5 +58,5 @@ volumeMounts:
 - mountPath: {{.Values.proxyInit.saMountPath.mountPath}}
   name: {{.Values.proxyInit.saMountPath.name}}
   readOnly: {{.Values.proxyInit.saMountPath.readOnly}}
-{{- end -}}  
+{{- end -}}
 {{- end -}}


### PR DESCRIPTION
The `ignoreInboundPorts` field is not parsed correctly when passed through the
`--set` Helm flag. This was discovered in https://github.com/linkerd/linkerd2/pull/5874#pullrequestreview-606779599.

This is happening because the value is not parsed into a string before using it
in the templating.

Before:

```
linkerd install --set proxyInit.ignoreInboundPorts="12345" |grep 12345
...
- "4190,4191,%!s(int64=12345)"
...
```

After:

```
linkerd install --set proxyInit.ignoreInboundPorts="12345" |grep 12345
...
- "4190,4191,12345"
...
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>