### PR TITLE
cli: update err msg when control-plane already exists.

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -54,7 +54,7 @@ If you are sure you'd like to have a fresh install, remove these resources with:
 Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
 `
 
-	errMsgLinkerdConfigResourceConflict = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nRun `linkerd upgrade` with the relevant binary, if you are looking to upgrade Linkerd.\n"
+	errMsgLinkerdConfigResourceConflict = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nRun the command `linkerd upgrade`, if you are looking to upgrade Linkerd.\n"
 	errMsgGlobalResourcesMissing        = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -54,7 +54,7 @@ If you are sure you'd like to have a fresh install, remove these resources with:
 Otherwise, you can use the --ignore-cluster flag to overwrite the existing global resources.
 `
 
-	errMsgLinkerdConfigResourceConflict = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nIf this is expected, use the --ignore-cluster flag to continue the installation.\n"
+	errMsgLinkerdConfigResourceConflict = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nRun `linkerd upgrade` with the relevant binary, if you are looking to upgrade Linkerd.\n"
 	errMsgGlobalResourcesMissing        = "Can't install the Linkerd control plane in the '%s' namespace. The required Linkerd global resources are missing.\nIf this is expected, use the --skip-checks flag to continue the installation.\n"
 )
 


### PR DESCRIPTION
Fixes #5889

Currently, The error msg that is sent when control-plane already
exists suggests to use `--ignore-cluster`. We should instead
suggest users to use `linkerd upgrade`.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
