### PR TITLE
In the `helm-upgrade` int test, install the proper viz chart version

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -477,7 +477,7 @@ run_helm-upgrade_test() {
   setup_helm
   helm_viz_chart="$( cd "$bindir"/.. && pwd )"/viz/charts/linkerd-viz
   run_test "$test_directory/install_test.go" --helm-path="$helm_path" --helm-chart="$helm_chart" \
-  --viz-helm-chart="$helm_viz_chart" --helm-stable-chart='linkerd/linkerd2' --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
+  --viz-helm-chart="$helm_viz_chart" --helm-stable-chart='linkerd/linkerd2' --viz-helm-stable-chart="linkerd/linkerd-viz" --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
   helm_cleanup
 }
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -504,13 +504,16 @@ func TestInstallHelm(t *testing.T) {
 	}
 
 	var chartToInstall string
+	var vizChartToInstall string
 	var args []string
 
 	if TestHelper.UpgradeHelmFromVersion() != "" {
 		chartToInstall = TestHelper.GetHelmStableChart()
+		vizChartToInstall = TestHelper.GetLinkerdVizHelmStableChart()
 		args = helmOverridesStable(helmTLSCerts)
 	} else {
 		chartToInstall = TestHelper.GetHelmChart()
+		vizChartToInstall = TestHelper.GetLinkerdVizHelmChart()
 		args = helmOverridesEdge(helmTLSCerts)
 	}
 
@@ -521,12 +524,11 @@ func TestInstallHelm(t *testing.T) {
 
 	TestHelper.WaitRollout(t)
 
-	vizChart := TestHelper.GetLinkerdVizHelmChart()
 	vizArgs := []string{
 		"--set", "linkerdVersion=" + TestHelper.GetVersion(),
 		"--set", "namespace=" + TestHelper.GetVizNamespace(),
 	}
-	if stdout, stderr, err := TestHelper.HelmCmdPlain("install", vizChart, "l5d-viz", vizArgs...); err != nil {
+	if stdout, stderr, err := TestHelper.HelmCmdPlain("install", vizChartToInstall, "l5d-viz", vizArgs...); err != nil {
 		testutil.AnnotatedFatalf(t, "'helm install' command failed",
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -47,6 +47,7 @@ type helm struct {
 	chart                   string
 	multiclusterChart       string
 	vizChart                string
+	vizStableChart          string
 	stableChart             string
 	releaseName             string
 	multiclusterReleaseName string
@@ -158,6 +159,7 @@ func NewTestHelper() *TestHelper {
 	helmChart := flag.String("helm-chart", "charts/linkerd2", "path to linkerd2's Helm chart")
 	multiclusterHelmChart := flag.String("multicluster-helm-chart", "charts/linkerd-multicluster", "path to linkerd2's multicluster Helm chart")
 	vizHelmChart := flag.String("viz-helm-chart", "charts/linkerd-viz", "path to linkerd2's viz extension Helm chart")
+	vizHelmStableChart := flag.String("viz-helm-stable-chart", "charts/linkerd-viz", "path to linkerd2's viz extension stable Helm chart")
 	helmStableChart := flag.String("helm-stable-chart", "linkerd/linkerd2", "path to linkerd2's stable Helm chart")
 	helmReleaseName := flag.String("helm-release", "", "install linkerd via Helm using this release name")
 	multiclusterHelmReleaseName := flag.String("multicluster-helm-release", "", "install linkerd multicluster via Helm using this release name")
@@ -208,6 +210,7 @@ func NewTestHelper() *TestHelper {
 			chart:                   *helmChart,
 			multiclusterChart:       *multiclusterHelmChart,
 			vizChart:                *vizHelmChart,
+			vizStableChart:          *vizHelmStableChart,
 			stableChart:             *helmStableChart,
 			releaseName:             *helmReleaseName,
 			multiclusterReleaseName: *multiclusterHelmReleaseName,
@@ -295,6 +298,12 @@ func (h *TestHelper) GetMulticlusterHelmChart() string {
 // GetLinkerdVizHelmChart returns the path to the Linkerd viz Helm chart
 func (h *TestHelper) GetLinkerdVizHelmChart() string {
 	return h.helm.vizChart
+}
+
+// GetLinkerdVizHelmStableChart returns the path to the Linkerd viz Helm
+// stable chart
+func (h *TestHelper) GetLinkerdVizHelmStableChart() string {
+	return h.helm.vizStableChart
 }
 
 // GetHelmStableChart returns the path to the Linkerd Helm stable chart


### PR DESCRIPTION
The `helm-upgrade` test was installing the current viz chart version from `viz/charts/linkerd-viz` instead of the latest stable published one, before attempting to perform the helm upgrade.

As seen below, we're passing `--helm-chart` and `helm-stable-chart` as parameters, but only `--viz-helm-chart`

```console
Test script: [install_test.go] Params: [--helm-path=/home/alpeb/src/pr/version2/linkerd2/bin/helm --helm-chart=/home/alpeb/src/pr/version2/linkerd2/charts/linkerd2 --viz-helm-chart=/home/alpeb/src/pr/version2/linkerd2/viz/charts/linkerd-viz --helm-stable-chart=linkerd/linkerd2 --helm-release=helm-test --upgrade-helm-from-version=stable-2.10.0]
```

So this PR adds a new `--viz-helm-stable-chart` parameter that instructs which version to install before performing the upgrade.

This is affecting #6000 which has changes in the viz chart that are going undetected and are failing the `helm-upgrade` test.
