### PR TITLE
Appease disk pressure in CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -150,11 +150,5 @@ jobs:
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
     - name: Run integration tests
-      if: ${{ !endsWith(matrix.integration_test, 'deep') }}
       run: |
-        bin/tests --images archive --name ${{ matrix.integration_test }} "$HOME/.linkerd"
-    - name: Run integration tests (deep)
-      if: ${{ endsWith(matrix.integration_test, 'deep') }}
-      run: |
-        # deep tests consume a lot of disk
         bin/tests --images archive --cleanup-docker --name ${{ matrix.integration_test }} "$HOME/.linkerd"

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -237,10 +237,6 @@ setup_cluster() {
   if [ -z "$skip_cluster_create" ]; then
     create_cluster "$@"
     image_load "$name"
-    if [ -n "$cleanup_docker" ]; then
-      rm -rf image-archives
-      docker system prune --force --all
-    fi
   fi
   check_cluster
 }
@@ -323,6 +319,10 @@ start_test() {
 start_single_test() {
   name=$1
   setup_cluster "$@"
+  if [ -n "$cleanup_docker" ]; then
+    rm -rf image-archives
+    docker system prune --force --all
+  fi
   run_"$name"_test
   exit_on_err "error calling 'run_${name}_test'"
   finish "$name"
@@ -331,6 +331,10 @@ start_single_test() {
 start_multicluster_test() {
   setup_cluster source "$@"
   setup_cluster target "$@"
+  if [ -n "$cleanup_docker" ]; then
+    rm -rf image-archives
+    docker system prune --force --all
+  fi
   run_multicluster_test
   exit_on_err "error calling 'run_multicluster_test'"
   finish source


### PR DESCRIPTION
While debugging the latest CI flakiness I only saw problems at
retrieving the images, which aren't surfaced as such unless you
explicitly ask for k8s events. After doing so I also found things like:

```
Warning   FreeDiskSpaceFailed       node/k3d-target-server-0 failed to garbage collect required amount of images. Wanted to free 5491729203 bytes, but freed 0 bytes
```

and entries in the k3d log such as:
```
I0526 15:21:25.045203      11 image_gc_manager.go:304] [imageGCManager]: Disk usage on image filesystem is at 87% which is over the high threshold (85%). Trying to free 5491729203 bytes down to the low threshold (80%).
E0526 15:21:25.046709      11 kubelet.go:1214] Image garbage collection failed multiple times in a row: failed to garbage collect required amount of images. Wanted to free 5491729203 bytes, but freed 0 bytes
```

So this PR expands the removal of the `images-archives.zip` file and the
docker images pruning to all tests, not just *-deep ones. :pray:
