### PR TITLE
spSharedInformers, tsSharedInformers may be nil, calling the metho will cause panic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,34 @@
 # Changes
 
+## edge-21.4.1
+
+This is a release candidate for `stable-2.10.1`!
+
+This includes several fixes for the core installation as well the Multicluster,
+Jaeger, and Viz extensions. There are two significant proxy fixes that address
+TLS detection and admin server failures.
+
+Thanks to all our 2.10 users who helped discover these issues!
+
+* Fixed TCP read and write bytes/sec calculations to group by label based off
+  inbound or outbound traffic
+* Updated dashboard build to use webpack v5
+* Modified the proxy-injector to add the opaque ports annotation to pods if
+  their namespace has it set
+* Added CA certs to the Viz extension's `metrics-api` container so that it can
+  validate the certifcate of an external Prometheus
+* Fixed an issue where inbound TLS detection from non-meshed workloads could
+  break
+* Fixed an issue where the admin server's HTTP detection would fail and not
+  recover; these are now handled gracefully and without logging warnings
+* Aligned the Helm installation heartbeat schedule to match that of the CLI
+* Fixed an issue with Multicluster's serivce mirror where it's endpoint repair
+  retries were not properly rate limited
+* Removed components from the control plane dashboard that now are part of the
+  Viz extension
+* Fixed components in the Jaeger extension to set the correct Prometheus scrape
+  values
+
 ## edge-21.3.4
 
 This release fixes some issues around publishing of CLI binary

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -229,6 +229,9 @@ func NewAPI(
 			api.rs = sharedInformers.Apps().V1().ReplicaSets()
 			api.syncChecks = append(api.syncChecks, api.rs.Informer().HasSynced)
 		case SP:
+			if spSharedInformers == nil {
+				panic("SP shared informer not configured")
+			}
 			api.sp = spSharedInformers.Linkerd().V1alpha2().ServiceProfiles()
 			api.syncChecks = append(api.syncChecks, api.sp.Informer().HasSynced)
 		case SS:
@@ -238,6 +241,9 @@ func NewAPI(
 			api.svc = sharedInformers.Core().V1().Services()
 			api.syncChecks = append(api.syncChecks, api.svc.Informer().HasSynced)
 		case TS:
+			if tsSharedInformers == nil {
+				panic("TS shared informer not configured")
+			}
 			api.ts = tsSharedInformers.Split().V1alpha1().TrafficSplits()
 			api.syncChecks = append(api.syncChecks, api.ts.Informer().HasSynced)
 		case Node:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
Subject
variable `spSharedInformers`, `tsSharedInformers` may be nil, calling the method will cause panic

Problem
The line 175 code are
```
var spSharedInformers sp.SharedInformerFactory
if spClient != nil {
	spSharedInformers = sp.NewSharedInformerFactory(spClient, 10*time.Minute)
}
```
if spclient is nil, then the variable spSharedInformers will nil. So calling the method will cause panic. And the tsSharedInformers is the same.
