### PR TITLE
Remove mention of `controller` in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -371,8 +371,6 @@ To develop with a webpack dev server:
     - `web` on :7777. This is the golang process that serves the dashboard.
     - `webpack-dev-server` on :8080 to manage rebuilding/reloading of the
       javascript.
-    - `controller` is port-forwarded from the Kubernetes cluster via `kubectl`
-      on :8185
     - `grafana` is port-forwarded from the Kubernetes cluster via `kubectl` on
       :3000
     - `metrics-api` is port-forwarded from the Kubernetes cluster via `kubectl`


### PR DESCRIPTION
Followup to #6396 which removed the port-forward for the no-longer
existing `controller` pod. This change just removes a mention to it from
the BUILD.md developer docs.
