### PR TITLE
release notes for edge-21.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,24 +5,25 @@
 This release fixes a problem with the HTTP body buffering that was added
 to support gRPC retries. Now, Only requests with a retry configuration
 are buffered (and only when their bodies are less than 64KB).
-Additionally, An Issue where forwarded HTTP traffic could fail to
-detect when the target pod was deleted, causing connections to forever
-has been fixed. This only impacted traffic forwarded directly to pod IPs
-(and not load balanced services)
 
-Finally, This release also includes some fixes in the CLI and dashboard.
+Additionally, An issue with the outbound ingress-mode proxy where forwarded
+HTTP traffic could fail to detect when the target pod was deleted, causing
+connections to retry forever has been fixed. This only impacted traffic
+forwarded directly to pod IPs (and not load balanced services).
+
+Finally, this release also includes some fixes in the CLI and dashboard.
 
 * Added a new check that verifies if the opaque ports annotation is
   misconfigured on services or pods (thanks @migue!)
 * Added support for resource aware completion for core linkerd command
-* Fixed an issue where `namespace` resource was also being shown
-  in the topology graph
-* Added uninstall cmd support for legacy extension installs
-* Updated core proxy dependencies i.e futures, hyper, socket2,
-  and tokio
+* Fixed an issue where `namespace` resource was erroneously being shown
+  in the dashboard's topology graph
+* Added uninstall command support for legacy extension installs
 * Updated the proxy to only wrap bodies when a request can be retried
 * Updated the proxy to prevent buffering indefinitely on requests
-  when endpoints are updated in ingress mode.
+  when endpoints are updated in ingress mode
+* Fixed spelling mistakes across various files in the project
+  (thanks @jsoref!)
 
 ## edge-21.6.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,13 @@
 ## edge-21.6.2
 
 This release fixes a problem with the HTTP body buffering that was added
-to support gRPC retries. Now, Only requests with a retry configuration
+to support gRPC retries. Now, only requests with a retry configuration
 are buffered (and only when their bodies are less than 64KB).
 
-Additionally, An issue with the outbound ingress-mode proxy where forwarded
+Additionally, an issue with the outbound ingress-mode proxy where forwarded
 HTTP traffic could fail to detect when the target pod was deleted, causing
 connections to retry forever has been fixed. This only impacted traffic
-forwarded directly to pod IPs (and not load balanced services).
+forwarded directly to pod IPs and not load balanced services.
 
 Finally, this release also includes some fixes in the CLI and dashboard.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ to support gRPC retries. Now, only requests with a retry configuration
 are buffered (and only when their bodies are less than 64KB).
 
 Additionally, an issue with the outbound ingress-mode proxy where forwarded
-HTTP traffic could fail to detect when the target pod was deleted, causing
+HTTP clients could fail to detect when the target pod was deleted, causing
 connections to retry forever has been fixed. This only impacted traffic
 forwarded directly to pod IPs and not load balanced services.
 
@@ -19,7 +19,7 @@ Finally, this release also includes some fixes in the CLI and dashboard.
 * Fixed an issue where `namespace` resource was erroneously being shown
   in the dashboard's topology graph
 * Added uninstall command support for legacy extension installs
-* Updated the proxy to only wrap bodies when a request can be retried
+* Updated the proxy to only buffer request bodies when a request can be retried
 * Updated the proxy to prevent buffering indefinitely on requests
   when endpoints are updated in ingress mode
 * Fixed spelling mistakes across various files in the project

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Changes
 
+## edge-21.6.2
+
+This release fixes a problem with the HTTP body buffering that was added
+to support gRPC retries. Now, Only requests with a retry configuration
+are buffered (and only when their bodies are less than 64KB).
+Additionally, An Issue where forwarded HTTP traffic could fail to
+detect when the target pod was deleted, causing connections to forever
+has been fixed. This only impacted traffic forwarded directly to pod IPs
+(and not load balanced services)
+
+Finally, This release also includes some fixes in the CLI and dashboard.
+
+* Added a new check that verifies if the opaque ports annotation is
+  misconfigured on services or pods (thanks @migue!)
+* Added support for resource aware completion for core linkerd command
+* Fixed an issue where `namespace` resource was also being shown
+  in the topology graph
+* Added uninstall cmd support for legacy extension installs
+* Updated core proxy dependencies i.e futures, hyper, socket2,
+  and tokio
+* Updated the proxy to only wrap bodies when a request can be retried
+* Updated the proxy to prevent buffering indefinitely on requests
+  when endpoints are updated in ingress mode.
+
 ## edge-21.6.1
 
 This release adds support for retrying HTTP/2 requests with small (<64KB)


### PR DESCRIPTION
## edge-21.6.2

This release fixes a problem with the HTTP body buffering that was added
to support gRPC retries. Now, only requests with a retry configuration
are buffered (and only when their bodies are less than 64KB).

Additionally, an issue with the outbound ingress-mode proxy where forwarded
HTTP clients could fail to detect when the target pod was deleted, causing
connections to retry forever has been fixed. This only impacted traffic
forwarded directly to pod IPs and not load balanced services.

Finally, this release also includes some fixes in the CLI and dashboard.

* Added a new check that verifies if the opaque ports annotation is
  misconfigured on services or pods (thanks @migue!)
* Added support for resource aware completion for core linkerd command
* Fixed an issue where `namespace` resource was erroneously being shown
  in the dashboard's topology graph
* Added uninstall command support for legacy extension installs
* Updated the proxy to only buffer request bodies when a request can be retried
* Updated the proxy to prevent buffering indefinitely on requests
  when endpoints are updated in ingress mode
* Fixed spelling mistakes across various files in the project
  (thanks @jsoref!)

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
