### PR TITLE
add switch to helm chart for disabling CRD deployment

### DIFF
--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -139,6 +139,7 @@ Kubernetes: `>=1.16.0-0`
 | debugContainer.image.name | string | `"cr.l5d.io/linkerd/debug"` | Docker image for the debug container |
 | debugContainer.image.pullPolicy | string | imagePullPolicy | Pull policy for the debug container Docker image |
 | debugContainer.image.version | string | linkerdVersion | Tag for the debug container Docker image |
+| deployCRDs | bool | `true` | enabled / disabled deploying CRDs. IF this is set to false, you must ensure the CRDs are deployed to the cluster before deploying this helm chart. |
 | disableHeartBeat | bool | `false` | Set to true to not start the heartbeat cronjob |
 | enableEndpointSlices | bool | `false` | enables the use of EndpointSlice informers for the destination service; enableEndpointSlices should be set to true only if EndpointSlice K8s feature gate is on; the feature is still experimental. |
 | enableH2Upgrade | bool | `true` | Allow proxies to perform transparent HTTP/2 upgrading |

--- a/charts/linkerd2/templates/serviceprofile-crd.yaml
+++ b/charts/linkerd2/templates/serviceprofile-crd.yaml
@@ -1,5 +1,5 @@
 ---
-{{ - if .Values.deployCRDs }}
+{{- if .Values.deployCRDs }}
 ###
 ### Service Profile CRD
 ###

--- a/charts/linkerd2/templates/serviceprofile-crd.yaml
+++ b/charts/linkerd2/templates/serviceprofile-crd.yaml
@@ -1,4 +1,5 @@
 ---
+{{ - if .Values.deployCRDs }}
 ###
 ### Service Profile CRD
 ###
@@ -277,3 +278,4 @@ spec:
     kind: ServiceProfile
     shortNames:
     - sp
+{{- end }}

--- a/charts/linkerd2/templates/trafficsplit-crd.yaml
+++ b/charts/linkerd2/templates/trafficsplit-crd.yaml
@@ -1,5 +1,5 @@
 ---
-{{ - if .Values.deployCRDs }}
+{{- if .Values.deployCRDs }}
 ###
 ### TrafficSplit CRD
 ### Copied from github.com/servicemeshinterface/smi-sdk-go/blob/d4e76b1cd7a33ead5f38d1262dd838a31c80f4e5/crds/split.yaml

--- a/charts/linkerd2/templates/trafficsplit-crd.yaml
+++ b/charts/linkerd2/templates/trafficsplit-crd.yaml
@@ -1,4 +1,5 @@
 ---
+{{ - if .Values.deployCRDs }}
 ###
 ### TrafficSplit CRD
 ### Copied from github.com/servicemeshinterface/smi-sdk-go/blob/d4e76b1cd7a33ead5f38d1262dd838a31c80f4e5/crds/split.yaml
@@ -93,3 +94,4 @@ spec:
                         description: Traffic weight value of this backend.
                         type: number
   preserveUnknownFields: false
+{{- end }}

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -151,6 +151,8 @@ omitWebhookSideEffects: false
 # -- Failure policy for the proxy injector
 webhookFailurePolicy: Ignore
 
+# -- enabled / disabled deploying CRDs. IF this is set to false, you must ensure the CRDs are deployed to the cluster before deploying this helm chart.
+deployCRDs: true
 
 # controllerImage -- Docker image for the destination and identity components
 controllerImage: cr.l5d.io/linkerd/controller

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -36,6 +36,7 @@ func TestRender(t *testing.T) {
 		EnableH2Upgrade:         true,
 		WebhookFailurePolicy:    "WebhookFailurePolicy",
 		OmitWebhookSideEffects:  false,
+		DeployCRDs:              true,
 		HeartbeatSchedule:       "1 2 3 4 5",
 		InstallNamespace:        true,
 		Identity:                defaultValues.Identity,

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -811,6 +811,7 @@ data:
         name: my.custom.registry/linkerd-io/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources:
       cpu:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources:
       cpu:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -739,6 +739,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: true

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -829,6 +829,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: test-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -829,6 +829,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: test-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources:
       cpu:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -829,6 +829,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: test-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources:
       cpu:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -829,6 +829,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: test-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources:
       cpu:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -808,6 +808,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -811,6 +811,7 @@ data:
         name: DebugImageName
         pullPolicy: DebugImagePullPolicy
         version: DebugVersion
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -811,6 +811,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -797,6 +797,7 @@ data:
         name: cr.l5d.io/linkerd/debug
         pullPolicy: ""
         version: install-debug-version
+    deployCRDs: true
     destinationProxyResources: null
     destinationResources: null
     disableHeartBeat: false

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -31,6 +31,7 @@ type (
 		EnableH2Upgrade              bool                `json:"enableH2Upgrade"`
 		EnablePodAntiAffinity        bool                `json:"enablePodAntiAffinity"`
 		WebhookFailurePolicy         string              `json:"webhookFailurePolicy"`
+		DeployCRDs                   bool                `json:"deployCRDs"`
 		OmitWebhookSideEffects       bool                `json:"omitWebhookSideEffects"`
 		DisableHeartBeat             bool                `json:"disableHeartBeat"`
 		HeartbeatSchedule            string              `json:"heartbeatSchedule"`

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -31,8 +31,8 @@ type (
 		EnableH2Upgrade              bool                `json:"enableH2Upgrade"`
 		EnablePodAntiAffinity        bool                `json:"enablePodAntiAffinity"`
 		WebhookFailurePolicy         string              `json:"webhookFailurePolicy"`
-		DeployCRDs                   bool                `json:"deployCRDs"`
 		OmitWebhookSideEffects       bool                `json:"omitWebhookSideEffects"`
+		DeployCRDs                   bool                `json:"deployCRDs"`
 		DisableHeartBeat             bool                `json:"disableHeartBeat"`
 		HeartbeatSchedule            string              `json:"heartbeatSchedule"`
 		InstallNamespace             bool                `json:"installNamespace"`

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -35,6 +35,7 @@ func TestNewValues(t *testing.T) {
 		EnablePodAntiAffinity:        false,
 		WebhookFailurePolicy:         "Ignore",
 		OmitWebhookSideEffects:       false,
+		DeployCRDs:                   true,
 		DisableHeartBeat:             false,
 		HeartbeatSchedule:            "",
 		InstallNamespace:             true,


### PR DESCRIPTION
## Problem ##
Currently the latest Linkerd cannot be deployed with Helm to any cluster that is either not of version 1.16+ or has special concern (RBAC, compliant processes, etc.) with regards to the deployment of CRDs.
While this problem can be handled when installing with the `linkerd` CLI by running `linkerd install config` and `linkerd install control-plane` separately, this does not apply to the Helm chart.

## Solution ##
This patch introduces a switch `deployCRDs` to the Helm chart, set to true by default. When set to false it will suppress the installation of the `serviceprofiles.linkerd.io` and `trafficsplits.split.smi-spec.io` CRDs.
