### PR TITLE
crds: remove matches field in TrafficSplit CRD

### DIFF
--- a/charts/linkerd2/templates/trafficsplit-crd.yaml
+++ b/charts/linkerd2/templates/trafficsplit-crd.yaml
@@ -38,21 +38,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -482,21 +482,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -565,21 +565,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -565,21 +565,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -565,21 +565,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -565,21 +565,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -551,21 +551,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -537,21 +537,6 @@ spec:
                 service:
                   description: The apex service of this split.
                   type: string
-                matches:
-                  description: The HTTP route groups that this traffic split should match.
-                  type: array
-                  items:
-                    type: object
-                    required: ['kind', 'name']
-                    properties:
-                      kind:
-                        description: Kind of the matching group.
-                        type: string
-                        enum:
-                          - HTTPRouteGroup
-                      name:
-                        description: Name of the matching group.
-                        type: string
                 backends:
                   description: The backend services of this split.
                   type: array


### PR DESCRIPTION
Currently, We do not support `matches` field in the TrafficSplit
CRD. This seems to be mistakenly added when OpenAPIV3 Validation
support was added.

This PR updates the TrafficSplit CRD to remove that field, while
also updating the golden test files.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
