### PR TITLE
Integration test for proxy-injector reinvocation

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -23,7 +23,7 @@ echo "cleaning up the all namespaces labelled with test.linkerd.io/is-test-data-
 kubectl --context="$k8s_context" delete ns -l test.linkerd.io/is-test-data-plane
 
 echo "cleaning up cluster-scoped resources labelled with test.linkerd.io/is-test-data-plane"
-kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings -l test.linkerd.io/is-test-data-plane
+kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings,mutatingwebhookconfiguration -l test.linkerd.io/is-test-data-plane
 
 echo "cleaning up linkerd resources [${k8s_context}]"
 "$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -103,7 +103,7 @@ func TestReinvocation(t *testing.T) {
 
 		injectionValidator := testutil.InjectValidator{
 			NoInitContainer: TestHelper.CNI() || TestHelper.Calico(),
-			// ****** TODO ****** this proofs the changes made by the z-kubemod mutating webhook
+			// ****** TODO ****** this proves the changes made by the z-kubemod mutating webhook
 			// weren't surfaced by the injector. Once the injector implements reinvocation
 			// the log level should be "debug"
 			LogLevel: "warn,linkerd=info",

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -1,0 +1,120 @@
+package inject
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/testutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+// TestReinvocation installs https://github.com/kubemod/kubemod, then creates a modrule that
+// adds the "linkerd.io/proxy-log-level: debug" annotation through a mutating webhook that
+// gets called after the linkerd injector. The latter should be reinvoked so it reacts to that
+// annotation.
+func TestReinvocation(t *testing.T) {
+	// We're using a slightly reduced version of kubemod
+	// - Has the test.linkerd.io/is-test-data-plane label
+	// - Doesn't contain the validating admission controller
+	// - The mutating admission controller was renamed to z-kubemod-mutating-webhook-configuration
+	//   so it runs after the linkerd injector (they're run alphabetically)
+	// - The command from the job generating the mwc cert and secret has been slightly changed in order
+	//   to account for that renaming (see yaml)
+	kubemodYAML, err := testutil.ReadFile("testdata/kubemod.yaml")
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "failed to read kubemod.yaml", "failed to read kubemod.yaml: %s", err)
+	}
+	o, err := TestHelper.KubectlApply(kubemodYAML, "")
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "failed to install kubemod",
+			"failed to install kubemod: %s\n%s", err, o)
+	}
+
+	ctx := context.Background()
+
+	nsAnnotations := map[string]string{
+		k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
+	}
+	TestHelper.WithDataPlaneNamespace(ctx, "reinvocation", nsAnnotations, t, func(t *testing.T, ns string) {
+		modruleYAML, err := testutil.ReadFile("testdata/modrule.yaml")
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "failed to read modrule.yaml", "failed to read modrule.yaml: %s", err)
+		}
+		err = TestHelper.RetryFor(30*time.Second, func() error {
+			o, err := TestHelper.KubectlApply(modruleYAML, ns)
+			if err != nil {
+				return fmt.Errorf("%s\n%s", err, o)
+			}
+			return nil
+		})
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "failed to apply modrule.yaml",
+				"failed to apply modrule.yaml: %s", err)
+		}
+
+		podsYAML, err := testutil.ReadFile("testdata/inject_test.yaml")
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "failed to read inject test file",
+				"failed to read inject test file: %s", err)
+		}
+		o, err = TestHelper.KubectlApply(podsYAML, ns)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "failed to install inject test file",
+				"failed to install inject test file: %s\n%s", err, o)
+		}
+
+		deployName := "inject-test-terminus"
+		var pod *v1.Pod
+		err = TestHelper.RetryFor(30*time.Second, func() error {
+			pods, err := TestHelper.GetPodsForDeployment(ctx, ns, deployName)
+			if err != nil {
+				return fmt.Errorf("failed to get pods for namespace %s", ns)
+			}
+
+			for _, p := range pods {
+				p := p //pin
+				creator, ok := p.Annotations[k8s.CreatedByAnnotation]
+				if ok && strings.Contains(creator, "proxy-injector") {
+					pod = &p
+					break
+				}
+			}
+			if pod == nil {
+				return fmt.Errorf("failed to find auto injected pod for deployment %s", deployName)
+			}
+			return nil
+		})
+
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "failed to find autoinjected pod: ", err.Error())
+		}
+
+		injectionValidator := testutil.InjectValidator{
+			// ****** TODO ****** this proofs the changes made by the z-kubemod mutating webhook
+			// weren't surfaced by the injector. Once the injector implements reinvocation
+			// the log level should be "debug"
+			LogLevel: "warn,linkerd=info",
+		}
+		if err := injectionValidator.ValidatePod(&pod.Spec); err != nil {
+			testutil.AnnotatedFatalf(t, "received unexpected output", "received unexpected output\n%s", err.Error())
+		}
+	})
+
+	o, err = TestHelper.Kubectl(kubemodYAML, "delete", "-f", "-")
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "failed to uninstall kubemod",
+			"failed to uninstall kubemod: %s\n%s", err, o)
+	}
+}

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -52,7 +52,7 @@ func TestReinvocation(t *testing.T) {
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "failed to read modrule.yaml", "failed to read modrule.yaml: %s", err)
 		}
-		err = TestHelper.RetryFor(30*time.Second, func() error {
+		err = TestHelper.RetryFor(40*time.Second, func() error {
 			o, err := TestHelper.KubectlApply(modruleYAML, ns)
 			if err != nil {
 				return fmt.Errorf("%s\n%s", err, o)
@@ -102,6 +102,7 @@ func TestReinvocation(t *testing.T) {
 		}
 
 		injectionValidator := testutil.InjectValidator{
+			NoInitContainer: TestHelper.CNI() || TestHelper.Calico(),
 			// ****** TODO ****** this proofs the changes made by the z-kubemod mutating webhook
 			// weren't surfaced by the injector. Once the injector implements reinvocation
 			// the log level should be "debug"

--- a/test/integration/reinvocation/testdata/inject_test.yaml
+++ b/test/integration/reinvocation/testdata/inject_test.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/test/integration/reinvocation/testdata/inject_test.yaml
+++ b/test/integration/reinvocation/testdata/inject_test.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inject-test-terminus
+spec:
+  selector:
+    matchLabels:
+      app: inject-test-terminus
+  template:
+    metadata:
+      labels:
+        app: inject-test-terminus
+    spec:
+      containers:
+      - name: bb-terminus
+        image: buoyantio/bb:v0.0.6
+        args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
+        ports:
+        - containerPort: 9090

--- a/test/integration/reinvocation/testdata/kubemod.yaml
+++ b/test/integration/reinvocation/testdata/kubemod.yaml
@@ -1,0 +1,421 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    admission.kubemod.io/ignore: "true"
+    control-plane: controller-manager
+    test.linkerd.io/is-test-data-plane: "true"
+  name: kubemod-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  name: modrules.api.kubemod.io
+spec:
+  group: api.kubemod.io
+  names:
+    kind: ModRule
+    listKind: ModRuleList
+    plural: modrules
+    singular: modrule
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModRule is the Schema for the modrules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ModRuleSpec defines the desired state of ModRule
+            properties:
+              match:
+                description: Match is a list of match items which consist of select queries and expected match values or regular expressions. When all match items for an object are positive, the rule is in effect.
+                items:
+                  description: MatchItem represents a single match query.
+                  properties:
+                    matchFor:
+                      description: 'MatchFor instructs how to match the results against the match... requirements. Valid values are: - "Any" - the match is considered positive if any of the results of select have a match. - "All" - the match is considered positive only if all of the results of select have a match.'
+                      enum:
+                      - Any
+                      - All
+                      type: string
+                    matchRegex:
+                      description: MatchRegex specifies the regular expression to compare the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to value.
+                      nullable: true
+                      type: string
+                    matchValue:
+                      description: MatchValue specifies the exact value to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to matchValue.
+                      nullable: true
+                      type: string
+                    matchValues:
+                      description: MatchValues specifies a list of values to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to any of the values in the array.
+                      items:
+                        type: string
+                      type: array
+                    negate:
+                      description: Negate indicates whether the match result should be to inverted. Defaults to false.
+                      type: boolean
+                    select:
+                      description: 'Select is a JSONPath query expression: https://goessner.net/articles/JsonPath/ which yields zero or more values. If no match value or regex is specified, if the query yields a non-empty result, the match is considered positive.'
+                      type: string
+                  required:
+                  - select
+                  type: object
+                minItems: 1
+                type: array
+              patch:
+                description: Patch is a list of patch operations to perform on the matching resources at the time of creation. The value part of a patch operation can be a golang template which accepts the resource as its context. This field must be provided for ModRules of type "patch"
+                items:
+                  description: PatchOperation represents a single JSON Patch operation.
+                  properties:
+                    op:
+                      description: Operation is the type of JSON Path operation to perform against the target element.
+                      enum:
+                      - add
+                      - replace
+                      - remove
+                      type: string
+                    path:
+                      description: Path is the JSON path to the target element.
+                      type: string
+                    select:
+                      description: 'Optional JSONPath query expression: https://goessner.net/articles/JsonPath/ used to construct path. A patch operation is created for each result of the query. A placeholder is created for each wildcard and filter in the expression. These placeholders can be used when constructing "path". For example, if select is "$.spec.containers[*].ports[?@.containerPort == 80]" placeholder #0 will point to the index of "containers" and #1 will point to the index of "ports". This allows us to define paths such as "/spec/template/spec/containers/#0/securityContext"'
+                      type: string
+                    value:
+                      description: 'Value is the JSON representation of the modification. The value is a golang template which is evaluated against the context of the target resource. KubeMod performs some analysis of the result of the template evaluation in order to infer its JSON type: - If the value matches the format of a JavaScript number, it is considered to be a number. - If the value matches a boolean literal (true/false), it is considered to be a boolean literal. - If the value matches ''null'', it is considered to be null. - If the value is surrounded by double-quotes, it is considered to be a string. - If the value is surrounded by brackets, it is considered to be a JSON array. - If the value is surrounded by curly braces, it is considered to be a JSON object. - If none of the above is true, the value is considered to be a string.'
+                      nullable: true
+                      type: string
+                  required:
+                  - op
+                  - path
+                  type: object
+                type: array
+              rejectMessage:
+                description: RejectMessage is an optional message displayed when a resource is rejected by a Reject ModRule. The field is a Golang template evaluated in the context of the object being rejected.
+                type: string
+              targetNamespaceRegex:
+                description: TargetNamespaceRegex is optional and only applies to ModRules in "kubemod-system" namespace. Its usage enables cluster-wide matching of namespaced resources.
+                type: string
+              type:
+                description: 'Type describes the type of a ModRule. Valid values are: - "Patch" - the rule performs modifications on all the matching resources as they are created. - "Reject" - the rule rejects the creation of all matching resources.'
+                enum:
+                - Patch
+                - Reject
+                type: string
+            required:
+            - match
+            - type
+            type: object
+          status:
+            description: ModRuleStatus defines the observed state of ModRule
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubemod-crt
+  namespace: kubemod-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubemod-crt
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - z-kubemod-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubemod-manager
+rules:
+- apiGroups:
+  - api.kubemod.io
+  resources:
+  - modrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - api.kubemod.io
+  resources:
+  - modrules/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubemod-crt
+  namespace: kubemod-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubemod-crt
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubemod-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubemod-crt
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubemod-crt
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubemod-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubemod-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubemod-manager
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubemod-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubemod-webapp-service
+  namespace: kubemod-system
+spec:
+  ports:
+  - name: api
+    port: 8081
+    targetPort: api
+  - name: metrics
+    port: 8082
+    targetPort: metrics
+  - name: health
+    port: 8083
+    targetPort: health
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubemod-webhook-service
+  namespace: kubemod-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: kubemod-operator
+    control-plane: controller-manager
+  name: kubemod-operator
+  namespace: kubemod-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kubemod-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubemod-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - command:
+        - /kubemod
+        - -operator
+        - -webapp
+        image: kubemod/kubemod:v0.13.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+        name: manager
+        ports:
+        - containerPort: 8081
+          name: api
+          protocol: TCP
+        - containerPort: 8082
+          name: metrics
+          protocol: TCP
+        - containerPort: 8083
+          name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8083
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubemod-crt-job
+  namespace: kubemod-system
+spec:
+  backoffLimit: 4
+  serviceAccountName: null
+  template:
+    spec:
+      containers:
+      # originally it was just ./cert-renew.sh, but we're inlining here in order
+      # to change the mwc name to z-kubemod-mutating-webhook-configuration
+      - command:
+        - /bin/sh
+        - -c
+        - source ./cert-generate.sh;
+          ca_bundle=$(cat ca.pem | base64 - | tr -d '\n' );
+          sed -r -i "s|Cg==|$ca_bundle|" patch-mutating-webhook-configuration.json;
+          kubectl create secret tls webhook-server-cert -n kubemod-system --cert=server.pem --key=server-key.pem --dry-run=client -o yaml | kubectl apply -n kubemod-system -f -;
+          kubectl patch mutatingwebhookconfiguration z-kubemod-mutating-webhook-configuration --type=json --patch "$(cat patch-mutating-webhook-configuration.json)"
+        image: kubemod/kubemod-crt:v1.1.0
+        name: kubemod-crt
+      restartPolicy: Never
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: z-kubemod-mutating-webhook-configuration
+  labels:
+    test.linkerd.io/is-test-data-plane: "true"
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: kubemod-webhook-service
+      namespace: kubemod-system
+      path: /mutate-api-kubemod-io-v1beta1-modrule
+  failurePolicy: Fail
+  name: mmodrule.kubemod.io
+  rules:
+  - apiGroups:
+    - api.kubemod.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - modrules
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: Cg==
+    service:
+      name: kubemod-webhook-service
+      namespace: kubemod-system
+      path: /dragnet-webhook
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: dragnet.kubemod.io
+  namespaceSelector:
+    matchExpressions:
+    - key: admission.kubemod.io/ignore
+      operator: NotIn
+      values:
+      - "true"
+  reinvocationPolicy: IfNeeded
+  rules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 3

--- a/test/integration/reinvocation/testdata/modrule.yaml
+++ b/test/integration/reinvocation/testdata/modrule.yaml
@@ -1,0 +1,15 @@
+apiVersion: api.kubemod.io/v1beta1
+kind: ModRule
+metadata:
+  name: my-modrule
+spec:
+  type: Patch
+  match:
+    - select: '$.kind'
+      matchValue: Pod
+  patch:
+    # Add custom annotation.
+    - op: add
+      path: /metadata/annotations/config.linkerd.io~1proxy-log-level
+      value: "debug"
+


### PR DESCRIPTION
Preliminary for #3750 and #6267

This uses [kubemod](https://github.com/kubemod/kubemod), a generic mutating webhook, in a new integration test to prove that the proxy-injector is ignoring changes made by webhooks that run after it.

Once we implement reinvocation for the injector, this test should also be changed to reflect that.
