### PR TITLE
Add missing psp for extensions

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -85,6 +85,7 @@ Kubernetes: `>=1.16.0-0`
 | jaeger.image.version | string | `"1.19.2"` |  |
 | jaeger.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | jaeger.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| linkerdNamespace | string | `"linkerd"` | Namespace of the Linkerd core control-plane install |
 | linkerdVersion | string | `"linkerdVersionValue"` |  |
 | namespace | string | `"linkerd-jaeger"` |  |
 | nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |

--- a/jaeger/charts/linkerd-jaeger/templates/psp.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/psp.yaml
@@ -11,7 +11,7 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - linkerd-linkerd-control-plane
+  - linkerd-{{.Values.linkerdNamespace}}-control-plane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/jaeger/charts/linkerd-jaeger/templates/psp.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/psp.yaml
@@ -5,46 +5,36 @@ metadata:
   name: psp
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: viz
+    linkerd.io/extension: jaeger
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
   verbs: ['use']
   resourceNames:
-  - linkerd-{{.Values.linkerdNamespace}}-control-plane
+  - linkerd-linkerd-control-plane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: viz-psp
+  name: jaeger-psp
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: viz
-    namespace: {{.Values.namespace}}
+    linkerd.io/extension: jaeger
 roleRef:
   kind: Role
   name: psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
+{{ if .Values.collector.enabled -}}
 - kind: ServiceAccount
-  name: tap
-  namespace: {{.Values.namespace}}
-- kind: ServiceAccount
-  name: web
-  namespace: {{.Values.namespace}}
-{{ if .Values.grafana.enabled -}}
-- kind: ServiceAccount
-  name: grafana
-  namespace: {{.Values.namespace}}
-{{ end -}}
-{{ if .Values.prometheus.enabled -}}
-- kind: ServiceAccount
-  name: prometheus
+  name: collector
   namespace: {{.Values.namespace}}
 {{ end -}}
 - kind: ServiceAccount
-  name: metrics-api
+  name: jaeger-injector
   namespace: {{.Values.namespace}}
+{{ if .Values.jaeger.enabled -}}
 - kind: ServiceAccount
-  name: tap-injector
+  name: jaeger
   namespace: {{.Values.namespace}}
+{{ end -}}

--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -69,11 +69,11 @@ metadata:
 webhooks:
 - name: jaeger-injector.linkerd.io
   {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector: 
+  namespaceSelector:
 {{ toYaml .Values.webhook.namespaceSelector | trim | indent 4 -}}
   {{- end }}
   {{- if .Values.webhook.objectSelector }}
-  objectSelector: 
+  objectSelector:
 {{ toYaml .Values.webhook.objectSelector | trim | indent 4 -}}
   {{- end }}
   clientConfig:
@@ -94,7 +94,7 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   sideEffects: None
-{{- if .Values.jaeger.enabled }}
+{{ if .Values.jaeger.enabled -}}
 ---
 ###
 ### jaeger RBAC
@@ -104,4 +104,4 @@ apiVersion: v1
 metadata:
   name: jaeger
   namespace: {{.Values.namespace}}
-{{- end -}}
+{{ end -}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collector.enabled }}
+{{ if .Values.collector.enabled -}}
 ---
 ###
 ### Tracing Collector Service
@@ -120,8 +120,8 @@ spec:
             path: collector-config.yaml
           name: collector-config
         name: collector-config-val
-{{- end -}}
-{{- if .Values.jaeger.enabled }}
+{{ end -}}
+{{ if .Values.jaeger.enabled -}}
 ---
 ###
 ### Tracing Jaeger Service
@@ -189,4 +189,4 @@ spec:
         {{- end }}
       dnsPolicy: ClusterFirst
       serviceAccountName: jaeger
-{{- end }}
+{{ end -}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -4,6 +4,9 @@ installNamespace: true
 
 namespace: linkerd-jaeger
 
+# -- Namespace of the Linkerd core control-plane install
+linkerdNamespace: linkerd
+
 # -- Default nodeSelector section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
 nodeSelector: &default_node_selector

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -25,6 +25,7 @@ var (
 		"templates/namespace.yaml",
 		"templates/jaeger-injector.yaml",
 		"templates/rbac.yaml",
+		"templates/psp.yaml",
 		"templates/tracing.yaml",
 	}
 )
@@ -43,7 +44,7 @@ func newCmdInstall() *cobra.Command {
   linkerd jaeger install | kubectl apply -f -
   # Install Jaeger extension into a non-default namespace.
   linkerd jaeger install --namespace custom | kubectl apply -f -
-  
+
 The installation can be configured by using the --set, --values, --set-string and --set-file flags.
 A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/linkerd-jaeger/README.md
   `,

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 09b8c09754744aff9027048d3863d2401e4547f07d87f6e3dee643947adb0976
+        checksum/config: 5bd7cf79e2089450866c91a4f139e93835bef192c11323db78aeb8c255fcf3b4
       labels:
         linkerd.io/extension: jaeger
         component: jaeger-injector
@@ -166,6 +166,39 @@ webhooks:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: jaeger
+  namespace: linkerd-jaeger
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jaeger-psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+roleRef:
+  kind: Role
+  name: psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: jaeger-injector
+  namespace: linkerd-jaeger
+- kind: ServiceAccount
   name: jaeger
   namespace: linkerd-jaeger
 ---

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 93ee231f45614b315429e63eb8c79ca948062c4f47b19c8c273ab943bd182ff3
+        checksum/config: cc99e06df34fab44bf1a6b2a80839f971716ff9ee14c130b9d74f0a0a3d60605
       labels:
         linkerd.io/extension: jaeger
         component: jaeger-injector
@@ -175,6 +175,42 @@ webhooks:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  name: jaeger
+  namespace: linkerd-jaeger
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jaeger-psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+roleRef:
+  kind: Role
+  name: psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: linkerd-jaeger
+- kind: ServiceAccount
+  name: jaeger-injector
+  namespace: linkerd-jaeger
+- kind: ServiceAccount
   name: jaeger
   namespace: linkerd-jaeger
 ---

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -32,7 +32,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 83c7853cc6f0083c78ce1a1862e1f02c4eccb7d2fa90d3ffa924ac75d728ad95
+        checksum/config: 526f4fb77f64bd384cc6913967444c5faec551a8cba1ad2cb87cb77ef767318d
       labels:
         linkerd.io/extension: jaeger
         component: jaeger-injector
@@ -168,6 +168,39 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["pods"]
   sideEffects: None
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jaeger-psp
+  namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
+roleRef:
+  kind: Role
+  name: psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: linkerd-jaeger
+- kind: ServiceAccount
+  name: jaeger-injector
+  namespace: linkerd-jaeger
 ---
 ###
 ### Tracing Collector Service

--- a/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
@@ -1,0 +1,17 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: multicluster-link-psp
+  namespace: {{.Values.namespace}}
+  labels:
+    linkerd.io/extension: multicluster
+    namespace: {{.Values.namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: psp
+subjects:
+- kind: ServiceAccount
+  name: linkerd-service-mirror-{{.Values.targetClusterName}}
+  namespace: {{.Values.namespace}}

--- a/multicluster/charts/linkerd-multicluster/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   name: psp
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: viz
+    linkerd.io/extension: multicluster
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -16,10 +16,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: viz-psp
+  name: multicluster-psp
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/extension: viz
+    linkerd.io/extension: multicluster
     namespace: {{.Values.namespace}}
 roleRef:
   kind: Role
@@ -27,24 +27,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: tap
-  namespace: {{.Values.namespace}}
-- kind: ServiceAccount
-  name: web
-  namespace: {{.Values.namespace}}
-{{ if .Values.grafana.enabled -}}
-- kind: ServiceAccount
-  name: grafana
-  namespace: {{.Values.namespace}}
-{{ end -}}
-{{ if .Values.prometheus.enabled -}}
-- kind: ServiceAccount
-  name: prometheus
-  namespace: {{.Values.namespace}}
-{{ end -}}
-- kind: ServiceAccount
-  name: metrics-api
-  namespace: {{.Values.namespace}}
-- kind: ServiceAccount
-  name: tap-injector
+  name: {{.Values.gateway.name}}
   namespace: {{.Values.namespace}}

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -85,6 +85,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				{Name: chartutil.ChartfileName},
 				{Name: "templates/namespace.yaml"},
 				{Name: "templates/gateway.yaml"},
+				{Name: "templates/psp.yaml"},
 				{Name: "templates/remote-access-service-mirror-rbac.yaml"},
 				{Name: "templates/link-crd.yaml"},
 			}

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -252,6 +252,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 			files := []*chartloader.BufferedFile{
 				{Name: chartutil.ChartfileName},
 				{Name: "templates/service-mirror.yaml"},
+				{Name: "templates/psp.yaml"},
 				{Name: "templates/gateway-mirror.yaml"},
 			}
 

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -390,6 +390,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -413,6 +427,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: prometheus
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -390,6 +390,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -413,6 +427,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: prometheus
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -377,6 +377,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -397,6 +411,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: prometheus
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -350,6 +350,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -370,6 +384,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: grafana
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -390,6 +390,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -413,6 +427,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: prometheus
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -390,6 +390,20 @@ metadata:
     namespace: linkerd-viz
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp
+  namespace: linkerd-viz
+  labels:
+    linkerd.io/extension: viz
+rules:
+- apiGroups: ['policy', 'extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - linkerd-linkerd-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
@@ -413,6 +427,12 @@ subjects:
   namespace: linkerd-viz
 - kind: ServiceAccount
   name: prometheus
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: metrics-api
+  namespace: linkerd-viz
+- kind: ServiceAccount
+  name: tap-injector
   namespace: linkerd-viz
 ---
 ###


### PR DESCRIPTION
This change fixes an issue where the `viz`, `jaeger` and `multicluster`
extensions did not have `podsecuritypolicy` Roles. This causes an issue
where the extensions aren't able to be installed on a cluster that has
pod security enabled.

Fixes #6122