### PR TITLE
cli: restrict repair cmd with the same server version

### DIFF
--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -25,9 +25,8 @@ var (
 	// 2.8 and below
 	repairNotApplicableVersionRegex = regexp.MustCompile(`^stable-2\.[0-8]\.([0-9]+)$`)
 
-	// repairApplicableVersionRegex matches versions 2.9.4 and above where repair
-	// would be useful
-	repairApplicableVersionRegex = regexp.MustCompile(`^stable-2\.(9|[0-9]{2})\.([0-9]+)$`)
+	// repairApplicableVersionRegex matches versions 2.9 versions upto 2.9.4
+	repairApplicableVersionRegex = regexp.MustCompile(`^stable-2\.9\.[0-4]$`)
 )
 
 // newCmdRepair creates a new cobra command `repair` which re-creates the
@@ -93,7 +92,7 @@ func repair(ctx context.Context, forced bool) error {
 			return fmt.Errorf("repair command is only applicable to 2.9 control-plane versions. Please try upgrading to the latest supported versions of Linkerd i.e 2.9.4 and above")
 		}
 
-		// Suggest 2.9.4 CLI version for all 2.9 server versions
+		// Suggest 2.9.4 CLI version for all 2.9 server versions upto 2.9.4
 		if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
 			return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
 		}

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -49,7 +49,7 @@ linkerd upgrade.`,
 
 			// Check if the CLI version matches with that of the server
 			clientVersion := version.Version
-			serverVersion := defaultVersionString
+			var serverVersion string
 			publicClient, err := public.NewExternalClient(cmd.Context(), controlPlaneNamespace, k8sAPI)
 			if err != nil {
 				return err

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -21,9 +21,13 @@ import (
 )
 
 var (
-	repairNotApplicableVersionRegex = regexp.MustCompile("stable-2.[0-8].*")
+	// repairNotApplicableVersionRegex matches older versions of Linkerd i.e
+	// 2.8 and below
+	repairNotApplicableVersionRegex = regexp.MustCompile(`^stable-2\.[0-8]\.([0-9]+)$`)
 
-	repairApplicableVersionRegex = regexp.MustCompile("stable-2.[9].*")
+	// repairApplicableVersionRegex matches versions 2.9.4 and above where repair
+	// would be useful
+	repairApplicableVersionRegex = regexp.MustCompile(`^stable-2\.(9|[0-9]{2})\.([0-9]+)$`)
 )
 
 // newCmdRepair creates a new cobra command `repair` which re-creates the
@@ -93,11 +97,11 @@ func repair(ctx context.Context, forced bool) error {
 
 			// Suggest 2.9.4 CLI version for all 2.9 server versions
 			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI")
+				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"2.9.4\" sh` to install the server version of the CLI")
 			}
 
 			// Suggest server version for everything else. This includes all edge versions
-			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", serverVersion)
+			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"%s\" sh` to install the server version of the CLI", serverVersion)
 		}
 	}
 

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -97,7 +97,7 @@ func repair(ctx context.Context, forced bool) error {
 
 			// Suggest 2.9.4 CLI version for all 2.9 server versions
 			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
+				return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
 			}
 
 			// Suggest server version for everything else. This includes all edge versions
@@ -177,8 +177,25 @@ func resetVersion(values *linkerd2.Values) error {
 	if err != nil {
 		return err
 	}
-	values.DebugContainer.Image.Version = defaults.DebugContainer.Image.Version
-	values.Proxy.Image.Version = defaults.Proxy.Image.Version
+
+	if values.DebugContainer != nil {
+		if values.DebugContainer.Image != nil {
+			values.DebugContainer.Image.Version = defaults.DebugContainer.Image.Version
+		}
+	}
+
+	if values.Proxy != nil {
+		if values.Proxy.Image != nil {
+			values.Proxy.Image.Version = defaults.Proxy.Image.Version
+		}
+	}
+
+	if values.ProxyInit != nil {
+		if values.ProxyInit.Image != nil {
+			values.ProxyInit.Image.Version = defaults.ProxyInit.Image.Version
+		}
+	}
+
 	values.CliVersion = defaults.CliVersion
 	values.ControllerImageVersion = defaults.ControllerImageVersion
 	values.LinkerdVersion = defaults.LinkerdVersion

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -87,22 +87,19 @@ func repair(ctx context.Context, forced bool) error {
 		return err
 	}
 
-	if !forced {
-		if serverVersion != clientVersion {
-
-			// Suggest directly upgrading to 2.9.4 or above for older versions
-			if repairNotApplicableVersionRegex.Match([]byte(serverVersion)) {
-				return fmt.Errorf("repair command is only applicable to 2.9 control-plane versions. Please try upgrading to the latest supported versions of Linkerd i.e 2.9.4 and above")
-			}
-
-			// Suggest 2.9.4 CLI version for all 2.9 server versions
-			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-				return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
-			}
-
-			// Suggest server version for everything else. This includes all edge versions
-			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `export LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI", serverVersion)
+	if !forced && serverVersion != clientVersion {
+		// Suggest directly upgrading to 2.9.4 or above for older versions
+		if repairNotApplicableVersionRegex.Match([]byte(serverVersion)) {
+			return fmt.Errorf("repair command is only applicable to 2.9 control-plane versions. Please try upgrading to the latest supported versions of Linkerd i.e 2.9.4 and above")
 		}
+
+		// Suggest 2.9.4 CLI version for all 2.9 server versions
+		if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
+			return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
+		}
+
+		// Suggest server version for everything else. This includes all edge versions
+		return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `export LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI", serverVersion)
 	}
 
 	// Load the stored config
@@ -123,7 +120,6 @@ func repair(ctx context.Context, forced bool) error {
 		return fmt.Errorf("Failed to load values from linkerd-config: %s", err)
 	}
 
-	// Reset version fields
 	err = resetVersion(&values)
 	if err != nil {
 		return fmt.Errorf("Failed to reset version fields in linkerd-config: %s", err)
@@ -178,22 +174,16 @@ func resetVersion(values *linkerd2.Values) error {
 		return err
 	}
 
-	if values.DebugContainer != nil {
-		if values.DebugContainer.Image != nil {
-			values.DebugContainer.Image.Version = defaults.DebugContainer.Image.Version
-		}
+	if values.DebugContainer != nil && values.DebugContainer.Image != nil {
+		values.DebugContainer.Image.Version = defaults.DebugContainer.Image.Version
 	}
 
-	if values.Proxy != nil {
-		if values.Proxy.Image != nil {
-			values.Proxy.Image.Version = defaults.Proxy.Image.Version
-		}
+	if values.Proxy != nil && values.Proxy.Image != nil {
+		values.Proxy.Image.Version = defaults.Proxy.Image.Version
 	}
 
-	if values.ProxyInit != nil {
-		if values.ProxyInit.Image != nil {
-			values.ProxyInit.Image.Version = defaults.ProxyInit.Image.Version
-		}
+	if values.ProxyInit != nil && values.ProxyInit.Image != nil {
+		values.ProxyInit.Image.Version = defaults.ProxyInit.Image.Version
 	}
 
 	values.CliVersion = defaults.CliVersion

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -97,11 +97,11 @@ func repair(ctx context.Context, forced bool) error {
 
 			// Suggest 2.9.4 CLI version for all 2.9 server versions
 			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"2.9.4\" sh` to install the server version of the CLI")
+				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
 			}
 
 			// Suggest server version for everything else. This includes all edge versions
-			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"%s\" sh` to install the server version of the CLI", serverVersion)
+			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `export LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI", serverVersion)
 		}
 	}
 

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -18,6 +18,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var (
+	versionRegex = regexp.MustCompile("stable-2.[8-9].*")
+)
+
 // newCmdRepair creates a new cobra command `repair` which re-creates the
 // linkerd-config-overrides secret if it has been deleted.
 func newCmdRepair() *cobra.Command {
@@ -60,10 +64,6 @@ linkerd upgrade.`,
 			}
 
 			if serverVersion != clientVersion {
-				versionRegex, err := regexp.Compile("stable-2.[8-9].*")
-				if err != nil {
-					return err
-				}
 				helperVersion := serverVersion
 				// Use 2.9.4 CLI version for all 2.9 versions
 				if versionRegex.Match([]byte(serverVersion)) {

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -94,11 +94,11 @@ func repair(ctx context.Context, forced bool) error {
 
 		// Suggest 2.9.4 CLI version for all 2.9 server versions upto 2.9.4
 		if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-			return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `export LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI")
+			return fmt.Errorf("Please run the repair command with a `stable-2.9.4` CLI.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"stable-2.9.4\" sh` to install the server version of the CLI")
 		}
 
 		// Suggest server version for everything else. This includes all edge versions
-		return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `export LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh; unset LINKERD2_VERSION` to install the server version of the CLI", serverVersion)
+		return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `curl -sL https://run.linkerd.io/install | LINKERD2_VERSION=\"%s\" sh` to install the server version of the CLI", serverVersion)
 	}
 
 	// Load the stored config

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -60,16 +60,16 @@ linkerd upgrade.`,
 			}
 
 			if serverVersion != clientVersion {
-				twoPointEightOrNineRegex, err := regexp.Compile("stable-2.[8-9].*")
+				versionRegex, err := regexp.Compile("stable-2.[8-9].*")
 				if err != nil {
 					return err
 				}
 				helperVersion := serverVersion
 				// Use 2.9.4 CLI version for all 2.9 versions
-				if twoPointEightOrNineRegex.Match([]byte(serverVersion)) {
+				if versionRegex.Match([]byte(serverVersion)) {
 					helperVersion = "stable-2.9.4"
 				}
-				return fmt.Errorf("Please run the repair command with a CLI version as that of the server.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", helperVersion)
+				return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", helperVersion)
 			}
 
 			// Load the stored config

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -21,7 +21,9 @@ import (
 )
 
 var (
-	versionRegex = regexp.MustCompile("stable-2.[8-9].*")
+	repairNotApplicableVersionRegex = regexp.MustCompile("stable-2.[0-8].*")
+
+	repairApplicableVersionRegex = regexp.MustCompile("stable-2.[9].*")
 )
 
 // newCmdRepair creates a new cobra command `repair` which re-creates the
@@ -84,8 +86,14 @@ func repair(ctx context.Context, forced bool) error {
 	if !forced {
 		if serverVersion != clientVersion {
 			helperVersion := serverVersion
+
+			// Suggest directly upgrading to 2.9.4 or above for older versions
+			if repairNotApplicableVersionRegex.Match([]byte(serverVersion)) {
+				return fmt.Errorf("repair command is only applicable to 2.9 control-plane versions. Please try upgrading to the latest supported versions of Linkerd i.e 2.9.4 and above")
+			}
+
 			// Use 2.9.4 CLI version for all 2.9 versions
-			if versionRegex.Match([]byte(serverVersion)) {
+			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
 				helperVersion = "stable-2.9.4"
 			}
 			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", helperVersion)

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -69,7 +69,7 @@ linkerd upgrade.`,
 				if twoPointEightOrNineRegex.Match([]byte(serverVersion)) {
 					helperVersion = "stable-2.9.4"
 				}
-				return fmt.Errorf("Please run the repair command with a CLI version as that of the server i.e %s\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", serverVersion, helperVersion)
+				return fmt.Errorf("Please run the repair command with a CLI version as that of the server.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", helperVersion)
 			}
 
 			// Load the stored config

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -85,18 +85,19 @@ func repair(ctx context.Context, forced bool) error {
 
 	if !forced {
 		if serverVersion != clientVersion {
-			helperVersion := serverVersion
 
 			// Suggest directly upgrading to 2.9.4 or above for older versions
 			if repairNotApplicableVersionRegex.Match([]byte(serverVersion)) {
 				return fmt.Errorf("repair command is only applicable to 2.9 control-plane versions. Please try upgrading to the latest supported versions of Linkerd i.e 2.9.4 and above")
 			}
 
-			// Use 2.9.4 CLI version for all 2.9 versions
+			// Suggest 2.9.4 CLI version for all 2.9 server versions
 			if repairApplicableVersionRegex.Match([]byte(serverVersion)) {
-				helperVersion = "stable-2.9.4"
+				return fmt.Errorf("Please run the repair command with a `2.9.4` CLI.\nRun `LINKERD2_VERSION=\"stable-2.9.4\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI")
 			}
-			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", helperVersion)
+
+			// Suggest server version for everything else. This includes all edge versions
+			return fmt.Errorf("Please run the repair command with a CLI that has the same version as the control plane.\nRun `LINKERD2_VERSION=\"%s\"; curl -sL https://run.linkerd.io/install | sh` to install the server version of the CLI", serverVersion)
 		}
 	}
 


### PR DESCRIPTION
Fixes #5917

Currently, When a repair cmd is ran with a CLI that is different
from the server version. This means it is possible for the cmd
to fail as the `Values` struct changes between versions.

This PR updates the cmd to restrict it to the version that the
server is on, but as the repair cmd is avialable only on `2.9.4`
we fall-back on to that version in the suggestion when the server
version is `2.9` or 2.8`.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
