### PR TITLE
Use the default distroless image

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -1,4 +1,4 @@
-ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies


### PR DESCRIPTION
linkerd/linkerd2#6392 reports that `distroless/cc:nonroot` image can be
troublesome. This change drops the `nonroot` variant, as the proxy is
already configured to run as a non-root user in practice.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
