### PR TITLE
Add missing ignoreInboundports to CNI config

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -37,6 +37,8 @@ Kubernetes: `>=1.16.0-0`
 | outboundProxyPort | int | `4140` | Outbound port for the proxy container |
 | portsToRedirect | string | `""` | Ports to redirect to proxy |
 | priorityClassName | string | `""` | Kubernetes priorityClassName for the CNI plugin's Pods |
+| proxyAdminPort | int | `4191` | Admin port for the proxy container |
+| proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -148,11 +148,8 @@ data:
         "outgoing-proxy-port": {{.Values.outboundProxyPort}},
         "proxy-uid": {{.Values.proxyUID}},
         "ports-to-redirect": [{{.Values.portsToRedirect}}],
-        {{- if .Values.ignoreInboundPorts }}
-        "inbound-ports-to-ignore": [
-          {{- include "partials.splitStringList" .Values.ignoreInboundPorts -}}
-        ],
-        {{- end }}
+        "inbound-ports-to-ignore": ["{{- .Values.proxyAdminPort }}","{{ .Values.proxyControlPort }}"
+        {{- if .Values.ignoreInboundPorts }},{{- include "partials.splitStringList" .Values.ignoreInboundPorts -}}{{- end }}],
         {{- if .Values.ignoreOutboundPorts }}
         "outbound-ports-to-ignore": [
           {{- include "partials.splitStringList" .Values.ignoreOutboundPorts -}}

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -10,6 +10,10 @@ outboundProxyPort: 4140
 ignoreInboundPorts: ""
 # -- Default set of outbound ports to skip via iptables
 ignoreOutboundPorts: ""
+# -- Admin port for the proxy container
+proxyAdminPort: 4191
+# -- Control port for the proxy container
+proxyControlPort: 4190
 # -- Docker image for the CNI plugin
 cniPluginImage:   "cr.l5d.io/linkerd/cni-plugin"
 # -- Tag for the CNI container Docker image

--- a/charts/partials/templates/_helpers.tpl
+++ b/charts/partials/templates/_helpers.tpl
@@ -4,12 +4,11 @@ Splits a coma separated list into a list of string values.
 For example "11,22,55,44" will become "11","22","55","44"
 */}}
 {{- define "partials.splitStringList" -}}
-{{- if gt (len .) 0 -}}
-{{- $ports := splitList "," . -}}
+{{- if gt (len (toString .)) 0 -}}
+{{- $ports := toString . | splitList "," -}}
 {{- $last := sub (len $ports) 1 -}}
 {{- range $i,$port := $ports -}}
 "{{$port}}"{{ternary "," "" (ne $i $last)}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
-

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -160,13 +160,6 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 		return nil, err
 	}
 
-	ignoreInboundPorts := []string{
-		fmt.Sprintf("%d", options.proxyControlPort),
-		fmt.Sprintf("%d", options.proxyAdminPort),
-	}
-
-	ignoreInboundPorts = append(ignoreInboundPorts, options.ignoreInboundPorts...)
-
 	portsToRedirect := []string{}
 	for _, p := range options.portsToRedirect {
 		portsToRedirect = append(portsToRedirect, fmt.Sprintf("%d", p))
@@ -177,7 +170,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.LogLevel = options.logLevel
 	installValues.InboundProxyPort = options.inboundPort
 	installValues.OutboundProxyPort = options.outboundPort
-	installValues.IgnoreInboundPorts = strings.Join(ignoreInboundPorts, ",")
+	installValues.IgnoreInboundPorts = strings.Join(options.ignoreInboundPorts, ",")
 	installValues.IgnoreOutboundPorts = strings.Join(options.ignoreOutboundPorts, ",")
 	installValues.PortsToRedirect = strings.Join(portsToRedirect, ",")
 	installValues.ProxyUID = options.proxyUID

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -123,7 +123,7 @@ data:
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
         "ports-to-redirect": [],
-        "inbound-ports-to-ignore": ["4190","4191"],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": false
       }

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -123,7 +123,7 @@ data:
         "outgoing-proxy-port": 5140,
         "proxy-uid": 12102,
         "ports-to-redirect": [],
-        "inbound-ports-to-ignore": ["5190","5191"],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": false
       }

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -123,7 +123,7 @@ data:
         "outgoing-proxy-port": 5140,
         "proxy-uid": 12102,
         "ports-to-redirect": [],
-        "inbound-ports-to-ignore": ["5190","5191"],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": false
       }

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -113,7 +113,7 @@ data:
         "outgoing-proxy-port": 5140,
         "proxy-uid": 12102,
         "ports-to-redirect": [],
-        "inbound-ports-to-ignore": ["5190","5191"],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": false
       }

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -123,7 +123,7 @@ data:
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
         "ports-to-redirect": [],
-        "inbound-ports-to-ignore": ["4190","4191","80","8080"],
+        "inbound-ports-to-ignore": ["4191","4190","80","8080"],
         "outbound-ports-to-ignore": ["443","1000"],
         "simulate": false,
         "use-wait-flag": false

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -125,6 +125,7 @@ data:
         "outgoing-proxy-port": 4140,
         "proxy-uid": 2102,
         "ports-to-redirect": [],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": false
       }

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -125,6 +125,7 @@ data:
         "outgoing-proxy-port": 5678,
         "proxy-uid": 1111,
         "ports-to-redirect": [],
+        "inbound-ports-to-ignore": ["4191","4190"],
         "simulate": false,
         "use-wait-flag": true
       }

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -33,6 +33,8 @@ type Values struct {
 	UseWaitFlag         bool   `json:"useWaitFlag"`
 	PriorityClassName   string `json:"priorityClassName"`
 	InstallNamespace    bool   `json:"installNamespace"`
+	ProxyAdminPort      string `json:"proxyAdminPort"`
+	ProxyControlPort    string `json:"proxyControlPort"`
 }
 
 // NewValues returns a new instance of the Values type.


### PR DESCRIPTION
This change fixes an issue where tap does not work when running Linkerd
through Linkerd CNI installed via helm charts. This issue was caused by
the CNI charts config not including tap control and admin ports in the
config. This caused tap request traffic to go to the inbound side of the
porxy as opposed to its respective control port.

Fixes #6224

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>