### PR TITLE
Skip NET_RAW & NET_ADMIN while copying pod drop capabilities.

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -624,6 +624,9 @@ func (conf *ResourceConfig) injectPodSpec(values *podPatch) {
 				values.Proxy.Capabilities.Add = append(values.Proxy.Capabilities.Add, string(add))
 			}
 			for _, drop := range sc.Capabilities.Drop {
+				if string(drop) == "NET_RAW" || string(drop) == "NET_ADMIN" {
+					continue
+				}
 				values.Proxy.Capabilities.Drop = append(values.Proxy.Capabilities.Drop, string(drop))
 			}
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -663,8 +663,8 @@ func (conf *ResourceConfig) injectPodSpec(values *podPatch) {
 func (conf *ResourceConfig) injectProxyInit(values *podPatch) {
 
 	// Fill common fields from Proxy into ProxyInit
-	values.ProxyInit.Capabilities = &l5dcharts.Capabilities{}
 	if values.Proxy.Capabilities != nil {
+		values.ProxyInit.Capabilities = &l5dcharts.Capabilities{}
 		values.ProxyInit.Capabilities.Add = values.Proxy.Capabilities.Add
 		values.ProxyInit.Capabilities.Drop = []string{}
 		for _, drop := range values.Proxy.Capabilities.Drop {


### PR DESCRIPTION
While copying the container drop capabilities into the sidecars we should
skip NET_RAW and NET_ADMIN as the init containers require them to setup
iptables.

Fixes #6254 

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
