### PR TITLE
Revert "CI: skip integration tests for markdown updates (#6168)"

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,6 @@
 name: Integration tests
 on:
-  pull_request:
-    paths-ignore:
+  pull_request: {}
   push:
     paths-ignore:
     - '*.md'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,6 @@ name: Integration tests
 on:
   pull_request:
     paths-ignore:
-    - 'web/app/package.json'
   push:
     paths-ignore:
     - '*.md'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,8 +2,6 @@ name: Integration tests
 on:
   pull_request:
     paths-ignore:
-    - '*.md'
-    - '**/*.md'
     - 'web/app/package.json'
   push:
     paths-ignore:
@@ -12,7 +10,7 @@ on:
     - 'web/app/package.json'
     branches:
     - main
-permissions: 
+permissions:
   contents: read
 env:
   GH_ANNOTATION: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,9 +1,6 @@
 name: Unit tests
 on:
-  pull_request:
-    paths-ignore:
-    - '*.md'
-    - '**/*.md'
+  pull_request: {}
   push:
     paths-ignore:
     - '*.md'


### PR DESCRIPTION
This reverts e6f90a04f3eaf4e20d8ceecd09c5b862adfaec9c

We've run into issues such as edits to ADOPTERS.md where CI checks do not run
that are required for all pull requests.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>