### PR TITLE
Change web base image from debian to scratch

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -53,13 +53,12 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly -o web/web -ldflags "-s -w" ./web
 
 ## package it all up
-FROM debian:buster-20210208-slim
+FROM scratch
 WORKDIR /linkerd
 
 COPY --from=await /tmp/linkerd-await .
 COPY LICENSE .
 COPY --from=golang /linkerd-build/web/web .
-RUN mkdir -p app
 COPY --from=webpack-bundle /linkerd-build/web/app/dist app/dist
 COPY web/templates templates
 COPY --from=golang /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
It only required removing `RUN mkdir -p app` from the Dockerfile, which
is not really needed.

This diminishes the image size and avoids having frequent vulnerability
reports by image scanners in clusters appearing in debian. We were
upgrading the base image whenever we could, but it's an issue for older
releases.

Addresses comment in #5198