### PR TITLE
Print error message when there is nothing to uninstall

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -100,6 +101,9 @@ func uninstallRunE(ctx context.Context, k8sAPI *k8s.KubernetesAPI) error {
 		return err
 	}
 
+	if len(resources) == 0 {
+		return errors.New("no resources found to uninstall")
+	}
 	for _, r := range resources {
 		if err := r.RenderResource(os.Stdout); err != nil {
 			return fmt.Errorf("error rendering Kubernetes resource:%v", err)

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -41,6 +42,9 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
+	if len(resources) == 0 {
+		return errors.New("no resources found to uninstall")
+	}
 	for _, r := range resources {
 		if err := r.RenderResource(os.Stdout); err != nil {
 			return fmt.Errorf("error rendering Kubernetes resource: %v", err)

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -38,5 +38,5 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	return pkgCmd.Uninstall(ctx, k8sAPI, "linkerd.io/extension=jaeger")
+	return pkgCmd.Uninstall(ctx, k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, JaegerExtensionName))
 }

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
+	pkgCmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	"github.com/linkerd/linkerd2/pkg/k8s/resource"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func newCmdUninstall() *cobra.Command {
@@ -22,7 +20,12 @@ func newCmdUninstall() *cobra.Command {
 This command provides all Kubernetes namespace-scoped and cluster-scoped resources (e.g services, deployments, RBACs, etc.) necessary to uninstall the Linkerd-jaeger extension.`,
 		Example: `linkerd uninstall | kubectl delete -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return uninstallRunE(cmd.Context())
+			err := uninstallRunE(cmd.Context())
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return nil
 		},
 	}
 
@@ -35,20 +38,5 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	resources, err := resource.FetchKubernetesResources(ctx, k8sAPI,
-		metav1.ListOptions{LabelSelector: "linkerd.io/extension=jaeger"},
-	)
-	if err != nil {
-		return err
-	}
-
-	if len(resources) == 0 {
-		return errors.New("no resources found to uninstall")
-	}
-	for _, r := range resources {
-		if err := r.RenderResource(os.Stdout); err != nil {
-			return fmt.Errorf("error rendering Kubernetes resource: %v", err)
-		}
-	}
-	return nil
+	return pkgCmd.Uninstall(ctx, k8sAPI, "linkerd.io/extension=jaeger")
 }

--- a/multicluster/cmd/uninstall.go
+++ b/multicluster/cmd/uninstall.go
@@ -53,7 +53,7 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 				return errors.New(strings.Join(err, "\n"))
 			}
 
-			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, "linkerd.io/extension=multicluster")
+			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, MulticlusterExtensionName))
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -47,7 +47,7 @@ func Uninstall(ctx context.Context, k8sAPI *k8s.KubernetesAPI, selector string) 
 	}
 
 	if len(resources) == 0 {
-		return errors.New("no resources found to uninstall")
+		return errors.New("No resources found to uninstall")
 	}
 	for _, r := range resources {
 		if err := r.RenderResource(os.Stdout); err != nil {

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -41,6 +42,9 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
+	if len(resources) == 0 {
+		return errors.New("no resources found to uninstall")
+	}
 	for _, r := range resources {
 		if err := r.RenderResource(os.Stdout); err != nil {
 			return fmt.Errorf("error rendering Kubernetes resource: %v", err)

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
+	pkgCmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/k8s"
-	"github.com/linkerd/linkerd2/pkg/k8s/resource"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func newCmdUninstall() *cobra.Command {
@@ -22,7 +20,12 @@ func newCmdUninstall() *cobra.Command {
 This command provides all Kubernetes namespace-scoped and cluster-scoped resources (e.g services, deployments, RBACs, etc.) necessary to uninstall the Linkerd-viz extension.`,
 		Example: `linkerd viz uninstall | kubectl delete -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return uninstallRunE(cmd.Context())
+			err := uninstallRunE(cmd.Context())
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return nil
 		},
 	}
 
@@ -35,20 +38,5 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	resources, err := resource.FetchKubernetesResources(ctx, k8sAPI,
-		metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, ExtensionName)},
-	)
-	if err != nil {
-		return err
-	}
-
-	if len(resources) == 0 {
-		return errors.New("no resources found to uninstall")
-	}
-	for _, r := range resources {
-		if err := r.RenderResource(os.Stdout); err != nil {
-			return fmt.Errorf("error rendering Kubernetes resource: %v", err)
-		}
-	}
-	return nil
+	return pkgCmd.Uninstall(ctx, k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, ExtensionName))
 }


### PR DESCRIPTION
Fixes #5994 

When running an uninstall command for Linkerd or a Linkerd extension and there are no resources to delete the command silently exits and prints no output.  This can be confusing.

We update the uninstall commands to print an error message to stderr if there are no resources to delete.  Since this message is printed to stderr instead of stdout, it does not interfere with piping the output to kubectl.

```console
> linkerd viz uninstall | kubectl delete -f -
Error: no resources found to uninstall
Usage:
  linkerd viz uninstall [flags]

Examples:
linkerd viz uninstall | kubectl delete -f -

Flags:
  -h, --help   help for uninstall

Global Flags:
      --api-addr string            Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)
      --as string                  Username to impersonate for Kubernetes operations
      --as-group stringArray       Group to impersonate for Kubernetes operations
      --cni-namespace string       Namespace in which the Linkerd CNI plugin is installed (default "linkerd-cni")
      --context string             Name of the kubeconfig context to use
      --kubeconfig string          Path to the kubeconfig file to use for CLI requests
  -L, --linkerd-namespace string   Namespace in which Linkerd is installed (default "linkerd")
      --verbose                    Turn on debug logging

No resources found
```

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
