### PR TITLE
Add support for proxy injector reinvocation

### DIFF
--- a/charts/linkerd2/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd2/templates/proxy-injector-rbac.yaml
@@ -94,6 +94,7 @@ webhooks:
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.proxyInjector.caBundle)) (empty .Values.proxyInjector.caBundle) }}
   failurePolicy: {{.Values.webhookFailurePolicy}}
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -1,5 +1,38 @@
 {{ $prefix := .Values.pathPrefix -}}
+{{ $alreadyInjected := .Values.alreadyInjected -}}
 [
+  {{- if $alreadyInjected }}
+  {
+    "op": "remove",
+    "path": "/metadata/annotations/linkerd.io~1created-by"
+  },
+  {
+    "op": "remove",
+    "path": "/metadata/annotations/linkerd.io~1identity-mode"
+  },
+  {
+    "op": "remove",
+    "path": "/metadata/annotations/linkerd.io~1proxy-version"
+  },
+  {{- if gt .Values.proxyInitIndex -1.0 }}
+  {
+    "op": "remove",
+    "path": "/spec/initContainers/{{ .Values.proxyInitIndex }}"
+  },
+  {{- end }}
+  {{ range .Values.containerIndices }}
+  {
+    "op": "remove",
+    "path": "/spec/containers/{{ . }}"
+  },
+  {{- end }}
+  {{ range .Values.volumeIndices }}
+  {
+    "op": "remove",
+    "path": "{{$prefix}}/spec/volumes/{{ . }}"
+  },
+  {{- end }}
+  {{- end }}
   {{- if .Values.addRootMetadata }}
   {
     "op": "add",
@@ -29,6 +62,12 @@
   },
   {{- end }}
   {{- range $label, $value := .Values.labels }}
+  {{- if $alreadyInjected }}
+  {
+    "op": "remove",
+    "path": "{{$prefix}}/metadata/labels/{{$label | replace "/" "~1"}}"
+  },
+  {{- end }}
   {
     "op": "add",
     "path": "{{$prefix}}/metadata/labels/{{$label | replace "/" "~1"}}",

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -259,7 +259,7 @@ func (resourceTransformerInject) generateReport(reports []inject.Report, output 
 			warningsPrinted = true
 		}
 
-		if r.Sidecar {
+		if r.OtherSidecar {
 			sidecar = append(sidecar, r.ResName())
 			warningsPrinted = true
 		}

--- a/cli/cmd/testdata/inject_emojivoto_istio.golden.stderr
+++ b/cli/cmd/testdata/inject_emojivoto_istio.golden.stderr
@@ -1,2 +1,2 @@
 Error transforming resources:
-failed to inject deployment/web: pod has a sidecar injected already
+failed to inject deployment/web: pod has a 3rd party sidecar injected already

--- a/cli/cmd/testdata/inject_emojivoto_istio.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_istio.golden.stderr.verbose
@@ -1,2 +1,2 @@
 Error transforming resources:
-failed to inject deployment/web: pod has a sidecar injected already
+failed to inject deployment/web: pod has a 3rd party sidecar injected already

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1613,7 +1614,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1611,7 +1612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bce2277a89759f9ac7669e8043ef265aca604e32fa847929ea3bfa3327905042
+        checksum/config: 947f6765b3d905bb3039518bc62e75e793b71c35077a41e998a447cbcdd0dd59
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1611,7 +1612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1611,7 +1612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1611,7 +1612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1744,7 +1745,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 67e053df1cc859aa15c82ff6e5e65c055041bb36ade50655e9bf44976521018f
+        checksum/config: bfad37112b96b6e013dc41570c1392d15e39a86b5045069ff2f3be121b879bce
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1744,7 +1745,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 67e053df1cc859aa15c82ff6e5e65c055041bb36ade50655e9bf44976521018f
+        checksum/config: bfad37112b96b6e013dc41570c1392d15e39a86b5045069ff2f3be121b879bce
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -620,6 +620,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1490,7 +1491,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -703,6 +703,7 @@ webhooks:
     caBundle: dGVzdC1wcm94eS1pbmplY3Rvci1jYS1idW5kbGU=
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1595,7 +1596,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 20a7b3bda0bfdd9b7cf388efb0b438612caa444c23e015168dae1cdb0109e34e
+        checksum/config: 43b44889d13d2f72c242740c80e9e1f34d7b4972e4c34ea2ca763d3c7db03bb7
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -703,6 +703,7 @@ webhooks:
     caBundle: dGVzdC1wcm94eS1pbmplY3Rvci1jYS1idW5kbGU=
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1728,7 +1729,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf6b4520e0ad2b0010db5a18443bd632c87ac0216f8f118e723e0f33f5842d7e
+        checksum/config: 25d57778ef08f0488f65425442e17e4d8d3f8dde38cf6c1967b1934f34e09f5f
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -703,6 +703,7 @@ webhooks:
     caBundle: dGVzdC1wcm94eS1pbmplY3Rvci1jYS1idW5kbGU=
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1744,7 +1745,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf6b4520e0ad2b0010db5a18443bd632c87ac0216f8f118e723e0f33f5842d7e
+        checksum/config: 25d57778ef08f0488f65425442e17e4d8d3f8dde38cf6c1967b1934f34e09f5f
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -703,6 +703,7 @@ webhooks:
     caBundle: dGVzdC1wcm94eS1pbmplY3Rvci1jYS1idW5kbGU=
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1728,7 +1729,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5e2cfa2bd882cd79c2104f822ff8062620bd9103e176aa47064940e2e0fbcff6
+        checksum/config: f96549a803c94c26c0b6096c94c24437ecbcc3dc661c2002ee3699e5ade4f39d
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1532,7 +1533,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: WebhookFailurePolicy
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1615,7 +1616,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 54ac8689f1236f2c97fa3bb59f9ac21abab03e06e06eca84b1fd9ba035dce1e8
+        checksum/config: dfac38d566deb1fb3525a79a967508edd6ceb50c719b6f62127e3e6bbdd9dae7
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -689,6 +689,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1611,7 +1612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 31ca92e63a48870d9b7cad9d7a613e2164b4b016577720744b2f0a1da3a3c844
+        checksum/config: 7f146039db892a5d5c7c8a9e53b3140889705c6176226af971ea9801741e43b9
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -675,6 +675,7 @@ webhooks:
     caBundle: cHJveHkgaW5qZWN0b3IgQ0EgYnVuZGxl
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
+  reinvocationPolicy: IfNeeded
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]
@@ -1597,7 +1598,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bce2277a89759f9ac7669e8043ef265aca604e32fa847929ea3bfa3327905042
+        checksum/config: 947f6765b3d905bb3039518bc62e75e793b71c35077a41e998a447cbcdd0dd59
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -229,6 +229,10 @@ func TestGetPodPatch(t *testing.T) {
 
 		fakeReq := getFakePodReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
+		_, err = conf.ParseMetaAndYAML(fakeReq.Object.Raw)
+		if err != nil {
+			t.Fatalf("Unexpected ParseMetaAndYAML error: %s", err)
+		}
 		patchJSON, err := conf.GetPodPatch(true)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)

--- a/controller/webhook/server.go
+++ b/controller/webhook/server.go
@@ -160,7 +160,6 @@ func (s *Server) processReq(ctx context.Context, data []byte) *admissionv1beta1.
 		return admissionReview
 	}
 	log.Infof("received admission review request %s", admissionReview.Request.UID)
-	log.Debugf("admission request: %+v", admissionReview.Request)
 
 	admissionResponse, err := s.handler(ctx, s.api, admissionReview.Request, s.recorder)
 	if err != nil {

--- a/pkg/healthcheck/sidecar.go
+++ b/pkg/healthcheck/sidecar.go
@@ -3,26 +3,21 @@ package healthcheck
 import (
 	"strings"
 
-	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 )
 
-// HasExistingSidecars returns true if the pod spec already has the proxy init
-// and sidecar containers injected. Otherwise, it returns false.
-func HasExistingSidecars(podSpec *corev1.PodSpec) bool {
+// Has3rdPartySidecars returns true if the pod spec already has a third party
+// init or sidecar containers already injected
+func Has3rdPartySidecars(podSpec *corev1.PodSpec) bool {
 	for _, container := range podSpec.Containers {
-		if strings.HasPrefix(container.Image, "cr.l5d.io/linkerd/proxy:") ||
-			strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
-			container.Name == k8s.ProxyContainerName ||
+		if strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
 			container.Name == "istio-proxy" {
 			return true
 		}
 	}
 
 	for _, ic := range podSpec.InitContainers {
-		if strings.HasPrefix(ic.Image, "cr.l5d.io/linkerd/proxy-init:") ||
-			strings.HasPrefix(ic.Image, "gcr.io/istio-release/proxy_init:") ||
-			ic.Name == "linkerd-init" ||
+		if strings.HasPrefix(ic.Image, "gcr.io/istio-release/proxy_init:") ||
 			ic.Name == "istio-init" {
 			return true
 		}

--- a/pkg/healthcheck/sidecar.go
+++ b/pkg/healthcheck/sidecar.go
@@ -6,9 +6,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Has3rdPartySidecars returns true if the pod spec already has a third party
+// HasThirdPartySidecars returns true if the pod spec already has a third party
 // init or sidecar containers already injected
-func Has3rdPartySidecars(podSpec *corev1.PodSpec) bool {
+func HasThirdPartySidecars(podSpec *corev1.PodSpec) bool {
 	for _, container := range podSpec.Containers {
 		if strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
 			container.Name == "istio-proxy" {

--- a/pkg/healthcheck/sidecar_test.go
+++ b/pkg/healthcheck/sidecar_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestHasExistingSidecars(t *testing.T) {
+func TestHas3rdPartySidecars(t *testing.T) {
 	for _, tc := range []struct {
 		podSpec  *corev1.PodSpec
 		expected bool
@@ -42,7 +42,7 @@ func TestHasExistingSidecars(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -62,7 +62,7 @@ func TestHasExistingSidecars(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -82,7 +82,7 @@ func TestHasExistingSidecars(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -102,7 +102,7 @@ func TestHasExistingSidecars(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -115,8 +115,8 @@ func TestHasExistingSidecars(t *testing.T) {
 			expected: true,
 		},
 	} {
-		if !reflect.DeepEqual(HasExistingSidecars(tc.podSpec), tc.expected) {
-			t.Errorf("expected: %v, got: %v", tc.expected, HasExistingSidecars(tc.podSpec))
+		if !reflect.DeepEqual(Has3rdPartySidecars(tc.podSpec), tc.expected) {
+			t.Errorf("expected: %v, got: %v", tc.expected, Has3rdPartySidecars(tc.podSpec))
 		}
 	}
 }

--- a/pkg/healthcheck/sidecar_test.go
+++ b/pkg/healthcheck/sidecar_test.go
@@ -115,8 +115,8 @@ func TestHas3rdPartySidecars(t *testing.T) {
 			expected: true,
 		},
 	} {
-		if !reflect.DeepEqual(Has3rdPartySidecars(tc.podSpec), tc.expected) {
-			t.Errorf("expected: %v, got: %v", tc.expected, Has3rdPartySidecars(tc.podSpec))
+		if !reflect.DeepEqual(HasThirdPartySidecars(tc.podSpec), tc.expected) {
+			t.Errorf("expected: %v, got: %v", tc.expected, HasThirdPartySidecars(tc.podSpec))
 		}
 	}
 }

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -274,7 +274,7 @@ func (conf *ResourceConfig) GetPodPatch(injectProxy bool) ([]byte, error) {
 
 	switch strings.ToLower(conf.workload.metaType.Kind) {
 	case k8s.Pod:
-		patch.addRemovals(conf.pod)
+		patch.addReinvokeRemovals(conf.pod)
 	case k8s.CronJob:
 		patch.PathPrefix = "/spec/jobTemplate/spec/template"
 	default:

--- a/pkg/inject/pod_patch.go
+++ b/pkg/inject/pod_patch.go
@@ -1,0 +1,109 @@
+package inject
+
+import (
+	l5dcharts "github.com/linkerd/linkerd2/pkg/charts/linkerd2"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type podPatch struct {
+	l5dcharts.Values
+	PathPrefix            string                    `json:"pathPrefix"`
+	AddRootMetadata       bool                      `json:"addRootMetadata"`
+	AddRootAnnotations    bool                      `json:"addRootAnnotations"`
+	AlreadyInjected       bool                      `json:"alreadyInjected"`
+	Annotations           map[string]string         `json:"annotations"`
+	AddRootLabels         bool                      `json:"addRootLabels"`
+	AddRootInitContainers bool                      `json:"addRootInitContainers"`
+	AddRootVolumes        bool                      `json:"addRootVolumes"`
+	Labels                map[string]string         `json:"labels"`
+	DebugContainer        *l5dcharts.DebugContainer `json:"debugContainer"`
+	ProxyInitIndex        int                       `json:"proxyInitIndex"`
+	ContainerIndices      []int                     `json:"containerIndices"`
+	VolumeIndices         []int                     `json:"volumeIndices"`
+}
+
+func newPodPatch(values l5dcharts.Values) *podPatch {
+	patch := &podPatch{
+		Values:      values,
+		Annotations: map[string]string{},
+		Labels:      map[string]string{},
+	}
+
+	return patch
+}
+
+func (patch *podPatch) getYAML() ([]byte, error) {
+	return yaml.Marshal(patch)
+}
+
+func (patch *podPatch) addRemovals(p pod) {
+	patch.checkContainers(p.spec)
+	if !patch.AlreadyInjected {
+		return
+	}
+	patch.volumesIndices(p.spec.Volumes)
+}
+
+func (patch *podPatch) checkContainers(podSpec *corev1.PodSpec) {
+	patch.ProxyInitIndex = -1
+	proxyIndex := -1
+	debugIndex := -1
+
+	for i, ic := range podSpec.InitContainers {
+		if ic.Name == k8s.InitContainerName {
+			patch.AlreadyInjected = true
+			patch.ProxyInitIndex = i
+			break
+		}
+	}
+
+	for i, c := range podSpec.Containers {
+		if c.Name == k8s.ProxyContainerName {
+			patch.AlreadyInjected = true
+			proxyIndex = i
+		}
+		if c.Name == k8s.DebugSidecarName {
+			debugIndex = i
+		}
+	}
+
+	patch.ContainerIndices = normalizeIndices(proxyIndex, debugIndex)
+}
+
+func (patch *podPatch) volumesIndices(volumes []corev1.Volume) {
+	xtablesIndex := -1
+	identityIndex := -1
+	for i, vol := range volumes {
+		if vol.Name == k8s.InitXtablesLockVolumeMountName {
+			xtablesIndex = i
+		} else if vol.Name == k8s.IdentityEndEntityVolumeName {
+			identityIndex = i
+		}
+	}
+	patch.VolumeIndices = normalizeIndices(xtablesIndex, identityIndex)
+}
+
+// normalizeIndices receives the current indices for a pair of
+// container/volumes and returns them in an array, such that they can be fed
+// into `remove` json-patch statements. According to the json patch spec "If
+// removing an element from an array, any elements above the specified index
+// are shifted one position to the left.". So for example (1,2) should be
+// transformed into (1,1).
+// When an index is -1 it means the item wasn't found.
+func normalizeIndices(a, b int) []int {
+	if a < 0 && b < 0 {
+		return []int{}
+	} else if a < 0 {
+		return []int{b}
+	} else if b < 0 {
+		return []int{a}
+	} else if a < b {
+		b--
+		return []int{a, b}
+	} else {
+		a--
+		return []int{b, a}
+	}
+}

--- a/pkg/inject/pod_patch.go
+++ b/pkg/inject/pod_patch.go
@@ -3,6 +3,7 @@ package inject
 import (
 	l5dcharts "github.com/linkerd/linkerd2/pkg/charts/linkerd2"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -38,9 +39,10 @@ func (patch *podPatch) getYAML() ([]byte, error) {
 	return yaml.Marshal(patch)
 }
 
-func (patch *podPatch) addRemovals(p pod) {
+func (patch *podPatch) addReinvokeRemovals(p pod) {
 	patch.checkContainers(p.spec)
 	if !patch.AlreadyInjected {
+		log.Debugf("skipped remove statements in patch for pod %s/%s", p.meta.Namespace, getPodName(p))
 		return
 	}
 	patch.volumesIndices(p.spec.Volumes)

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -71,10 +71,7 @@ type Report struct {
 func newReport(conf *ResourceConfig) *Report {
 	var name string
 	if conf.IsPod() {
-		name = conf.pod.meta.Name
-		if name == "" {
-			name = conf.pod.meta.GenerateName
-		}
+		name = getPodName(conf.pod)
 	} else if m := conf.workload.Meta; m != nil {
 		name = m.Name
 	}
@@ -241,4 +238,12 @@ func (r *Report) ThrowInjectError() []error {
 	}
 
 	return errs
+}
+
+func getPodName(p pod) string {
+	name := p.meta.Name
+	if name == "" {
+		name = p.meta.GenerateName
+	}
+	return name
 }

--- a/pkg/inject/report.go
+++ b/pkg/inject/report.go
@@ -85,7 +85,7 @@ func newReport(conf *ResourceConfig) *Report {
 	if conf.HasPodTemplate() {
 		report.InjectDisabled, report.InjectDisabledReason, report.InjectAnnotationAt = report.disabledByAnnotation(conf)
 		report.HostNetwork = conf.pod.spec.HostNetwork
-		report.OtherSidecar = healthcheck.Has3rdPartySidecars(conf.pod.spec)
+		report.OtherSidecar = healthcheck.HasThirdPartySidecars(conf.pod.spec)
 		report.UDP = checkUDPPorts(conf.pod.spec)
 		if conf.pod.spec.AutomountServiceAccountToken != nil {
 			report.AutomountServiceAccountToken = *conf.pod.spec.AutomountServiceAccountToken

--- a/pkg/inject/report_test.go
+++ b/pkg/inject/report_test.go
@@ -78,8 +78,7 @@ func TestInjectable(t *testing.T) {
 					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
 				},
 			},
-			injectable: false,
-			reasons:    []string{sidecarExists},
+			injectable: true,
 		},
 		{
 			podSpec: &corev1.PodSpec{
@@ -104,8 +103,7 @@ func TestInjectable(t *testing.T) {
 					k8s.ProxyInjectAnnotation: k8s.ProxyInjectEnabled,
 				},
 			},
-			injectable: false,
-			reasons:    []string{sidecarExists},
+			injectable: true,
 		},
 		{
 			unsupportedResource: true,
@@ -241,7 +239,7 @@ func TestInjectable(t *testing.T) {
 			},
 
 			injectable: false,
-			reasons:    []string{hostNetworkEnabled, sidecarExists, injectEnableAnnotationAbsent},
+			reasons:    []string{hostNetworkEnabled, injectEnableAnnotationAbsent},
 		},
 		{
 			podSpec: &corev1.PodSpec{},

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -103,7 +103,7 @@ func TestReinvocation(t *testing.T) {
 
 		injectionValidator := testutil.InjectValidator{
 			NoInitContainer: TestHelper.CNI() || TestHelper.Calico(),
-			LogLevel: "debug",
+			LogLevel:        "debug",
 		}
 		if err := injectionValidator.ValidatePod(&pod.Spec); err != nil {
 			testutil.AnnotatedFatalf(t, "received unexpected output", "received unexpected output\n%s", err.Error())

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -103,10 +103,7 @@ func TestReinvocation(t *testing.T) {
 
 		injectionValidator := testutil.InjectValidator{
 			NoInitContainer: TestHelper.CNI() || TestHelper.Calico(),
-			// ****** TODO ****** this proves the changes made by the z-kubemod mutating webhook
-			// weren't surfaced by the injector. Once the injector implements reinvocation
-			// the log level should be "debug"
-			LogLevel: "warn,linkerd=info",
+			LogLevel: "debug",
 		}
 		if err := injectionValidator.ValidatePod(&pod.Spec); err != nil {
 			testutil.AnnotatedFatalf(t, "received unexpected output", "received unexpected output\n%s", err.Error())


### PR DESCRIPTION
Fixes #3750 and partially #6267

As of k8s 1.15 mutating webhooks can be reinvoked whenever another mutating webhook running after the current one mutates the pod being persisted.
Enabling reinvocation for the injector will allow configuring the proxy with annotations generated by such other mutating webhooks.

The implementation consists on adding "remove" statements into the json patch returned by the injector, implemented mostly in the new file `pkg/inject/pod_patch.go` which now holds the `podPatch`, moved from `pkg/inject/inject.go`.

This also updates the "reinvocation" integration test introduced in #6309 to properly verify the reinvocation is happening.

And this also means the "existing proxy sidecar" check is no longer relevant, and has been limited to "existing 3rd party sidecar".

Possible followup: refactor the CLI inject and uninject commands to properly leverage the cleanup done by this patch.