### PR TITLE
Upgrade k3d to v4.4.5

### DIFF
--- a/bin/k3d
+++ b/bin/k3d
@@ -2,7 +2,7 @@
 
 set -eu
 
-k3dversion=v3.4.0
+k3dversion=v4.4.5
 
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin


### PR DESCRIPTION
This gives us by default k8s clusters on v1.21.

This k3d version also requires a newish docker, so let's see if it works in CI!