### PR TITLE
Remove viz components in control plane dashboard

### DIFF
--- a/web/app/js/components/ServiceMesh.jsx
+++ b/web/app/js/components/ServiceMesh.jsx
@@ -58,13 +58,10 @@ const getPodClassification = pod => {
 
 const componentsToDeployNames = {
   Destination: 'linkerd-controller',
-  Grafana: 'grafana',
   Identity: 'linkerd-identity',
-  Prometheus: 'prometheus',
+  'Proxy Injector': 'linkerd-proxy-injector',
   'Public API': 'linkerd-controller',
   'Service Profile Validator': 'linkerd-sp-validator',
-  Tap: 'linkerd-tap',
-  'Web UI': 'web',
 };
 
 class ServiceMesh extends React.Component {
@@ -234,8 +231,7 @@ class ServiceMesh extends React.Component {
         <StatusTable
           data={components}
           statusColumnTitle="Pod Status"
-          shouldLink={false}
-          api={this.api} />
+          shouldLink={false} />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
This change modifies the `/controlplane` dashboard page by removing viz
components that are no longer part of the core control plane install. It
also adds `Proxy Injector` to the list of components since that was
missing from the list.

Fixes #5898

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>

![image](https://user-images.githubusercontent.com/2197104/113218613-7481e280-9245-11eb-927e-a296ab58db57.png)
