### PR TITLE
Expand `bin/image-load` command to specify images

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -281,11 +281,11 @@ image_load() {
   cluster_name=$1
   case $images in
     docker)
-      "$bindir"/image-load --k3d "$cluster_name"
+      "$bindir"/image-load --k3d --cluster "$cluster_name"
       exit_on_err "error calling '$bindir/image-load'"
       ;;
     archive)
-      "$bindir"/image-load --k3d --archive "$cluster_name"
+      "$bindir"/image-load --k3d --archive --cluster "$cluster_name"
       exit_on_err "error calling '$bindir/image-load'"
       ;;
   esac

--- a/bin/image-load
+++ b/bin/image-load
@@ -4,6 +4,7 @@ set -eo pipefail
 
 kind=""
 k3d=""
+cluster=""
 archive=""
 images_default=(proxy controller web metrics-api grafana debug cni-plugin jaeger-webhook tap)
 images=()
@@ -12,7 +13,7 @@ usage() {
   printf "Load into KinD/k3d the referred Linkerd images. If no images are specified all of them are loaded (%s)\n" "${images_default[*]}"
   echo ""
   echo "Usage:"
-  echo "    bin/image-load [--kind] [--k3d] [--archive] [image] [image]..."
+  echo "    bin/image-load [--kind] [--k3d] [--cluster name] [--archive] [image] [image]..."
   echo ""
   echo "Examples:"
   echo ""
@@ -26,6 +27,7 @@ usage() {
   echo "    bin/image-load --k3d --archive"
   echo ""
   echo "Available Commands:"
+  echo "    --cluster: target cluster name (defaults to 'k3s-default' under k3d, and 'kind' under KinD)."
   echo "    --kind: use a KinD cluster (default)."
   echo "    --k3d: use a k3d cluster."
   echo "    --archive: load the images from local .tar files in the current directory."
@@ -37,6 +39,15 @@ do
     -h|--help)
       usage
       exit 0
+      ;;
+    --cluster)
+      cluster=$2
+      if [ -z "$cluster" ]; then
+        echo 'Error: the argument for --cluster was not specified' >&2
+        usage
+        exit 1
+      fi
+      shift
       ;;
     --kind)
       kind=1
@@ -74,13 +85,17 @@ if [ -n "$k3d" ]; then
     usage
     exit 1
   fi
-  cluster=${1:-"k3s-default"}
+  if [ -z "$cluster" ]; then
+    cluster="k3s-default"
+  fi
   bin="$bindir"/k3d
   image_sub_cmd=(image import -c "$cluster")
 else
   kind=1
-  cluster=${1:-"kind"}
   bin="$bindir"/kind
+  if [ -z "$cluster" ]; then
+    cluster="kind"
+  fi
   if [ $archive ]; then
     image_sub_cmd=(load image-archive --name "$cluster")
   else

--- a/bin/image-load
+++ b/bin/image-load
@@ -5,28 +5,37 @@ set -eo pipefail
 kind=""
 k3d=""
 archive=""
+images_default=(proxy controller web metrics-api grafana debug cni-plugin jaeger-webhook tap)
+images=()
+
+usage() {
+  printf "Load into KinD/k3d the referred Linkerd images. If no images are specified all of them are loaded (%s)\n" "${images_default[*]}"
+  echo ""
+  echo "Usage:"
+  echo "    bin/image-load [--kind] [--k3d] [--archive] [image] [image]..."
+  echo ""
+  echo "Examples:"
+  echo ""
+  echo "    # Load all the images from the local docker instance into KinD"
+  echo "    bin/image-load"
+  echo ""
+  echo "    # Load only the proxy and controller images into k3d"
+  echo "    bin/image-load --k3d proxy controller"
+  echo ""
+  echo "    # Load all the images from tar files located under the 'image-archives' directory into k3d"
+  echo "    bin/image-load --k3d --archive"
+  echo ""
+  echo "Available Commands:"
+  echo "    --kind: use a KinD cluster (default)."
+  echo "    --k3d: use a k3d cluster."
+  echo "    --archive: load the images from local .tar files in the current directory."
+}
 
 while :
 do
   case $1 in
     -h|--help)
-      echo "Load into KinD/k3d the images for Linkerd's proxy, controller, metrics-api, web, grafana, cli-bin, tap, debug and cni-plugin."
-      echo ""
-      echo "Usage:"
-      echo "    bin/image-load [--kind] [--k3d] [--archive]"
-      echo ""
-      echo "Examples:"
-      echo ""
-      echo "    # Load images from the local docker instance into KinD"
-      echo "    bin/image-load"
-      echo ""
-      echo "    # Load images from tar files located under the 'image-archives' directory into k3d"
-      echo "    bin/image-load --k3d --archive"
-      echo ""
-      echo "Available Commands:"
-      echo "    --kind: use a KinD cluster (default)."
-      echo "    --k3d: use a k3d cluster."
-      echo "    --archive: load the images from local .tar files in the current directory."
+      usage
       exit 0
       ;;
     --kind)
@@ -39,10 +48,22 @@ do
       archive=1
       ;;
     *)
-      break
+      if [ -z "$1" ]; then
+        break
+      fi
+      if echo "$1" | grep -q '^-.*' ; then
+        echo "Unexpected flag: $1" >&2
+        usage
+        exit 1
+      fi
+      images+=("$1")
   esac
   shift
 done
+
+if [ ${#images[@]} -eq 0 ]; then
+  images=("${images_default[@]}")
+fi
 
 bindir=$( cd "${0%/*}" && pwd )
 
@@ -50,6 +71,7 @@ if [ -n "$k3d" ]; then
   if [ -n "$kind" ]; then
     echo $k3d
     echo "Error: --kind and --k3d can't be used simultaneously" >&2
+    usage
     exit 1
   fi
   cluster=${1:-"k3s-default"}
@@ -79,23 +101,30 @@ fi
 "$bin" version
 
 rm -f load_fail
-for img in proxy controller web metrics-api grafana debug cni-plugin jaeger-webhook tap; do
-  printf 'Importing %s...\n' $img
+for i in "${!images[@]}"; do
   if [ $archive ]; then
-    param="image-archives/$img.tar"
+    param="image-archives/${images[$i]}.tar"
   else
-    param="$DOCKER_REGISTRY/$img:$TAG"
+    param="$DOCKER_REGISTRY/${images[$i]}:$TAG"
   fi
 
   if [ -n "$kind" ]; then
+    printf 'Importing %s...\n' "${images[$i]}"
     "$bin" "${image_sub_cmd[@]}" "${param[@]}" || touch load_fail &
   else
     # "k3d image import" commands don't behave well when parallelized
-    "$bin" "${image_sub_cmd[@]}" "${param[@]}"
+    # but all the images can be loaded in a single invocation
+    images[$i]=$param
   fi
 done
 
-wait < <(jobs -p)
+if [ -n "$kind" ]; then
+  wait < <(jobs -p)
+else
+  printf 'Importing %s...\n' "${images[@]}"
+  "$bin" "${image_sub_cmd[@]}" "${images[@]}"
+fi
+
 if [ -f load_fail ]; then
   echo "Loading docker images into the cluster failed."
   rm load_fail

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -102,7 +102,7 @@ then
   then
     distro="kind"
   fi
-  "$bindir"/image-load --"$distro" --archive "$cluster"
+  "$bindir"/image-load --"$distro" --archive --cluster "$cluster"
 else
   for image in cni-plugin controller debug grafana proxy web
   do


### PR DESCRIPTION
Addresses #6169 in part.

Improve `bin/image-load` commands to receive as arguments the images we
want to load (any from proxy, controller, web, metrics-api, grafana, debug, cni-plugin, jaeger-webhook or tap).

If nothing is passed, it loads them all, as it currently does.

Note that now in order to specify a target cluster different that the default (`k3s-default` for k3d and `kind` for KinD) you need to use the new `--cluster` flag.