### PR TITLE
Increase all testing timeouts to 60 minutes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,7 +112,7 @@ jobs:
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
     - name: Checkout code
       # actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         - cni-calico-deep
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -348,7 +348,7 @@ run_test(){
 
   printf 'Test script: [%s] Params: [%s]\n' "${filename##*/}" "$*"
   # Exit on failure here
-  GO111MODULE=on go test --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --k8s-context="$context" --integration-tests "$@" || exit 1
+  GO111MODULE=on go test -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --k8s-context="$context" --integration-tests "$@" || exit 1
 }
 
 # Returns the latest version for the release channel
@@ -386,7 +386,7 @@ install_version() {
 
     (
         set -x
-        "$linkerd_path" check 2>&1
+        "$linkerd_path" check --wait 60m 2>&1
     )
     exit_on_err 'install_version() - linkerd check failed'
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -861,7 +861,7 @@ func testCheckCommand(t *testing.T, stage, expectedVersion, namespace, cliVersio
 	var golden string
 	proxyStage := "proxy"
 	if stage == proxyStage {
-		cmd = []string{"check", "--proxy", "--expected-version", expectedVersion, "--namespace", namespace, "--wait=0"}
+		cmd = []string{"check", "--proxy", "--expected-version", expectedVersion, "--namespace", namespace, "--wait=60m"}
 		// if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
 		// golden = "check.multicluster.proxy.golden"
 		// } else if TestHelper.CNI() {
@@ -871,10 +871,10 @@ func testCheckCommand(t *testing.T, stage, expectedVersion, namespace, cliVersio
 			golden = "check.proxy.golden"
 		}
 	} else if stage == "config" {
-		cmd = []string{"check", "config", "--expected-version", expectedVersion, "--wait=0"}
+		cmd = []string{"check", "config", "--expected-version", expectedVersion, "--wait=60m"}
 		golden = "check.config.golden"
 	} else {
-		cmd = []string{"check", "--expected-version", expectedVersion, "--wait=0"}
+		cmd = []string{"check", "--expected-version", expectedVersion, "--wait=60m"}
 		// if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
 		// golden = "check.multicluster.golden"
 		// } else if TestHelper.CNI() {
@@ -970,7 +970,7 @@ func TestCheckPostInstall(t *testing.T) {
 }
 
 func TestCheckViz(t *testing.T) {
-	cmd := []string{"viz", "check", "--wait=0"}
+	cmd := []string{"viz", "check", "--wait=60m"}
 	golden := "check.viz.golden"
 	if TestHelper.ExternalPrometheus() {
 		golden = "check.viz.external-prometheus.golden"
@@ -1213,7 +1213,7 @@ func TestRestarts(t *testing.T) {
 
 func TestCheckMulticluster(t *testing.T) {
 	if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
-		cmd := []string{"multicluster", "check", "--wait=0"}
+		cmd := []string{"multicluster", "check", "--wait=60m"}
 		golden := "check.multicluster.golden"
 		timeout := time.Minute
 		err := TestHelper.RetryFor(timeout, func() error {

--- a/test/integration/uninstall/uninstall_test.go
+++ b/test/integration/uninstall/uninstall_test.go
@@ -42,7 +42,7 @@ func TestInstall(t *testing.T) {
 	var (
 		vizCmd  = []string{"viz", "install"}
 		vizArgs = []string{
-			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace())}
+			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()), "--wait", "60m"}
 	)
 
 	// Install Linkerd Viz Extension

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -182,7 +182,7 @@ func (h *KubernetesHelper) GetResources(ctx context.Context, containerName, depl
 func (h *KubernetesHelper) CheckPods(ctx context.Context, namespace string, deploymentName string, replicas int) error {
 	var checkedPods []corev1.Pod
 
-	err := h.retryFor(6*time.Minute, func() error {
+	err := h.retryFor(60*time.Minute, func() error {
 		checkedPods = []corev1.Pod{}
 		pods, err := h.GetPodsForDeployment(ctx, namespace, deploymentName)
 		if err != nil {
@@ -325,7 +325,7 @@ func (h *KubernetesHelper) URLFor(ctx context.Context, namespace, deployName str
 func (h *KubernetesHelper) WaitRollout(t *testing.T) {
 	for deploy, deploySpec := range LinkerdDeployReplicasEdge {
 		if deploySpec.Namespace == "linkerd" {
-			o, err := h.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=120s", "deploy/"+deploy)
+			o, err := h.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=60m", "deploy/"+deploy)
 			if err != nil {
 				AnnotatedFatalf(t,
 					fmt.Sprintf("failed to wait rollout of deploy/%s", deploy),

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -477,6 +477,8 @@ func (h *TestHelper) HelmUpgrade(chart string, arg ...string) (string, string, e
 		h.helm.releaseName,
 		"--kube-context", h.k8sContext,
 		"--set", "namespace=" + h.namespace,
+		"--timeout", "60m",
+		"--wait",
 		chart,
 	}, arg...)
 	return combinedOutput("", h.helm.path, withParams...)
@@ -490,6 +492,8 @@ func (h *TestHelper) HelmInstall(chart string, arg ...string) (string, string, e
 		chart,
 		"--kube-context", h.k8sContext,
 		"--set", "namespace=" + h.namespace,
+		"--timeout", "60m",
+		"--wait",
 	}, arg...)
 	return combinedOutput("", h.helm.path, withParams...)
 }


### PR DESCRIPTION
This prevents early test failures due to the flakiness we have started observing
in GitHub-hosted runners recently. After testing the release process on my
linkerd2 fork, I've observed a release workflow taking over 30 minutes.

This bumps all timeouts to 60 minutes when testing. The intention of this to fix
the "waiting for deployment" errors we have seen in both PR and release
workflows.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
