### PR TITLE
Add parent obj validation for ReplicaSets

### DIFF
--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -503,7 +503,7 @@ func (api *API) GetOwnerKindAndName(ctx context.Context, pod *corev1.Pod, retry 
 			}
 		}
 
-		if ok := isValidRSParent(rsObj); !ok {
+		if isValidRSParent(rsObj) {
 			return strings.ToLower(parent.Kind), parent.Name
 		}
 		parentObj = rsObj

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -503,7 +503,7 @@ func (api *API) GetOwnerKindAndName(ctx context.Context, pod *corev1.Pod, retry 
 			}
 		}
 
-		if isValidRSParent(rsObj) {
+		if !isValidRSParent(rsObj) {
 			return strings.ToLower(parent.Kind), parent.Name
 		}
 		parentObj = rsObj

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -1113,11 +1113,9 @@ func isValidRSParent(rs *appsv1.ReplicaSet) bool {
 
 	validParentKinds := []string{
 		k8s.Job,
-		k8s.ReplicationController,
 		k8s.StatefulSet,
 		k8s.DaemonSet,
 		k8s.Deployment,
-		k8s.CronJob,
 	}
 
 	rsOwner := rs.GetOwnerReferences()[0]

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -1060,6 +1060,31 @@ metadata:
     name: my-cronjob`,
 			},
 		},
+		{
+			expectedOwnerKind: "replicaset",
+			expectedOwnerName: "invalid-rs-parent-2abdffa",
+			podConfig: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid-rs-parent-dcfq4
+  namespace: default
+  ownerReferences:
+  - apiVersion: v1
+    kind: ReplicaSet
+    name: invalid-rs-parent-2abdffa`,
+			extraConfigs: []string{`
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: invalid-rs-parent-2abdffa
+  namespace: default
+  ownerReferences:
+  - apiVersion: invalidParent/v1
+    kind: InvalidParentKind
+    name: invalid-parent`,
+			},
+		},
 	} {
 		tt := tt // pin
 		for _, retry := range []bool{


### PR DESCRIPTION
The problem is for parent objects that are not supported in Linkerd, we
cannot get any metrics. For example, using a Rollout will not report any
metrics higher than a pod level.

To fix, add validation for ReplicaSet owners; if it's a valid parent,
use parent Kind and Name, otherwise use ReplicaSet.

Tested using CLI/UI

Interim solution for #6429 

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
