### PR TITLE
Create gateway-port option for mc link (#6175)

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -205,13 +205,14 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				return err
 			}
 
-			gatewayPort := opts.gatewayPort
-			if gatewayPort == 0 {
-				serviceGatewayPort, err := extractGatewayPort(gateway)
-				if err != nil {
-					return err
-				}
-				gatewayPort = serviceGatewayPort
+			gatewayPort, err := extractGatewayPort(gateway)
+			if err != nil {
+				return err
+			}
+
+			// Override with user provided gateway port if present
+			if opts.gatewayPort != 0 {
+				gatewayPort = opts.gatewayPort
 			}
 
 			selector, err := metav1.ParseToLabelSelector(opts.selector)
@@ -326,7 +327,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	cmd.Flags().StringVar(&opts.logLevel, "log-level", opts.logLevel, "Log level for the Multicluster components")
 	cmd.Flags().StringVar(&opts.dockerRegistry, "registry", opts.dockerRegistry, "Docker registry to pull service mirror controller image from")
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
-	cmd.Flags().StringVar(&opts.gatewayAddresses, "gateway-addresses", opts.gatewayAddresses, "If specified overwrites gateway addresses when gateway service is not type LoadBalancer (comma separated list)")
+	cmd.Flags().StringVar(&opts.gatewayAddresses, "gateway-addresses", opts.gatewayAddresses, "If specified, overwrites gateway addresses when gateway service is not type LoadBalancer (comma separated list)")
 	cmd.Flags().Uint32Var(&opts.gatewayPort, "gateway-port", opts.gatewayPort, "If specified, overwrites gateway port when gateway service is not type LoadBalancer")
 
 	return cmd

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -43,6 +43,7 @@ type (
 		dockerRegistry          string
 		selector                string
 		gatewayAddresses        string
+		gatewayPort             uint32
 	}
 )
 
@@ -204,9 +205,13 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				return err
 			}
 
-			gatewayPort, err := extractGatewayPort(gateway)
-			if err != nil {
-				return err
+			gatewayPort := opts.gatewayPort
+			if gatewayPort == 0 {
+				serviceGatewayPort, err := extractGatewayPort(gateway)
+				if err != nil {
+					return err
+				}
+				gatewayPort = serviceGatewayPort
 			}
 
 			selector, err := metav1.ParseToLabelSelector(opts.selector)
@@ -322,6 +327,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	cmd.Flags().StringVar(&opts.dockerRegistry, "registry", opts.dockerRegistry, "Docker registry to pull service mirror controller image from")
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
 	cmd.Flags().StringVar(&opts.gatewayAddresses, "gateway-addresses", opts.gatewayAddresses, "If specified overwrites gateway addresses when gateway service is not type LoadBalancer (comma separated list)")
+	cmd.Flags().Uint32Var(&opts.gatewayPort, "gateway-port", opts.gatewayPort, "If specified, overwrites gateway port when gateway service is not type LoadBalancer")
 
 	return cmd
 }
@@ -340,6 +346,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 		logLevel:                defaults.LogLevel,
 		selector:                k8s.DefaultExportedServiceSelector,
 		gatewayAddresses:        "",
+		gatewayPort:             0,
 	}, nil
 }
 


### PR DESCRIPTION
In case of a NodePort service type, there might be non-kubernetes load
balancers that map a public port to the selected NodePorts. This is not
something that is detectable, so a flag needs to be provided to specify
the public port during the `mc link` command.

Note that the probe port can already be set using `--set
gateway.probe.port 1234`.

Fixes #6175

Signed-off-by: Peter Smit <peter.smit@inscripta.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
