### PR TITLE
support ServiceProfiles with dstOverrides in stat_summary

### DIFF
--- a/test/integration/trafficsplit/trafficsplit_test.go
+++ b/test/integration/trafficsplit/trafficsplit_test.go
@@ -156,9 +156,7 @@ func validateTrafficSplit(actual *statTsRow, expected *statTsRow) error {
 	return nil
 }
 
-func validateExpectedTsOutput(rows map[string]*statTsRow, expectedBackendSvc, expectedFailingSvc *statTsRow) error {
-	backendSvcLeafKey := "backend-svc"
-	backendFailingSvcLeafKey := "failing-svc"
+func validateExpectedTsOutput(rows map[string]*statTsRow, expectedBackendSvc, expectedFailingSvc *statTsRow, backendSvcLeafKey, backendFailingSvcLeafKey string) error {
 
 	backendRow, ok := rows[backendSvcLeafKey]
 	if !ok {
@@ -182,7 +180,7 @@ func validateExpectedTsOutput(rows map[string]*statTsRow, expectedBackendSvc, ex
 
 func TestTrafficSplitCli(t *testing.T) {
 
-	for _, version := range []string{"v1alpha1", "v1alpha2"} {
+	for _, version := range []string{"v1alpha1", "v1alpha2", "sp"} {
 		// pin version variable
 		version := version
 		ctx := context.Background()
@@ -233,24 +231,36 @@ func TestTrafficSplitCli(t *testing.T) {
 					}
 
 					var weight string
-					if version == "v1alpha1" {
+					if version == "v1alpha1" || version == "sp" {
 						weight = "500m"
 					} else {
 						weight = "500"
 					}
 
+					name := "backend-traffic-split"
+					apex := "backend-svc"
+					backendLeaf := "backend-svc"
+					failingLeaf := "failing-svc"
+
+					if version == "sp" {
+						name = "backend-svc.default.svc.cluster.local"
+						apex = "backend-svc.default.svc.cluster.local"
+						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
+						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
+					}
+
 					expectedBackendSvcOutput := &statTsRow{
-						name:    "backend-traffic-split",
-						apex:    "backend-svc",
-						leaf:    "backend-svc",
+						name:    name,
+						apex:    apex,
+						leaf:    backendLeaf,
 						weight:  weight,
 						success: "100.00%",
 						rps:     "0.5rps",
 					}
 					expectedFailingSvcOutput := &statTsRow{
-						name:       "backend-traffic-split",
-						apex:       "backend-svc",
-						leaf:       "failing-svc",
+						name:       name,
+						apex:       apex,
+						leaf:       failingLeaf,
 						weight:     "0",
 						success:    "-",
 						rps:        "-",
@@ -259,7 +269,7 @@ func TestTrafficSplitCli(t *testing.T) {
 						latencyP99: "-",
 					}
 
-					if err := validateExpectedTsOutput(rows, expectedBackendSvcOutput, expectedFailingSvcOutput); err != nil {
+					if err := validateExpectedTsOutput(rows, expectedBackendSvcOutput, expectedFailingSvcOutput, backendLeaf, failingLeaf); err != nil {
 						return err
 					}
 					return nil
@@ -296,30 +306,41 @@ func TestTrafficSplitCli(t *testing.T) {
 					}
 
 					var weight string
-					if version == "v1alpha1" {
+					if version == "v1alpha1" || version == "sp" {
 						weight = "500m"
 					} else {
 						weight = "500"
 					}
 
+					name := "backend-traffic-split"
+					apex := "backend-svc"
+					backendLeaf := "backend-svc"
+					failingLeaf := "failing-svc"
+					if version == "sp" {
+						name = "backend-svc.default.svc.cluster.local"
+						apex = "backend-svc.default.svc.cluster.local"
+						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
+						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
+					}
+
 					expectedBackendSvcOutput := &statTsRow{
-						name:    "backend-traffic-split",
-						apex:    "backend-svc",
-						leaf:    "backend-svc",
+						name:    name,
+						apex:    apex,
+						leaf:    backendLeaf,
 						weight:  weight,
 						success: "100.00%",
 						rps:     "0.5rps",
 					}
 					expectedFailingSvcOutput := &statTsRow{
-						name:    "backend-traffic-split",
-						apex:    "backend-svc",
-						leaf:    "failing-svc",
+						name:    name,
+						apex:    apex,
+						leaf:    failingLeaf,
 						weight:  weight,
 						success: "0.00%",
 						rps:     "0.5rps",
 					}
 
-					if err := validateExpectedTsOutput(rows, expectedBackendSvcOutput, expectedFailingSvcOutput); err != nil {
+					if err := validateExpectedTsOutput(rows, expectedBackendSvcOutput, expectedFailingSvcOutput, backendLeaf, failingLeaf); err != nil {
 						return err
 					}
 					return nil

--- a/test/integration/trafficsplit/trafficsplit_test.go
+++ b/test/integration/trafficsplit/trafficsplit_test.go
@@ -13,7 +13,11 @@ import (
 
 var TestHelper *testutil.TestHelper
 
-const zeroRPS = "0.0rps"
+const (
+	zeroRPS          = "0.0rps"
+	backendSvc       = "backend-svc"
+	backendAuthority = "backend-svc.default.svc.cluster.local"
+)
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
@@ -243,8 +247,8 @@ func TestTrafficSplitCli(t *testing.T) {
 					failingLeaf := "failing-svc"
 
 					if version == "sp" {
-						name = "backend-svc.default.svc.cluster.local"
-						apex = "backend-svc.default.svc.cluster.local"
+						name = backendAuthority
+						apex = backendAuthority
 						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
 						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
 					}
@@ -313,12 +317,12 @@ func TestTrafficSplitCli(t *testing.T) {
 					}
 
 					name := "backend-traffic-split"
-					apex := "backend-svc"
-					backendLeaf := "backend-svc"
+					apex := backendSvc
+					backendLeaf := backendSvc
 					failingLeaf := "failing-svc"
 					if version == "sp" {
-						name = "backend-svc.default.svc.cluster.local"
-						apex = "backend-svc.default.svc.cluster.local"
+						name = backendAuthority
+						apex = backendAuthority
 						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
 						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
 					}

--- a/test/integration/trafficsplit/trafficsplit_test.go
+++ b/test/integration/trafficsplit/trafficsplit_test.go
@@ -16,7 +16,8 @@ var TestHelper *testutil.TestHelper
 const (
 	zeroRPS          = "0.0rps"
 	backendSvc       = "backend-svc"
-	backendAuthority = "backend-svc.default.svc.cluster.local"
+	failingSvc       = "failing-svc"
+	backendAuthority = "backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local"
 )
 
 func TestMain(m *testing.M) {
@@ -71,39 +72,6 @@ func parseStatTsRow(out string, expectedRowCount, expectedColumnCount int) (map[
 	return statRows, nil
 }
 
-func parseStatRows(out string, expectedRowCount, expectedColumnCount int) ([]*testutil.RowStat, error) {
-	rows, err := testutil.CheckRowCount(out, expectedRowCount)
-	if err != nil {
-		return nil, err
-	}
-
-	var statRows []*testutil.RowStat
-
-	for _, row := range rows {
-		fields := strings.Fields(row)
-
-		if len(fields) != expectedColumnCount {
-			return nil, fmt.Errorf(
-				"Expected [%d] columns in stat output, got [%d]; full output:\n%s",
-				expectedColumnCount, len(fields), row)
-		}
-
-		row := &testutil.RowStat{
-			Name:               fields[0],
-			Meshed:             fields[1],
-			Success:            fields[2],
-			Rps:                fields[3],
-			P50Latency:         fields[4],
-			P95Latency:         fields[5],
-			P99Latency:         fields[6],
-			TCPOpenConnections: fields[7],
-		}
-
-		statRows = append(statRows, row)
-
-	}
-	return statRows, nil
-}
 func statTrafficSplit(from string, ns string) (map[string]*statTsRow, error) {
 	cmd := []string{"viz", "stat", "ts", "--from", from, "--namespace", ns, "-t", "30s", "--unmeshed"}
 	out, err := TestHelper.LinkerdRun(cmd...)
@@ -242,15 +210,13 @@ func TestTrafficSplitCli(t *testing.T) {
 					}
 
 					name := "backend-traffic-split"
-					apex := "backend-svc"
-					backendLeaf := "backend-svc"
-					failingLeaf := "failing-svc"
+					apex := backendSvc
+					backendLeaf := backendSvc
+					failingLeaf := failingSvc
 
 					if version == "sp" {
 						name = backendAuthority
 						apex = backendAuthority
-						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
-						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
 					}
 
 					expectedBackendSvcOutput := &statTsRow{
@@ -319,12 +285,10 @@ func TestTrafficSplitCli(t *testing.T) {
 					name := "backend-traffic-split"
 					apex := backendSvc
 					backendLeaf := backendSvc
-					failingLeaf := "failing-svc"
+					failingLeaf := failingSvc
 					if version == "sp" {
 						name = backendAuthority
 						apex = backendAuthority
-						backendLeaf = "backend-svc.default.svc.cluster.local.:8080"
-						failingLeaf = "failing-svc.default.svc.cluster.local.:8080"
 					}
 
 					expectedBackendSvcOutput := &statTsRow{
@@ -356,197 +320,4 @@ func TestTrafficSplitCli(t *testing.T) {
 			})
 		})
 	}
-}
-
-func TestTrafficSplitCliWithSP(t *testing.T) {
-
-	version := "sp"
-	ctx := context.Background()
-	TestHelper.WithDataPlaneNamespace(ctx, fmt.Sprintf("trafficsplit-test-%s", version), map[string]string{}, t, func(t *testing.T, prefixedNs string) {
-		out, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/applications-at-diff-ports.yaml")
-		if err != nil {
-			testutil.AnnotatedFatal(t, "'linkerd inject' command failed", err)
-		}
-
-		out, err = TestHelper.KubectlApply(out, prefixedNs)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
-				"'kubectl apply' command failed\n%s", out)
-		}
-
-		TsResourceFile := fmt.Sprintf("testdata/%s/traffic-split-leaf-weights.yaml", version)
-		TsResource, err := testutil.ReadFile(TsResourceFile)
-
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "cannot read updated traffic split resource",
-				"cannot read updated traffic split resource: %s, %s", TsResource, err)
-		}
-
-		out, err = TestHelper.KubectlApply(TsResource, prefixedNs)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "failed to update traffic split resource",
-				"failed to update traffic split resource: %s\n %s", err, out)
-		}
-
-		// wait for deployments to start
-		for _, deploy := range []string{"backend", "failing", "slow-cooker"} {
-			if err := TestHelper.CheckPods(ctx, prefixedNs, deploy, 1); err != nil {
-				if rce, ok := err.(*testutil.RestartCountError); ok {
-					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
-				} else {
-					testutil.AnnotatedError(t, "CheckPods timed-out", err)
-				}
-			}
-		}
-
-		t.Run(fmt.Sprintf("ensure traffic is sent to one backend only for %s", version), func(t *testing.T) {
-			timeout := 40 * time.Second
-			err := TestHelper.RetryFor(timeout, func() error {
-				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "--namespace", prefixedNs, "--from", "deploy/slow-cooker", "-t", "30s")
-				if err != nil {
-					return err
-				}
-
-				rows, err := parseStatRows(out, 1, 8)
-				if err != nil {
-					return err
-				}
-
-				expectedRows := []*testutil.RowStat{
-					{
-						Name:               "backend",
-						Meshed:             "1/1",
-						Success:            "100.00%",
-						TCPOpenConnections: "1",
-					},
-				}
-
-				if err := validateRowStats(expectedRows, rows); err != nil {
-					return err
-				}
-				return nil
-			})
-
-			if err != nil {
-				testutil.AnnotatedFatal(t, fmt.Sprintf("timed-out ensuring traffic is sent to one backend only (%s)", timeout), err)
-			}
-		})
-
-		t.Run(fmt.Sprintf("update traffic split resource with equal weights for %s", version), func(t *testing.T) {
-
-			updatedTsResourceFile := fmt.Sprintf("testdata/%s/updated-traffic-split-leaf-weights.yaml", version)
-			updatedTsResource, err := testutil.ReadFile(updatedTsResourceFile)
-
-			if err != nil {
-				testutil.AnnotatedFatalf(t, "cannot read updated traffic split resource",
-					"cannot read updated traffic split resource: %s, %s", updatedTsResource, err)
-			}
-
-			out, err := TestHelper.KubectlApply(updatedTsResource, prefixedNs)
-			if err != nil {
-				testutil.AnnotatedFatalf(t, "failed to update traffic split resource",
-					"failed to update traffic split resource: %s\n %s", err, out)
-			}
-		})
-
-		t.Run(fmt.Sprintf("ensure traffic is sent to both backends for %s", version), func(t *testing.T) {
-			timeout := 40 * time.Second
-			err := TestHelper.RetryFor(timeout, func() error {
-
-				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "-n", prefixedNs, "--from", "deploy/slow-cooker", "-t", "30s")
-				if err != nil {
-					return err
-				}
-
-				rows, err := parseStatRows(out, 2, 8)
-				if err != nil {
-					return err
-				}
-
-				expectedRows := []*testutil.RowStat{
-					{
-						Name:               "backend",
-						Meshed:             "1/1",
-						Success:            "100.00%",
-						TCPOpenConnections: "1",
-					},
-					{
-						Name:               "failing",
-						Meshed:             "1/1",
-						Success:            "0.00%",
-						TCPOpenConnections: "1",
-					},
-				}
-
-				if err := validateRowStats(expectedRows, rows); err != nil {
-					return err
-				}
-				return nil
-			})
-
-			if err != nil {
-				testutil.AnnotatedFatal(t, fmt.Sprintf("timed-out ensuring traffic is sent to both backends (%s)", timeout), err)
-			}
-		})
-	})
-}
-
-func validateRowStats(expectedRowStats, actualRowStats []*testutil.RowStat) error {
-
-	if len(expectedRowStats) != len(actualRowStats) {
-		return fmt.Errorf("Expected number of rows to be %d, but found %d", len(expectedRowStats), len(actualRowStats))
-	}
-
-	for i := 0; i < len(expectedRowStats); i++ {
-		err := compareRowStat(expectedRowStats[i], actualRowStats[i])
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func compareRowStat(expectedRow, actualRow *testutil.RowStat) error {
-
-	if actualRow.Name != expectedRow.Name {
-		return fmt.Errorf("Expected name to be '%s', got '%s'",
-			expectedRow.Name, actualRow.Name)
-	}
-
-	if actualRow.Meshed != expectedRow.Meshed {
-		return fmt.Errorf("Expected meshed to be '%s', got '%s'",
-			expectedRow.Meshed, actualRow.Meshed)
-	}
-
-	if !strings.HasSuffix(actualRow.Rps, "rps") {
-		return fmt.Errorf("Unexpected rps for [%s], got [%s]",
-			actualRow.Name, actualRow.Rps)
-	}
-
-	if !strings.HasSuffix(actualRow.P50Latency, "ms") {
-		return fmt.Errorf("Unexpected p50 latency for [%s], got [%s]",
-			actualRow.Name, actualRow.P50Latency)
-	}
-
-	if !strings.HasSuffix(actualRow.P95Latency, "ms") {
-		return fmt.Errorf("Unexpected p95 latency for [%s], got [%s]",
-			actualRow.Name, actualRow.P95Latency)
-	}
-
-	if !strings.HasSuffix(actualRow.P99Latency, "ms") {
-		return fmt.Errorf("Unexpected p99 latency for [%s], got [%s]",
-			actualRow.Name, actualRow.P99Latency)
-	}
-
-	if actualRow.Success != expectedRow.Success {
-		return fmt.Errorf("Expected success to be '%s', got '%s'",
-			expectedRow.Success, actualRow.Success)
-	}
-
-	if actualRow.TCPOpenConnections != expectedRow.TCPOpenConnections {
-		return fmt.Errorf("Expected tcp to be '%s', got '%s'",
-			expectedRow.TCPOpenConnections, actualRow.TCPOpenConnections)
-	}
-
-	return nil
 }

--- a/viz/metrics-api/stat_summary.go
+++ b/viz/metrics-api/stat_summary.go
@@ -285,6 +285,9 @@ func (s *grpcServer) getTrafficSplits(req *pb.StatSummaryRequest) ([]*v1alpha1.T
 		ts, err = s.k8sAPI.TS().Lister().TrafficSplits(res.GetNamespace()).Get(res.GetName())
 		trafficSplits = []*v1alpha1.TrafficSplit{ts}
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	var serviceProfiles []*v1alpha2.ServiceProfile
 	if res.GetNamespace() == "" {
@@ -295,6 +298,9 @@ func (s *grpcServer) getTrafficSplits(req *pb.StatSummaryRequest) ([]*v1alpha1.T
 		var sp *v1alpha2.ServiceProfile
 		sp, err = s.k8sAPI.SP().Lister().ServiceProfiles(res.GetNamespace()).Get(res.GetName())
 		serviceProfiles = []*v1alpha2.ServiceProfile{sp}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	for _, sp := range serviceProfiles {


### PR DESCRIPTION
Currently, TrafficSplits done through `ServiceProfiles` do not
appear in the UI anywhere as they specifically search for
TrafficSplit resources and ignore ServiceProfiles.

This PR adds `ServiceProfiles` into the stat_summary logic
while keeping most of the logic same but converting
SPs into TSs and making it work.


## Working

Traffic Split metrics can be viewed as follows, even if they
are created with service profiles with dstOverrides.

### Apply Traffic Splitting through `ServiceProfiles`

```bash
on ⛵ kind-kind  linkerd2 on 🌱 taru [📦++1🤷‍] via 🐼 v1.16.5 took 1m11s 
➜ k create ns linkerd-trafficsplit-test-sp                                                                                                                                ~/work/linkerd2
namespace/linkerd-trafficsplit-test-sp created

on ⛵ kind-kind  linkerd2 on 🌱 taru [📦++1🤷‍] via 🐼 v1.16.5 
➜ ./bin/linkerd inject ./test/integration/trafficsplit/testdata/application.yaml | k -n linkerd-trafficsplit-test-sp apply -f -                                           ~/work/linkerd2

document missing "kind" field, skipped
deployment "backend" injected
service "backend-svc" skipped
deployment "failing" injected
service "failing-svc" skipped
deployment "slow-cooker" injected
service "slow-cooker" skipped

deployment.apps/backend created
service/backend-svc created
deployment.apps/failing created
service/failing-svc created
deployment.apps/slow-cooker created
service/slow-cooker created

on ⛵ kind-kind  linkerd2 on 🌱 taru [📦++1🤷‍] via 🐼 v1.16.5 
➜ k apply -f ./test/integration/trafficsplit/testdata/sp/updated-traffic-split-leaf-weights.yaml -n linkerd-trafficsplit-test-sp                                          ~/work/linkerd2
serviceprofile.linkerd.io/backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local created

on ⛵ kind-kind  linkerd2 on 🌱 taru [📦++1🤷‍] via 🐼 v1.16.5 
➜ k describe sp -n linkerd-trafficsplit-test-sp                                                                                                                           ~/work/linkerd2
Name:         backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
Namespace:    linkerd-trafficsplit-test-sp
Labels:       <none>
Annotations:  <none>
API Version:  linkerd.io/v1alpha2
Kind:         ServiceProfile
Metadata:
  Creation Timestamp:  2021-07-01T11:05:06Z
  Generation:          1
  Managed Fields:
    API Version:  linkerd.io/v1alpha2
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
      f:spec:
        .:
        f:dstOverrides:
    Manager:         kubectl-client-side-apply
    Operation:       Update
    Time:            2021-07-01T11:05:06Z
  Resource Version:  1398
  UID:               fce0a250-1396-4a14-9729-e19030048c7a
Spec:
  Dst Overrides:
    Authority:  backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
    Weight:     500m
    Authority:  failing-svc.linkerd-trafficsplit-test-sp.svc.cluster.local:8081
    Weight:     500m
Events:         <none>
```


### CLI

```bash
on ⛵ kind-kind  linkerd2 on 🌱 taru [📦++1🤷‍] via 🐼 v1.16.5 
➜ ./bin/linkerd viz stat ts -n linkerd-trafficsplit-test-sp --from deploy/slow-cooker              ~/work/linkerd2 NAME                                                         APEX                                                         LEAF          WEIGHT   SUCCESS      RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local   backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local   backend-svc     500m   100.00%   0.1rps           1ms           2ms           2ms
backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local   backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local   failing-svc     500m     0.00%   0.2rps           1ms           2ms           2ms
```

### Dashboard

In the TrafficSplit tab

![image](https://user-images.githubusercontent.com/7892868/124114769-97ad6f80-da8a-11eb-95e3-f6bf8a6897f6.png)


(The traffic split links here are broken, as they are authortities here but the dashboard expects a service name.This will be fixed in this or a future PR )


Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
