### PR TITLE
multicluster: add proxy extension checks

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -209,7 +209,7 @@ func multiclusterCategory(hc *healthChecker) *healthcheck.Category {
 
 	checkers = append(checkers,
 		*healthcheck.NewChecker("multicluster extension proxies are healthy").
-			WithHintAnchor("l5d-jaeger-proxy-healthy").
+			WithHintAnchor("l5d-multicluster-proxy-healthy").
 			Fatal().
 			WithRetryDeadline(hc.RetryDeadline).
 			SurfaceErrorOnRetry().
@@ -225,7 +225,7 @@ func multiclusterCategory(hc *healthChecker) *healthcheck.Category {
 
 	checkers = append(checkers,
 		*healthcheck.NewChecker("multicluster extension proxies are up-to-date").
-			WithHintAnchor("l5d-jaeger-proxy-cp-version").
+			WithHintAnchor("l5d-multicluster-proxy-cp-version").
 			Warning().
 			WithCheck(func(ctx context.Context) error {
 				var err error
@@ -257,7 +257,7 @@ func multiclusterCategory(hc *healthChecker) *healthcheck.Category {
 
 	checkers = append(checkers,
 		*healthcheck.NewChecker("multicluster extension proxies and cli versions match").
-			WithHintAnchor("l5d-jaeger-proxy-cli-version").
+			WithHintAnchor("l5d-multicluster-proxy-cli-version").
 			Warning().
 			WithCheck(func(ctx context.Context) error {
 				var pods []corev1.Pod

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1435,9 +1435,11 @@ func (hc *HealthChecker) CheckProxyVersionsUpToDate(pods []corev1.Pod) error {
 func CheckProxyVersionsUpToDate(pods []corev1.Pod, versions version.Channels) error {
 	outdatedPods := []string{}
 	for _, pod := range pods {
-		proxyVersion := k8s.GetProxyVersion(pod)
-		if err := versions.Match(proxyVersion); err != nil {
-			outdatedPods = append(outdatedPods, fmt.Sprintf("\t* %s (%s)", pod.Name, proxyVersion))
+		if containsProxy(pod) {
+			proxyVersion := k8s.GetProxyVersion(pod)
+			if err := versions.Match(proxyVersion); err != nil {
+				outdatedPods = append(outdatedPods, fmt.Sprintf("\t* %s (%s)", pod.Name, proxyVersion))
+			}
 		}
 	}
 	if len(outdatedPods) > 0 {

--- a/test/integration/testdata/check.multicluster.golden
+++ b/test/integration/testdata/check.multicluster.golden
@@ -1,5 +1,8 @@
 linkerd-multicluster
 --------------------
 √ Link CRD exists
+√ multicluster extension proxies are healthy
+√ multicluster extension proxies are up-to-date
+√ multicluster extension proxies and cli versions match
 
 Status check results are √

--- a/test/integration/testdata/check.multicluster.proxy.golden
+++ b/test/integration/testdata/check.multicluster.proxy.golden
@@ -63,5 +63,8 @@ linkerd-control-plane-proxy
 linkerd-multicluster
 --------------------
 √ Link CRD exists
+√ multicluster extension proxies are healthy
+√ multicluster extension proxies are up-to-date
+√ multicluster extension proxies and cli versions match
 
 Status check results are √


### PR DESCRIPTION
Fixes #6046

This PR updates the multicluster checks to also include the proxy
version checks for the extension components.

The following checks are performed:
- multicluster extension proxies are healthy
- multicluster extension proxies are up-to-date
- multicluster extension proxies and cli versions match


With Multicluster, These checks are performed across the link
namespaces as there are multiple links that can exist.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
