### PR TITLE
Added Bink to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,6 +7,7 @@
 - [Apester](https://apester.com)
 - [AppddictionStudio](https://appddicitonstudio.com)
 - [Attest](https://www.askattest.com)
+- [Bink](https://bink.com)
 - [Buoyant](https://buoyant.io)
 - [Candide](https://candidegardening.com)
 - [Celonis](https://celonis.com)


### PR DESCRIPTION
Signed-off-by: Chris Pressland <mail@cpressland.io>

Subject
Adding Bink to the `ADOPTERS.md` file in quest for Linkerd Swag.

Problem
Lack of Linkerd Swag

Solution
After using Linkerd successfully in production for nearly three years, we at Bink need Linkerd Swag to continue to promote its awesomeness.