### PR TITLE
Release notes for edge-21.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,24 +4,24 @@
 
 This edge release updates the proxy-init container to check whether the iptables
 rules have already been added, which prevents errors if the proxy-init container
-is restarted. Also, the `viz stat` command of the linkerd CLI now has tab
-completion for kubernetes resources, saving you precious keystrokes! Finally,
-the proxy has been updated with several fixes and improvements.
+is restarted. Also, the `viz stat` command now has tab completion for Kubernetes
+resources, saving you precious keystrokes! Finally, the proxy has been updated
+with several fixes and improvements.
 
 * Added instructions to `build.md` for using a locally built proxy
   (thanks @jroper!)
-* Added support for kubernetes resource aware tab completion to the `viz stat`
+* Added support for Kubernetes resource aware tab completion to the `viz stat`
   command
 * Updated `proxy-init` to skip configuring firewall if rules exists
-* Fixed viz uninstall to delete all RBAC objects (thanks @aryan9600!)
+* Fixed `viz uninstall` to delete all RBAC objects (thanks @aryan9600!)
 * Improved diagnostics for rejected profile discovery
-* Added an l5d-client-id header on mutually-authenticated inbound requests so
+* Added the `l5d-client-id` header on mutually-authenticated inbound requests so
   that applications can discover the client's identity.
 * Reduced proxy resource usage when there are no profiles
-* Updated proxy to fail connections when HTTP detection fails
-* Changed proxy to assume meshed connections are HTTP/2
+* Changed the admin server to assume all meshed connections are HTTP/2 and fail
+  connections when that is not the case
 * Updated the proxy to require the `l5d-dst-override` header on outbound
-  requests when the proxy is in `ingress` mode
+  requests when the proxy is in ingress-mode
 * Removed support for TCP-forwarding in ingress-mode
 
 ## edge-21.5.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,26 @@
 # Changes
 
+## edge-21.5.2
+
+This edge release updates the proxy-init container to check whether the iptables
+rules have already been added, which prevents errors if the proxy-init container
+is restarted. Also, the linkerd cli now has tab completion for kubernetes
+resources, saving you precious keystrokes! Finally, the proxy has been updated
+with several fixes and improvements.
+
+* Added instructions to `build.md` for using a locally built proxy
+  (thanks @jroper!)
+* Added support for kubernetes resource aware tab completion
+* Updated `proxy-init` to skip configuring firewall if rules exists
+* Fixed viz uninstall to delete all RBAC objects (thanks @aryan9600!)
+* Improved diagnostics for rejected profile discovery
+* Added proxy logic to set the l5d-client-id header
+* Reduced proxy resource usage when there are no profiles
+* Updated proxy to fail connections when HTTP detection fails
+* Changed proxy to assume meshed connections are HTTP/2
+* Updated the proxy to require the `l5d-dst-override` header
+* Removed support for TCP-forwarding in ingress-mode
+
 ## edge-21.5.1
 
 This edge release adds support for versioned hint URLs in `linkerd check` and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,21 +4,24 @@
 
 This edge release updates the proxy-init container to check whether the iptables
 rules have already been added, which prevents errors if the proxy-init container
-is restarted. Also, the linkerd cli now has tab completion for kubernetes
-resources, saving you precious keystrokes! Finally, the proxy has been updated
-with several fixes and improvements.
+is restarted. Also, the `viz stat` command of the linkerd CLI now has tab
+completion for kubernetes resources, saving you precious keystrokes! Finally,
+the proxy has been updated with several fixes and improvements.
 
 * Added instructions to `build.md` for using a locally built proxy
   (thanks @jroper!)
-* Added support for kubernetes resource aware tab completion
+* Added support for kubernetes resource aware tab completion to the `viz stat`
+  command
 * Updated `proxy-init` to skip configuring firewall if rules exists
 * Fixed viz uninstall to delete all RBAC objects (thanks @aryan9600!)
 * Improved diagnostics for rejected profile discovery
-* Added proxy logic to set the l5d-client-id header
+* Added an l5d-client-id header on mutually-authenticated inbound requests so
+  that applications can discover the client's identity.
 * Reduced proxy resource usage when there are no profiles
 * Updated proxy to fail connections when HTTP detection fails
 * Changed proxy to assume meshed connections are HTTP/2
-* Updated the proxy to require the `l5d-dst-override` header
+* Updated the proxy to require the `l5d-dst-override` header on outbound
+  requests when the proxy is in `ingress` mode
 * Removed support for TCP-forwarding in ingress-mode
 
 ## edge-21.5.1


### PR DESCRIPTION
## edge-21.5.2

This edge release updates the proxy-init container to check whether the iptables
rules have already been added, which prevents errors if the proxy-init container
is restarted. Also, the linkerd cli now has tab completion for kubernetes
resources, saving you precious keystrokes! Finally, the proxy has been updated
with several fixes and improvements.

* Added instructions to `build.md` for using a locally built proxy
  (thanks @jroper!)
* Added support for kubernetes resource aware tab completion
* Updated `proxy-init` to skip configuring firewall if rules exists
* Fixed viz uninstall to delete all RBAC objects (thanks @aryan9600!)
* Improved diagnostics for rejected profile discovery
* Added proxy logic to set the l5d-client-id header
* Reduced proxy resource usage when there are no profiles
* Updated proxy to fail connections when HTTP detection fails
* Changed proxy to assume meshed connections are HTTP/2
* Updated the proxy to require the `l5d-dst-override` header
* Removed support for TCP-forwarding in ingress-mode

Signed-off-by: Charles Pretzer <charles@buoyant.io>
