### PR TITLE
Add peer label to TCP read and write stat queries

### DIFF
--- a/viz/metrics-api/gateways.go
+++ b/viz/metrics-api/gateways.go
@@ -117,10 +117,11 @@ func (s *grpcServer) getGatewaysMetrics(ctx context.Context, req *pb.GatewaysReq
 	labels, groupBy := buildGatewaysRequestLabels(req)
 
 	promQueries := map[promType]string{
-		promGatewayAlive: gatewayAliveQuery,
+		promGatewayAlive: fmt.Sprintf(gatewayAliveQuery, labels.String(), groupBy.String()),
 	}
 
-	metricsResp, err := s.getPrometheusMetrics(ctx, promQueries, gatewayLatencyQuantileQuery, labels.String(), timeWindow, groupBy.String())
+	quantileQueries := generateQuantileQueries(gatewayLatencyQuantileQuery, labels.String(), timeWindow, groupBy.String())
+	metricsResp, err := s.getPrometheusMetrics(ctx, promQueries, quantileQueries)
 
 	if err != nil {
 		return nil, err

--- a/viz/metrics-api/prometheus.go
+++ b/viz/metrics-api/prometheus.go
@@ -180,6 +180,12 @@ func promDirectionLabels(direction string) model.LabelSet {
 	}
 }
 
+func promPeerLabel(peer string) model.LabelSet {
+	return model.LabelSet{
+		model.LabelName("peer"): model.LabelValue(peer),
+	}
+}
+
 func promResourceType(resource *pb.Resource) model.LabelName {
 	l5dLabel := k8s.KindToL5DLabel(resource.Type)
 	return model.LabelName(l5dLabel)
@@ -193,6 +199,9 @@ func (s *grpcServer) getPrometheusMetrics(ctx context.Context, requestQueryTempl
 		var query string
 		if pt == promTCPConnections || pt == promGatewayAlive || pt == promNumMirroredServices {
 			query = fmt.Sprintf(requestQueryTemplate, labels, groupBy)
+		} else if pt == promTCPReadBytes || pt == promTCPWriteBytes {
+			// TCP read/write labels get set in the previous step to include additional 'peer' label
+			query = requestQueryTemplate
 		} else {
 			query = fmt.Sprintf(requestQueryTemplate, labels, timeWindow, groupBy)
 		}

--- a/viz/metrics-api/prometheus.go
+++ b/viz/metrics-api/prometheus.go
@@ -24,16 +24,15 @@ type promResult struct {
 }
 
 const (
-	promGatewayAlive        = promType("QUERY_GATEWAY_ALIVE")
-	promNumMirroredServices = promType("QUERY_NUM_MIRRORED_SERVICES")
-	promRequests            = promType("QUERY_REQUESTS")
-	promActualRequests      = promType("QUERY_ACTUAL_REQUESTS")
-	promTCPConnections      = promType("QUERY_TCP_CONNECTIONS")
-	promTCPReadBytes        = promType("QUERY_TCP_READ_BYTES")
-	promTCPWriteBytes       = promType("QUERY_TCP_WRITE_BYTES")
-	promLatencyP50          = promType("0.5")
-	promLatencyP95          = promType("0.95")
-	promLatencyP99          = promType("0.99")
+	promGatewayAlive   = promType("QUERY_GATEWAY_ALIVE")
+	promRequests       = promType("QUERY_REQUESTS")
+	promActualRequests = promType("QUERY_ACTUAL_REQUESTS")
+	promTCPConnections = promType("QUERY_TCP_CONNECTIONS")
+	promTCPReadBytes   = promType("QUERY_TCP_READ_BYTES")
+	promTCPWriteBytes  = promType("QUERY_TCP_WRITE_BYTES")
+	promLatencyP50     = promType("0.5")
+	promLatencyP95     = promType("0.95")
+	promLatencyP99     = promType("0.99")
 
 	namespaceLabel         = model.LabelName("namespace")
 	dstNamespaceLabel      = model.LabelName("dst_namespace")

--- a/viz/metrics-api/stat_summary.go
+++ b/viz/metrics-api/stat_summary.go
@@ -490,32 +490,35 @@ func buildTrafficSplitRequestLabels(req *pb.StatSummaryRequest) (labels model.La
 	return labels, groupBy
 }
 
-func buildTCPStatsRequestLabels(req *pb.StatSummaryRequest, reqLabels model.LabelSet) (labels model.LabelSet) {
+func buildTCPStatsRequestLabels(req *pb.StatSummaryRequest, reqLabels model.LabelSet) string {
 	switch req.Outbound.(type) {
 	case *pb.StatSummaryRequest_ToResource, *pb.StatSummaryRequest_FromResource:
 		// If TCP stats are queried from a resource to another one (i.e outbound -- from/to), then append peer='dst'
-		labels = reqLabels.Merge(promPeerLabel("dst"))
+		reqLabels = reqLabels.Merge(promPeerLabel("dst"))
 
 	default:
 		// If TCP stats are not queried from a specific resource (i.e inbound -- no to/from), then append peer='src'
-		labels = reqLabels.Merge(promPeerLabel("src"))
+		reqLabels = reqLabels.Merge(promPeerLabel("src"))
 	}
-	return
+	return reqLabels.String()
 }
 
 func (s *grpcServer) getStatMetrics(ctx context.Context, req *pb.StatSummaryRequest, timeWindow string) (map[rKey]*pb.BasicStats, map[rKey]*pb.TcpStats, error) {
 	reqLabels, groupBy := buildRequestLabels(req)
 	promQueries := map[promType]string{
-		promRequests: reqQuery,
+		promRequests: fmt.Sprintf(reqQuery, reqLabels.String(), timeWindow, groupBy.String()),
 	}
 
 	if req.TcpStats {
+		promQueries[promTCPConnections] = fmt.Sprintf(tcpConnectionsQuery, reqLabels.String(), groupBy.String())
+		// For TCP read/write bytes total we add an additional 'peer' label with a value of either 'src' or 'dst'
 		tcpLabels := buildTCPStatsRequestLabels(req, reqLabels)
-		promQueries[promTCPConnections] = tcpConnectionsQuery
-		promQueries[promTCPReadBytes] = fmt.Sprintf(tcpReadBytesQuery, tcpLabels.String(), timeWindow, groupBy.String())
-		promQueries[promTCPWriteBytes] = fmt.Sprintf(tcpWriteBytesQuery, tcpLabels.String(), timeWindow, groupBy.String())
+		promQueries[promTCPReadBytes] = fmt.Sprintf(tcpReadBytesQuery, tcpLabels, timeWindow, groupBy.String())
+		promQueries[promTCPWriteBytes] = fmt.Sprintf(tcpWriteBytesQuery, tcpLabels, timeWindow, groupBy.String())
 	}
-	results, err := s.getPrometheusMetrics(ctx, promQueries, latencyQuantileQuery, reqLabels.String(), timeWindow, groupBy.String())
+
+	quantileQueries := generateQuantileQueries(latencyQuantileQuery, reqLabels.String(), timeWindow, groupBy.String())
+	results, err := s.getPrometheusMetrics(ctx, promQueries, quantileQueries)
 
 	if err != nil {
 		return nil, nil, err
@@ -537,10 +540,11 @@ func (s *grpcServer) getTrafficSplitMetrics(ctx context.Context, req *pb.StatSum
 	reqLabels := generateLabelStringWithRegex(labels, "authority", stringToMatch)
 
 	promQueries := map[promType]string{
-		promRequests: reqQuery,
+		promRequests: fmt.Sprintf(reqQuery, reqLabels, timeWindow, groupBy.String()),
 	}
 
-	results, err := s.getPrometheusMetrics(ctx, promQueries, latencyQuantileQuery, reqLabels, timeWindow, groupBy.String())
+	quantileQueries := generateQuantileQueries(latencyQuantileQuery, reqLabels, timeWindow, groupBy.String())
+	results, err := s.getPrometheusMetrics(ctx, promQueries, quantileQueries)
 
 	if err != nil {
 		return nil, err

--- a/viz/metrics-api/stat_summary_test.go
+++ b/viz/metrics-api/stat_summary_test.go
@@ -742,8 +742,8 @@ status:
 						`histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (le, namespace, pod))`,
 						`sum(increase(response_total{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod, classification, tls)`,
 						`sum(tcp_open_connections{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}) by (namespace, pod)`,
-						`sum(increase(tcp_read_bytes_total{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod)`,
-						`sum(increase(tcp_write_bytes_total{direction="inbound", namespace="emojivoto", pod="emojivoto-1"}[1m])) by (namespace, pod)`,
+						`sum(increase(tcp_read_bytes_total{direction="inbound", namespace="emojivoto", peer="src", pod="emojivoto-1"}[1m])) by (namespace, pod)`,
+						`sum(increase(tcp_write_bytes_total{direction="inbound", namespace="emojivoto", peer="src", pod="emojivoto-1"}[1m])) by (namespace, pod)`,
 					},
 				},
 				req: &pb.StatSummaryRequest{

--- a/viz/metrics-api/top_routes.go
+++ b/viz/metrics-api/top_routes.go
@@ -240,15 +240,16 @@ func (s *grpcServer) getRouteMetrics(ctx context.Context, req *pb.TopRoutesReque
 	groupBy := "rt_route"
 
 	queries := map[promType]string{
-		promRequests: routeReqQuery,
+		promRequests: fmt.Sprintf(routeReqQuery, reqLabels, timeWindow, groupBy),
 	}
 
 	if req.GetOutbound() != nil && req.GetNone() == nil {
 		// If this req has an Outbound, then query the actual request counts as well.
-		queries[promActualRequests] = actualRouteReqQuery
+		queries[promActualRequests] = fmt.Sprintf(actualRouteReqQuery, reqLabels, timeWindow, groupBy)
 	}
 
-	results, err := s.getPrometheusMetrics(ctx, queries, routeLatencyQuantileQuery, reqLabels, timeWindow, groupBy)
+	quantileQueries := generateQuantileQueries(routeLatencyQuantileQuery, reqLabels, timeWindow, groupBy)
+	results, err := s.getPrometheusMetrics(ctx, queries, quantileQueries)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #5693 

<details>
<summary> PR description before update </summary>
Hi and many apologies for taking so long with this one! I spent more time than usual trying to understand the metrics-api and what is happening behind the scenes with `linkerd viz stat`.

### What
---

> linkerd viz stat sums tcp_read_bytes_total and tcp_write_bytes_total over both peer="src" and peer="dst", for both inbound and outbound metrics. It should use peer="src" for inbound metrics, and peer="dst" for outbound.
[ #5693]

* I tried to keep the changes very small in this PR. I added some logic to both `stat_summary.go` and to `prometheus.go` in viz to add the peer label to TCP stat queries (only read/write).

* If we have an inbound query we add `peer="src"`; for outbound requests we add `peer="dst"`

### How
---

The solution feels a bit hacky to me. I thought of a few alternatives but ultimately decided to stick with this one since it was the simplest and smallest.

When we build the stat queries we first build a set of request labels. These labels are used for all of our stat queries -- including the latency quantiles. I thought adding `peer=...` as a label to all of them is not feasible so instead I added the label only to the TCP stats. If we request TCP stats, we add the additional peer label to the request labels and then instead of storing the tcp query in the `promQueries` map, we add the templated request to include the TCP labels.

At first I thought of including an additional `tcpLabels` argument to `getPrometheusMetrics(...)`. This would result in a larger change so I thought it'd be better to try without it first and see what people think. I also thought of creating the peer labels when we template out the queries in `getPrometheusMetrics(...)`. It got complicated pretty quickly since we need to first look at the request labels to figure out the direction and then we need to insert the label in the request labels set (request labels is a string in this case). Finally, there was the option of adding the peer label to all queries which again seemed unfeasible to me.

### Output
---

To test the output I used emojivoto. I wanted to see first how the logs differ (to confirm the label is included in the query) and second to see how the numbers differ now that the peer label is included.


```sh
# edges
SRC          DST        SRC_NS        DST_NS      SECURED
vote-bot     web        emojivoto     emojivoto   √      
web          emoji      emojivoto     emojivoto   √      
web          voting     emojivoto     emojivoto   √      
prometheus   emoji      linkerd-viz   emojivoto   √      
prometheus   vote-bot   linkerd-viz   emojivoto   √      
prometheus   voting     linkerd-viz   emojivoto   √      
```

I mainly tested with `web` and `vote-bot`.

**Before the change**

```sh
---

$ linkerd viz stat deploy/web -n emojivoto -o wide

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    94.85%   2.3rps           3ms           5ms           5ms          3        4843.9B/s         5675.3B/s

request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\"}[1m])) by (namespace, deployment)"
request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\"}[1m])) by (namespace, deployment)"

---

$ linkerd viz stat deploy/vote-bot -n emojivoto --to deploy/web -o wide
NAME       MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
vote-bot      1/1    85.59%   2.0rps           5ms           9ms          10ms          1        4518.9B/s          153.8B/s

time="2021-03-15T13:33:04Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (namespace, deployment)"
timrequest:\n\tsum(increase(tcp_write_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (namespace, deployment)"

---
 
$ linkerd viz stat deploy/web -n emojivoto --from deploy/vote-bot -o wide

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    91.53%   2.0rps           5ms           9ms          10ms          1        4507.4B/s          155.8B/s

time="2021-03-15T13:35:29Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"
time="2021-03-15T13:35:29Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"

---
$ linkerd viz stat deploy/emoji -n emojivoto --from deploy/web -o wide
NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
emoji      1/1   100.00%   2.0rps           1ms           2ms           3ms          1        2211.5B/s          203.2B/s

time="2021-03-15T13:36:20Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"emoji\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"
time="2021-03-15T13:36:20Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"emoji\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"

---
$ linkerd viz stat deploy/voting -n emojivoto --from deploy/web -o wide
NAME     MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
voting      1/1    89.83%   1.0rps           1ms           1ms           1ms          1          56.2B/s           95.1B/s

time="2021-03-15T13:37:19Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"voting\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"
time="2021-03-15T13:37:19Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"voting\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\"}[1m])) by (dst_namespace, dst_deployment)"

```

**After the changes**: 

```sh
$ linkerd viz stat deploy/web -n emojivoto -o wide

# With peer=src READ_BYTES/SEC changed from 4k+ to 181 (what voting-bot typically sends)

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    90.98%   2.2rps           9ms          89ms          98ms          3         181.4B/s         5082.2B/s

time="2021-03-15T13:53:42Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\", peer=\"src\"}[1m])) by (namespace, deployment)"
time="2021-03-15T13:53:42Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\", peer=\"src\"}[1m])) by (namespace, deployment)"


---
$ linkerd viz stat deploy/vote-bot -n emojivoto --to deploy/web -o wide

NAME       MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
vote-bot      1/1    94.69%   1.9rps           7ms          30ms          90ms          1        4320.9B/s          150.3B/s

time="2021-03-15T13:54:36Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (namespace, deployment)"
time="2021-03-15T13:54:36Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (namespace, deployment)"

---
$ linkerd viz stat deploy/web -n emojivoto --from deploy/vote-bot -o wide

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    94.07%   2.0rps           5ms          10ms          10ms          1        4508.3B/s          152.9B/s

time="2021-03-15T13:55:25Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"
time="2021-03-15T13:55:25Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"v
---
$ linkerd viz stat deploy/emoji -n emojivoto --from deploy/web -o wide

NAME    MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
emoji      1/1   100.00%   2.0rps           1ms           2ms           3ms          1        2211.4B/s          203.2B/s

time="2021-03-15T13:56:16Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"emoji\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"
time="2021-03-15T13:56:16Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"outbound\", dst_deployment=\"emoji\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"

---
$ linkerd viz stat deploy/voting -n emojivoto --from deploy/web -o wide

NAME     MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
voting      1/1    77.97%   1.0rps           1ms           1ms           1ms          1          53.4B/s           95.3B/s
```


**To conclude** the labels to me seem to be set correctly (outbounds get peer=dst and inbounds get peer=src). 

For inbound reads it seems that the calculations have changed, i.e for `linkerd viz stat deploy/web` we go from  4843.9B/s to 180B/s+ which is the total amount of bytes `vote-bot` seems to usually send to our web service. 

However, I'm a bit confused because some numbers don't seem to add up -- for example when we do `linkerd viz stat deploy/vote-bot --to deploy/web` it shows that 4k+ bytes have been read in by vote-bot, I'm confused how and why this is happening. This is also true in the case of ` linkerd viz stat deploy/emoji  --from deploy/web`: it shows 2k bytes have been read in, since this is outbound I assume it's from the pov of `web` -- so web has read 2k and written 200 bytes, not sure why it read so many and I think I misunderstand something.

Anyway, apologies for the "read total" tangent and the delay in getting this together. Please let me know if the proposed approach is not well suited, thought in this case a minimal change would be better but more than happy to keep looking into it.
</details>

---

**Update**:  I've addressed Dennis and Alex's comments.

* Added a new test case for outbound tcp stats (this will also check whether the peer=dst label is set correctly on outbound requests).
* In `stat_summary` I've added a comment to indicate why we build a set of labels specifically for TCP stats.
* Most notably, I refactored `getPrometheus(...)` and got rid of the following params: _timeWindow_, _groupBy_ , _labels_ and _latencyQueryTemplate_ 
*  The function now accepts as parameters a context, a map[promType]string for request queries and a map[promType]string for latency (quantile) queries.
* Whenever we call getPrometheus(...) we template out both the request queries and latency queries and just pass these in as arguments.

I also created a helper function to template out the quantile queries based on a template and a set of labels; this is because I was repeating the same code throughout all of the calling functions and I thought it made sense to have it as a separate helper. I didn't do this for the request queries because I thought `sprintf` actually made more sense, it was a bit more explicit and shorter to write so I thought it didn't warrant its own helper function(s).

Last but not least there is a bit of duplication when we fetch the metrics asynchronously (we do the same thing, once for request queries and once for quantile queries). I'm not sure what would be more readable here, I extracted the code in a separate function but to me personally that didn't feel more readable and so I ended up leaving it as is.


### Tests
---

After refactoring, `linkerd viz stat` behaves the same way (I haven't checked gateways or routes).

```
$ linkerd viz stat deploy/web -n emojivoto -o wide

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    91.91%   2.3rps           2ms           4ms           5ms          3         185.3B/s         5180.0B/s

# same value as before, latency seems to have dropped

time="2021-03-22T18:19:44Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\", peer=\"src\"}[1m])) by (namespace, deployment)"

time="2021-03-22T18:19:44Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"web\", direction=\"inbound\", namespace=\"emojivoto\", peer=\"src\"}[1m])) by (namespace, deployment)"

# queries show the peer label
---

$ linkerd viz stat deploy/web -n emojivoto --from deploy/vote-bot -o wide

NAME   MESHED   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99   TCP_CONN   READ_BYTES/SEC   WRITE_BYTES/SEC
web       1/1    93.16%   1.9rps           3ms           4ms           4ms          1        4503.4B/s          153.1B/s


# stats same as before except for latency which seems to have dropped a bit

time="2021-03-22T18:22:10Z" level=debug msg="Query request:\n\tsum(increase(tcp_write_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"

time="2021-03-22T18:22:10Z" level=debug msg="Query request:\n\tsum(increase(tcp_read_bytes_total{deployment=\"vote-bot\", direction=\"outbound\", dst_deployment=\"web\", dst_namespace=\"emojivoto\", namespace=\"emojivoto\", peer=\"dst\"}[1m])) by (dst_namespace, dst_deployment)"

# queries show the right label
```

**Update 2**: I'm getting a lint error for `promNumMirroredServices` -- it's not in use anywhere. I was wondering about this when I refactored the code, I haven't seen any queries made for the num of mirrored services. Do we want to add a query in as part of this change or remove the promType? Not sure how to proceed.

Signed-off-by: mateiidavid <matei.david.35@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
