### PR TITLE
viz: fix uninstall for legacy linkerd-viz (#6213)

### DIFF
--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -14,6 +14,10 @@ const (
 	// ExtensionName is the value that the viz extension resources should be labeled with
 	ExtensionName = "viz"
 
+	// LegacyExtensionName is the value that the viz extension resources were labeled with
+	// until 15d1809bd043192bb21cacbc96112cce35bf384f
+	LegacyExtensionName = "linkerd-viz"
+
 	vizChartName            = "linkerd-viz"
 	defaultLinkerdNamespace = "linkerd"
 	maxRps                  = 100.0

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -8,6 +8,8 @@ import (
 	pkgCmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func newCmdUninstall() *cobra.Command {
@@ -38,5 +40,11 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	return pkgCmd.Uninstall(ctx, k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, ExtensionName))
+	extensionReq, err := labels.NewRequirement(k8s.LinkerdExtensionLabel, selection.In, []string{ExtensionName, LegacyExtensionName})
+	if err != nil {
+		return err
+	}
+
+	selector := labels.NewSelector().Add(*extensionReq)
+	return pkgCmd.Uninstall(ctx, k8sAPI, selector.String())
 }


### PR DESCRIPTION
Prior to 15d1809bd043192bb21cacbc96112cce35bf384f, the name for viz objects was
`linkerd-viz` and people may still want to uninstall them using the current version of linkerd.

To support this, an additional code path is included when the fast path fails to
suggest things to remove.

Tested with my broken cluster.

Fixes #6213

Signed-off-by: Josh Soref <jsoref@users.noreply.github.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
