### PR TITLE
Handle pod lookups for pods that map to a host IP and host port

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -204,7 +204,7 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 			fqn = fmt.Sprintf("%s.%s.svc.%s", service.Name, service.Namespace, s.clusterDomain)
 		} else {
 			// If the IP does not map to a service, check if it maps to a pod
-			pod, err := s.ips.GetPod(ip.String())
+			pod, err := s.ips.GetPod(ip.String(), port)
 			if err != nil {
 				return err
 			}

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -148,6 +148,13 @@ func NewEndpointsWatcher(k8sAPI *k8s.API, log *logging.Entry, enableEndpointSlic
 
 	k8sAPI.Pod().Informer().AddIndexers(cache.Indexers{podIPIndex: func(obj interface{}) ([]string, error) {
 		if pod, ok := obj.(*corev1.Pod); ok {
+			// Pods that run in the host network are indexed by the host IP
+			// indexer in the IP watcher; they should be skipped by the pod
+			// IP indexer which is responsible only for indexing pod network
+			// pods.
+			if pod.Spec.HostNetwork {
+				return nil, nil
+			}
 			return []string{pod.Status.PodIP}, nil
 		}
 		return []string{""}, fmt.Errorf("object is not a pod")

--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -197,6 +197,7 @@ func (iw *IPWatcher) GetPod(podIP string, port uint32) (*corev1.Pod, error) {
 		iw.log.Warnf("found conflicting %s:%d endpoint on the host network: %s", podIP, port, strings.Join(conflictingPods, ","))
 		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting host network endpoint %s:%d", len(hostIPPods), podIP, port)
 	}
+
 	// The address did not map to a pod in the host network, so now we check
 	// if the IP maps to a pod IP in the pod network.
 	podIPPods, err := iw.getIndexedPods(podIPIndex, podIP)
@@ -215,6 +216,7 @@ func (iw *IPWatcher) GetPod(podIP string, port uint32) (*corev1.Pod, error) {
 		iw.log.Warnf("found conflicting %s IP on the pod network: %s", podIP, strings.Join(conflictingPods, ","))
 		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting pod network IP %s", len(podIPPods), podIP)
 	}
+
 	iw.log.Debugf("no pod found for %s:%d", podIP, port)
 	return nil, nil
 }

--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -103,9 +103,9 @@ func NewIPWatcher(k8sAPI *k8s.API, endpoints *EndpointsWatcher, log *logging.Ent
 				// containers' ports should be added to the indexer.
 				//
 				// If the pod does not run in the host network but does have a
-				// host IP, then one of it's containers should specify a host
-				// port. That hostIP:hostPort address should be added to the
-				// indexer.
+				// host IP, then one or more of it's containers should specify
+				// a host port. Each hostIP:hostPort address should be added
+				// to the indexer.
 				if pod.Spec.HostNetwork {
 					for _, c := range pod.Spec.Containers {
 						for _, p := range c.Ports {

--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -196,7 +196,7 @@ func (iw *IPWatcher) GetPod(podIP string, port uint32) (*corev1.Pod, error) {
 		iw.log.Debugf("found host network pod that maps to the address %s:%d", podIP, port)
 		return hostIPPods[0], nil
 	} else if len(hostIPPods) > 1 {
-		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting host network address %s:%d", len(hostIPPods), podIP, port)
+		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting host network address %s:%d; first two: %s/%s, %s/%s", len(hostIPPods), podIP, port, hostIPPods[0].Namespace, hostIPPods[0].Name, hostIPPods[1].Namespace, hostIPPods[1].Name)
 	}
 	// The address did not map to a pod in the host network, so now we check
 	// if the IP maps to a pod IP in the pod network.
@@ -209,7 +209,7 @@ func (iw *IPWatcher) GetPod(podIP string, port uint32) (*corev1.Pod, error) {
 		return podIPPods[0], nil
 	}
 	if len(podIPPods) > 1 {
-		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting pod network IP %s", len(podIPPods), podIP)
+		return nil, status.Errorf(codes.FailedPrecondition, "found %d pods with a conflicting pod network IP %s: first two: %s/%s, %s/%s", len(podIPPods), podIP, podIPPods[0].Namespace, podIPPods[0].Name, podIPPods[1].Namespace, podIPPods[1].Name)
 	}
 	iw.log.Infof("no pod found for %s:%d", podIP, port)
 	return nil, nil

--- a/controller/api/destination/watcher/ip_watcher_test.go
+++ b/controller/api/destination/watcher/ip_watcher_test.go
@@ -799,7 +799,7 @@ status:
 			t.Fatal("expected no pod to be found with unmapped host port")
 		}
 		// Get pod IP pod and expect an error
-		pod, err = watcher.GetPod(podIP, 12346)
+		_, err = watcher.GetPod(podIP, 12346)
 		if err == nil {
 			t.Fatal("expected error when getting by pod IP and unmapped host port, but got none")
 		}

--- a/controller/api/destination/watcher/ip_watcher_test.go
+++ b/controller/api/destination/watcher/ip_watcher_test.go
@@ -803,7 +803,7 @@ status:
 		if err == nil {
 			t.Fatal("expected error when getting by pod IP and unmapped host port, but got none")
 		}
-		if !strings.Contains(err.Error(), "Pod IP address conflict") {
+		if !strings.Contains(err.Error(), "pods with conflicting pod IP") {
 			t.Fatalf("expected error to be pod IP address conflict, but got: %s", err)
 		}
 	})

--- a/controller/api/destination/watcher/ip_watcher_test.go
+++ b/controller/api/destination/watcher/ip_watcher_test.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/cache"
@@ -677,7 +678,7 @@ status:
 	}
 }
 
-func TestIpWatcherGetSvc(t *testing.T) {
+func TestIpWatcherGetSvcID(t *testing.T) {
 	name := "service"
 	namespace := "test"
 	clusterIP := "10.256.0.1"
@@ -733,6 +734,77 @@ spec:
 		}
 		if svc != nil {
 			t.Fatalf("Expected not to find service mapped to [%s]", badClusterIP)
+		}
+	})
+}
+
+func TestIpWatcherGetPod(t *testing.T) {
+	podIP := "10.255.0.1"
+	hostIP := "172.0.0.1"
+	var hostPort uint32 = 12345
+	expectedPodName := "hostPortPod1"
+	k8sConfigs := []string{`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostPortPod1
+  namespace: ns
+spec:
+  containers:
+  - image: test
+    name: hostPortContainer
+    ports:
+    - containerPort: 12345
+      hostIP: 172.0.0.1
+      hostPort: 12345
+status:
+  phase: Running
+  podIP: 10.255.0.1
+  hostIP: 172.0.0.1`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: ns
+status:
+  phase: Running
+  podIP: 10.255.0.1`,
+	}
+	t.Run("get pod by host IP and host port", func(t *testing.T) {
+		k8sAPI, err := k8s.NewFakeAPI(k8sConfigs...)
+		if err != nil {
+			t.Fatalf("failed to create new fake API: %s", err)
+		}
+		endpoints := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), false)
+		watcher := NewIPWatcher(k8sAPI, endpoints, logging.WithField("test", t.Name()))
+		k8sAPI.Sync(nil)
+		// Get host IP pod that is mapped to the port `hostPort`
+		pod, err := watcher.GetPod(hostIP, hostPort)
+		if err != nil {
+			t.Fatalf("failed to get pod: %s", err)
+		}
+		if pod == nil {
+			t.Fatalf("failed to find pod mapped to %s:%d", hostIP, hostPort)
+		}
+		if pod.Name != expectedPodName {
+			t.Fatalf("expected pod name to be %s, but got %s", expectedPodName, pod.Name)
+		}
+		// Get host IP pod with unmapped host port
+		pod, err = watcher.GetPod(hostIP, 12346)
+		if err != nil {
+			t.Fatalf("expected no error when getting host IP pod with unmapped host port, but got: %s", err)
+		}
+		if pod != nil {
+			t.Fatal("expected no pod to be found with unmapped host port")
+		}
+		// Get pod IP pod and expect an error
+		pod, err = watcher.GetPod(podIP, 12346)
+		if err == nil {
+			t.Fatal("expected error when getting by pod IP and unmapped host port, but got none")
+		}
+		if !strings.Contains(err.Error(), "Pod IP address conflict") {
+			t.Fatalf("expected error to be pod IP address conflict, but got: %s", err)
 		}
 	})
 }

--- a/controller/api/destination/watcher/ip_watcher_test.go
+++ b/controller/api/destination/watcher/ip_watcher_test.go
@@ -823,7 +823,7 @@ status:
 		if err == nil {
 			t.Fatal("expected error when getting by pod IP and unmapped host port, but got none")
 		}
-		if !strings.Contains(err.Error(), "pods with conflicting pod IP") {
+		if !strings.Contains(err.Error(), "pods with a conflicting pod network IP") {
 			t.Fatalf("expected error to be pod IP address conflict, but got: %s", err)
 		}
 	})


### PR DESCRIPTION
This fixes an issue where pod lookups by host IP and host port fail even though
the cluster has a matching pod.

Usually these manifested as `FailedPrecondition` errors, but the messages were
too long and resulted in http/2 errors. This change depends on #5893 which fixes
that separate issue.

This changes how often those `FailedPrecondition` errors actually occur. The
destination service now considers pod host IPs and should reduce the frequency
of those errors.

Closes #5881 

---

Lookups like this happen when a pod is created with a host IP and host port set
in its spec. It still has a pod IP when running, but requests to
`hostIP:hostPort` will also be redirected to the pod. Combinations of host IP
and host Port are unique to the cluster and enforced by Kubernetes.

Currently, the destination services fails to find pods in this scenario because
we only keep an index with pod and their pod IPs, not pods and their host IPs.
To fix this, we now also keep an index of pods and their host IPs—if and only if
they have the host IP set.

Now when doing a pod lookup, we consider both the IP and the port. We perform
the following steps:

1. Do a lookup by IP in the pod podIP index
  - If only one pod is found then return it
2. 0 or more than 1 pods have the same pod IP
3. Do a lookup by IP in the pod hostIP index
  - If any number of pods were found, we know that IP maps to a node IP.
    Therefore, we search for a pod with a matching host Port. If one exists then
    return it; if not then there is no pod that matches `hostIP:port`
4. The IP does not map to a host IP
5. If multiple pods were found in `1`, then we know there are pods with
   conflicting podIPs and an error is returned
6. If no pounds were found in `1` then there is no pod that matches `IP:port`

---

Aside from the additional IP watcher test being added, this can be tested with
the following steps:

1. Create a kind cluster. kind is required because it's pods in `kube-system`
   have the same pod IPs; this not the case with k3d: `bin/kind create cluster`
2. Install Linkerd with `4445` marked as opaque: `linkerd install --set
   proxy.opaquePorts="4445" |kubectl apply -f -`
2. Get the node IP: `kubectl get -o wide nodes`
3. Pull my fork of `tcp-echo`:

```
$ git clone https://github.com/kleimkuhler/tcp-echo
...
$ git checkout --track kleimkuhler/host-pod-repro
```

5. `helm package .`
7. Install `tcp-echo` with the server not injected and correct host IP: `helm
   install tcp-echo tcp-echo-0.1.0.tgz --set server.linkerdInject="false" --set
   hostIP="..."`
8. Looking at the client's proxy logs, you should not observe any errors or
   protocol detection timeouts.
9. Looking at the server logs, you should see all the requests coming through
   correctly.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
