### PR TITLE
Changelog for edge-21.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 This edge supersedes `edge-21.4.2` as a release candidate for `stable-2.10.1`!
 
-This release adds support for TrafficSplit `v1alpha2. `v1alpha1` will be
+This release adds support for TrafficSplit `v1alpha2`. `v1alpha1` will be
 marked deprecated and removed in a future release.
 Additionally, It includes improvements to the web and `proxy-init` images.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,8 @@
 
 This edge supersedes `edge-21.4.2` as a release candidate for `stable-2.10.1`!
 
-This release adds support for TrafficSplit `v1alpha2`. `v1alpha1` will be
-marked deprecated and removed in a future release.
-Additionally, It includes improvements to the web and `proxy-init` images.
+This release adds support for TrafficSplit `v1alpha2`. Additionally, It includes
+improvements to the web and `proxy-init` images.
 
 * Added Support for TrafficSplit `v1alpha2`
 * Changed web base image from debian to scratch

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Changes
 
+## edge-21.4.3
+
+This edge supersedes `edge-21.4.2` as a release candidate for `stable-2.10.1`!
+
+This release adds support for TrafficSplit `v1alpha2. `v1alpha1` will be
+marked deprecated and removed in a future release.
+Additionally, It includes improvements to the web and `proxy-init` images.
+
+* Added Support for TrafficSplit `v1alpha2`
+* Changed web base image from debian to scratch
+* Bumped the `proxy-init` image to `v1.3.11` which updates
+  the go version to be `1.16.2`
+
 ## edge-21.4.2
 
 This edge release is another candidate for `stable-2.10.1`!


### PR DESCRIPTION
This edge supersedes `edge-21.4.2` as a release candidate for `stable-2.10.1`!

This release adds support for TrafficSplit `v1alpha2`. Additionally, It includes
improvements to the web and `proxy-init` images.

* Added Support for TrafficSplit `v1alpha2`
* Changed web base image from debian to scratch
* Bumped the `proxy-init` image to `v1.3.11` which updates
  the go version to be `1.16.2`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
