### PR TITLE
Only check proxy version of running pods

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -154,8 +154,6 @@ const (
 	certKeyName                   = "tls.crt"
 	keyOldKeyName                 = "key.pem"
 	keyKeyName                    = "tls.key"
-
-	podStatusRunning = "Running"
 )
 
 // AllowedClockSkew sets the allowed skew in clock synchronization
@@ -1432,7 +1430,7 @@ func CheckProxyVersionsUpToDate(pods []corev1.Pod, versions version.Channels) er
 	outdatedPods := []string{}
 	for _, pod := range pods {
 		status := k8s.GetPodStatus(pod)
-		if status == podStatusRunning && containsProxy(pod) {
+		if status == string(corev1.PodRunning) && containsProxy(pod) {
 			proxyVersion := k8s.GetProxyVersion(pod)
 			if err := versions.Match(proxyVersion); err != nil {
 				outdatedPods = append(outdatedPods, fmt.Sprintf("\t* %s (%s)", pod.Name, proxyVersion))
@@ -2509,7 +2507,7 @@ func validateDataPlanePods(pods []corev1.Pod, targetNamespace string) error {
 			continue
 		}
 
-		if status != podStatusRunning && status != "Evicted" {
+		if status != string(corev1.PodRunning) && status != "Evicted" {
 			return fmt.Errorf("The \"%s\" pod is not running", pod.Name)
 		}
 
@@ -2583,7 +2581,7 @@ func CheckPodsRunning(pods []corev1.Pod, podsNotFoundMsg string) error {
 		return fmt.Errorf(podsNotFoundMsg)
 	}
 	for _, pod := range pods {
-		if pod.Status.Phase != podStatusRunning {
+		if pod.Status.Phase != corev1.PodRunning {
 			return fmt.Errorf("%s status is %s", pod.Name, pod.Status.Phase)
 		}
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -462,7 +462,11 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 			"'kubectl apply' command failed\n%s", out)
 	}
-	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
+	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+	if TestHelper.ExternalPrometheus() {
+		delete(expectedVizDeployments, "prometheus")
+	}
+	TestHelper.WaitRollout(t, expectedVizDeployments)
 }
 
 // These need to be updated (if there are changes) once a new stable is released
@@ -542,7 +546,11 @@ func TestInstallHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm install' command failed",
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
-	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
+	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+	if TestHelper.ExternalPrometheus() {
+		delete(expectedVizDeployments, "prometheus")
+	}
+	TestHelper.WaitRollout(t, expectedVizDeployments)
 }
 
 func TestControlPlaneResourcesPostInstall(t *testing.T) {
@@ -645,7 +653,11 @@ func TestUpgradeHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
-	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
+	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+	if TestHelper.ExternalPrometheus() {
+		delete(expectedVizDeployments, "prometheus")
+	}
+	TestHelper.WaitRollout(t, expectedVizDeployments)
 
 	TestHelper.AddInstalledExtension(vizExtensionName)
 }

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -943,12 +943,18 @@ func getCheckOutput(t *testing.T, goldenFile string, namespace string) string {
 		testutil.AnnotatedFatal(t, fmt.Sprintf("failed to retrieve pods: %s", err), err)
 	}
 
+	proxyVersionErr := ""
+	err = healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{})
+	if err != nil {
+		proxyVersionErr = err.Error()
+	}
+
 	tpl := template.Must(template.ParseFiles("testdata" + "/" + goldenFile))
 	vars := struct {
 		ProxyVersionErr string
 		HintURL         string
 	}{
-		healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{}).Error(),
+		proxyVersionErr,
 		healthcheck.HintBaseURL(TestHelper.GetVersion()),
 	}
 

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -462,7 +462,14 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 			"'kubectl apply' command failed\n%s", out)
 	}
-	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+
+	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
+	// mutate it's original value.
+	vizDeployments := testutil.LinkerdVizDeployReplicas
+	expectedVizDeployments := make(map[string]testutil.DeploySpec)
+	for k, v := range vizDeployments {
+		expectedVizDeployments[k] = v
+	}
 	if TestHelper.ExternalPrometheus() {
 		delete(expectedVizDeployments, "prometheus")
 	}
@@ -546,7 +553,14 @@ func TestInstallHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm install' command failed",
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
-	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+
+	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
+	// mutate it's original value.
+	vizDeployments := testutil.LinkerdVizDeployReplicas
+	expectedVizDeployments := make(map[string]testutil.DeploySpec)
+	for k, v := range vizDeployments {
+		expectedVizDeployments[k] = v
+	}
 	if TestHelper.ExternalPrometheus() {
 		delete(expectedVizDeployments, "prometheus")
 	}
@@ -653,7 +667,14 @@ func TestUpgradeHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
-	expectedVizDeployments := testutil.LinkerdVizDeployReplicas
+
+	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
+	// mutate it's original value.
+	vizDeployments := testutil.LinkerdVizDeployReplicas
+	expectedVizDeployments := make(map[string]testutil.DeploySpec)
+	for k, v := range vizDeployments {
+		expectedVizDeployments[k] = v
+	}
 	if TestHelper.ExternalPrometheus() {
 		delete(expectedVizDeployments, "prometheus")
 	}

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -465,9 +465,8 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 
 	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
 	// mutate it's original value.
-	vizDeployments := testutil.LinkerdVizDeployReplicas
 	expectedVizDeployments := make(map[string]testutil.DeploySpec)
-	for k, v := range vizDeployments {
+	for k, v := range testutil.LinkerdVizDeployReplicas {
 		expectedVizDeployments[k] = v
 	}
 	if TestHelper.ExternalPrometheus() {
@@ -556,9 +555,8 @@ func TestInstallHelm(t *testing.T) {
 
 	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
 	// mutate it's original value.
-	vizDeployments := testutil.LinkerdVizDeployReplicas
 	expectedVizDeployments := make(map[string]testutil.DeploySpec)
-	for k, v := range vizDeployments {
+	for k, v := range testutil.LinkerdVizDeployReplicas {
 		expectedVizDeployments[k] = v
 	}
 	if TestHelper.ExternalPrometheus() {
@@ -670,9 +668,8 @@ func TestUpgradeHelm(t *testing.T) {
 
 	// It is necessary to clone LinkerdVizDeployReplicas so that we do not
 	// mutate it's original value.
-	vizDeployments := testutil.LinkerdVizDeployReplicas
 	expectedVizDeployments := make(map[string]testutil.DeploySpec)
-	for k, v := range vizDeployments {
+	for k, v := range testutil.LinkerdVizDeployReplicas {
 		expectedVizDeployments[k] = v
 	}
 	if TestHelper.ExternalPrometheus() {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -430,7 +430,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 			"'kubectl apply' command failed\n%s", cmdOut)
 	}
 
-	TestHelper.WaitRollout(t)
+	TestHelper.WaitRollout(t, testutil.LinkerdDeployReplicasEdge)
 
 	if TestHelper.ExternalPrometheus() {
 
@@ -462,6 +462,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 			"'kubectl apply' command failed\n%s", out)
 	}
+	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
 }
 
 // These need to be updated (if there are changes) once a new stable is released
@@ -535,13 +536,13 @@ func TestInstallHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm install' command failed",
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
-
-	TestHelper.WaitRollout(t)
+	TestHelper.WaitRollout(t, testutil.LinkerdDeployReplicasEdge)
 
 	if stdout, stderr, err := TestHelper.HelmCmdPlain("install", vizChartToInstall, "l5d-viz", vizArgs...); err != nil {
 		testutil.AnnotatedFatalf(t, "'helm install' command failed",
 			"'helm install' command failed\n%s\n%s", stdout, stderr)
 	}
+	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
 }
 
 func TestControlPlaneResourcesPostInstall(t *testing.T) {
@@ -637,12 +638,15 @@ func TestUpgradeHelm(t *testing.T) {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
+	TestHelper.WaitRollout(t, testutil.LinkerdDeployReplicasEdge)
 
 	vizChart := TestHelper.GetLinkerdVizHelmChart()
 	if stdout, stderr, err := TestHelper.HelmCmdPlain("upgrade", vizChart, "l5d-viz", vizArgs...); err != nil {
 		testutil.AnnotatedFatalf(t, "'helm upgrade' command failed",
 			"'helm upgrade' command failed\n%s\n%s", stdout, stderr)
 	}
+	TestHelper.WaitRollout(t, testutil.LinkerdVizDeployReplicas)
+
 	TestHelper.AddInstalledExtension(vizExtensionName)
 }
 

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -320,17 +320,15 @@ func (h *KubernetesHelper) URLFor(ctx context.Context, namespace, deployName str
 	return pf.URLFor(""), nil
 }
 
-// WaitRollout blocks until all the deployments in the linkerd namespace have been
-// completely rolled out (and their pods are ready)
-func (h *KubernetesHelper) WaitRollout(t *testing.T) {
-	for deploy, deploySpec := range LinkerdDeployReplicasEdge {
-		if deploySpec.Namespace == "linkerd" {
-			o, err := h.Kubectl("", "--namespace=linkerd", "rollout", "status", "--timeout=60m", "deploy/"+deploy)
-			if err != nil {
-				AnnotatedFatalf(t,
-					fmt.Sprintf("failed to wait rollout of deploy/%s", deploy),
-					"failed to wait for rollout of deploy/%s: %s: %s", deploy, err, o)
-			}
+// WaitRollout blocks until all the given deployments have been completely
+// rolled out (and their pods are ready)
+func (h *KubernetesHelper) WaitRollout(t *testing.T, deploys map[string]DeploySpec) {
+	for deploy, deploySpec := range deploys {
+		o, err := h.Kubectl("", "--namespace="+deploySpec.Namespace, "rollout", "status", "--timeout=60m", "deploy/"+deploy)
+		if err != nil {
+			AnnotatedFatalf(t,
+				fmt.Sprintf("failed to wait rollout of deploy/%s", deploy),
+				"failed to wait for rollout of deploy/%s: %s: %s", deploy, err, o)
 		}
 	}
 }

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -67,19 +67,28 @@ type Service struct {
 }
 
 // LinkerdDeployReplicasEdge is a map containing the number of replicas for each Deployment and the main
-// container name, in the current code-base
+// container name in the current core installation
 var LinkerdDeployReplicasEdge = map[string]DeploySpec{
 	"linkerd-destination":    {"linkerd", 1},
-	"tap":                    {"linkerd-viz", 1},
-	"grafana":                {"linkerd-viz", 1},
 	"linkerd-identity":       {"linkerd", 1},
-	"web":                    {"linkerd-viz", 1},
 	"linkerd-proxy-injector": {"linkerd", 1},
 }
 
 // LinkerdDeployReplicasStable is a map containing the number of replicas for each Deployment and the main
 // container name. Override whenever edge deviates from stable.
 var LinkerdDeployReplicasStable = LinkerdDeployReplicasEdge
+
+// LinkerdVizDeployReplicas is a map containing the number of replicas for
+// each Deployment and the main container name in the current linkerd-viz
+// installation
+var LinkerdVizDeployReplicas = map[string]DeploySpec{
+	"prometheus":   {"linkerd-viz", 1},
+	"metrics-api":  {"linkerd-viz", 1},
+	"grafana":      {"linkerd-viz", 1},
+	"tap":          {"linkerd-viz", 1},
+	"tap-injector": {"linkerd-viz", 1},
+	"web":          {"linkerd-viz", 1},
+}
 
 // NewGenericTestHelper returns a new *TestHelper from the options provided as function parameters.
 // This helper was created to be able to reuse this package without hard restrictions


### PR DESCRIPTION
This changes the data plane and control plane checks to only consider pods that
are in a running state.

This is currently an issue in scenarios when upgrading and an old pod is still
terminating while the upgraded pod is already running. Running the `check`
command will report that the old pod has an unexpected proxy version even though
it is terminating; it should not warn in this case.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
