### PR TITLE
Add support for legacy names in extension uninstall

### DIFF
--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -82,7 +82,12 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 				}
 			}
 
-			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, k8s.ControllerNSLabel)
+			selector, err := pkgCmd.GetLabelSelector(k8s.ControllerNSLabel)
+			if err != nil {
+				return err
+			}
+
+			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}

--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -19,6 +19,10 @@ const (
 	// JaegerExtensionName is the name of jaeger extension
 	JaegerExtensionName = "jaeger"
 
+	// JaegerLegacyExtension is the name of the jaeger extension prior to
+	// stable-2.10.0 when the linkerd prefix was removed.
+	JaegerLegacyExtension = "linkerd-jaeger"
+
 	// linkerdJaegerExtensionCheck adds checks related to the jaeger extension
 	linkerdJaegerExtensionCheck healthcheck.CategoryID = "linkerd-jaeger"
 )

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -38,5 +38,10 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	return pkgCmd.Uninstall(ctx, k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, JaegerExtensionName))
+	selector, err := pkgCmd.GetLabelSelector(k8s.LinkerdExtensionLabel, JaegerExtensionName, JaegerLegacyExtension)
+	if err != nil {
+		return err
+	}
+
+	return pkgCmd.Uninstall(ctx, k8sAPI, selector)
 }

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -30,6 +30,10 @@ const (
 	// MulticlusterExtensionName is the name of the multicluster extension
 	MulticlusterExtensionName = "multicluster"
 
+	// MulticlusterLegacyExtension is the name of the multicluster extension
+	// prior to stable-2.10.0 when the linkerd prefix was removed.
+	MulticlusterLegacyExtension = "linkerd-multicluster"
+
 	// linkerdMulticlusterExtensionCheck adds checks related to the multicluster extension
 	linkerdMulticlusterExtensionCheck healthcheck.CategoryID = "linkerd-multicluster"
 

--- a/multicluster/cmd/uninstall.go
+++ b/multicluster/cmd/uninstall.go
@@ -53,7 +53,12 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 				return errors.New(strings.Join(err, "\n"))
 			}
 
-			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, MulticlusterExtensionName))
+			selector, err := pkgCmd.GetLabelSelector(k8s.LinkerdExtensionLabel, MulticlusterExtensionName, MulticlusterLegacyExtension)
+			if err != nil {
+				return err
+			}
+
+			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -124,4 +126,23 @@ func ConfigureKubeContextFlagCompletion(cmd *cobra.Command, kubeconfigPath strin
 
 			return suggestions, cobra.ShellCompDirectiveDefault
 		})
+}
+
+// GetLabelSelector creates a label selector as a string based on a label key
+// whose value may be in the set provided as an argument to the function. If the
+// value set is empty then the selector will match resources where the label key
+// exists regardless of value.
+func GetLabelSelector(labelKey string, labelValues ...string) (string, error) {
+	selectionOp := selection.In
+	if len(labelValues) < 1 {
+		selectionOp = selection.Exists
+	}
+
+	labelRequirement, err := labels.NewRequirement(labelKey, selectionOp, labelValues)
+	if err != nil {
+		return "", err
+	}
+
+	selector := labels.NewSelector().Add(*labelRequirement)
+	return selector.String(), nil
 }

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -8,8 +8,6 @@ import (
 	pkgCmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 )
 
 func newCmdUninstall() *cobra.Command {
@@ -40,11 +38,10 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	extensionReq, err := labels.NewRequirement(k8s.LinkerdExtensionLabel, selection.In, []string{ExtensionName, LegacyExtensionName})
+	selector, err := pkgCmd.GetLabelSelector(k8s.LinkerdExtensionLabel, ExtensionName, LegacyExtensionName)
 	if err != nil {
 		return err
 	}
 
-	selector := labels.NewSelector().Add(*extensionReq)
-	return pkgCmd.Uninstall(ctx, k8sAPI, selector.String())
+	return pkgCmd.Uninstall(ctx, k8sAPI, selector)
 }


### PR DESCRIPTION
closes #6225 

## What
---

Because extension label values have been changed, an older install of an extension will fail to be uninstalled with a more recent CLI version. This is because the uninstall command checks the new label value which doesn't match older installs.

This small change fixes that by checking both -- the new, non-prefixed version and the old prefixed one. The bug should have a relatively small impact since there are only a few edge releases that contain the prefixed label value (an exception being stable-2.10.0 which used the prefixed version still).

## How
---

Instead of using an equality based string (`linkerd.io/extension=<name>`) we are using the selection operator `In` to select a value from an array. Each extension may have two values: `linkerd-<name>` or `<name>`. I have added the prefixed version as a "legacy name" to all extensions now.

I thought it would make sense to extract all of this common logic into `pkg/cmd` rather than keep it on an extension-by-extension basis. Furthermore, I thought it would make sense to make the function's parameter variadic so we can easily add/remove label values in the future; being in `pkg/cmd` means we can reuse it across the codebase.

Finally, for each extension uninstall we change the argument from the equality based label to a selector of type string.


## Tests
---

**Old extension, new cli `uninstall`**:
```
# verify extensions are installed; we are looking for the legacy name here so we use the prefix
# I used edge-21.2.3
❯ k get ns -A -l 'linkerd.io/extension in (linkerd-viz, linkerd-multicluster, linkerd-jaeger)' -o wide
NAME                   STATUS   AGE
linkerd-multicluster   Active   162m
linkerd-viz            Active   2m6s
linkerd-jaeger         Active   117s

# verify namespace does have the old label value
❯ k get ns linkerd-jaeger -o yaml
apiVersion: v1
kind: Namespace
metadata:
  labels:
    linkerd.io/extension: linkerd-jaeger
  name: linkerd-jaeger

# switch back to branch, build cli

❯ bin/build-cli-bin
target/cli/linux-amd64/linkerd

# uninstall all extensions

# verify they were cleaned up
❯ k get ns -A -l 'linkerd.io/extension in (linkerd-viz, linkerd-multicluster, linkerd-jaeger)' -o wide
No resources found
```

**New extension, new cli `uninstall`**:
```
# verify we can still uninstall recent versions with the proposed changes
# I used my branch which is based off latest main
# install extensions
❯ k get ns -A -l 'linkerd.io/extension in (viz, multicluster, jaeger)'
NAME                   STATUS   AGE
linkerd-viz            Active   57s
linkerd-jaeger         Active   48s
linkerd-multicluster   Active   36s

# verify label value is what we expect it to be (without a prefix)
❯ k get ns linkerd-multicluster -o yaml | rg 'labels' -A 5
  labels:
    linkerd.io/extension: multicluster
  name: linkerd-multicluster

# uninstall extensions

# verify they were cleaned up
❯ k get ns -A -l 'linkerd.io/extension in (viz, multicluster, jaeger)'
No resources found
```

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
