### PR TITLE
update go.mod and docker images to go 1.16.2

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.1
+      image: golang:1.16.2
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.1
+      image: golang:1.16.2
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.1
+      image: golang:1.16.2
     steps:
       - name: Prerequisites
         run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install unzip

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.16.1
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.16.1
     steps:
     - name: Checkout code
       # actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.13.4
+      image: golang:1.16.1
     steps:
       - name: Prerequisites
         run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install unzip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.14.15
+      image: golang:1.16.1
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: golang:1.16.1
+      image: golang:1.16.2
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -2,7 +2,7 @@ ARG RUNTIME_IMAGE=debian:buster-20210208-slim
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -2,7 +2,7 @@ ARG RUNTIME_IMAGE=debian:buster-20210208-slim
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -2,7 +2,7 @@ ARG BUILDPLATFORM=linux/amd64
 ARG BUILD_STAGE=single-arch
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -2,7 +2,7 @@ ARG BUILDPLATFORM=linux/amd64
 ARG BUILD_STAGE=single-arch
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.14
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0

--- a/jaeger/injector/Dockerfile
+++ b/jaeger/injector/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/jaeger/injector/Dockerfile
+++ b/jaeger/injector/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -352,7 +352,7 @@ spec:
       pathRegex: /route-1`,
 		},
 		{
-			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration foo"),
+			err: errors.New("ServiceProfile \"name.ns.svc.cluster.local\" RetryBudget: time: invalid duration \"foo\""),
 			sp: `apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/viz/metrics-api/util/api_utils_test.go
+++ b/viz/metrics-api/util/api_utils_test.go
@@ -65,8 +65,8 @@ func TestBuildStatSummaryRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {
@@ -138,8 +138,8 @@ func TestBuildTopRoutesRequest(t *testing.T) {
 
 	t.Run("Rejects invalid time windows", func(t *testing.T) {
 		expectations := map[string]string{
-			"1": "time: missing unit in duration 1",
-			"s": "time: invalid duration s",
+			"1": "time: missing unit in duration \"1\"",
+			"s": "time: invalid duration \"s\"",
 		}
 
 		for timeWindow, msg := range expectations {

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.2-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 RUN curl -fsSvLo linkerd-await https://github.com/olix0r/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.14.15-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.16.1-alpine as go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/


### PR DESCRIPTION
This change updates all Dockerfiles and GitHub workflows to
to use go 1.16.2 

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>