### PR TITLE
Make 'linkerd check' hint URLs dependent on version

### DIFF
--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -3,6 +3,6 @@ category
 √ check1
 × check2
     This should contain instructions for fail
-    see https://linkerd.io/checks/#hint-anchor for hints
+    see https://linkerd.io/checks/latest/#hint-anchor for hints
 
 Status check results are ×

--- a/cli/cmd/testdata/check_output_json.golden
+++ b/cli/cmd/testdata/check_output_json.golden
@@ -10,7 +10,7 @@
         },
         {
           "description": "check2",
-          "hint": "https://linkerd.io/checks/#hint-anchor",
+          "hint": "https://linkerd.io/checks/latest/#hint-anchor",
           "error": "This should contain instructions for fail",
           "result": "error"
         }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -160,11 +160,6 @@ const (
 	keyKeyName                    = "tls.key"
 )
 
-// HintBaseURL is the base URL on the linkerd.io website that all check hints
-// point to. Each check adds its own `hintAnchor` to specify a location on the
-// page.
-const HintBaseURL = "https://linkerd.io/checks/#"
-
 // AllowedClockSkew sets the allowed skew in clock synchronization
 // between the system running inject command and the node(s), being
 // based on assumed node's heartbeat interval (5 minutes) plus default TLS

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -368,7 +368,7 @@ func (h *handler) handleAPICheck(w http.ResponseWriter, req *http.Request, p htt
 				success = false
 			}
 			errMsg = result.Err.Error()
-			hintURL = fmt.Sprintf("%s%s", healthcheck.HintBaseURL, result.HintAnchor)
+			hintURL = fmt.Sprintf("%s%s", healthcheck.HintBaseURL(), result.HintAnchor)
 		}
 		results[result.Category] = append(results[result.Category], &CheckResult{
 			CheckResult: result,

--- a/web/srv/testdata/api_check_output.json
+++ b/web/srv/testdata/api_check_output.json
@@ -15,7 +15,7 @@
             "Warning": true,
             "Err": {},
             "ErrMsg": "check2-error",
-            "HintURL": "https://linkerd.io/checks/#check2-hint-anchor"
+            "HintURL": "https://linkerd.io/checks/latest/#check2-hint-anchor"
         }],
         "linkerd-config": [{
             "Category": "linkerd-config",


### PR DESCRIPTION
The URLs have now the form `https://linkerd.io/checks/xx/#anchor` where
`xx` is extracted from the stable version string. If we're on an edge
version, or if it's a developer version such as `git-sha` or
`dev-sha-user`, then the `xx` will be `latest`.

These changes are coupled with linkerd/website#980
