### PR TITLE
Build CLI for M1 chips

### DIFF
--- a/bin/docker-build-cli-bin
+++ b/bin/docker-build-cli-bin
@@ -31,7 +31,7 @@ docker_build cli-bin "$tag" "$dockerfile" \
 
 IMG=$(docker_repo cli-bin):$tag
 ID=$(docker create "$IMG")
-OS="darwin windows linux-amd64"
+OS="darwin windows linux-amd64 darwin-arm64"
 if [ -n "$DOCKER_MULTIARCH" ]; then
     OS+=" linux-arm64 linux-arm"
 fi

--- a/bin/docker-pull-binaries
+++ b/bin/docker-pull-binaries
@@ -23,7 +23,7 @@ shorttag=${tag#v}
 
 # create the cli-bin container in order to extract the binaries
 id=$(docker create "$(docker_repo cli-bin):$tag")
-OS="darwin windows linux-amd64"
+OS="darwin windows linux-amd64 darwin-arm64"
 if [ -n "$DOCKER_MULTIARCH" ]; then
     OS+=" linux-arm64 linux-arm"
 fi

--- a/cli/Dockerfile-bin
+++ b/cli/Dockerfile-bin
@@ -33,12 +33,14 @@ RUN go generate -mod=readonly ./viz/static
 
 # Cache builds without version info
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd-darwin -tags prod -mod=readonly -ldflags "-s -w" ./cli
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /out/linkerd-darwin-arm64 -tags prod -mod=readonly -ldflags "-s -w" ./cli
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd-linux-amd64 -tags prod -mod=readonly -ldflags "-s -w" ./cli
 RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd-windows -tags prod -mod=readonly -ldflags "-s -w" ./cli
 
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd-darwin -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
+RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /out/linkerd-darwin -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd-linux-amd64 -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd-windows -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 


### PR DESCRIPTION
This change modifies the Linkerd build scripts to start building darwin
arm64 CLI binaries. This is to ensure architecture compatibility for the
M1 Apple CPU.

Fixes #5886