### PR TITLE
Add endpoint in profile response for requests on pod DNS.

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -384,9 +384,6 @@ func (s *server) sendPodProfile(stream pb.Destination_GetProfileServer, pod *cor
 
 	// If there are opaque ports then update the profile translator
 	// with a service profile that has those values
-	//
-	// TODO: Remove endpoint from profileTranslator and set it here
-	// similar to opaque ports
 	if len(opaquePorts) != 0 {
 		sp := sp.ServiceProfile{}
 		sp.Spec.OpaquePorts = opaquePorts

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -202,14 +202,16 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 			fqn = fmt.Sprintf("%s.%s.svc.%s", service.Name, service.Namespace, s.clusterDomain)
 		} else {
 			// If the IP does not map to a service, check if it maps to a pod
-			pod, err := getPod(s.k8sAPI, ip.String(), port, log)
+			pod, err := getPodByIP(s.k8sAPI, ip.String(), port, log)
 			if err != nil {
 				return err
 			}
 
-			// If the IP maps to a pod, we create a single endpoint and
-			// return it in the DestinationProfile response
-			err = s.sendPodProfile(stream, pod, port)
+			// The IP may or may not map to a pod (pod argument can be nil). If
+			// pod is not nil we will return a single endpoint in the
+			// DestinationProfile response, otherwise we return a default
+			// profile response.
+			err = s.sendEndpointProfile(stream, pod, port)
 			if err != nil {
 				log.Debugf("Failed to send profile response to pod: %v", err)
 				return err
@@ -224,8 +226,8 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 			return nil
 		}
 	} else {
-		var podName string
-		service, podName, err = parseK8sServiceName(host, s.clusterDomain)
+		var hostname string
+		service, hostname, err = parseK8sServiceName(host, s.clusterDomain)
 		if err != nil {
 			log.Debugf("Invalid service %s", path)
 			return status.Errorf(codes.InvalidArgument, "invalid service: %s", err)
@@ -234,16 +236,15 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 		// If the pod name (instance ID) is not empty, it means we parsed a DNS
 		// name. When we fetch the profile using a pod's DNS name, we want to
 		// return an endpoint in the profile response.
-		if podName != "" {
-			pod, err := s.k8sAPI.Pod().Lister().Pods(service.Namespace).Get(podName)
+		if hostname != "" {
+			pod, err := getPodByHostname(s.k8sAPI, hostname, service, s.log)
 			if err != nil {
-				log.Debugf("Failed to get pod %s/%s: %s", service.Namespace, podName, err)
-				return err
+				log.Errorf("Failed to get pod for hostname %s: %v", hostname, err)
 			}
 
-			err = s.sendPodProfile(stream, pod, port)
+			err = s.sendEndpointProfile(stream, pod, port)
 			if err != nil {
-				log.Debugf("Failed to send profile response to pod %s/%s: %v", service.Namespace, podName, err)
+				log.Debugf("Failed to send profile response for host %s: %v", hostname, err)
 				return err
 			}
 
@@ -336,11 +337,12 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 	return nil
 }
 
-// sendPodProfile accepts the GetProfile response stream, a pod and its port and
-// returns an error if it cannot stream a profile response back to the client. The
-// profile response sent here is different to a service's since it also includes
-// an endpoint.
-func (s *server) sendPodProfile(stream pb.Destination_GetProfileServer, pod *corev1.Pod, port uint32) error {
+// sendEndpointProfile will send a DestinationProfile response that contains an
+// endpoint to the client. It accepts the gRPC stream object an optional pod and
+// the port used in the GetProfile request. If the pod argument is supplied,
+// then sendEndpointProfile will reply with an endpoint; otherwise, the response
+// will contain the default profile.
+func (s *server) sendEndpointProfile(stream pb.Destination_GetProfileServer, pod *corev1.Pod, port uint32) error {
 	log := s.log
 	var endpoint *pb.WeightedAddr
 	opaquePorts := make(map[uint32]struct{})
@@ -425,11 +427,38 @@ func getSvcID(k8sAPI *k8s.API, clusterIP string, log *logging.Entry) (*watcher.S
 	return service, nil
 }
 
-// getPod returns a pod that maps to the given IP address. The pod can either
+// getPodByHostname returns a pod that maps to the given hostname (or an
+// instanceID). The hostname is generally the prefix of the pod's DNS name;
+// since it may be arbitrary we need to look at the corresponding service's
+// Endpoints object to see whether the hostname matches a pod.
+func getPodByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID, log *logging.Entry) (*corev1.Pod, error) {
+	ep, err := k8sAPI.Endpoint().Lister().Endpoints(svcID.Namespace).Get(svcID.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, subset := range ep.Subsets {
+		for _, addr := range subset.Addresses {
+			if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" {
+				continue
+			}
+
+			if hostname == addr.Hostname {
+				podName := addr.TargetRef.Name
+				podNamespace := addr.TargetRef.Namespace
+				return k8sAPI.Pod().Lister().Pods(podNamespace).Get(podName)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no pod found in Endpoints %s/%s", svcID.Namespace, svcID.Name)
+}
+
+// getPodByIP returns a pod that maps to the given IP address. The pod can either
 // be in the host network or the pod network. If the pod is in the host
 // network, then it must have a container port that exposes `port` as a host
 // port.
-func getPod(k8sAPI *k8s.API, podIP string, port uint32, log *logging.Entry) (*corev1.Pod, error) {
+func getPodByIP(k8sAPI *k8s.API, podIP string, port uint32, log *logging.Entry) (*corev1.Pod, error) {
 	// First we check if the address maps to a pod in the host network.
 	addr := fmt.Sprintf("%s:%d", podIP, port)
 	hostIPPods, err := getIndexedPods(k8sAPI, watcher.HostIPIndex, addr)

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -237,7 +237,7 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 		// name. When we fetch the profile using a pod's DNS name, we want to
 		// return an endpoint in the profile response.
 		if hostname != "" {
-			pod, err := getPodByHostname(s.k8sAPI, hostname, service, s.log)
+			pod, err := getPodByHostname(s.k8sAPI, hostname, service)
 			if err != nil {
 				log.Errorf("Failed to get pod for hostname %s: %v", hostname, err)
 			}
@@ -431,7 +431,7 @@ func getSvcID(k8sAPI *k8s.API, clusterIP string, log *logging.Entry) (*watcher.S
 // instanceID). The hostname is generally the prefix of the pod's DNS name;
 // since it may be arbitrary we need to look at the corresponding service's
 // Endpoints object to see whether the hostname matches a pod.
-func getPodByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID, log *logging.Entry) (*corev1.Pod, error) {
+func getPodByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID) (*corev1.Pod, error) {
 	ep, err := k8sAPI.Endpoint().Lister().Endpoints(svcID.Namespace).Get(svcID.Name)
 	if err != nil {
 		return nil, err

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -213,7 +213,7 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 			// profile response.
 			err = s.sendEndpointProfile(stream, pod, port)
 			if err != nil {
-				log.Debugf("Failed to send profile response to IP %s: %v", ip.String(), err)
+				log.Debugf("Failed to send profile response for endpoint %s:%d: %v", ip.String(), port, err)
 				return err
 			}
 

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -435,6 +435,7 @@ func getPodByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID)
 		return nil, err
 	}
 
+	//TODO: add support for headless services with non-pod endpoints.
 	for _, subset := range ep.Subsets {
 		for _, addr := range subset.Addresses {
 			if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" {

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -1154,7 +1154,7 @@ status:
 
 		k8sAPI.Sync(nil)
 		// Get host IP pod that is mapped to the port `hostPort1`
-		pod, err := getPod(k8sAPI, hostIP, hostPort1, logging.WithFields(nil))
+		pod, err := getPodByIP(k8sAPI, hostIP, hostPort1, logging.WithFields(nil))
 		if err != nil {
 			t.Fatalf("failed to get pod: %s", err)
 		}
@@ -1167,7 +1167,7 @@ status:
 		// Get host IP pod that is mapped to the port `hostPort2`; this tests
 		// that the indexer properly adds multiple containers from a single
 		// pod.
-		pod, err = getPod(k8sAPI, hostIP, hostPort2, logging.WithFields(nil))
+		pod, err = getPodByIP(k8sAPI, hostIP, hostPort2, logging.WithFields(nil))
 		if err != nil {
 			t.Fatalf("failed to get pod: %s", err)
 		}
@@ -1178,7 +1178,7 @@ status:
 			t.Fatalf("expected pod name to be %s, but got %s", expectedPodName, pod.Name)
 		}
 		// Get host IP pod with unmapped host port
-		pod, err = getPod(k8sAPI, hostIP, 12347, logging.WithFields(nil))
+		pod, err = getPodByIP(k8sAPI, hostIP, 12347, logging.WithFields(nil))
 		if err != nil {
 			t.Fatalf("expected no error when getting host IP pod with unmapped host port, but got: %s", err)
 		}
@@ -1186,7 +1186,7 @@ status:
 			t.Fatal("expected no pod to be found with unmapped host port")
 		}
 		// Get pod IP pod and expect an error
-		_, err = getPod(k8sAPI, podIP, 12346, logging.WithFields(nil))
+		_, err = getPodByIP(k8sAPI, podIP, 12346, logging.WithFields(nil))
 		if err == nil {
 			t.Fatal("expected error when getting by pod IP and unmapped host port, but got none")
 		}

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -18,12 +18,14 @@ const fullyQualifiedName = "name1.ns.svc.mycluster.local"
 const fullyQualifiedNameOpaque = "name3.ns.svc.mycluster.local"
 const fullyQualifiedNameOpaqueService = "name4.ns.svc.mycluster.local"
 const fullyQualifiedNameSkipped = "name5.ns.svc.mycluster.local"
+const fullyQualifiedPodDNS = "pod-0.statefulset-svc.ns.svc.mycluster.local"
 const clusterIP = "172.17.12.0"
 const clusterIPOpaque = "172.17.12.1"
 const podIP1 = "172.17.0.12"
 const podIP2 = "172.17.0.13"
 const podIPOpaque = "172.17.0.14"
 const podIPSkipped = "172.17.0.15"
+const podIPStatefulSet = "172.17.13.15"
 const port uint32 = 8989
 const opaquePort uint32 = 4242
 const skippedPort uint32 = 24224
@@ -269,11 +271,54 @@ spec:
         value: 0.0.0.0:4143
       name: linkerd-proxy`,
 	}
+
+	meshedStatefulSetPodResource := []string{
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: statefulset-svc
+  namespace: ns
+spec:
+  type: LoadBalancer
+  clusterIP: 172.17.13.5
+  ports:
+  - port: 8989`,
+		`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name:	statefulset-svc
+  namespace: ns
+subsets:
+- addresses:
+  - ip: 172.17.13.15
+    hostname: pod-0
+    targetRef:
+      kind: Pod
+      name: pod-0
+      namespace: ns
+  ports:
+  - port: 8989`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    linkerd.io/control-plane-ns: linkerd
+  name: pod-0
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.13.15`,
+	}
+
 	res := append(meshedPodResources, clientSP...)
 	res = append(res, unmeshedPod)
 	res = append(res, meshedOpaquePodResources...)
 	res = append(res, meshedOpaqueServiceResources...)
 	res = append(res, meshedSkippedPodResource...)
+	res = append(res, meshedStatefulSetPodResource...)
 	k8sAPI, err := k8s.NewFakeAPI(res...)
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
@@ -641,6 +686,56 @@ func TestGetProfiles(t *testing.T) {
 		routes := last.GetRoutes()
 		if len(routes) != 1 {
 			t.Fatalf("Expected 1 route but got %d: %v", len(routes), routes)
+		}
+	})
+
+	t.Run("Return profile with endpoint when using pod DNS", func(t *testing.T) {
+		server := makeServer(t)
+		stream := &bufferingGetProfileStream{
+			updates:          []*pb.DestinationProfile{},
+			MockServerStream: util.NewMockServerStream(),
+		}
+		stream.Cancel()
+
+		epAddr, err := toAddress(podIPStatefulSet, port)
+		if err != nil {
+			t.Fatalf("Got error: %s", err)
+		}
+
+		err = server.GetProfile(&pb.GetDestination{
+			Scheme:       "k8s",
+			Path:         fmt.Sprintf("%s:%d", fullyQualifiedPodDNS, port),
+			ContextToken: "ns:ns",
+		}, stream)
+		if err != nil {
+			t.Fatalf("Got error: %s", err)
+		}
+
+		// An explanation for why we expect 1 to 3 updates is in test cases
+		// above
+		if len(stream.updates) == 0 || len(stream.updates) > 3 {
+			t.Fatalf("Expected 1 to 3 updates but got %d: %v", len(stream.updates), stream.updates)
+		}
+
+		first := stream.updates[0]
+		if first.Endpoint == nil {
+			t.Fatalf("Expected response to have endpoint field")
+		}
+		if first.OpaqueProtocol {
+			t.Fatalf("Expected port %d to not be an opaque protocol, but it was", port)
+		}
+		_, exists := first.Endpoint.MetricLabels["namespace"]
+		if !exists {
+			t.Fatalf("Expected 'namespace' metric label to exist but it did not")
+		}
+		if first.GetEndpoint().GetProtocolHint() == nil {
+			t.Fatalf("Expected protocol hint but found none")
+		}
+		if first.GetEndpoint().GetProtocolHint().GetOpaqueTransport() != nil {
+			t.Fatalf("Expected pod to not support opaque traffic on port %d", port)
+		}
+		if first.Endpoint.Addr.String() != epAddr.String() {
+			t.Fatalf("Expected endpoint IP to be %s, but it was %s", epAddr.Ip, first.Endpoint.Addr.Ip)
 		}
 	})
 


### PR DESCRIPTION
Closes #6253 


### What
---

When we send a profile request with a pod IP, we get back an endpoint as part of the response. This has two advantages: we avoid building a load balancer and we can treat endpoint failure differently (with more of a fail fast approach). At the moment, when we use a pod DNS as the target of the profile lookup, we don't have an endpoint returned in the
response.

Through this change, the behaviour will be consistent. Whenever we look up a pod (either through IP or DNS name) we will get an endpoint back. The change also attempts to simplify some of the logic in GetProfile.


### How
---

We already have a way to build an endpoint and return it back to the client; I sought to re-use most of the code in an effort to also simplify `GetProfile()`. I extracted most of the code that would have been duplicated into a separate method that is responsible for building the address, looking at annotations for opaque ports and for sending the response back.

In addition, to support a pod DNS fqn I've expanded on the `else` branch of the topmost if statement -- if our host is not an IP, we parse the host to get the k8s fqn. If the parsing function returns an instance ID along with the ServiceID, then we know we are dealing directly with a pod -- if we do, we fetch the pod using the core informer and then return an endpoint for it.

### Tests
---

I've tested this mostly with the destination client script. For the tests, I used the following pods:
```
❯ kgp -n emojivoto -o wide

NAME                        READY   STATUS    RESTARTS   AGE     IP           NODE                NOMINATED NODE   READINESS GATES
voting-ff4c54b8d-zbqc4      2/2     Running   0          3m58s   10.42.0.53   k3d-west-server-0   <none>           <none>
web-0                       2/2     Running   0          3m58s   10.42.0.55   k3d-west-server-0   <none>           <none>
vote-bot-7d89964475-tfq7j   2/2     Running   0          3m58s   10.42.0.54   k3d-west-server-0   <none>           <none>
emoji-79cc56f589-57tsh      2/2     Running   0          3m58s   10.42.0.52   k3d-west-server-0   <none>           <none>

# emoji pod has an opaque port set to 8080.
# web-svc is a headless service and it backs a statefulset (which is why we have web-0).
# without a headless service we can't lookup based on pod DNS.
```

**`Responses before the change`**: 
```
# request on IP, this is how things work at the moment. I included this because there shouldn't be
# any diff between the response given here and the response we get with the change.
# note: this corresponds to the emoji pod which has opaque ports set to 8080.
❯ go run controller/script/destination-client/main.go -method getProfile -path 10.42.0.52:8080
INFO[0000] opaque_protocol:true retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} endpoint:{addr:{ip:{ipv4:170524724} port:8080} weight:10000 metric_labels:{key:"control_plane_ns" value:"linkerd"} metric_labels:{key:"deployment" value:"emoji"} metric_labels:{key:"namespace" value:"emojivoto"} metric_labels:{key:"pod" value:"emoji-79cc56f589-57tsh"} metric_labels:{key:"pod_template_hash" value:"79cc56f589"} metric_labels:{key:"serviceaccount" value:"emoji"} tls_identity:{dns_like_identity:{name:"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local"}} protocol_hint:{h2:{} opaque_transport:{inbound_port:4143}}}
INFO[0000]

# request web-0 by IP
# there shouldn't be any diff with the response we get after the change
❯ go run controller/script/destination-client/main.go -method getProfile -path 10.42.0.55:8080
INFO[0000] retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} endpoint:{addr:{ip:{ipv4:170524727} port:8080} weight:10000 metric_labels:{key:"control_plane_ns" value:"linkerd"} metric_labels:{key:"namespace" value:"emojivoto"} metric_labels:{key:"pod" value:"web-0"} metric_labels:{key:"serviceaccount" value:"web"} metric_labels:{key:"statefulset" value:"web"} tls_identity:{dns_like_identity:{name:"web.emojivoto.serviceaccount.identity.linkerd.cluster.local"}} protocol_hint:{h2:{}}}
INFO[0000]

# request web-0 by DNS name -- will not work.
❯ go run controller/script/destination-client/main.go -method getProfile -path web-0.web-svc.emojivoto.svc.cluster.loc
al:8080
INFO[0000] fully_qualified_name:"web-0.web-svc.emojivoto.svc.cluster.local" retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} dst_overrides:{authority:"web-svc.emojivoto.svc.cluster.local.:8080" weight:10000}
INFO[0000]
INFO[0000] fully_qualified_name:"web-0.web-svc.emojivoto.svc.cluster.local" retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} dst_overrides:{authority:"web-svc.emojivoto.svc.cluster.local.:8080" weight:10000}
INFO[0000]
# ^
# |
#  -->  no endpoint in the response
```

**`Responses after the change`**:

```
# request profile for emoji, we see opaque transport being set on the endpoint.
❯ go run controller/script/destination-client/main.go -method getProfile -path 10.42.0.52:8080
INFO[0000] opaque_protocol:true retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} endpoint:{addr:{ip:{ipv4:170524724} port:8080} weight:10000 metric_labels:{key:"control_plane_ns" value:"linkerd"} metric_labels:{key:"deployment" value:"emoji"} metric_labels:{key:"namespace" value:"emojivoto"} metric_labels:{key:"pod" value:"emoji-79cc56f589-57tsh"} metric_labels:{key:"pod_template_hash" value:"79cc56f589"} metric_labels:{key:"serviceaccount" value:"emoji"} tls_identity:{dns_like_identity:{name:"emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local"}} protocol_hint:{h2:{} opaque_transport:{inbound_port:4143}}}
INFO[0000]

# request profile for web-0 with IP.
❯ go run controller/script/destination-client/main.go -method getProfile -path 10.42.0.55:8080
INFO[0000] retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} endpoint:{addr:{ip:{ipv4:170524727} port:8080} weight:10000 metric_labels:{key:"control_plane_ns" value:"linkerd"} metric_labels:{key:"namespace" value:"emojivoto"} metric_labels:{key:"pod" value:"web-0"} metric_labels:{key:"serviceaccount" value:"web"} metric_labels:{key:"statefulset" value:"web"} tls_identity:{dns_like_identity:{name:"web.emojivoto.serviceaccount.identity.linkerd.cluster.local"}} protocol_hint:{h2:{}}}
INFO[0000]

# request profile for web-0 with pod DNS, resp contains endpoint.
❯ go run controller/script/destination-client/main.go -method getProfile -path web-0.web-svc.emojivoto.svc.cluster.local:8080
INFO[0000] retry_budget:{retry_ratio:0.2 min_retries_per_second:10 ttl:{seconds:10}} endpoint:{addr:{ip:{ipv4:170524727} port:8080} weight:10000 metric_labels:{key:"control_plane_ns" value:"linkerd"} metric_labels:{key:"namespace" value:"emojivoto"} metric_labels:{key:"pod" value:"web-0"} metric_labels:{key:"serviceaccount" value:"web"} metric_labels:{key:"statefulset" value:"web"} tls_identity:{dns_like_identity:{name:"web.emojivoto.serviceaccount.identity.linkerd.cluster.local"}} protocol_hint:{h2:{}}}
INFO[0000]
```

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
