### PR TITLE
Replace buildx actions in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
         path: ${{ env.DOCKER_BUILDKIT_CACHE }}
         key: ${{ runner.os }}-buildx-${{ matrix.target }}-${{ env.TAG }}
         restore-keys: ${{ runner.os }}-buildx-${{ matrix.target }}-
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@126d331dc69f4a1aa02452e374835e6a5d565613
+      uses: docker/setup-buildx-action@e673438944759779e411a0f7ceef3ba437dccfa0
     - name: Build & Push Multi Arch Images
       env:
-        #DOCKER_TRACE: 1
         DOCKER_MULTIARCH: 1
         DOCKER_PUSH: 1
       run: |


### PR DESCRIPTION
Replaced the deprecated `crazy-max/ghaction-docker-buildx` github action
which was generating some warnings in the `release.yml` workflow, with
`docker/setup-qemu-action` and `docker/setup-buildx-action`, as per
instructions in https://github.com/crazy-max/ghaction-docker-buildx .
Tested fine in a fork :+1: