### PR TITLE
Skip reinvocation integration test in ARM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## edge-21.6.4
+## edge-21.6.5
 
 This release contains a few improvements, from many contributors!  Also under
 the hood, the destination service has received updates in preparation to the

--- a/test/integration/reinvocation/reinvocation_test.go
+++ b/test/integration/reinvocation/reinvocation_test.go
@@ -32,6 +32,9 @@ func TestReinvocation(t *testing.T) {
 	//   so it runs after the linkerd injector (they're run alphabetically)
 	// - The command from the job generating the mwc cert and secret has been slightly changed in order
 	//   to account for that renaming (see yaml)
+	if os.Getenv("RUN_ARM_TEST") != "" {
+		t.Skip("Skipped. Kubemod does not support ARM yet")
+	}
 	kubemodYAML, err := testutil.ReadFile("testdata/kubemod.yaml")
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "failed to read kubemod.yaml", "failed to read kubemod.yaml: %s", err)


### PR DESCRIPTION
Kubemod images are not multi-arch apparently

Also bumping edge to 21.6.5 because 21.6.4 failed because of this.