### PR TITLE
checks: use caching with opaqueports check

### DIFF
--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -260,8 +260,14 @@ func NewAPI(
 // Sync waits for all informers to be synced.
 func (api *API) Sync(stopCh <-chan struct{}) {
 	api.sharedInformers.Start(stopCh)
-	api.spSharedInformers.Start(stopCh)
-	api.tsSharedInformers.Start(stopCh)
+
+	if api.spSharedInformers != nil {
+		api.spSharedInformers.Start(stopCh)
+	}
+
+	if api.tsSharedInformers != nil {
+		api.tsSharedInformers.Start(stopCh)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2273,7 +2273,7 @@ func (hc *HealthChecker) checkMisconfiguredOpaquePortAnnotations(ctx context.Con
 
 	endpoints, err := hc.GetEndpoints(ctx)
 	if err != nil {
-		return fmt.Errorf("couldn't list endpoints in the cluster: %s", err)
+		return fmt.Errorf("couldn't list endpoints in the namespace/%s: %s", hc.DataPlaneNamespace, err)
 	}
 
 	dataPlanePods, err := hc.GetDataPlanePods(ctx)
@@ -2300,7 +2300,7 @@ func (hc *HealthChecker) checkMisconfiguredOpaquePortAnnotations(ctx context.Con
 				if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" {
 					pod, ok := podsMap[addr.TargetRef.Name]
 					if !ok {
-						return fmt.Errorf("couldn't find pod for %s", addr.TargetRef.Name)
+						return fmt.Errorf("could not find pod %s mentioned in the endpoint %s/%s as a target", pod.Name, endpoint.Namespace, endpoint.Name)
 					}
 					pods = append(pods, &pod)
 				}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2300,7 +2300,7 @@ func (hc *HealthChecker) checkMisconfiguredOpaquePortAnnotations(ctx context.Con
 				if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" {
 					pod, ok := podsMap[addr.TargetRef.Name]
 					if !ok {
-						return fmt.Errorf("couldn't find pod for")
+						return fmt.Errorf("couldn't find pod for %s", addr.TargetRef.Name)
 					}
 					pods = append(pods, &pod)
 				}
@@ -2372,7 +2372,7 @@ func (hc *HealthChecker) GetServices(ctx context.Context) ([]corev1.Service, err
 	return svcList.Items, nil
 }
 
-// GetServices returns all endpoints within data plane namespace as a map
+// GetEndpoints returns all endpoints within data plane namespace as a map
 // with key as `<endpointsNamespace>/<endpointsName>`
 func (hc *HealthChecker) GetEndpoints(ctx context.Context) (map[string]corev1.Endpoints, error) {
 	allEndpoints, err := hc.kubeAPI.CoreV1().Endpoints(hc.DataPlaneNamespace).List(ctx, metav1.ListOptions{})

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2268,6 +2268,7 @@ func (hc *HealthChecker) checkMisconfiguredOpaquePortAnnotations(ctx context.Con
 	// Initialize and sync the kubernetes API
 	// This is used instead of `hc.kubeAPI` to limit multiple k8s API requests
 	// and use the caching logic in the shared informers
+	// TODO: move the shared informer code out of `controller/`, and into `pkg` to simplify the dependency tree.
 	kubeAPI := controllerK8s.NewAPI(hc.kubeAPI, nil, nil, controllerK8s.Endpoint, controllerK8s.Pod, controllerK8s.Svc)
 	kubeAPI.Sync(ctx.Done())
 

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3407,8 +3407,7 @@ func TestCheckOpaquePortAnnotations(t *testing.T) {
 	hc := NewHealthChecker(
 		[]CategoryID{LinkerdOpaquePortsDefinitionChecks},
 		&Options{
-			DataPlaneNamespace:    "test-ns",
-			ControlPlaneNamespace: "linkerd",
+			DataPlaneNamespace: "test-ns",
 		},
 	)
 
@@ -3441,7 +3440,6 @@ metadata:
   name: my-service-deployment
   namespace: test-ns
   labels:
-    linkerd.io/control-plane-ns: linkerd
     service: service-1
 spec:
   containers:
@@ -3504,7 +3502,6 @@ metadata:
   service: service-1
   labels:
     service: service-1
-    linkerd.io/control-plane-ns: linkerd
   annotations:
     config.linkerd.io/opaque-ports: "9200"
 spec:
@@ -3566,7 +3563,6 @@ metadata:
   service: service-1
   labels:
     service: service-1
-    linkerd.io/control-plane-ns: linkerd
   annotations:
     config.linkerd.io/opaque-ports: "9200"
 spec:
@@ -3629,7 +3625,6 @@ metadata:
   namespace: test-ns
   service: service-1
   labels:
-    linkerd.io/control-plane-ns: linkerd
     service: service-1
 spec:
   containers:
@@ -3691,7 +3686,6 @@ metadata:
   namespace: test-ns
   service: service-1
   labels:
-    linkerd.io/control-plane-ns: linkerd
     service: service-1
   annotations:
     config.linkerd.io/opaque-ports: "9300"

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3407,7 +3407,8 @@ func TestCheckOpaquePortAnnotations(t *testing.T) {
 	hc := NewHealthChecker(
 		[]CategoryID{LinkerdOpaquePortsDefinitionChecks},
 		&Options{
-			DataPlaneNamespace: "test-ns",
+			DataPlaneNamespace:    "test-ns",
+			ControlPlaneNamespace: "linkerd",
 		},
 	)
 
@@ -3440,6 +3441,7 @@ metadata:
   name: my-service-deployment
   namespace: test-ns
   labels:
+    linkerd.io/control-plane-ns: linkerd
     service: service-1
 spec:
   containers:
@@ -3502,6 +3504,7 @@ metadata:
   service: service-1
   labels:
     service: service-1
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     config.linkerd.io/opaque-ports: "9200"
 spec:
@@ -3563,6 +3566,7 @@ metadata:
   service: service-1
   labels:
     service: service-1
+    linkerd.io/control-plane-ns: linkerd
   annotations:
     config.linkerd.io/opaque-ports: "9200"
 spec:
@@ -3625,6 +3629,7 @@ metadata:
   namespace: test-ns
   service: service-1
   labels:
+    linkerd.io/control-plane-ns: linkerd
     service: service-1
 spec:
   containers:
@@ -3686,6 +3691,7 @@ metadata:
   namespace: test-ns
   service: service-1
   labels:
+    linkerd.io/control-plane-ns: linkerd
     service: service-1
   annotations:
     config.linkerd.io/opaque-ports: "9300"
@@ -3734,9 +3740,9 @@ subsets:
 			}
 			err = hc.checkMisconfiguredOpaquePortAnnotations(context.Background())
 			if err == nil && tc.expected != nil {
-				t.Fatalf("Expected check to be successful, got: %s", err)
+				t.Fatalf("Expected check to fail with %s", tc.expected.Error())
 			}
-			if err != nil {
+			if err != nil && tc.expected != nil {
 				if err.Error() != tc.expected.Error() {
 					t.Fatalf("Expected error: %s, received: %s", tc.expected, err)
 				}


### PR DESCRIPTION
Fixes #6272

The opaqueports is prone to fail, with `context deadline exceeded`
as there are numerous k8s API requests being performed.

This PR updates the pre-fetching logic to instead use
`controller/k8s` which provides a wrapper around `pkg/k8s` with
caching by using shared informers underneath!

This commit includes the following changes:
- Update `checkMisconfiguredOpaquePortAnnotations` to use
  `controllerk8s.KubeAPI` instead of `hc.kubeAPI`
- `kubeAPI.Sync` fn also had to be updated as it fails to check
if the sp and ts sharedinformers are nil, which might be the
case in cases like this where they are not needed.

We had to use `controllerK8s.NewAPI` for the initialization
instead of `controllerk8s.InitializeAPI` to take-in
`hc.kubeAPI` so as to support unit testing, etc as `hc.kubeAPI`
is how we pass the fake resources in unit tests.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
