### PR TITLE
Do not require --cluster in image-load

### DIFF
--- a/bin/image-load
+++ b/bin/image-load
@@ -44,11 +44,6 @@ do
       ;;
     --cluster)
       cluster=$2
-      if [ -z "$cluster" ]; then
-        echo 'Error: the argument for --cluster was not specified' >&2
-        usage
-        exit 1
-      fi
       shift
       ;;
     --kind)


### PR DESCRIPTION
`image-load` script still correctly defaults to `k3s-default` or `kind` based on
the k8s distro being used.

Found when trying to use the `install-pr` script and `--cluster` was being
required.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
