### PR TITLE
Fix linkerd check --proxy failure on Jobs

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2500,7 +2500,7 @@ func validateDataPlanePods(pods []corev1.Pod, targetNamespace string) error {
 
 	for _, pod := range pods {
 		status := k8s.GetPodStatus(pod)
-		// Skip validing meshed pods that are in the `Completed` state
+		// Skip validating meshed pods that are in the `Completed` state
 		// as they do not have a running proxy
 		if status == "Completed" {
 			continue

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2500,6 +2500,12 @@ func validateDataPlanePods(pods []corev1.Pod, targetNamespace string) error {
 
 	for _, pod := range pods {
 		status := k8s.GetPodStatus(pod)
+		// Skip validing meshed pods that are in the `Completed` state
+		// as they do not have a running proxy
+		if status == "Completed" {
+			continue
+		}
+
 		if status != "Running" && status != "Evicted" {
 			return fmt.Errorf("The \"%s\" pod is not running", pod.Name)
 		}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1653,6 +1653,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "emoji-d9c7866bb-7v74n"},
 				Status: corev1.PodStatus{
 					Phase: "Succeeded",
+					Reason: "Completed",
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
 							Name:  k8s.ProxyContainerName,
@@ -1689,6 +1690,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "web-6cfbccc48-5g8px"},
 				Status: corev1.PodStatus{
 					Phase: "Succeeded",
+					Reason: "Completed",
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
 							Name:  k8s.ProxyContainerName,
@@ -1699,7 +1701,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 			},
 		}
 
-		err := checkMisconfiguredPodsLabels(pods)
+		err := validateDataPlanePods(pods, "emojivoto")
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1652,7 +1652,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "emoji-d9c7866bb-7v74n"},
 				Status: corev1.PodStatus{
-					Phase: "Succeeded",
+					Phase:  "Succeeded",
 					Reason: "Completed",
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
@@ -1689,7 +1689,7 @@ func TestValidateDataPlanePods(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "web-6cfbccc48-5g8px"},
 				Status: corev1.PodStatus{
-					Phase: "Succeeded",
+					Phase:  "Succeeded",
 					Reason: "Completed",
 					ContainerStatuses: []corev1.ContainerStatus{
 						{


### PR DESCRIPTION
When `linkerd check --proxy` is run in a given namespace, the check
command ensures that all pods within that namespace have a running proxy
and that and the pod is in a `Running` status.

This however, is not necessarily true when dealing with CronJobs or Jobs
as these resources create pods that run their containers for a short period
of time and then terminate. When these pods terminate, they get placed
in a `Completed` phase and their sidecars are no longer running. This
causes an issue in `linkerd check --proxy` because that command expects
that pods will always be in a running state.

This change effectively skips checking the proxy status of a pod if that
pod is in a `Completed` phase as a pod no longer has an actively running
proxy

Fixes #6128

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>