### PR TITLE
Don't fail integration tests for restart counts==2

### DIFF
--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -222,12 +222,13 @@ func (h *KubernetesHelper) CheckPods(ctx context.Context, namespace string, depl
 		for _, status := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
 			errStr := fmt.Sprintf("Container [%s] in pod [%s] in namespace [%s] has restart count [%d]",
 				status.Name, pod.Name, pod.Namespace, status.RestartCount)
-			if status.RestartCount == 1 {
+			if status.RestartCount == 0 {
+				continue
+			}
+			if status.RestartCount < 3 {
 				return &RestartCountError{errStr}
 			}
-			if status.RestartCount > 1 {
-				return errors.New(errStr)
-			}
+			return errors.New(errStr)
 		}
 	}
 


### PR DESCRIPTION
Integration tests were erroring for container restart counts strictly
greater than 1. We've observed restart counts of 2 sporadically in
`metrics-api` and `tap`, when they attempt to hit the
`selfsubjectaccessreviews` k8s API:

```
$ k -n linkerd-viz logs metrics-api-6fdf46b87c-bjpnt metrics-api -p
time="2021-05-28T21:52:38Z" level=info msg="running version dev-undefined"
time="2021-05-28T21:52:38Z" level=fatal msg="Failed to initialize K8s API: Post \"https://10.43.0.1:443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews\": EOF"
```

Removed this flakiness by only erroring for 3 and greater restart
counts.
