### PR TITLE
destination: prefer `sp.dstOverrides` over `trafficsplit`

### DIFF
--- a/controller/api/destination/traffic_split_adaptor.go
+++ b/controller/api/destination/traffic_split_adaptor.go
@@ -53,7 +53,10 @@ func (tsa *trafficSplitAdaptor) publish() {
 	if tsa.profile != nil {
 		merged = *tsa.profile
 	}
-	if tsa.split != nil {
+
+	// Update only if `dstOverrides` is empty, to give preference
+	// to serviceprofiles over trafficsplits
+	if tsa.split != nil && len(merged.Spec.DstOverrides) == 0 {
 		overrides := []*sp.WeightedDst{}
 		for _, backend := range tsa.split.Spec.Backends {
 			dst := &sp.WeightedDst{


### PR DESCRIPTION
This updates the destination to prefer `serviceprofiles.dstOverrides`
over `trafficsplits`. This is useful as it is improtant for
ServiceProfile to take preference over TrafficSplits when both are
present.

This also makes integration testing the `smi-adaptor` easier.

This also adds unit tests in the `traffic_split_adaptor` to check
for the same.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
