### PR TITLE
Fix check repeatedly printing error on retry

### DIFF
--- a/pkg/healthcheck/healthcheck_output.go
+++ b/pkg/healthcheck/healthcheck_output.go
@@ -171,7 +171,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 	prettyPrintResults := func(result *CheckResult) {
 		lastCategory = printCategory(wout, lastCategory, result)
 
-		if restartSpinnerOnRetry(spin, result) {
+		spin.Stop()
+		if result.Retry {
+			restartSpinner(spin, result)
 			return
 		}
 
@@ -188,7 +190,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 
 		lastCategory = printCategory(wout, lastCategory, result)
 
-		if restartSpinnerOnRetry(spin, result) {
+		spin.Stop()
+		if result.Retry {
+			restartSpinner(spin, result)
 			return
 		}
 
@@ -207,7 +211,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 			return
 		}
 
-		if restartSpinnerOnRetry(spin, result) {
+		spin.Stop()
+		if result.Retry {
+			restartSpinner(spin, result)
 			return
 		}
 
@@ -374,17 +380,11 @@ func getResultStatus(result *CheckResult) string {
 	return status
 }
 
-func restartSpinnerOnRetry(spin *spinner.Spinner, result *CheckResult) bool {
-	spin.Stop()
-	if result.Retry {
-		if isatty.IsTerminal(os.Stdout.Fd()) {
-			spin.Suffix = fmt.Sprintf(" %s", result.Err)
-			spin.Color("bold") // this calls spin.Restart()
-		}
-		return true
+func restartSpinner(spin *spinner.Spinner, result *CheckResult) {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		spin.Suffix = fmt.Sprintf(" %s", result.Err)
+		spin.Color("bold") // this calls spin.Restart()
 	}
-
-	return false
 }
 
 func printCategory(wout io.Writer, lastCategory CategoryID, result *CheckResult) CategoryID {

--- a/pkg/healthcheck/healthcheck_output.go
+++ b/pkg/healthcheck/healthcheck_output.go
@@ -171,7 +171,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 	prettyPrintResults := func(result *CheckResult) {
 		lastCategory = printCategory(wout, lastCategory, result)
 
-		restartSpinnerOnRetry(spin, result)
+		if restartSpinnerOnRetry(spin, result) {
+			return
+		}
 
 		status := getResultStatus(result)
 
@@ -186,7 +188,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 
 		lastCategory = printCategory(wout, lastCategory, result)
 
-		restartSpinnerOnRetry(spin, result)
+		if restartSpinnerOnRetry(spin, result) {
+			return
+		}
 
 		status := getResultStatus(result)
 
@@ -203,7 +207,9 @@ func runChecksTable(wout io.Writer, hc Runner, output string) bool {
 			return
 		}
 
-		restartSpinnerOnRetry(spin, result)
+		if restartSpinnerOnRetry(spin, result) {
+			return
+		}
 
 		status := getResultStatus(result)
 
@@ -368,15 +374,17 @@ func getResultStatus(result *CheckResult) string {
 	return status
 }
 
-func restartSpinnerOnRetry(spin *spinner.Spinner, result *CheckResult) {
+func restartSpinnerOnRetry(spin *spinner.Spinner, result *CheckResult) bool {
 	spin.Stop()
 	if result.Retry {
 		if isatty.IsTerminal(os.Stdout.Fd()) {
 			spin.Suffix = fmt.Sprintf(" %s", result.Err)
 			spin.Color("bold") // this calls spin.Restart()
 		}
-		return
+		return true
 	}
+
+	return false
 }
 
 func printCategory(wout io.Writer, lastCategory CategoryID, result *CheckResult) CategoryID {


### PR DESCRIPTION
PR#6038 refactored `healthcheck_output.go` to accomodate the printing
check results in `short` output. In that refactor the spinner display
was code section was changed so that that code could be shared in the
different `prettyPrintResults` functions.

Previously, the function would exit early prior to printing to avoid
showing the the check error output if the check was undergoing a retry.
After the refactor, that code was inadvertently removed causing check
to always print the error message and then continue retrying.

This caused output like this:
```
kubernetes-version
------------------
 is running the minimum Kubernetes API version
 is running the minimum kubectl version

linkerd-existence
-----------------
 'linkerd-config' config map exists
 heartbeat ServiceAccount exist
 control plane replica sets are ready
 no unschedulable pods
 control plane pods are ready
    pod/linkerd-identity-7cbd8bcbdf-hlmdw container linkerd-proxy is not
ready
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
 control plane pods are ready
    No running pods for "linkerd-proxy-injector"
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
 control plane pods are ready
    No running pods for "linkerd-proxy-injector"
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
 control plane pods are ready
    No running pods for "linkerd-proxy-injector"
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
 control plane pods are ready
    No running pods for "linkerd-proxy-injector"
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
 control plane pods are ready
    No running pods for "linkerd-proxy-injector"
    see https://linkerd.io/checks/#l5d-api-control-ready for hints
```

This change fixes the issue by forcing the print function to exit early
to avoid the repeated output message. We still want the message to be
printed once, only after check has given up retrying. This change should
handle that case.

Fixes #6080

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
