### PR TITLE
injector: Fix ns opaque ports annotation overriding all service annotations

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -361,7 +361,13 @@ func (conf *ResourceConfig) GetConfigAnnotation(annotationKey string) (string, b
 // CreateAnnotationPatch returns a json patch which adds the opaque ports
 // annotation with the `opaquePorts` value.
 func (conf *ResourceConfig) CreateAnnotationPatch(opaquePorts string) ([]byte, error) {
-	addRootAnnotations := len(conf.workload.Meta.Annotations) == 0
+	addRootAnnotations := false
+	if conf.IsPod() {
+		addRootAnnotations = len(conf.pod.meta.Annotations) == 0
+	} else {
+		addRootAnnotations = len(conf.workload.Meta.Annotations) == 0
+	}
+
 	patch := &annotationPatch{
 		AddRootAnnotations: addRootAnnotations,
 		OpaquePorts:        opaquePorts,

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -361,7 +361,7 @@ func (conf *ResourceConfig) GetConfigAnnotation(annotationKey string) (string, b
 // CreateAnnotationPatch returns a json patch which adds the opaque ports
 // annotation with the `opaquePorts` value.
 func (conf *ResourceConfig) CreateAnnotationPatch(opaquePorts string) ([]byte, error) {
-	addRootAnnotations := len(conf.pod.meta.Annotations) == 0
+	addRootAnnotations := len(conf.workload.Meta.Annotations) == 0
 	patch := &annotationPatch{
 		AddRootAnnotations: addRootAnnotations,
 		OpaquePorts:        opaquePorts,


### PR DESCRIPTION
Fixes #6117 

### What
---

> Applying a config.linkerd.io/opaque-ports annotation on a namespace will override all service level annotations such as those used for external-dns

When applying a service with existing annotations to a namespace that has an opaque ports annotation, we would expect the service to inherit the opaque ports annotation but keep its existing annotations. At the moment, this is not the case; when inheriting its annotation from the namespace, all of the service annotations are overridden.

The issue comes from how the annotation patch is generated in the `proxy-injector`. When we generate a patch for services, we first check whether we should add just the opaque annotation or if we should also create the annotations map. When checking for the length of the service's existing annotations map, we check the `resourceConfig`'s pod object -- for a service, the resourceConfig struct will always have an empty annotations map in the embedded pod object.

The fix is quite simple, since we know we only create the annotation patch for services, check the workload object instead of the pod. Pods already inherit all namespace config values at injection time  so it's safe to assume the annotation patch wouldn't be called on a pod.

I think we could also do a quick check on the underlying object's kind here if we want to also preserve the pod annotation lookup, something like:
```
sz = 0
if resourceConfig.Kind == "pod"
  sz = check pod annotation sz
else
  sz = check svc annotation sz 
```

For simplicity, I changed it to the workload instead of checking the kind but I don't mind adding more logic in.

### Tests
---



``` yaml
# for this service
apiVersion: v1
kind: Service
metadata:
  annotations:
    acme.io/foo: bar
    external-dns.alpha.kubernetes.io/internal-hostname: nginx.internal.example.org.
    external-dns.alpha.kubernetes.io/ttl: "10"
  creationTimestamp: "2021-05-13T09:14:06Z"
  name: web-svc
  namespace: emojivoto
  resourceVersion: "105676"
  uid: d2ec67aa-18e8-417f-9ae0-1a9107786201
spec:
---
# applied to this namespace
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "22"
    linkerd.io/inject: enabled
  name: emojivoto
  resourceVersion: "105722"
status:
  phase: Active
```

* *Before*
```sh
# proxy injector generates 2 Adds in the patch
time="2021-05-13T09:21:03Z" level=info msg="received service/web-svc"
time="2021-05-13T09:21:03Z" level=debug msg="using namespace emojivoto config.linkerd.io/opaque-ports annotation value"
time="2021-05-13T09:21:03Z" level=info msg="annotation patch generated for: service/web-svc"
time="2021-05-13T09:21:03Z" level=debug msg="annotation patch: [\n  {\n    \"op\": \"add\",\n    \"path\": \"/metadata/annotations\",\n    \"value\": {}\n  },\n  {\n    \"op\": \"add\",\n    \"path\": \"/metadata/annotations/config.linkerd.io~1opaque-ports\",\n    \"value\": \"22\"\n  }\n]"


# which gives us a service with missing annotations
 k get svc web-svc -o yaml -n emojivoto
apiVersion: v1
kind: Service
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "22"
  name: web-svc
  namespace: emojivoto
```


* *After the change*:
```sh
# for the same manifests, we only get one Add (an append to the existing annotations map)
time="2021-05-13T09:44:19Z" level=info msg="received service/web-svc"
time="2021-05-13T09:44:19Z" level=debug msg="using namespace emojivoto config.linkerd.io/opaque-ports annotation value"
time="2021-05-13T09:44:19Z" level=info msg="annotation patch generated for: service/web-svc"
time="2021-05-13T09:44:19Z" level=debug msg="annotation patch: [\n  {\n    \"op\": \"add\",\n    \"path\": \"/metadata/annotations/config.linkerd.io~1opaque-ports\",\n    \"value\": \"22\"\n  }\n]"

# which gives us a service with existing and new annotation(s)
apiVersion: v1
kind: Service
metadata:
  annotations:
    acme.io/foo: bar
    config.linkerd.io/opaque-ports: "22"
    external-dns.alpha.kubernetes.io/internal-hostname: nginx.internal.example.org.
    external-dns.alpha.kubernetes.io/ttl: "10"
  name: web-svc
  namespace: emojivoto

```

### Update:
---

There may be cases when we want a pod to be annotated but not injected. Added in a check to see what the underlying resource type is -- if we deal with a pod, check pod annotations otherwise the embedded object.

```
# in the same namespace, remove linkerd inject annotation
# this makes sure we check resources that shouldn't be injected can still be annotated
kind: Namespace
metadata:
  annotations:
    config.linkerd.io/opaque-ports: "22"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Namespace","metadata":{"annotations":{"linkerd.io/inject":"enabled"},"name":"emojivoto"}}
  creationTimestamp: "2021-05-13T09:14:06Z"

# get a random pod from a random deployment, grep the annotation field (it won't any opaque annotations)
$ kubectl get po vote-bot-69754c864f-xzqf2 -n linkerd -o yaml -n emojivoto | rg annotations -A 4
  annotations:
    linkerd.io/created-by: linkerd/proxy-injector dev-30fa4354-matei
    linkerd.io/identity-mode: default
    linkerd.io/proxy-version: dev-30fa4354-matei
  creationTimestamp: "2021-05-13T09:14:06Z"

# restart deployment, this time it won't be injected since injection was disabled on the namespace
# it should still inherit opaque ports from namespace
$ k get po vote-bot-c9fb5bbbd-86hrm -n emojivoto -o yaml | rg 'annotations' -A 2
  annotations:
    config.linkerd.io/opaque-ports: "22"
    kubectl.kubernetes.io/restartedAt: "2021-05-13T15:29:54Z"
--
        f:annotations:
          .: {}
          f:kubectl.kubernetes.io/restartedAt: {}

# inherited opaque ports but is not injected, what we'd expect in this case
# since we want it to be _just_ annotated.
```

Signed-off-by: Matei David <matei@buoyant.io>
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
