### PR TITLE
Get rid of `CheckDeployments()` in integration tests

### DIFF
--- a/test/integration/edges/edges_test.go
+++ b/test/integration/edges/edges_test.go
@@ -87,10 +87,6 @@ func TestDirectEdges(t *testing.T) {
 			}
 		}
 
-		if err := TestHelper.CheckDeployment(ctx, testNamespace, "terminus", 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", "terminus", err)
-		}
-
 		// get terminus pod ip
 
 		ip, err := TestHelper.Kubectl("", "-n", testNamespace, "get", "pod", "-ojsonpath=\"{.items[*].status.podIP}\"")
@@ -127,10 +123,6 @@ func TestDirectEdges(t *testing.T) {
 			} else {
 				testutil.AnnotatedError(t, "CheckPods timed-out", err)
 			}
-		}
-
-		if err := TestHelper.CheckDeployment(ctx, testNamespace, "slow-cooker", 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "error validating deployment [%s]:\n%s", "terminus", err)
 		}
 
 		// check edges

--- a/test/integration/externalresources/rabbitmq_test.go
+++ b/test/integration/externalresources/rabbitmq_test.go
@@ -41,9 +41,6 @@ func TestRabbitMQDeploy(t *testing.T) {
 				testutil.AnnotatedError(t, "CheckPods timed-out %s", err)
 			}
 		}
-		if err := TestHelper.CheckDeployment(ctx, testNamespace, "rabbitmq", 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment  timed-out", "Error validating deployment [%s]: \n%s", "rabbitmq", err)
-		}
 		// inject rabbitmq-client
 		stdout, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/rabbitmq-client.yaml")
 		if err != nil {
@@ -60,9 +57,6 @@ func TestRabbitMQDeploy(t *testing.T) {
 			} else {
 				testutil.AnnotatedError(t, "CheckPods timed-out %s", err)
 			}
-		}
-		if err := TestHelper.CheckDeployment(ctx, testNamespace, "rabbitmq-client", 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment  timed-out", "Error validating deployment [%s]: \n%s", "rabbitmq", err)
 		}
 		// Verify client output
 		golden := "check.rabbitmq.golden"

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -137,10 +137,6 @@ func TestUpgradeTestAppWorksBeforeUpgrade(t *testing.T) {
 					testutil.AnnotatedError(t, "CheckPods timed-out", err)
 				}
 			}
-
-			if err := TestHelper.CheckDeployment(ctx, testAppNamespace, deploy, 1); err != nil {
-				testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-			}
 		}
 
 		if err := testutil.ExerciseTestAppEndpoint("/api/list", testAppNamespace, TestHelper); err != nil {
@@ -540,7 +536,7 @@ func TestControlPlaneResourcesPostInstall(t *testing.T) {
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
 		expectedServices = append(expectedServices, testutil.Service{Namespace: "linkerd-viz", Name: "prometheus"})
-		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1}
 	}
 
 	// Upgrade Case
@@ -1158,7 +1154,7 @@ func TestCheckProxy(t *testing.T) {
 func TestRestarts(t *testing.T) {
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
-		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1}
 	}
 	for deploy, spec := range expectedDeployments {
 		if err := TestHelper.CheckPods(context.Background(), spec.Namespace, deploy, spec.Replicas); err != nil {

--- a/test/integration/opaqueports/opaque_ports_test.go
+++ b/test/integration/opaqueports/opaque_ports_test.go
@@ -65,10 +65,6 @@ func TestOpaquePorts(t *testing.T) {
 		}
 	}
 
-	if err := TestHelper.CheckDeployment(ctx, opaquePortsNs, opaquePodApp, 1); err != nil {
-		testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", opaquePodApp, err)
-	}
-
 	// Check that the opaque service test application started correctly.
 	if err := TestHelper.CheckPods(ctx, opaquePortsNs, opaqueSvcApp, 1); err != nil {
 		if rce, ok := err.(*testutil.RestartCountError); ok {
@@ -76,10 +72,6 @@ func TestOpaquePorts(t *testing.T) {
 		} else {
 			testutil.AnnotatedError(t, "CheckPods timed-out", err)
 		}
-	}
-
-	if err := TestHelper.CheckDeployment(ctx, opaquePortsNs, opaqueSvcApp, 1); err != nil {
-		testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", opaqueSvcApp, err)
 	}
 
 	// Wait for slow-cookers to start sending requests

--- a/test/integration/serviceprofiles/serviceprofiles_test.go
+++ b/test/integration/serviceprofiles/serviceprofiles_test.go
@@ -62,10 +62,6 @@ func testProfiles(t *testing.T) {
 				testutil.AnnotatedError(t, "CheckPods timed-out", err)
 			}
 		}
-
-		if err := TestHelper.CheckDeployment(ctx, testNamespace, deploy, 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-		}
 	}
 
 	testCases := []testCase{

--- a/test/integration/smimetrics/smi-metrics_test.go
+++ b/test/integration/smimetrics/smi-metrics_test.go
@@ -68,10 +68,6 @@ func TestSMIMetrics(t *testing.T) {
 		}
 	}
 
-	if err := TestHelper.CheckDeployment(ctx, testNamespace, "smi-metrics", 1); err != nil {
-		testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "error validating deployment [%s]:\n%s", "terminus", err)
-	}
-
 	testCases := []testCase{
 		{
 			name: "linkerd-controller",

--- a/test/integration/tap/tap_test.go
+++ b/test/integration/tap/tap_test.go
@@ -90,10 +90,6 @@ func TestCliTap(t *testing.T) {
 					testutil.AnnotatedError(t, "CheckPods timed-out", err)
 				}
 			}
-
-			if err := TestHelper.CheckDeployment(ctx, prefixedNs, deploy, 1); err != nil {
-				testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-			}
 		}
 
 		t.Run("tap a deployment", func(t *testing.T) {

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -163,10 +163,6 @@ func TestTracing(t *testing.T) {
 				testutil.AnnotatedError(t, "CheckPods timed-out", err)
 			}
 		}
-
-		if err := TestHelper.CheckDeployment(ctx, deploy.ns, deploy.name, 1); err != nil {
-			testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy.name, err)
-		}
 	}
 
 	t.Run("expect full trace", func(t *testing.T) {

--- a/test/integration/trafficsplit/trafficsplit_test.go
+++ b/test/integration/trafficsplit/trafficsplit_test.go
@@ -170,10 +170,6 @@ func TestTrafficSplitCli(t *testing.T) {
 					testutil.AnnotatedError(t, "CheckPods timed-out", err)
 				}
 			}
-
-			if err := TestHelper.CheckDeployment(ctx, prefixedNs, deploy, 1); err != nil {
-				testutil.AnnotatedErrorf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-			}
 		}
 
 		t.Run("ensure traffic is sent to one backend only", func(t *testing.T) {

--- a/test/integration/uninstall/uninstall_test.go
+++ b/test/integration/uninstall/uninstall_test.go
@@ -73,7 +73,7 @@ func TestResourcesPostInstall(t *testing.T) {
 
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {
-		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1, Containers: []string{}}
+		expectedDeployments["prometheus"] = testutil.DeploySpec{Namespace: "linkerd-viz", Replicas: 1}
 	}
 	// Upgrade Case
 	if TestHelper.UpgradeHelmFromVersion() != "" {
@@ -86,9 +86,6 @@ func TestResourcesPostInstall(t *testing.T) {
 			} else {
 				testutil.AnnotatedError(t, "CheckPods timed-out", err)
 			}
-		}
-		if err := TestHelper.CheckDeployment(ctx, spec.Namespace, deploy, spec.Replicas); err != nil {
-			testutil.AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
 		}
 	}
 }

--- a/testutil/install.go
+++ b/testutil/install.go
@@ -33,9 +33,6 @@ func TestResourcesPostInstall(namespace string, services []Service, deploys map[
 				AnnotatedFatal(t, "CheckPods timed-out", err)
 			}
 		}
-		if err := h.CheckDeployment(ctx, spec.Namespace, deploy, spec.Replicas); err != nil {
-			AnnotatedFatalf(t, "CheckDeployment timed-out", "Error validating deployment [%s]:\n%s", deploy, err)
-		}
 	}
 }
 

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -151,45 +151,6 @@ func (h *KubernetesHelper) Kubectl(stdin string, arg ...string) (string, error) 
 	return string(out), err
 }
 
-// getDeployments gets all deployments with a count of their ready replicas in
-// the specified namespace.
-func (h *KubernetesHelper) getDeployments(ctx context.Context, namespace string) (map[string]int, error) {
-	deploys, err := h.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	deployments := map[string]int{}
-	for _, deploy := range deploys.Items {
-		deployments[deploy.GetName()] = int(deploy.Status.ReadyReplicas)
-	}
-	return deployments, nil
-}
-
-// CheckDeployment checks that a deployment in a namespace contains the expected
-// number of replicas.
-func (h *KubernetesHelper) CheckDeployment(ctx context.Context, namespace string, deploymentName string, replicas int) error {
-	return h.retryFor(30*time.Second, func() error {
-		deploys, err := h.getDeployments(ctx, namespace)
-		if err != nil {
-			return err
-		}
-
-		count, ok := deploys[deploymentName]
-		if !ok {
-			return fmt.Errorf("Deployment [%s] in namespace [%s] not found",
-				deploymentName, namespace)
-		}
-
-		if count != replicas {
-			return fmt.Errorf("Expected deployment [%s] in namespace [%s] to have [%d] replicas, but found [%d]",
-				deploymentName, namespace, replicas, count)
-		}
-
-		return nil
-	})
-}
-
 // GetConfigUID returns the uid associated to the linkerd-config ConfigMap resource
 // in the given namespace
 func (h *KubernetesHelper) GetConfigUID(ctx context.Context, namespace string) (string, error) {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -55,9 +55,8 @@ type helm struct {
 
 // DeploySpec is used to hold information about what deploys we should verify during testing
 type DeploySpec struct {
-	Namespace  string
-	Replicas   int
-	Containers []string
+	Namespace string
+	Replicas  int
 }
 
 // Service is used to hold information about a Service we should verify during testing
@@ -69,14 +68,14 @@ type Service struct {
 // LinkerdDeployReplicasEdge is a map containing the number of replicas for each Deployment and the main
 // container name, in the current code-base
 var LinkerdDeployReplicasEdge = map[string]DeploySpec{
-	"linkerd-controller":     {"linkerd", 1, []string{"public-api"}},
-	"linkerd-destination":    {"linkerd", 1, []string{"destination"}},
-	"tap":                    {"linkerd-viz", 1, []string{"tap"}},
-	"grafana":                {"linkerd-viz", 1, []string{}},
-	"linkerd-identity":       {"linkerd", 1, []string{"identity"}},
-	"linkerd-sp-validator":   {"linkerd", 1, []string{"sp-validator"}},
-	"web":                    {"linkerd-viz", 1, []string{"web"}},
-	"linkerd-proxy-injector": {"linkerd", 1, []string{"proxy-injector"}},
+	"linkerd-controller":     {"linkerd", 1},
+	"linkerd-destination":    {"linkerd", 1},
+	"tap":                    {"linkerd-viz", 1},
+	"grafana":                {"linkerd-viz", 1},
+	"linkerd-identity":       {"linkerd", 1},
+	"linkerd-sp-validator":   {"linkerd", 1},
+	"web":                    {"linkerd-viz", 1},
+	"linkerd-proxy-injector": {"linkerd", 1},
 }
 
 // LinkerdDeployReplicasStable is a map containing the number of replicas for each Deployment and the main
@@ -139,7 +138,7 @@ func NewGenericTestHelper(
 // MulticlusterDeployReplicas is a map containing the number of replicas for each Deployment and the main
 // container name for multicluster components
 var MulticlusterDeployReplicas = map[string]DeploySpec{
-	"linkerd-gateway": {"linkerd-multicluster", 1, []string{"nginx"}},
+	"linkerd-gateway": {"linkerd-multicluster", 1},
 }
 
 // NewTestHelper creates a new instance of TestHelper for the current test run.


### PR DESCRIPTION
`CheckDeployments()` verified that some deployment had the appropriate
number of replicas in the Ready state. `CheckPods()` does the same, plus
checking if there were restarts (a single restart returns
`RestartCountError` which only triggers a warning on the calling side,
more restarts trigger a regular error). We were always calling the
former followed by a call to the latter which is superfluous, so we're
getting rid of the latter.

Also, the `testutil.DeploySpec` struct had a `Containers` field for
checking the name of containers, but that wasn't always checked and
didn't really represent a potential error that wouldn't be clearly
manifested otherwise (like in golden files), so that was simplified as
well.
