### PR TITLE
edge-21.6.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 This release moves the Linkerd proxy to a more minimal Docker base image,
 adds a check for detecting certain network misconfigurations, and replaces
-the deprecated OpenCensus collector with the OpenTelemetry collecting in the
+the deprecated OpenCensus collector with the OpenTelemetry collector in the
 jaeger extension.
 
 * Switched the Linkerd proxy's base docker image from Debian to a minimal

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Changes
 
+## edge-21.6.3
+
+This release moves the Linkerd proxy to a more minimal Docker base image,
+adds a check for detecting certain network misconfigurations, and replaces
+the deprecated OpenCensus collector with the OpenTelemetry collecting in the
+jaeger extension.
+
+* Switched the Linkerd proxy's base docker image from Debian to a minimal
+  distroless base image (thanks @tskinn!)
+* Added a check to verify that Linkerd's clusterNetworks settings match the
+  cluster's pod CIDR networks (thanks @aryan9600!)
+* Replaced the deprecated OpenCensus collector with the OpenTelemetry
+  collector in the jaeger extension (thanks @aatarasoff!)
+
 ## edge-21.6.2
 
 This release fixes a problem with the HTTP body buffering that was added


### PR DESCRIPTION
This release moves the Linkerd proxy to a more minimal Docker base image,
adds a check for detecting certain network misconfigurations, and replaces
the deprecated OpenCensus collector with the OpenTelemetry collecting in the
jaeger extension.

* Switched the Linkerd proxy's base docker image from Debian to a minimal
  distroless base image (thanks @tskinn!)
* Added a check to verify that Linkerd's clusterNetworks settings match the
  cluster's pod CIDR networks (thanks @aryan9600!)
* Replaced the deprecated OpenCensus collector with the OpenTelemetry
  collector in the jaeger extension (thanks @aatarasoff!)

Signed-off-by: Alex Leong <alex@buoyant.io>
