### PR TITLE
Check cert provided by external issuers is CA

### DIFF
--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -125,6 +125,10 @@ func (svc *Service) loadCredentials() (tls.Issuer, error) {
 		return nil, fmt.Errorf("failed to verify issuer credentials for '%s' with trust anchors: %s", svc.expectedName, err)
 	}
 
+	if !creds.Certificate.IsCA {
+		return nil, fmt.Errorf("failed to verify issuer certificate: it must be an intermediate-CA, but it is not")
+	}
+
 	log.Debugf("Loaded issuer cert: %s", creds.EncodeCertificatePEM())
 	return tls.NewCA(*creds, *svc.validity), nil
 }


### PR DESCRIPTION
When the issuer certificate is dynamically loaded in indentity service, we should validate that proposed certificate is indeed an intermediate certification authority.

Signed-off-by: Alexey Kostin <rumanzo@yandex.ru>

Tested via helm setup on problem configuration described [here](https://github.com/linkerd/linkerd2/issues/6428)

Fixes #6453

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
