### PR TITLE
Fix helm-upgrade and upgrade-stable integration tests

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -35,18 +35,6 @@ var (
 
 	helmTLSCerts *tls.CA
 
-	linkerdSvcStable = []testutil.Service{
-		{Namespace: "linkerd", Name: "linkerd-controller-api"},
-		{Namespace: "linkerd", Name: "linkerd-dst"},
-		{Namespace: "linkerd", Name: "linkerd-grafana"},
-		{Namespace: "linkerd", Name: "linkerd-identity"},
-		{Namespace: "linkerd", Name: "linkerd-prometheus"},
-		{Namespace: "linkerd", Name: "linkerd-web"},
-		{Namespace: "linkerd", Name: "linkerd-tap"},
-		{Namespace: "linkerd", Name: "linkerd-dst-headless"},
-		{Namespace: "linkerd", Name: "linkerd-identity-headless"},
-	}
-
 	linkerdSvcEdge = []testutil.Service{
 		{Namespace: "linkerd", Name: "linkerd-controller-api"},
 		{Namespace: "linkerd", Name: "linkerd-dst"},
@@ -57,6 +45,9 @@ var (
 		{Namespace: "linkerd", Name: "linkerd-dst-headless"},
 		{Namespace: "linkerd", Name: "linkerd-identity-headless"},
 	}
+
+	// Override in case edge starts to deviate from stable service-wise
+	linkerdSvcStable = linkerdSvcEdge
 
 	multiclusterSvcs = []testutil.Service{
 		{Namespace: "linkerd-multicluster", Name: "linkerd-gateway"},
@@ -476,11 +467,11 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 // These need to be updated (if there are changes) once a new stable is released
 func helmOverridesStable(root *tls.CA) []string {
 	return []string{
-		"--set", "global.controllerLogLevel=debug",
-		"--set", "global.linkerdVersion=" + TestHelper.UpgradeHelmFromVersion(),
-		"--set", "global.proxy.image.version=" + TestHelper.UpgradeHelmFromVersion(),
-		"--set", "global.identityTrustDomain=cluster.local",
-		"--set", "global.identityTrustAnchorsPEM=" + root.Cred.Crt.EncodeCertificatePEM(),
+		"--set", "controllerLogLevel=debug",
+		"--set", "linkerdVersion=" + TestHelper.UpgradeHelmFromVersion(),
+		"--set", "proxy.image.version=" + TestHelper.UpgradeHelmFromVersion(),
+		"--set", "identityTrustDomain=cluster.local",
+		"--set", "identityTrustAnchorsPEM=" + root.Cred.Crt.EncodeCertificatePEM(),
 		"--set", "identity.issuer.tls.crtPEM=" + root.Cred.Crt.EncodeCertificatePEM(),
 		"--set", "identity.issuer.tls.keyPEM=" + root.Cred.EncodePrivateKeyPEM(),
 		"--set", "identity.issuer.crtExpiry=" + root.Cred.Crt.Certificate.NotAfter.Format(time.RFC3339),
@@ -533,17 +524,14 @@ func TestInstallHelm(t *testing.T) {
 
 	TestHelper.WaitRollout(t)
 
-	if TestHelper.UpgradeHelmFromVersion() == "" {
-		vizChart := TestHelper.GetLinkerdVizHelmChart()
-		vizArgs := []string{
-			"--set", "linkerdVersion=" + TestHelper.GetVersion(),
-			"--set", "namespace=" + TestHelper.GetVizNamespace(),
-		}
-		// Install Viz Extension Chart
-		if stdout, stderr, err := TestHelper.HelmInstallPlain(vizChart, "l5d-viz", vizArgs...); err != nil {
-			testutil.AnnotatedFatalf(t, "'helm install' command failed",
-				"'helm install' command failed\n%s\n%s", stdout, stderr)
-		}
+	vizChart := TestHelper.GetLinkerdVizHelmChart()
+	vizArgs := []string{
+		"--set", "linkerdVersion=" + TestHelper.GetVersion(),
+		"--set", "namespace=" + TestHelper.GetVizNamespace(),
+	}
+	if stdout, stderr, err := TestHelper.HelmCmdPlain("install", vizChart, "l5d-viz", vizArgs...); err != nil {
+		testutil.AnnotatedFatalf(t, "'helm install' command failed",
+			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
 }
 
@@ -604,8 +592,7 @@ func TestCheckHelmStableBeforeUpgrade(t *testing.T) {
 		t.Skip("Skipping as this is not a helm upgrade test")
 	}
 
-	// TODO: make checkOutput as true once 2.9 releases
-	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), false)
+	testCheckCommand(t, "", TestHelper.UpgradeHelmFromVersion(), "", TestHelper.UpgradeHelmFromVersion(), true)
 }
 
 func TestUpgradeHelm(t *testing.T) {
@@ -644,18 +631,11 @@ func TestUpgradeHelm(t *testing.T) {
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
 
-	// Install Viz Extension, as there was no viz with stable
-	// TOODO: Update this to upgrade once this will be the newer stable/edge
 	vizChart := TestHelper.GetLinkerdVizHelmChart()
-	vizArgs := []string{
-		"--set", "linkerdVersion=" + TestHelper.GetVersion(),
-		"--set", "namespace=" + TestHelper.GetVizNamespace(),
-		"--wait",
-	}
-	// Install Viz Extension Chart
-	if stdout, stderr, err := TestHelper.HelmInstallPlain(vizChart, "l5d-viz", vizArgs...); err != nil {
-		testutil.AnnotatedFatalf(t, "'helm install' command failed",
-			"'helm install' command failed\n%s\n%s", stdout, stderr)
+	vizArgs := []string{"--wait"}
+	if stdout, stderr, err := TestHelper.HelmCmdPlain("upgrade", vizChart, "l5d-viz", vizArgs...); err != nil {
+		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
+			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
 	TestHelper.AddInstalledExtension(vizExtensionName)
 }

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -66,20 +66,6 @@ type Service struct {
 	Name      string
 }
 
-// LinkerdDeployReplicasStable is a map containing the number of replicas for each Deployment and the main
-// container name
-var LinkerdDeployReplicasStable = map[string]DeploySpec{
-	"linkerd-controller":     {"linkerd", 1, []string{"public-api"}},
-	"linkerd-destination":    {"linkerd", 1, []string{"destination"}},
-	"linkerd-tap":            {"linkerd", 1, []string{"tap"}},
-	"linkerd-grafana":        {"linkerd", 1, []string{}},
-	"linkerd-identity":       {"linkerd", 1, []string{"identity"}},
-	"linkerd-prometheus":     {"linkerd", 1, []string{}},
-	"linkerd-sp-validator":   {"linkerd", 1, []string{"sp-validator"}},
-	"linkerd-web":            {"linkerd", 1, []string{"web"}},
-	"linkerd-proxy-injector": {"linkerd", 1, []string{"proxy-injector"}},
-}
-
 // LinkerdDeployReplicasEdge is a map containing the number of replicas for each Deployment and the main
 // container name, in the current code-base
 var LinkerdDeployReplicasEdge = map[string]DeploySpec{
@@ -92,6 +78,10 @@ var LinkerdDeployReplicasEdge = map[string]DeploySpec{
 	"web":                    {"linkerd-viz", 1, []string{"web"}},
 	"linkerd-proxy-injector": {"linkerd", 1, []string{"proxy-injector"}},
 }
+
+// LinkerdDeployReplicasStable is a map containing the number of replicas for each Deployment and the main
+// container name. Override whenever edge deviates from stable.
+var LinkerdDeployReplicasStable = LinkerdDeployReplicasEdge
 
 // NewGenericTestHelper returns a new *TestHelper from the options provided as function parameters.
 // This helper was created to be able to reuse this package without hard restrictions
@@ -498,10 +488,10 @@ func (h *TestHelper) HelmInstall(chart string, arg ...string) (string, string, e
 	return combinedOutput("", h.helm.path, withParams...)
 }
 
-// HelmInstallPlain runs the helm install subcommand, with the provided arguments and no defaults
-func (h *TestHelper) HelmInstallPlain(chart string, releaseName string, arg ...string) (string, string, error) {
+// HelmCmdPlain runs a helm subcommand, with the provided arguments and no defaults
+func (h *TestHelper) HelmCmdPlain(cmd, chart, releaseName string, arg ...string) (string, string, error) {
 	withParams := append([]string{
-		"install",
+		cmd,
 		releaseName,
 		chart,
 		"--kube-context", h.k8sContext,


### PR DESCRIPTION
Update `install_test.go` now that the upgrade test is done from 2.10.
This also implied installing viz right after core.

Refactored `HelmInstallPlain()` into `HelmCmdPlain()` to work for both
helm install and upgrade.