### PR TITLE
Versioned `linkerd check` hint URLs

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -106,7 +106,7 @@ instead of the output format described above.  E.g.
         },
         {
           "description": "linkerd-viz Namespace exists",
-          "hint": "https://linkerd.io/checks/#l5d-viz-ns-exists",
+          "hint": "https://linkerd.io/2/checks/#l5d-viz-ns-exists",
           "error": "could not find the linkerd-viz extension",
           "result": "error"
         }

--- a/cli/cmd/testdata/check_output.golden
+++ b/cli/cmd/testdata/check_output.golden
@@ -3,6 +3,6 @@ category
 √ check1
 × check2
     This should contain instructions for fail
-    see https://linkerd.io/checks/#hint-anchor for hints
+    see https://linkerd.io/2/checks/#hint-anchor for hints
 
 Status check results are ×

--- a/cli/cmd/testdata/check_output_json.golden
+++ b/cli/cmd/testdata/check_output_json.golden
@@ -10,7 +10,7 @@
         },
         {
           "description": "check2",
-          "hint": "https://linkerd.io/checks/#hint-anchor",
+          "hint": "https://linkerd.io/2/checks/#hint-anchor",
           "error": "This should contain instructions for fail",
           "result": "error"
         }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -156,11 +156,6 @@ const (
 	keyKeyName                    = "tls.key"
 )
 
-// DefaultHintBaseURL is the base URL on the linkerd.io website that all check hints
-// point to. Each check adds its own `hintAnchor` to specify a location on the
-// page.
-const DefaultHintBaseURL = "https://linkerd.io/checks/#"
-
 // AllowedClockSkew sets the allowed skew in clock synchronization
 // between the system running inject command and the node(s), being
 // based on assumed node's heartbeat interval (5 minutes) plus default TLS
@@ -367,13 +362,12 @@ type Category struct {
 }
 
 // NewCategory returns an instance of Category with the specified data
-// and the DefaultHintBaseURL
 func NewCategory(id CategoryID, checkers []Checker, enabled bool) *Category {
 	return &Category{
 		ID:          id,
 		checkers:    checkers,
 		enabled:     enabled,
-		hintBaseURL: DefaultHintBaseURL,
+		hintBaseURL: HintBaseURL(version.Version),
 	}
 }
 
@@ -496,7 +490,7 @@ func (hc *HealthChecker) GetCategories() []*Category {
 //
 // Note that all checks should include a `hintAnchor` with a corresponding section
 // in the linkerd check faq:
-// https://linkerd.io/checks/#
+// https://linkerd.io/{major-version}/checks/#
 func (hc *HealthChecker) allCategories() []*Category {
 	return []*Category{
 		NewCategory(

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -946,8 +946,10 @@ func getCheckOutput(t *testing.T, goldenFile string, namespace string) string {
 	tpl := template.Must(template.ParseFiles("testdata" + "/" + goldenFile))
 	vars := struct {
 		ProxyVersionErr string
+		HintURL         string
 	}{
 		healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{}).Error(),
+		healthcheck.HintBaseURL(TestHelper.GetVersion()),
 	}
 
 	var expected bytes.Buffer
@@ -982,8 +984,10 @@ func TestCheckViz(t *testing.T) {
 	tpl := template.Must(template.ParseFiles("testdata" + "/" + golden))
 	vars := struct {
 		ProxyVersionErr string
+		HintURL         string
 	}{
 		healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{}).Error(),
+		healthcheck.HintBaseURL(TestHelper.GetVersion()),
 	}
 
 	var expected bytes.Buffer

--- a/test/integration/testdata/check.viz.external-prometheus.golden
+++ b/test/integration/testdata/check.viz.external-prometheus.golden
@@ -11,7 +11,7 @@ linkerd-viz
 √ viz extension proxies are healthy
 ‼ viz extension proxies are up-to-date
     {{.ProxyVersionErr}}
-    see https://linkerd.io/checks/#l5d-viz-proxy-cp-version for hints
+    see https://linkerd.io/2/checks/#l5d-viz-proxy-cp-version for hints
 √ viz extension proxies and cli versions match
 √ can initialize the client
 √ viz extension self-check

--- a/test/integration/testdata/check.viz.golden
+++ b/test/integration/testdata/check.viz.golden
@@ -11,7 +11,7 @@ linkerd-viz
 √ viz extension proxies are healthy
 ‼ viz extension proxies are up-to-date
     {{.ProxyVersionErr}}
-    see https://linkerd.io/checks/#l5d-viz-proxy-cp-version for hints
+    see {{.HintURL}}l5d-viz-proxy-cp-version for hints
 √ viz extension proxies and cli versions match
 √ prometheus is installed and configured correctly
 √ can initialize the client

--- a/test/integration/testdata/check.viz.proxy.golden
+++ b/test/integration/testdata/check.viz.proxy.golden
@@ -11,7 +11,7 @@ linkerd-viz
 √ viz extension proxies are healthy
 ‼ viz extension proxies are up-to-date
     {{.ProxyVersionErr}}
-    see https://linkerd.io/checks/#l5d-viz-proxy-cp-version for hints
+    see {{.HintURL}}l5d-viz-proxy-cp-version for hints
 √ viz extension proxies and cli versions match
 √ prometheus is installed and configured correctly
 √ can initialize the client

--- a/test/integration/tracing/testdata/check.jaeger.golden
+++ b/test/integration/tracing/testdata/check.jaeger.golden
@@ -8,7 +8,7 @@ linkerd-jaeger
 √ jaeger extension proxies are healthy
 ‼ jaeger extension proxies are up-to-date
     {{.ProxyVersionErr}}
-    see https://linkerd.io/checks/#l5d-jaeger-proxy-cp-version for hints
+    see {{.HintURL}}l5d-jaeger-proxy-cp-version for hints
 √ jaeger extension proxies and cli versions match
 
 Status check results are √

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -92,8 +92,10 @@ func TestTracing(t *testing.T) {
 		tpl := template.Must(template.ParseFiles("testdata" + "/" + golden))
 		vars := struct {
 			ProxyVersionErr string
+			HintURL         string
 		}{
 			healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{}).Error(),
+			healthcheck.HintBaseURL(TestHelper.GetVersion()),
 		}
 
 		var expected bytes.Buffer

--- a/web/srv/testdata/api_check_output.json
+++ b/web/srv/testdata/api_check_output.json
@@ -13,7 +13,7 @@
             "Warning": true,
             "Err": {},
             "ErrMsg": "check2-error",
-            "HintURL": "https://linkerd.io/checks/#check2-hint-anchor"
+            "HintURL": "https://linkerd.io/2/checks/#check2-hint-anchor"
         }],
         "linkerd-config": [{
             "Category": "linkerd-config",


### PR DESCRIPTION
Supersedes #5885

We've recently refactored the linkerd docs in the website to host separate sections for each major 2.x version. The [Troubleshooting page](https://linkerd.io/2.10/tasks/troubleshooting/) section is also versioned, but currently the hint URLs output by `linkerd check` commands point to `https://linkerd.io/checks` which redirects to `https://linkerd.io/2.10/tasks/troubleshooting`.

This PR changes the base of those hint URL so that instead it points to `https://linkerd.io/{version}/checks` where `{version}` is the CLI's major version. If the CLI is not in a stable version (edge or local dev version) then `{version}` will be `2` which the site will redirect to the latest stable version.

This change is coupled with linkerd/website#5885 that takes care of the website-side of things.