### PR TITLE
Skip printing usage if the command syntax is correct

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -172,7 +172,8 @@ func configureAndRunChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, s
 		}
 		installManifest, err = renderInstallManifest(cmd.Context())
 		if err != nil {
-			return fmt.Errorf("Error rendering install manifest: %v", err)
+			fmt.Fprint(os.Stderr, fmt.Errorf("Error rendering install manifest: %v", err))
+			os.Exit(1)
 		}
 	} else {
 		checks = append(checks, healthcheck.LinkerdConfigChecks)


### PR DESCRIPTION
If kubernetes system is not up, we were displaying usage after the error, masking the actual issue in the logs.

I agree to the DCO for all the commits in this PR

Subject
Skip printing usage if the command syntax is correct

Problem
Extraneous usage details mask the actual error
 
Solution
Avoid displaying command usage if the syntax was correct

Validation
Re-run after the fix

Fixes #6422

DCO Sign off
Signed-off-by: Dileep Reddem <dileepreddyr@gmail.com>