### PR TITLE
Emit event when issuing leaf certificate

### DIFF
--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	v1machinery "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -149,8 +150,11 @@ func Main(args []string) {
 		log.Fatalf("Failed to construct k8s event recorder: %s", err)
 	}
 
-	recordEventFunc := func(eventType, reason, message string) {
-		recorder.Event(deployment, eventType, reason, message)
+	recordEventFunc := func(parent runtime.Object, eventType, reason, message string) {
+		if parent == nil {
+			parent = deployment
+		}
+		recorder.Event(parent, eventType, reason, message)
 	}
 
 	//

--- a/controller/cmd/identity/main.go
+++ b/controller/cmd/identity/main.go
@@ -141,7 +141,7 @@ func Main(args []string) {
 	// Create K8s event recorder
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
-		Interface: k8sAPI.CoreV1().Events(*controllerNS),
+		Interface: k8sAPI.CoreV1().Events(""),
 	})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: componentName})
 	deployment, err := k8sAPI.AppsV1().Deployments(*controllerNS).Get(ctx, componentName, v1machinery.GetOptions{})


### PR DESCRIPTION
We emit a Kubernetes event from the identity controller when successfully issuing a leaf certificate.  The events include the identity, expiry, and a hash of the certificate.  For example:

```
emojivoto   2m51s       Normal    IssuedLeafCertificate   serviceaccount/default                         issued certificate for default.emojivoto.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:34 +0000 UTC: 279a8df5785bb4967dce7f71aabe6eb5
emojivoto   2m53s       Normal    IssuedLeafCertificate   serviceaccount/emoji                           issued certificate for emoji.emojivoto.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:32 +0000 UTC: 1152fce9ebef255555241aa8d6c2c10b
emojivoto   2m51s       Normal    IssuedLeafCertificate   serviceaccount/voting                          issued certificate for voting.emojivoto.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:34 +0000 UTC: 72d0f3f54c66fb2b6ef523e7be448544
emojivoto   2m51s       Normal    IssuedLeafCertificate   serviceaccount/web                             issued certificate for web.emojivoto.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:34 +0000 UTC: 1e748e4aac9a6847908f836ec454a97f
linkerd     3m8s        Normal    IssuedLeafCertificate   serviceaccount/linkerd-destination             issued certificate for linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:17 +0000 UTC: f0164fdd3e5fc1204979edd9aebc10e6
linkerd     3m7s        Normal    IssuedLeafCertificate   serviceaccount/linkerd-identity                issued certificate for linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:18 +0000 UTC: dcbbd6f47024c321ef35d93f40586406
linkerd     3m7s        Normal    IssuedLeafCertificate   serviceaccount/linkerd-proxy-injector          issued certificate for linkerd-proxy-injector.linkerd.serviceaccount.identity.linkerd.cluster.local until 2021-06-25 21:19:18 +0000 UTC: 82938ecaaa682aeb156aae39add2628d
```

Signed-off-by: Alex Leong <alex@buoyant.io>

