### PR TITLE
cli: show spinner for extension checks

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/linkerd/linkerd2/cli/flag"
 	jaegerCmd "github.com/linkerd/linkerd2/jaeger/cmd"
 	mcCmd "github.com/linkerd/linkerd2/multicluster/cmd"
@@ -19,6 +20,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/version"
 	vizHealthCheck "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	valuespkg "helm.sh/helm/v3/pkg/cli/values"
@@ -251,6 +253,9 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 		fmt.Fprintln(wout, strings.Repeat("=", len(headerTxt)))
 	}
 
+	spin := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spin.Writer = wout
+
 	for i, ns := range namespaces {
 		if opts.output != healthcheck.JSONOutput && i < len(namespaces) {
 			// add a new line to space out each check output
@@ -289,12 +294,17 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 			}
 		}
 		if err == nil {
+			if isatty.IsTerminal(os.Stdout.Fd()) {
+				spin.Suffix = fmt.Sprintf(" Running %s extension check", extension)
+				spin.Color("bold") // this calls spin.Restart()
+			}
 			plugin := exec.Command(path, args...)
 			var stdout, stderr bytes.Buffer
 			plugin.Stdout = &stdout
 			plugin.Stderr = &stderr
 			plugin.Run()
 			extensionResults, err := healthcheck.ParseJSONCheckOutput(stdout.Bytes())
+			spin.Stop()
 			if err != nil {
 				command := fmt.Sprintf("%s %s", path, strings.Join(args, " "))
 				if len(stderr.String()) > 0 {


### PR DESCRIPTION
Fixes #5837

Currently, When extension checks are running through `linkerd check`
we don't really any show status. This means that when the check
is run directly after a extension install, The CLI looks like it
got struck somewhere with no status as per the issue description.

This PR updates the code to show a spinner with the name of
extension of whose the check is being ran.

```bash

control-plane-version
---------------------
 control plane is up-to-date
 control plane and cli versions match
    control plane running stable-2.10.0 but cli running dev-e5ff84ce-tarun
    see https://linkerd.io/checks/#l5d-version-control for hints

Status check results are

Linkerd extensions checks
=========================

linkerd-jaeger
--------------
 linkerd-jaeger extension Namespace exists
 collector and jaeger service account exists
 collector config map exists
 jaeger extension pods are injected
 jaeger extension pods are running

Status check results are

/ Running viz extension check
```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
