### PR TITLE
cli: make inject add the right annotation with `--ingress`

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -201,12 +201,9 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		// prevents injector from taking a different code path in the ignress mode
 		delete(rt.overrideAnnotations, k8s.ProxyInjectAnnotation)
 		conf.AppendPodAnnotation(k8s.CreatedByAnnotation, k8s.CreatedByAnnotationValue())
-	} else {
+	} else if !rt.values.Proxy.IsIngress { // Add enabled annotation only if its not ingress mode to prevent overriding the annotation
 		// flag the auto-injector to inject the proxy, regardless of the namespace annotation
-		// Add enabled annotation only if its not ingress mode to prevent overriding the annotation
-		if !rt.values.Proxy.IsIngress {
-			conf.AppendPodAnnotation(k8s.ProxyInjectAnnotation, k8s.ProxyInjectEnabled)
-		}
+		conf.AppendPodAnnotation(k8s.ProxyInjectAnnotation, k8s.ProxyInjectEnabled)
 	}
 
 	patchJSON, err := conf.GetPodPatch(rt.injectProxy)

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -203,7 +203,10 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		conf.AppendPodAnnotation(k8s.CreatedByAnnotation, k8s.CreatedByAnnotationValue())
 	} else {
 		// flag the auto-injector to inject the proxy, regardless of the namespace annotation
-		conf.AppendPodAnnotation(k8s.ProxyInjectAnnotation, k8s.ProxyInjectEnabled)
+		// Add enabled annotation only if its not ingress mode to prevent overriding the annotation
+		if !rt.values.Proxy.IsIngress {
+			conf.AppendPodAnnotation(k8s.ProxyInjectAnnotation, k8s.ProxyInjectEnabled)
+		}
 	}
 
 	patchJSON, err := conf.GetPodPatch(rt.injectProxy)

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -95,6 +95,9 @@ func TestUninjectAndInject(t *testing.T) {
 	opaquePortsConfig := defaultConfig()
 	opaquePortsConfig.Proxy.OpaquePorts = "3000,5000-6000,mysql"
 
+	ingressConfig := defaultConfig()
+	ingressConfig.Proxy.IsIngress = true
+
 	proxyIgnorePortsConfig := defaultConfig()
 	proxyIgnorePortsConfig.ProxyInit.IgnoreInboundPorts = "22,8100-8102"
 	proxyIgnorePortsConfig.ProxyInit.IgnoreOutboundPorts = "5432"
@@ -298,6 +301,13 @@ func TestUninjectAndInject(t *testing.T) {
 			reportFileName:   "inject_emojivoto_deployment_opaque_ports.report",
 			injectProxy:      true,
 			testInjectConfig: opaquePortsConfig,
+		},
+		{
+			inputFileName:    "inject_emojivoto_pod.input.yml",
+			goldenFileName:   "inject_emojivoto_pod_ingress.golden.yml",
+			reportFileName:   "inject_emojivoto_pod_ingress.report",
+			injectProxy:      true,
+			testInjectConfig: ingressConfig,
 		},
 	}
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -1,0 +1,166 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+    linkerd.io/identity-mode: default
+    linkerd.io/inject: ingress
+    linkerd.io/proxy-version: test-inject-proxy-version
+  labels:
+    app: vote-bot
+    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/workload-ns: emojivoto
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v10
+    name: vote-bot
+  - env:
+    - name: LINKERD2_PROXY_LOG
+      value: warn,linkerd=info
+    - name: LINKERD2_PROXY_LOG_FORMAT
+      value: plain
+    - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+      value: linkerd-dst-headless.linkerd.svc.cluster.local.:8086
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_NETWORKS
+      value: 10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16
+    - name: LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT
+      value: 100ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT
+      value: 1000ms
+    - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+      value: 0.0.0.0:4190
+    - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+      value: 0.0.0.0:4191
+    - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+      value: 127.0.0.1:4140
+    - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+      value: 0.0.0.0:4143
+    - name: LINKERD2_PROXY_INGRESS_MODE
+      value: "true"
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+      value: svc.cluster.local.
+    - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION
+      value: 25,443,587,3306,5432,11211
+    - name: _pod_ns
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: _pod_nodeName
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+      value: |
+        {"ns":"$(_pod_ns)", "nodeName":"$(_pod_nodeName)"}
+    - name: LINKERD2_PROXY_IDENTITY_DIR
+      value: /var/run/linkerd/identity/end-entity
+    - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
+        JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4
+        MDcxMjQ3WhcNMzAwODI2MDcxMjQ3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5r
+        ZXJkLmNsdXN0ZXIubG9jYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARqc70Z
+        l1vgw79rjB5uSITICUA6GyfvSFfcuIis7B/XFSkkwAHU5S/s1AAP+R0TX7HBWUC4
+        uaG4WWsiwJKNn7mgo3AwbjAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB
+        /wIBATAdBgNVHQ4EFgQU5YtjVVPfd7I7NLHsn2C26EByGV0wKQYDVR0RBCIwIIIe
+        aWRlbnRpdHkubGlua2VyZC5jbHVzdGVyLmxvY2FsMAoGCCqGSM49BAMCA0kAMEYC
+        IQCN7lBFLDDvjx6V0+XkjpKERRsJYf5adMvnloFl48ilJgIhANtxhndcr+QJPuC8
+        vgUC0d2/9FMueIVMb+46WTCOjsqr
+        -----END CERTIFICATE-----
+    - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+      value: /var/run/secrets/kubernetes.io/serviceaccount/token
+    - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+      value: linkerd-identity-headless.linkerd.svc.cluster.local.:8080
+    - name: _pod_sa
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+    - name: _l5d_ns
+      value: linkerd
+    - name: _l5d_trustdomain
+      value: cluster.local
+    - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+      value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+    - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+      value: linkerd-identity.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+    - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+      value: linkerd-destination.$(_l5d_ns).serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+    image: cr.l5d.io/linkerd/proxy:test-inject-proxy-version
+    imagePullPolicy: IfNotPresent
+    livenessProbe:
+      httpGet:
+        path: /live
+        port: 4191
+      initialDelaySeconds: 10
+    name: linkerd-proxy
+    ports:
+    - containerPort: 4143
+      name: linkerd-proxy
+    - containerPort: 4191
+      name: linkerd-admin
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 4191
+      initialDelaySeconds: 2
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsUser: 2102
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /var/run/linkerd/identity/end-entity
+      name: linkerd-identity-end-entity
+  initContainers:
+  - args:
+    - --incoming-proxy-port
+    - "4143"
+    - --outgoing-proxy-port
+    - "4140"
+    - --proxy-uid
+    - "2102"
+    - --inbound-ports-to-ignore
+    - 4190,4191
+    image: cr.l5d.io/linkerd/proxy-init:v1.3.9
+    imagePullPolicy: IfNotPresent
+    name: linkerd-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50Mi
+      requests:
+        cpu: 10m
+        memory: 10Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: false
+      runAsUser: 0
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
+  - emptyDir:
+      medium: Memory
+    name: linkerd-identity-end-entity
+---

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.report
@@ -1,0 +1,3 @@
+
+pod "vote-bot" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.report.verbose
@@ -1,0 +1,10 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+√ at least one resource can be injected or annotated
+√ pod specs do not include UDP ports
+√ pods do not have automountServiceAccountToken set to "false"
+
+pod "vote-bot" injected
+


### PR DESCRIPTION
Currently, When `--ingress` flag is used with inject. The
CLI is not setting `linkerd.io/inject: ingress`. Instead,
we get a `linkerd.io/inject: enabled`.

This is because we are setting the annotation to `ingress` in
`getOverrideAnnotations` which is being overriden to `enabled`
later in the inject pipeline at `transform`. This PR updates
the `transform` to only add the `enabled` annotation if its
not ingress mode injection.

After this change:

```bash
 ./bin/go-run cli inject https://gist.githubusercontent.com/Pothulapati/941eef18a862aee9adb805aeddaef844/raw/005f4facb3b5805c48b0baf3f480f1fc6fd67f27/shell.yaml --ingress --proxy-cpu-limit 50m
github.com/linkerd/linkerd2/cli/cmd
github.com/linkerd/linkerd2/cli
apiVersion: v1
kind: Pod
metadata:
  annotations:
    config.linkerd.io/proxy-cpu-limit: 50m
    linkerd.io/inject: ingress
  name: shell-demo
spec:
  containers:
  - image: nginx
    name: nginx
    volumeMounts:
    - mountPath: /usr/share/nginx/html
      name: shared-data
  dnsPolicy: Default
  volumes:
  - emptyDir: {}
    name: shared-data
---

pod "shell-demo" injected
```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
