### PR TITLE
multicluster: make service mirror honour `requeueLimit`

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -604,7 +604,7 @@ func (rcsw *RemoteClusterServiceWatcher) processEvents(ctx context.Context) {
 			switch e := err.(type) {
 			case RetryableError:
 				{
-					rcsw.log.Infof("Requeues: %d, Limit: %d for event %s", rcsw.eventsQueue.NumRequeues(event), rcsw.requeueLimit, event)
+					rcsw.log.Warnf("Requeues: %d, Limit: %d for event %s", rcsw.eventsQueue.NumRequeues(event), rcsw.requeueLimit, event)
 					if (rcsw.eventsQueue.NumRequeues(event) < rcsw.requeueLimit) && !done {
 						rcsw.log.Errorf("Error processing %s (will retry): %s", event, e)
 						rcsw.eventsQueue.AddRateLimited(event)

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -604,8 +604,8 @@ func (rcsw *RemoteClusterServiceWatcher) processEvents(ctx context.Context) {
 			switch e := err.(type) {
 			case RetryableError:
 				{
+					rcsw.log.Infof("Requeues: %d, Limit: %d for event %s", rcsw.eventsQueue.NumRequeues(event), rcsw.requeueLimit, event)
 					if (rcsw.eventsQueue.NumRequeues(event) < rcsw.requeueLimit) && !done {
-						rcsw.log.Infof("Requeues: %d, Limit: %d for event %s", rcsw.eventsQueue.NumRequeues(event), rcsw.requeueLimit, event)
 						rcsw.log.Errorf("Error processing %s (will retry): %s", event, e)
 						rcsw.eventsQueue.AddRateLimited(event)
 					} else {

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -148,7 +148,7 @@ func NewRemoteClusterServiceWatcher(
 			"cluster":    clusterName,
 			"apiAddress": cfg.Host,
 		}),
-		eventsQueue:  workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter()),
+		eventsQueue:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		requeueLimit: requeueLimit,
 		repairPeriod: repairPeriod,
 	}, nil
@@ -485,7 +485,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateService(service *corev1.S
 		localService, err := rcsw.localAPIClient.Svc().Lister().Services(service.Namespace).Get(localName)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
-				rcsw.eventsQueue.AddRateLimited(&RemoteServiceCreated{
+				rcsw.eventsQueue.Add(&RemoteServiceCreated{
 					service: service,
 				})
 				return nil
@@ -497,7 +497,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateService(service *corev1.S
 		if ok && lastMirroredRemoteVersion != service.ResourceVersion {
 			endpoints, err := rcsw.localAPIClient.Endpoint().Lister().Endpoints(service.Namespace).Get(localName)
 			if err == nil {
-				rcsw.eventsQueue.AddRateLimited(&RemoteServiceUpdated{
+				rcsw.eventsQueue.Add(&RemoteServiceUpdated{
 					localService:   localService,
 					localEndpoints: endpoints,
 					remoteUpdate:   service,
@@ -514,7 +514,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateService(service *corev1.S
 			_, isMirroredRes := localSvc.Labels[consts.MirroredResourceLabel]
 			clusterName := localSvc.Labels[consts.RemoteClusterNameLabel]
 			if isMirroredRes && (clusterName == rcsw.link.TargetClusterName) {
-				rcsw.eventsQueue.AddRateLimited(&RemoteServiceDeleted{
+				rcsw.eventsQueue.Add(&RemoteServiceDeleted{
 					Name:      service.Name,
 					Namespace: service.Namespace,
 				})
@@ -539,7 +539,7 @@ func (rcsw *RemoteClusterServiceWatcher) getMirrorServices() ([]*corev1.Service,
 
 func (rcsw *RemoteClusterServiceWatcher) handleOnDelete(service *corev1.Service) {
 	if rcsw.isExportedService(service) {
-		rcsw.eventsQueue.AddRateLimited(&RemoteServiceDeleted{
+		rcsw.eventsQueue.Add(&RemoteServiceDeleted{
 			Name:      service.Name,
 			Namespace: service.Namespace,
 		})
@@ -628,11 +628,11 @@ func (rcsw *RemoteClusterServiceWatcher) processEvents(ctx context.Context) {
 // Start starts watching the remote cluster
 func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 	rcsw.remoteAPIClient.Sync(rcsw.stopper)
-	rcsw.eventsQueue.AddRateLimited(&OrphanedServicesGcTriggered{})
+	rcsw.eventsQueue.Add(&OrphanedServicesGcTriggered{})
 	rcsw.remoteAPIClient.Svc().Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(svc interface{}) {
-				rcsw.eventsQueue.AddRateLimited(&OnAddCalled{svc.(*corev1.Service)})
+				rcsw.eventsQueue.Add(&OnAddCalled{svc.(*corev1.Service)})
 			},
 			DeleteFunc: func(obj interface{}) {
 				service, ok := obj.(*corev1.Service)
@@ -648,10 +648,10 @@ func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 						return
 					}
 				}
-				rcsw.eventsQueue.AddRateLimited(&OnDeleteCalled{service})
+				rcsw.eventsQueue.Add(&OnDeleteCalled{service})
 			},
 			UpdateFunc: func(old, new interface{}) {
-				rcsw.eventsQueue.AddRateLimited(&OnUpdateCalled{new.(*corev1.Service)})
+				rcsw.eventsQueue.Add(&OnUpdateCalled{new.(*corev1.Service)})
 			},
 		},
 	)
@@ -660,7 +660,7 @@ func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 	// We need to issue a RepairEndpoints immediately to populate the gateway
 	// mirror endpoints.
 	ev := RepairEndpoints{}
-	rcsw.eventsQueue.AddRateLimited(&ev)
+	rcsw.eventsQueue.Add(&ev)
 
 	go func() {
 		ticker := time.NewTicker(rcsw.repairPeriod)
@@ -668,7 +668,7 @@ func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 			select {
 			case <-ticker.C:
 				ev := RepairEndpoints{}
-				rcsw.eventsQueue.AddRateLimited(&ev)
+				rcsw.eventsQueue.Add(&ev)
 			case <-rcsw.stopper:
 				return
 			}
@@ -682,7 +682,7 @@ func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 func (rcsw *RemoteClusterServiceWatcher) Stop(cleanupState bool) {
 	close(rcsw.stopper)
 	if cleanupState {
-		rcsw.eventsQueue.AddRateLimited(&ClusterUnregistered{})
+		rcsw.eventsQueue.Add(&ClusterUnregistered{})
 	}
 	rcsw.eventsQueue.ShutDown()
 }


### PR DESCRIPTION
Fixes #5374

Currently, Whenever the `gatewayAddress` is changed the service
mirror component keeps trying to repairEndpoints (which is
invoked every `repairPeriod`). This behavior is fine and
expected

but as the service mirror does not honor `requeueLimit` currently,
It keeps on requeuing the same event and keeps trying with no limit.

The condition that we use to limit requeues
`if (rcsw.eventsQueue.NumRequeues(event) < rcsw.requeueLimit)` does
not work for the following reason:

- For this queue to actually track requeues, `AddRateLimited` has to be
  used instead which makes `NumRequeues` actually return the actual
  number of requeues for a specific event.

This change updates the requeuing logic to use `AddRateLimited` instead
of `Add`

After these changes, The logs in the service mirror are as follows

```bash
time="2021-03-30T16:52:31Z" level=info msg="Received: OnAddCalled: {svc: Service: {name: grafana, namespace: linkerd-viz, annotations: [[linkerd.io/created-by=linkerd/helm git-0e2ecd7b]], labels [[linkerd.io/extension=viz]]}}" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Requeues: 1, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=error msg="Error processing RepairEndpoints (will retry): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Requeues: 2, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=error msg="Error processing RepairEndpoints (will retry): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=info msg="Requeues: 3, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:52:31Z" level=error msg="Error processing RepairEndpoints (giving up): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Requeues: 0, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=error msg="Error processing RepairEndpoints (will retry): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Requeues: 1, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=error msg="Error processing RepairEndpoints (will retry): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Requeues: 2, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=error msg="Error processing RepairEndpoints (will retry): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Received: RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=warning msg="Error resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=info msg="Requeues: 3, Limit: 3 for event RepairEndpoints" apiAddress="https://172.18.0.4:6443" cluster=remote
time="2021-03-30T16:53:31Z" level=error msg="Error processing RepairEndpoints (giving up): Inner errors:\n\tError resolving 'foobar': lookup foobar on 10.43.0.10:53: no such host" apiAddress="https://172.18.0.4:6443" cluster=remote

```

As seen, The `RepairEndpoints` is called every `repairPeriod` which
is 1 minute by default. Whenever a failure happens, It is retried
but now the failures are tracked and the event is given up if it
reaches the `reuqueLimit` which is 3 by default.

This also fixes the requeuing logic for all type of events
not just `repairEndpoints`.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
