### PR TITLE
Remove controller port-forward in web dev script

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -27,14 +27,8 @@ USAGE
 }; function --help { '-h' ;}
 
 check-for-linkerd-and-viz() {
-  controller_pod=$(get-pod linkerd controller)
   metrics_api_pod=$(get-pod linkerd-viz metrics-api)
   grafana_pod=$(get-pod linkerd-viz grafana)
-
-  if [[ -z "${controller_pod// }" ]]; then
-    err 'Controller is not running. Have you installed Linkerd?'
-    exit 1
-  fi
 
   if [[ -z "${metrics_api_pod// }" ]]; then
     err 'Metrics-api is not running. Have you installed Linkerd-Viz?'
@@ -111,7 +105,6 @@ run() {
   build
 
   check-for-linkerd-and-viz && (
-    port-forward linkerd controller 8185 8085 &
     port-forward linkerd-viz metrics-api 8085 &
     port-forward linkerd-viz grafana 3000 &
   )


### PR DESCRIPTION
Now that we no longer have a `controller` pod after #6039, there is no
need to port-forward the controller pod in the bin/web script. This
change removes the code that does that.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>
