### PR TITLE
Fix namespace always showing up in topology graph

### DIFF
--- a/pkg/k8s/completion.go
+++ b/pkg/k8s/completion.go
@@ -48,11 +48,11 @@ func (c *CommandCompletion) Complete(args []string, toComplete string) ([]string
 
 	suggestions := []string{}
 	if len(args) == 0 && toComplete == "" {
-		return StatAllResourceTypes, nil
+		return CompletionResourceTypes, nil
 	}
 
 	if len(args) == 0 && toComplete != "" {
-		for _, t := range StatAllResourceTypes {
+		for _, t := range CompletionResourceTypes {
 			if strings.HasPrefix(t, toComplete) {
 				suggestions = append(suggestions, t)
 			}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -75,6 +75,7 @@ var StatAllResourceTypes = []string{
 	ReplicaSet,
 }
 
+// CompletionResourceTypes represents resources the CLI's uses for autocompleting resource type names
 var CompletionResourceTypes = []string{
 	Namespace,
 	DaemonSet,

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -62,6 +62,20 @@ var AllResources = []string{
 
 // StatAllResourceTypes represents the resources to query in StatSummary when Resource.Type is "all"
 var StatAllResourceTypes = []string{
+	DaemonSet,
+	StatefulSet,
+	Job,
+	Deployment,
+	ReplicationController,
+	Pod,
+	Service,
+	TrafficSplit,
+	Authority,
+	CronJob,
+	ReplicaSet,
+}
+
+var CompletionResourceTypes = []string{
 	Namespace,
 	DaemonSet,
 	StatefulSet,

--- a/viz/metrics-api/stat_summary_test.go
+++ b/viz/metrics-api/stat_summary_test.go
@@ -1319,13 +1319,6 @@ status:
 								{
 									Table: &pb.StatTable_PodGroup_{
 										PodGroup: &pb.StatTable_PodGroup{
-											Rows: []*pb.StatTable_PodGroup_Row{},
-										},
-									},
-								},
-								{
-									Table: &pb.StatTable_PodGroup_{
-										PodGroup: &pb.StatTable_PodGroup{
 											Rows: []*pb.StatTable_PodGroup_Row{
 												{
 													Resource: &pb.Resource{


### PR DESCRIPTION
In #6091, code was added to include the the namespace in the list of all
stat resource types. This was added to so that we'd have a complete list
of resources types that could be suggested by the CLI autocompletion
code. However, this list was also used by the web frontend in a query
that gathered metrics from all resource types. This then caused the
query to inadvertently create an inbound metric for deployment that
showed traffic from given namespace.

This change, breaks up the code so that we have a separate list for the
autocompletion code without the namespace value and the original list
used by the web frontend prior to #6091.

Fixes #6211

**Before:**
![Screenshot 2021-06-07 172508](https://user-images.githubusercontent.com/2197104/121096135-3362fd00-c7b7-11eb-8fb3-87b7598ca81d.png)

**After:**
![Screenshot 2021-06-07 172843](https://user-images.githubusercontent.com/2197104/121096170-4675cd00-c7b7-11eb-8f90-2c38f64c39b7.png)
