### PR TITLE
artifacthub-repo.yml file to claim charts ownership

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -71,6 +71,8 @@ if [ "$1" = package ]; then
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-"$version".yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm
 
+    cp "$rootdir"/charts/linkerd2/artifacthub-repo.yml "$rootdir"/target/helm/
+
     # restore version in Values files
     setValues "$fullVersion" "linkerdVersionValue"
 fi

--- a/charts/linkerd2-cni/OWNERS
+++ b/charts/linkerd2-cni/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- grampelberg
-- alpeb
-- ihcsim
-reviewers:
-- grampelberg
-- alpeb
-- ihcsim

--- a/charts/linkerd2/OWNERS
+++ b/charts/linkerd2/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- grampelberg
-- alpeb
-- ihcsim
-reviewers:
-- grampelberg
-- alpeb
-- ihcsim

--- a/charts/linkerd2/artifacthub-repo.yml
+++ b/charts/linkerd2/artifacthub-repo.yml
@@ -1,0 +1,14 @@
+#repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+owners:
+  - name: olix0r
+    email: ver@buoyant.io
+  - name: alpeb
+    email: alejandro@buoyant.io
+  - name: adleong
+    email: alex@buoyant.io
+  - name: hawkw
+    email: eliza@buoyant.io
+  - name: kleimkuhler
+    email: kevinl@buoyant.io
+  - name: pothulapati
+    email: tarun@buoyant.io


### PR DESCRIPTION
The owners in that file match the entries in MAINTAINERS.md.
On the next release build this will upload that file into our Helm repo,
and we'll be able to claim ownership of the chart at artifacthub.io.

Once we do that we'll get a `repositoryID` we can add into that file, to
obtain the "Verified publisher" badge.

This change also removes a couple of no longer relevant OWNERS files.
