### PR TITLE
artifacthub.io Verified Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,7 @@ jobs:
         mkdir -p target/helm
         gsutil cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
         bin/helm-build package
+        cp charts/artifacthub-repo-edge.yml target/helm/artifacthub-repo.yml
         gsutil rsync target/helm gs://helm.linkerd.io/edge
     - name: Stable Helm chart creation and upload
       if: startsWith(github.ref, 'refs/tags/stable')
@@ -336,4 +337,5 @@ jobs:
         mkdir -p target/helm
         gsutil cp gs://helm.linkerd.io/stable/index.yaml target/helm/index-pre.yaml
         bin/helm-build package
+        cp charts/artifacthub-repo-stable.yml target/helm/artifacthub-repo.yml
         gsutil rsync target/helm gs://helm.linkerd.io/stable

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -71,8 +71,6 @@ if [ "$1" = package ]; then
     mv "$rootdir"/target/helm/index-pre.yaml "$rootdir"/target/helm/index-pre-"$version".yaml
     "$bindir"/helm repo index --url "https://helm.linkerd.io/$repo/" --merge "$rootdir"/target/helm/index-pre-"$version".yaml "$rootdir"/target/helm
 
-    cp "$rootdir"/charts/linkerd2/artifacthub-repo.yml "$rootdir"/target/helm/
-
     # restore version in Values files
     setValues "$fullVersion" "linkerdVersionValue"
 fi

--- a/charts/artifacthub-repo-edge.yml
+++ b/charts/artifacthub-repo-edge.yml
@@ -1,0 +1,14 @@
+repositoryID: 3f724e34-9d3c-459e-99ba-aa8f09620ff4
+owners:
+  - name: olix0r
+    email: ver@buoyant.io
+  - name: alpeb
+    email: alejandro@buoyant.io
+  - name: adleong
+    email: alex@buoyant.io
+  - name: hawkw
+    email: eliza@buoyant.io
+  - name: kleimkuhler
+    email: kevinl@buoyant.io
+  - name: pothulapati
+    email: tarun@buoyant.io

--- a/charts/artifacthub-repo-stable.yml
+++ b/charts/artifacthub-repo-stable.yml
@@ -1,4 +1,4 @@
-#repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+#repositoryID: To be determined after the stable repo gets claimed
 owners:
   - name: olix0r
     email: ver@buoyant.io


### PR DESCRIPTION
 Followup to #6181
    
After having uploaded the `artifacthub-repo.yml` file, we were able to
claim ownership of the linkerd2-edge repo. This generated a
`repositoryID` in artifacthub.io that we're adding into this same file,
so that we can be marked as "Verified Publisher".
    
Also we moved that file one level up into `charts/` so it doesn't get
included in the built chart. And created two versions of that file, one
for edge and another for stable (whose ID will be received when the next
stable helm release is pushed), that will be copied into the helm repo
by the `release.yml` workflow.
