### PR TITLE
'linkerd identity' should return the leaf cert

### DIFF
--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -86,14 +86,17 @@ This command initiates a port-forward to a given pod or a set of pods and fetche
 					fmt.Printf("\n%s\n", resultCert.err)
 					return nil
 				}
-				certChain := resultCert.Certificate
-				cert := certChain[len(certChain)-1]
-				result, err := certinfo.CertificateText(cert)
-				if err != nil {
-					fmt.Printf("\n%s\n", err)
-					return nil
+				for _, cert := range resultCert.Certificate {
+					if cert.IsCA {
+						continue
+					}
+					result, err := certinfo.CertificateText(cert)
+					if err != nil {
+						fmt.Printf("\n%s\n", err)
+						return nil
+					}
+					fmt.Print(result)
 				}
-				fmt.Print(result)
 			}
 			return nil
 		},


### PR DESCRIPTION
... not the root, from the cert chain retrieved from the connection to
the pod.

Fixes #5901

Before:
```console
$ linkerd identity -n emojivoto emoji-696d9d8f95-zgpxz

POD emoji-696d9d8f95-zgpxz (1 of 1)

Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1 (0x1)
    Signature Algorithm: ECDSA-SHA256
        Issuer: CN=identity.linkerd.cluster.local
        Validity
            Not Before: Mar 15 20:14:49 2021 UTC
            Not After : Mar 15 20:15:09 2022 UTC
        Subject: CN=identity.linkerd.cluster.local
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    b7:6d:bc:0f:b5:2c:3e:76:a8:0d:9a:82:e8:ff:e1:
                    4d:9e:2a:fe:d3:7a:c0:8a:28:ce:22:fc:09:72:f8:
                    c8:a4
                Y:
                    3b:7e:d6:6b:b4:2e:15:c6:3e:c7:ae:dd:80:25:91:
                    78:97:f1:1c:3c:29:b4:a4:99:e2:78:03:0e:a7:d5:
                    e7:47
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:TRUE

    Signature Algorithm: ECDSA-SHA256
         30:45:02:21:00:8f:02:00:26:c6:2a:ab:17:8a:ea:02:1d:ee:
         81:2d:8f:c5:d7:92:55:0a:d0:90:21:8d:72:83:bf:c0:8a:6d:
         44:02:20:30:b6:22:7e:98:ff:80:2e:04:25:61:b0:fd:d0:d6:
         2b:44:a8:e8:98:7d:ef:31:a4:f1:11:de:93:fb:96:14:49
```

After:
```console
$ linkerd identity -n emojivoto emoji-696d9d8f95-zgpxz

POD emoji-696d9d8f95-zgpxz (1 of 1)

Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 6 (0x6)
    Signature Algorithm: ECDSA-SHA256
        Issuer: CN=identity.linkerd.cluster.local
        Validity
            Not Before: Mar 15 20:21:55 2021 UTC
            Not After : Mar 16 20:22:35 2021 UTC
        Subject: CN=emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local
        Subject Public Key Info:
            Public Key Algorithm: ECDSA
                Public-Key: (256 bit)
                X:
                    ac:5f:07:97:d4:0b:21:f0:f7:2d:a0:a5:85:19:c7:
                    e7:3b:08:05:cf:c9:61:21:5a:f3:00:70:7e:a1:1b:
                    87:9e
                Y:
                    a6:76:ef:7c:10:43:6e:55:e4:5d:ec:81:c0:cc:1c:
                    08:6c:81:4c:cb:c9:e4:53:89:1d:ab:6e:e6:ec:c4:
                    76:5b
                Curve: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Subject Alternative Name:
                DNS:emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local

    Signature Algorithm: ECDSA-SHA256
         30:45:02:20:6a:10:b4:97:96:6b:54:a3:5f:02:36:8d:78:96:
         8f:f7:0c:7b:1e:7b:4a:b2:2c:c2:a5:b0:16:47:bd:64:58:a3:
         02:21:00:cc:95:7d:d1:6a:25:d3:81:a7:bb:63:8f:d9:65:a4:
         93:77:6e:76:b8:50:22:bb:85:8c:38:f6:f8:c8:a3:3d:e9
```