### PR TITLE
Separate protocol hint setting from H2 upgrades

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -329,13 +329,11 @@ func toWeightedAddr(address watcher.Address, opaquePorts, skippedInboundPorts ma
 	// If the pod is controlled by any Linkerd control plane, then it can be
 	// hinted that this destination knows H2 (and handles our orig-proto
 	// translation)
-	var hint *pb.ProtocolHint
+	hint := &pb.ProtocolHint{}
 	if controllerNSLabel != "" && !isSkippedInboundPort {
 		if enableH2Upgrade {
-			hint = &pb.ProtocolHint{
-				Protocol: &pb.ProtocolHint_H2_{
-					H2: &pb.ProtocolHint_H2{},
-				},
+			hint.Protocol = &pb.ProtocolHint_H2_{
+				H2: &pb.ProtocolHint_H2{},
 			}
 		}
 		if _, ok := opaquePorts[address.Port]; ok {

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -330,11 +330,13 @@ func toWeightedAddr(address watcher.Address, opaquePorts, skippedInboundPorts ma
 	// hinted that this destination knows H2 (and handles our orig-proto
 	// translation)
 	var hint *pb.ProtocolHint
-	if enableH2Upgrade && controllerNSLabel != "" && !isSkippedInboundPort {
-		hint = &pb.ProtocolHint{
-			Protocol: &pb.ProtocolHint_H2_{
-				H2: &pb.ProtocolHint_H2{},
-			},
+	if controllerNSLabel != "" && !isSkippedInboundPort {
+		if enableH2Upgrade {
+			hint = &pb.ProtocolHint{
+				Protocol: &pb.ProtocolHint_H2_{
+					H2: &pb.ProtocolHint_H2{},
+				},
+			}
 		}
 		if _, ok := opaquePorts[address.Port]; ok {
 			port, err := getInboundPort(&address.Pod.Spec)

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -413,12 +413,12 @@ func TestGet(t *testing.T) {
 			t.Fatalf("Expected len(addrs) to be > 0")
 		}
 
-		if addrs[0].ProtocolHint != nil {
+		if addrs[0].GetProtocolHint().GetProtocol() != nil || addrs[0].GetProtocolHint().GetOpaqueTransport() != nil {
 			t.Fatalf("Expected protocol hint for %s to be nil but got %+v", path, addrs[0].ProtocolHint)
 		}
 
 		if addrs[0].TlsIdentity != nil {
-			t.Fatalf("Expected protocol hint for %s to be nil but got %+v", path, addrs[0].TlsIdentity)
+			t.Fatalf("Expected TLS identity for %s to be nil but got %+v", path, addrs[0].TlsIdentity)
 		}
 	})
 }
@@ -682,10 +682,10 @@ func TestGetProfiles(t *testing.T) {
 		if !exists {
 			t.Fatalf("Expected 'namespace' metric label to exist but it did not")
 		}
-		if first.Endpoint.ProtocolHint == nil {
+		if first.GetEndpoint().GetProtocolHint() == nil {
 			t.Fatalf("Expected protocol hint but found none")
 		}
-		if first.Endpoint.ProtocolHint.GetOpaqueTransport() != nil {
+		if first.GetEndpoint().GetProtocolHint().GetOpaqueTransport() != nil {
 			t.Fatalf("Expected pod to not support opaque traffic on port %d", port)
 		}
 		if first.Endpoint.Addr.String() != epAddr.String() {
@@ -745,7 +745,7 @@ func TestGetProfiles(t *testing.T) {
 		if first.Endpoint == nil {
 			t.Fatalf("Expected response to have endpoint field")
 		}
-		if first.Endpoint.ProtocolHint != nil {
+		if first.Endpoint.GetProtocolHint().GetProtocol() != nil || first.Endpoint.GetProtocolHint().GetOpaqueTransport() != nil {
 			t.Fatalf("Expected no protocol hint but found one")
 		}
 	})
@@ -884,12 +884,12 @@ func TestGetProfiles(t *testing.T) {
 			t.Fatalf("Expected to not be nil")
 		}
 
-		if addr.ProtocolHint != nil {
+		if addr.GetProtocolHint().GetProtocol() != nil || addr.GetProtocolHint().GetOpaqueTransport() != nil {
 			t.Fatalf("Expected protocol hint for %s to be nil but got %+v", path, addr.ProtocolHint)
 		}
 
 		if addr.TlsIdentity != nil {
-			t.Fatalf("Expected protocol hint for %s to be nil but got %+v", path, addr.TlsIdentity)
+			t.Fatalf("Expected TLS identity for %s to be nil but got %+v", path, addr.TlsIdentity)
 		}
 	})
 }


### PR DESCRIPTION
While uncommon, if H2 upgrades are disabled it's possible for an opaque workload
to not have it's `hint.OpaqueTransport` field set in it's destination profile
response.

This changes the H2 upgrade enabled check to be specific for setting the
`hint.Protocol` while allowing `hint.OpaqueTransport` to be set independent of
that value.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
