### PR TITLE
Add helm upgrade timeout to install test

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -628,9 +628,10 @@ func TestUpgradeHelm(t *testing.T) {
 		"--set", "proxyInjectorProxyResources.cpu.limit=1060m",
 		"--set", "proxyInjectorProxyResources.memory.request=106Mi",
 		"--atomic",
+		"--timeout", "60m",
 		"--wait",
 	}
-	extraArgs, extraVizArgs := helmOverridesEdge(helmTLSCerts)
+	extraArgs, vizArgs := helmOverridesEdge(helmTLSCerts)
 	args = append(args, extraArgs...)
 	if stdout, stderr, err := TestHelper.HelmUpgrade(TestHelper.GetHelmChart(), args...); err != nil {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
@@ -638,7 +639,6 @@ func TestUpgradeHelm(t *testing.T) {
 	}
 
 	vizChart := TestHelper.GetLinkerdVizHelmChart()
-	vizArgs := append(extraVizArgs, "--wait")
 	if stdout, stderr, err := TestHelper.HelmCmdPlain("upgrade", vizChart, "l5d-viz", vizArgs...); err != nil {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)


### PR DESCRIPTION
While we continue to deal with Actions CI timeouts, this adds an additional
timeout to the `helm upgrade` command in the install integration tests.

This was encounted in this [CI run](https://github.com/linkerd/linkerd2/runs/2633032438?check_suite_focus=true).

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
