### PR TITLE
jaeger: fix helm indentation in templates

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collector.enabled }}
+{{- if .Values.collector.enabled -}}
 ---
 ###
 ### collector RBAC
@@ -8,18 +8,7 @@ apiVersion: v1
 metadata:
   name: collector
   namespace: {{.Values.namespace}}
-{{- end }}
-{{- if .Values.jaeger.enabled }}
----
-###
-### jaeger RBAC
-###
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: jaeger
-  namespace: {{.Values.namespace}}
-{{- end }}
+{{ end -}}
 ---
 ###
 ### Jaeger Injector RBAC
@@ -105,3 +94,14 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   sideEffects: None
+{{- if .Values.jaeger.enabled }}
+---
+###
+### jaeger RBAC
+###
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: jaeger
+  namespace: {{.Values.namespace}}
+{{- end -}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -120,7 +120,7 @@ spec:
             path: collector-config.yaml
           name: collector-config
         name: collector-config-val
-{{- end }}
+{{- end -}}
 {{- if .Values.jaeger.enabled }}
 ---
 ###

--- a/jaeger/cmd/install_test.go
+++ b/jaeger/cmd/install_test.go
@@ -27,6 +27,18 @@ func TestRender(t *testing.T) {
 			nil,
 			"install_default.golden",
 		},
+		{
+			map[string]interface{}{
+				"jaeger": map[string]interface{}{"enabled": false},
+			},
+			"install_jaeger_disabled.golden",
+		},
+		{
+			map[string]interface{}{
+				"collector": map[string]interface{}{"enabled": false},
+			},
+			"install_collector_disabled.golden",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93ee231f45614b315429e63eb8c79ca948062c4f47b19c8c273ab943bd182ff3
+        checksum/config: 09b8c09754744aff9027048d3863d2401e4547f07d87f6e3dee643947adb0976
       labels:
         linkerd.io/extension: jaeger
         component: jaeger-injector
@@ -89,15 +89,6 @@ spec:
   - name: jaeger-injector
     port: 443
     targetPort: jaeger-injector
----
-###
-### collector RBAC
-###
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: collector
-  namespace: linkerd-jaeger
 ---
 ###
 ### Jaeger Injector RBAC
@@ -177,122 +168,6 @@ apiVersion: v1
 metadata:
   name: jaeger
   namespace: linkerd-jaeger
----
-###
-### Tracing Collector Service
-###
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: collector-config
-  namespace: linkerd-jaeger
-  labels:
-    component: collector
-data:
-  collector-config: |
-    receivers:
-      opencensus:
-        port: 55678
-      zipkin:
-        port: 9411
-      jaeger:
-        jaeger-thrift-http-port: 14268
-    queued-exporters:
-      jaeger-all-in-one:
-        num-workers: 4
-        queue-size: 100
-        retry-on-failure: true
-        sender-type: jaeger-thrift-http
-        jaeger-thrift-http:
-          collector-endpoint: http://jaeger.linkerd-jaeger:14268/api/traces
-          timeout: 5s
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: collector
-  namespace: linkerd-jaeger
-  labels:
-    component: collector
-spec:
-  type: ClusterIP
-  ports:
-  - name: opencensus
-    port: 55678
-    protocol: TCP
-    targetPort: 55678
-  - name: zipkin
-    port: 9411
-    protocol: TCP
-    targetPort: 9411
-  - name: jaeger
-    port: 14268
-    protocol: TCP
-    targetPort: 14268
-  selector:
-    component: collector
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/name: collector
-    app.kubernetes.io/part-of: Linkerd
-    component: collector
-  name: collector
-  namespace: linkerd-jaeger
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      component: collector
-  minReadySeconds: 5
-  progressDeadlineSeconds: 120
-  template:
-    metadata:
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8888"
-        prometheus.io/scrape: "true"
-      labels:
-        component: collector
-    spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      containers:
-      - command:
-        - /occollector_linux
-        - --config=/conf/collector-config.yaml
-        env:
-        - name: GOGC
-          value: "80"
-        image: omnition/opencensus-collector:0.1.11
-        imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133
-        name: oc-collector
-        ports:
-        - containerPort: 55678
-        - containerPort: 9411
-        - containerPort: 14268
-        - containerPort: 8888
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133
-        volumeMounts:
-        - mountPath: /conf
-          name: collector-config-val
-      serviceAccountName: collector
-      volumes:
-      - configMap:
-          items:
-          - key: collector-config
-            path: collector-config.yaml
-          name: collector-config
-        name: collector-config-val
 ---
 ###
 ### Tracing Jaeger Service

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93ee231f45614b315429e63eb8c79ca948062c4f47b19c8c273ab943bd182ff3
+        checksum/config: 83c7853cc6f0083c78ce1a1862e1f02c4eccb7d2fa90d3ffa924ac75d728ad95
       labels:
         linkerd.io/extension: jaeger
         component: jaeger-injector
@@ -170,15 +170,6 @@ webhooks:
   sideEffects: None
 ---
 ###
-### jaeger RBAC
-###
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: jaeger
-  namespace: linkerd-jaeger
----
-###
 ### Tracing Collector Service
 ###
 apiVersion: v1
@@ -293,65 +284,3 @@ spec:
             path: collector-config.yaml
           name: collector-config
         name: collector-config-val
----
-###
-### Tracing Jaeger Service
-###
-apiVersion: v1
-kind: Service
-metadata:
-  name: jaeger
-  namespace: linkerd-jaeger
-  labels:
-    component: jaeger
-spec:
-  type: ClusterIP
-  selector:
-    component: jaeger
-  ports:
-    - name: collection
-      port: 14268
-    - name: ui
-      port: 16686
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/name: jaeger
-    app.kubernetes.io/part-of: Linkerd
-    component: jaeger
-  name: jaeger
-  namespace: linkerd-jaeger
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      component: jaeger
-  template:
-    metadata:
-      annotations:
-        config.linkerd.io/proxy-await: "enabled"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "14269"
-        prometheus.io/scrape: "true"
-      labels:
-        component: jaeger
-    spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-      containers:
-      - args:
-        - --query.base-path=/jaeger
-        image: jaegertracing/all-in-one:1.19.2
-        imagePullPolicy: Always
-        name: jaeger
-        ports:
-        - containerPort: 14269
-          name: admin
-        - containerPort: 14268
-          name: collection
-        - containerPort: 16686
-          name: ui
-      dnsPolicy: ClusterFirst
-      serviceAccountName: jaeger


### PR DESCRIPTION
PR #6120 added flags to disable and enable jaeger, and opencensus
collector.

The helm indentation was not correctly set, which seems
add additional unecessary new-lines.

This PR fixes that while also adding new tests, to test
and track the manifests with these options.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
