### PR TITLE
Fix templating for Prometheus pod annotations

### DIFF
--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -224,7 +224,7 @@ spec:
         {{- with .Values.prometheus.proxy }}
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
-        {{- with .Values.podAnnotations }}{{  . | trim | nindent 8 }}{{- end }}
+        {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
         linkerd.io/extension: viz
         component: prometheus


### PR DESCRIPTION
Closes #6148

Tested with the following `values.yaml`:

```
podAnnotations:
  foo: bar
```

```
$ bin/helm-build
$ helm template linkerd ./viz/charts/linkerd-viz --values values.yaml
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
