### PR TITLE
Restrict permissions in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,9 @@ on:
   schedule:
     - cron: '40 5 * * 3'
 
+permissions: 
+  content: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,9 +17,6 @@ on:
   schedule:
     - cron: '40 5 * * 3'
 
-permissions: 
-  content: read
-
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,6 +12,8 @@ on:
     - 'web/app/package.json'
     branches:
     - main
+permissions: 
+  content: read
 env:
   GH_ANNOTATION: true
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,7 +13,7 @@ on:
     branches:
     - main
 permissions: 
-  content: read
+  contents: read
 env:
   GH_ANNOTATION: true
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
     - "*"
 permissions: 
-  content: read
+  contents: read
 env:
   GH_ANNOTATION: true
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
     - "*"
+permissions: 
+  content: read
 env:
   GH_ANNOTATION: true
 jobs:
@@ -218,6 +220,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-20.04
     needs: [choco_pack]
+    permissions:
+      contents: write
     steps:
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -264,6 +268,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-20.04
     needs: [gh_release]
+    permissions:
+      contents: write
     steps:
     - name: Create linkerd/website repository dispatch event
       # peter-evans/repository-dispatch@v1

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -8,6 +8,8 @@ on:
     - 'web/app/package.json'
     branches:
     - main
+permissions: 
+  content: read
 jobs:
   go_lint:
     name: Go lint

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -9,7 +9,7 @@ on:
     branches:
     - main
 permissions: 
-  content: read
+  contents: read
 jobs:
   go_lint:
     name: Go lint

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,6 +10,8 @@ on:
     - '**/*.md'
     branches:
     - main
+permissions: 
+  content: read
 jobs:
   go_unit_tests:
     name: Go unit tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ on:
     branches:
     - main
 permissions: 
-  content: read
+  contents: read
 jobs:
   go_unit_tests:
     name: Go unit tests


### PR DESCRIPTION
Fixes #6171

Added a workflow-level restrictive `permissions: content: read` statement in all the workflows to limit the `GITHUB_TOKEN` privileges, overridding with laxer perms there where required.
