### PR TITLE
edge-21.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ expiry date, and a hash of the certificate. Additionally, this release fixes an
 issue with the clusterNetworks healthcheck.
 
 * Updated the identity controller to emit Kubernetes events when successfully
-  issuing leaf certificates to injected pods 
+  issuing leaf certificates to injected pods.
 * Fixed an issue in `linkerd check` where the clusterNetworks healthcheck
   would fail if the `podCIDR` field is omitted from a node's spec.
 * Removed unnecessary controller port-forward logic from the `bin/web` script.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Changes
 
+## edge-21.7.1
+
+This edge release adds support for emitting Kubernetes events in the identity
+controller when issuing leaf certificates. The event includes the identity,
+expiry date, and a hash of the certificate. Additionally, this release fixes an
+issue with the clusterNetworks healthcheck.
+
+* Updated the identity controller to emit Kubernetes events when successfully
+  issuing leaf certificates to injected pods 
+* Fixed an issue in `linkerd check` where the clusterNetworks healthcheck
+  would fail if the `podCIDR` field is omitted from a node's spec.
+* Removed unnecessary controller port-forward logic from the `bin/web` script.
+
 ## edge-21.6.5
 
 This release contains a few improvements, from many contributors!  Also under

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,9 @@
 
 This edge release adds support for emitting Kubernetes events in the identity
 controller when issuing leaf certificates. The event includes the identity,
-expiry date, and a hash of the certificate. Additionally, this release fixes an
-issue with the clusterNetworks healthcheck.
+expiry date, and a hash of the certificate. Additionally, this release contains
+many dependency updates for the control plane's components, and it includes a
+fix for an issue with the clusterNetworks healthcheck.
 
 * Updated the identity controller to emit Kubernetes events when successfully
   issuing leaf certificates to injected pods.


### PR DESCRIPTION
This edge release adds support for emitting Kubernetes events in the identity
controller when issuing leaf certificates. The event includes the identity,
expiry date, and a hash of the certificate. Additionally, this release fixes an
issue with the clusterNetworks healthcheck.

* Updated the identity controller to emit Kubernetes events when successfully
  issuing leaf certificates to injected pods
* Fixed an issue in `linkerd check` where the clusterNetworks healthcheck
  would fail if the `podCIDR` field is omitted from a node's spec.
* Removed unnecessary controller port-forward logic from the `bin/web` script.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
