### PR TITLE
Increase `linkerd viz check` timeout in integration test

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -995,7 +995,7 @@ func TestCheckViz(t *testing.T) {
 		testutil.AnnotatedFatal(t, fmt.Sprintf("failed to parse check.viz.golden template: %s", err), err)
 	}
 
-	timeout := time.Minute
+	timeout := 5 * time.Minute
 	err = TestHelper.RetryFor(timeout, func() error {
 		out, err := TestHelper.LinkerdRun(cmd...)
 		if err != nil {


### PR DESCRIPTION
Increase timeout when doing `linkerd viz check` in particular to avoid
upgrade tests to fail, given the prometheus pod takes a while to come up
on thus to replace the old one.
