### PR TITLE
add shell completion for all viz subcommands

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -77,7 +77,7 @@ func ConfigureNamespaceFlagCompletion(
 				}
 
 				cc := k8s.NewCommandCompletion(k8sAPI, "")
-				results, err := cc.Complete([]string{"namespaces"}, toComplete)
+				results, err := cc.Complete([]string{k8s.Namespace}, toComplete)
 				if err != nil {
 					return nil, cobra.ShellCompDirectiveError
 				}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/k8s/resource"
 	"github.com/prometheus/common/log"
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -55,4 +56,33 @@ func Uninstall(ctx context.Context, k8sAPI *k8s.KubernetesAPI, selector string) 
 		}
 	}
 	return nil
+}
+
+// ConfigureNamespaceFlagCompletion sets up resource-aware completion for command
+// flags that accept a namespace name
+func ConfigureNamespaceFlagCompletion(
+	cmd *cobra.Command,
+	flagNames []string,
+	kubeconfigPath string,
+	impersonate string,
+	impersonateGroup []string,
+	kubeContext string,
+) {
+	for _, flagName := range flagNames {
+		cmd.RegisterFlagCompletionFunc(flagName,
+			func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveError
+				}
+
+				cc := k8s.NewCommandCompletion(k8sAPI, "")
+				results, err := cc.Complete([]string{"namespaces"}, toComplete)
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveError
+				}
+
+				return results, cobra.ShellCompDirectiveDefault
+			})
+	}
 }

--- a/pkg/k8s/completion.go
+++ b/pkg/k8s/completion.go
@@ -60,6 +60,12 @@ func (c *CommandCompletion) Complete(args []string, toComplete string) ([]string
 		return suggestions, nil
 	}
 
+	// Similar to kubectl, we don't provide resource completion
+	// when the resource provided is in format <kind>/<resourceName>
+	if strings.Contains(args[0], "/") {
+		return []string{}, nil
+	}
+
 	resType, err := CanonicalResourceNameFromFriendlyName(args[0])
 	if err != nil {
 		return nil, fmt.Errorf("%s is not a valid resource name", args)
@@ -68,13 +74,6 @@ func (c *CommandCompletion) Complete(args []string, toComplete string) ([]string
 	// if we are looking for namespace suggestions clear namespace selector
 	if resType == "namespace" {
 		c.namespace = ""
-	}
-
-	// Similar to kubectl's completion for bash and zsh only, we don't provide
-	// resource completion when the resource provided is in format
-	// <kind>/<resourceName>.
-	if strings.Contains(args[0], "/") {
-		return []string{}, nil
 	}
 
 	gvr, err := c.getGroupVersionKindForResource(resType)

--- a/viz/cmd/check.go
+++ b/viz/cmd/check.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	vizHealthCheck "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	"github.com/spf13/cobra"
@@ -57,6 +58,10 @@ code.`,
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }
 

--- a/viz/cmd/edges.go
+++ b/viz/cmd/edges.go
@@ -14,11 +14,12 @@ import (
 	coreUtil "github.com/linkerd/linkerd2/controller/api/util"
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/metrics-api/util"
-	"github.com/linkerd/linkerd2/viz/pkg"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
 	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -83,8 +84,37 @@ func NewCmdEdges() *cobra.Command {
 
   # Get all edges between pods in all namespaces.
   linkerd viz edges po --all-namespaces`,
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: pkg.ValidTargets,
+		Args: cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			// This command requires only one argument. Ff we already have
+			// one after requesting autocompletion i.e. [tab][tab]
+			// skip running validArgsFunction
+			if len(args) > 0 {
+				return []string{}, cobra.ShellCompDirectiveError
+			}
+
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			if options.allNamespaces {
+				options.namespace = v1.NamespaceAll
+			}
+
+			cc := k8s.NewCommandCompletion(k8sAPI, options.namespace)
+
+			results, err := cc.Complete(args, toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			return results, cobra.ShellCompDirectiveDefault
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.namespace == "" {
 				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
@@ -138,6 +168,10 @@ func NewCmdEdges() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the specified resource")
 	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
 	cmd.PersistentFlags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", options.allNamespaces, "If present, returns edges across all namespaces, ignoring the \"--namespace\" flag")
+
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }
 

--- a/viz/cmd/edges.go
+++ b/viz/cmd/edges.go
@@ -86,7 +86,7 @@ func NewCmdEdges() *cobra.Command {
   linkerd viz edges po --all-namespaces`,
 		Args: cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			// This command requires only one argument. Ff we already have
+			// This command requires only one argument. If we already have
 			// one after requesting autocompletion i.e. [tab][tab]
 			// skip running validArgsFunction
 			if len(args) > 0 {

--- a/viz/cmd/list.go
+++ b/viz/cmd/list.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
-	"github.com/linkerd/linkerd2/pkg/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	vizLabels "github.com/linkerd/linkerd2/viz/pkg/labels"
 	"github.com/spf13/cobra"
@@ -26,7 +25,7 @@ func newCmdList() *cobra.Command {
 		Short: "Lists which pods can be tapped",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			k8sAPI, err := pkgK8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
 				return err
 			}
@@ -90,5 +89,8 @@ func newCmdList() *cobra.Command {
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "The namespace to list pods in")
 	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", options.allNamespaces, "If present, list pods across all namespaces")
 
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }

--- a/viz/cmd/profile.go
+++ b/viz/cmd/profile.go
@@ -94,7 +94,7 @@ func newCmdProfile() *cobra.Command {
 
 			// Profiles require completion for only services so prepend the service resource
 			// type to the list of args
-			results, err := cc.Complete([]string{"service"}, toComplete)
+			results, err := cc.Complete([]string{k8s.Service}, toComplete)
 			if err != nil {
 				return nil, cobra.ShellCompDirectiveError
 			}

--- a/viz/cmd/profile.go
+++ b/viz/cmd/profile.go
@@ -73,6 +73,34 @@ func newCmdProfile() *cobra.Command {
   linkerd viz profile -n emojivoto web-svc --tap deploy/web --tap-duration 10s --tap-route-limit 5
 `,
 		Args: cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			// Skip providing suggestions if one or more arguments are provided
+			// We either have a suggestion selected or more multiple args are provided
+			// which is not allowed for this command.
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			cc := k8s.NewCommandCompletion(k8sAPI, options.namespace)
+
+			// Profiles require completion for only services so prepend the service resource
+			// type to the list of args
+			results, err := cc.Complete([]string{"service"}, toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			return results, cobra.ShellCompDirectiveDefault
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			api.CheckClientOrExit(healthcheck.Options{
 				ControlPlaneNamespace: controlPlaneNamespace,
@@ -110,6 +138,10 @@ func newCmdProfile() *cobra.Command {
 	cmd.PersistentFlags().DurationVar(&options.tapDuration, "tap-duration", options.tapDuration, "Duration over which tap data is collected (for example: \"10s\", \"1m\", \"10m\")")
 	cmd.PersistentFlags().UintVar(&options.tapRouteLimit, "tap-route-limit", options.tapRouteLimit, "Max number of routes to add to the profile")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace of the service")
+
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }
 

--- a/viz/cmd/routes.go
+++ b/viz/cmd/routes.go
@@ -105,6 +105,9 @@ This command will only display traffic which is sent to a service that has a Ser
 	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, fmt.Sprintf("Output format; one of: \"%s\", \"%s\", or \"%s\"", tableOutput, wideOutput, jsonOutput))
 	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
 
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace", "to-namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }
 

--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -253,30 +253,10 @@ If no resource name is specified, displays stats about all resources of the spec
 	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
 	cmd.PersistentFlags().BoolVar(&options.unmeshed, "unmeshed", options.unmeshed, "If present, include unmeshed resources in the output")
 
-	configureFlagCompletions(cmd)
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace", "to-namespace", "from-namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
-}
-
-func configureFlagCompletions(cmd *cobra.Command) {
-	flagNames := []string{"namespace", "to-namespace", "from-namespace"}
-	for _, flagName := range flagNames {
-		cmd.RegisterFlagCompletionFunc(flagName,
-			func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
-				if err != nil {
-					return nil, cobra.ShellCompDirectiveError
-				}
-
-				cc := k8s.NewCommandCompletion(k8sAPI, "")
-				results, err := cc.Complete([]string{"namespaces"}, toComplete)
-				if err != nil {
-					cobra.CompErrorln(err.Error())
-					return nil, cobra.ShellCompDirectiveError
-				}
-
-				return results, cobra.ShellCompDirectiveDefault
-			})
-	}
 }
 
 func respToRows(resp *pb.StatSummaryResponse) []*pb.StatTable_PodGroup_Row {

--- a/viz/cmd/top.go
+++ b/viz/cmd/top.go
@@ -18,7 +18,6 @@ import (
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	metricsAPI "github.com/linkerd/linkerd2/viz/metrics-api"
 	metricsPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
-	vizpkg "github.com/linkerd/linkerd2/viz/pkg"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
@@ -320,8 +319,33 @@ func NewCmdTop() *cobra.Command {
 
   # display traffic for the web-dlbvj pod in the default namespace
   linkerd viz top pod/web-dlbvj`,
-		Args:      cobra.RangeArgs(1, 2),
-		ValidArgs: vizpkg.ValidTargets,
+		Args: cobra.RangeArgs(1, 2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			// This command requires at most two arguments if we already have
+			// two after requesting autocompletion i.e. [tab][tab]
+			// skip running validArgsFunction
+			if len(args) > 1 {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			cc := k8s.NewCommandCompletion(k8sAPI, options.namespace)
+
+			results, err := cc.Complete(args, toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			return results, cobra.ShellCompDirectiveDefault
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.namespace == "" {
 				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
@@ -397,6 +421,9 @@ func NewCmdTop() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&options.routes, "routes", options.routes, "Display data per route instead of per path")
 	cmd.PersistentFlags().StringVarP(&options.labelSelector, "selector", "l", options.labelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='")
 
+	pkgcmd.ConfigureNamespaceFlagCompletion(
+		cmd, []string{"namespace", "to-namespace"},
+		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
 }
 


### PR DESCRIPTION
This change is part of #5981 and follows up from #6091. It adds resource
aware shell completion for all viz subcommands and their related flags
where applicable.

Related to #5981

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>