### PR TITLE
multi cluster: Add replicas, nodeSelector, tolerations, affinity & resources to helm chart

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -71,15 +71,20 @@ Kubernetes: `>=1.16.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| gateway.affinity | object | `{}` | Affinity for gateway pods. (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
+| gateway.nodeSelector | object | `{}` |  |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | gateway.probe.seconds | int | `3` |  |
+| gateway.replicas | int | `1` | The number of gateway replicas |
+| gateway.resources | object | `{}` | Default resources for the gateway pods. If null, that resource won't be set |
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
+| gateway.tolerations | list | `[]` | Toleration settings for the gateway pods. (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | installNamespace | bool | `true` | If the namespace should be installed |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -71,11 +71,11 @@ Kubernetes: `>=1.16.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| gateway.affinity | object | `{}` | Affinity for gateway pods. (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
+| gateway.affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) settings for gateway pods. |
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
-| gateway.nodeSelector | object | `{}` | Node Selector settings for the gateway pods. (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
+| gateway.nodeSelector | object | `{}` | [Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) settings for the gateway pods. |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
@@ -84,7 +84,7 @@ Kubernetes: `>=1.16.0-0`
 | gateway.resources | object | `{}` | Default resources for the gateway pods. If null, that resource won't be set |
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
-| gateway.tolerations | list | `[]` | Toleration settings for the gateway pods. (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
+| gateway.tolerations | list | `[]` | [Toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) settings for the gateway pods. |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | installNamespace | bool | `true` | If the namespace should be installed |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -75,7 +75,7 @@ Kubernetes: `>=1.16.0-0`
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
-| gateway.nodeSelector | object | `{}` |  |
+| gateway.nodeSelector | object | `{}` | Node Selector settings for the gateway pods. (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -15,7 +15,7 @@ metadata:
   name: {{.Values.gateway.name}}
   namespace: {{.Values.namespace}}
 spec:
-  replicas: 1
+  replicas: {{.Values.gateway.replicas}}
   selector:
     matchLabels:
       app: {{.Values.gateway.name}}
@@ -32,6 +32,20 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{.Values.gateway.name}}
 ---
 apiVersion: v1

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -32,8 +32,10 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause
+          {{- with .Values.gateway.resources }}
           resources:
-            {{- toYaml .Values.gateway.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -16,11 +16,11 @@ gateway:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # -- Node Selector settings for the gateway pods. (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+  # -- [Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) settings for the gateway pods.
   nodeSelector: {}
-  # -- Toleration settings for the gateway pods. (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  # -- [Toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) settings for the gateway pods.
   tolerations: []
-  # -- Affinity for gateway pods. (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  # -- [Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) settings for gateway pods.
   affinity: {}
   # -- Service Type of gateway Service
   serviceType: LoadBalancer

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -14,7 +14,8 @@ gateway:
     #   memory: 128Mi
     # requests:
     #   cpu: 100m
-    #   memory: 128Mi 
+    #   memory: 128Mi
+
   # -- Node Selector settings for the gateway pods. (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   nodeSelector: {}
   # -- Toleration settings for the gateway pods. (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -7,15 +7,20 @@ gateway:
   port: 4143
   # -- The number of gateway replicas
   replicas: 1
-
+  # -- Default resources for the gateway pods. If null, that resource won't be set
   resources: {}
-
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi 
+  # -- Node Selector settings for the gateway pods. (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
   nodeSelector: {}
-  
+  # -- Toleration settings for the gateway pods. (https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
   tolerations: []
-
+  # -- Affinity for gateway pods. (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
   affinity: {}
-
   # -- Service Type of gateway Service
   serviceType: LoadBalancer
   # nodePort -- Set the gateway nodePort (for LoadBalancer or NodePort) to a specific value

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -5,6 +5,17 @@ gateway:
   name: linkerd-gateway
   # -- The port on which all the gateway will accept incoming traffic
   port: 4143
+  # -- The number of gateway replicas
+  replicas: 1
+
+  resources: {}
+
+  nodeSelector: {}
+  
+  tolerations: []
+
+  affinity: {}
+
   # -- Service Type of gateway Service
   serviceType: LoadBalancer
   # nodePort -- Set the gateway nodePort (for LoadBalancer or NodePort) to a specific value

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -39,14 +39,19 @@ type Values struct {
 
 // Gateway contains all opttions related to the Gateway Service
 type Gateway struct {
-	Enabled            bool              `json:"enabled"`
-	Name               string            `json:"name"`
-	Port               uint32            `json:"port"`
-	NodePort           uint32            `json:"nodePort"`
-	ServiceType        string            `json:"serviceType"`
-	Probe              *Probe            `json:"probe"`
-	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
-	LoadBalancerIP     string            `json:"loadBalancerIP"`
+	Enabled            bool                   `json:"enabled"`
+	Name               string                 `json:"name"`
+	Port               uint32                 `json:"port"`
+	Replicas           uint32                 `json:"replicas"`
+	Resources          *Resources             `json:"resources"`
+	NodeSelector       map[string]string      `json:"nodeSelector"`
+	Tolerations        []interface{}          `json:"tolerations"`
+	Affinity           map[string]interface{} `json:"affinity"`
+	NodePort           uint32                 `json:"nodePort"`
+	ServiceType        string                 `json:"serviceType"`
+	Probe              *Probe                 `json:"probe"`
+	ServiceAnnotations map[string]string      `json:"serviceAnnotations"`
+	LoadBalancerIP     string                 `json:"loadBalancerIP"`
 }
 
 // Probe contains all options for the Probe Service
@@ -55,6 +60,18 @@ type Probe struct {
 	Port     uint32 `json:"port"`
 	NodePort uint32 `json:"nodePort"`
 	Seconds  uint32 `json:"seconds"`
+}
+
+// Constraints wraps the Limit and Request settings for computational resources
+type Constraints struct {
+	Limit   string `json:"limit"`
+	Request string `json:"request"`
+}
+
+// Resources represents the computational resources setup for a given container
+type Resources struct {
+	CPU    Constraints `json:"cpu"`
+	Memory Constraints `json:"memory"`
 }
 
 // NewInstallValues returns a new instance of the Values type.


### PR DESCRIPTION
Support replicas, nodeSelector, affinity, resources and tolerations for linkerd-multicluster Chart.

There is support to choose nodes for linkerd and linkerd-viz charts but no support for linkerd-multicluster chart.

Properties replicas, nodeSelector, affinity, resources and tolerations are added to values.yml and processed in templates in the chart.