### PR TITLE
Drop special review requirements for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,2 @@
 # By default, the maintainers group is responsible for everything.
-*			@linkerd/maintainers
-
-# These documents have special review requirements:
-/CHANGES.md		@adleong @olix0r
-/CODE_OF_CONDUCT.md	@olix0r
-/CONTRIBUTING.md	@olix0r
-/DCO    		@olix0r
-/GOVERNANCE.md		@olix0r
-/LICENSE		@olix0r
-/MAINTAINERS.md		@olix0r
-/README.md	    	@olix0r
-/SECURITY.md		@olix0r
-/SECURITY_AUDIT.pdf	@olix0r
+*   @linkerd/maintainers


### PR DESCRIPTION
I don't think I need to be in the critical path on changes or other
document changes. The normal maintainers review requirements should
apply; and I'm sure I'll be looped-in when it's needed.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
