### PR TITLE
Ignore pods in "Terminating" when watching IP addresses.

### DIFF
--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -112,6 +112,15 @@ status:
   phase: Failed
   podIP: 172.17.0.13`,
 		`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name2-4
+  namespace: ns
+  deletionTimestamp: 2021-01-01T00:00:00Z
+status:
+  podIP: 172.17.0.13`,
+		`
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:

--- a/controller/api/destination/watcher/ip_watcher.go
+++ b/controller/api/destination/watcher/ip_watcher.go
@@ -154,7 +154,7 @@ func (iw *IPWatcher) GetPod(podIP string) (*corev1.Pod, error) {
 	pods := make([]*corev1.Pod, 0)
 	for _, obj := range objs {
 		pod := obj.(*corev1.Pod)
-		if podTerminated(pod) {
+		if !podReceivingTraffic(pod) {
 			continue
 		}
 		pods = append(pods, pod)
@@ -168,9 +168,12 @@ func (iw *IPWatcher) GetPod(podIP string) (*corev1.Pod, error) {
 	return pods[0], nil
 }
 
-func podTerminated(pod *corev1.Pod) bool {
+func podReceivingTraffic(pod *corev1.Pod) bool {
 	phase := pod.Status.Phase
-	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
+	podTerminated := phase == corev1.PodSucceeded || phase == corev1.PodFailed
+	podTerminating := pod.DeletionTimestamp != nil
+
+	return !podTerminating && !podTerminated
 }
 
 func (iw *IPWatcher) addService(obj interface{}) {
@@ -296,9 +299,7 @@ func (iw *IPWatcher) getOrNewServiceSubscriptions(clusterIP string) *serviceSubs
 						continue
 					}
 
-					// Ignore terminated pods,
-					// their IPs can be reused for new Running pods
-					if podTerminated(pod) {
+					if !podReceivingTraffic(pod) {
 						continue
 					}
 


### PR DESCRIPTION
Some CNIs reasssign the IP of a terminating pod to a new pod, which
leads to duplicate IPs in the cluster.

It eventually triggers #5939.

This commit will make the IPWatcher, when given an IP, filter out the terminating pods
(when a pod is given a deletionTimestamp).

The issue is hard reproduce because we are not able to assign a
particular IP to a pod manually.

Fixes #5939

Signed-off-by: Bruce <wenliang.chen@personio.de>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
