### PR TITLE
Enable readOnlyFileSystem for cni plugin chart

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -49,6 +49,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -246,6 +247,10 @@ spec:
         - mountPath: /host{{.Values.destCNINetDir}}
           name: cni-net-dir
         {{- end }}
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       {{- if ne .Values.destCNIBinDir .Values.destCNINetDir }}
       - name: cni-bin-dir
@@ -259,3 +264,5 @@ spec:
         hostPath:
           path: {{.Values.destCNINetDir}}
       {{- end }}
+      - name: linkerd-tmp-dir
+        emptyDir: {}

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -28,6 +28,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -197,6 +198,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -204,4 +209,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -28,6 +28,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -198,6 +199,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/kubernetes/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -205,4 +210,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/kubernetes/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -28,6 +28,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -196,8 +197,14 @@ spec:
         volumeMounts:
         - mountPath: /host/etc/kubernetes/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-net-dir
         hostPath:
           path: /etc/kubernetes/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -18,6 +18,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -188,6 +189,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/kubernetes/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -195,4 +200,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/kubernetes/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}
 ---

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -28,6 +28,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -198,6 +199,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -205,4 +210,6 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}
 ---

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -30,6 +30,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -198,6 +199,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -205,3 +210,5 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
+      - name: linkerd-tmp-dir
+        emptyDir: {}

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -30,6 +30,7 @@ spec:
   volumes:
   - hostPath
   - secret
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -199,6 +200,10 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d-test
           name: cni-net-dir
+        - mountPath: /tmp
+          name: linkerd-tmp-dir
+        securityContext:
+          readOnlyRootFilesystem: true
       volumes:
       - name: cni-bin-dir
         hostPath:
@@ -206,3 +211,5 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d-test
+      - name: linkerd-tmp-dir
+        emptyDir: {}

--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -100,7 +100,7 @@ done
 
 echo "Wrote linkerd CNI binaries to ${dir}"
 
-TMP_CONF='/linkerd/linkerd-cni.conf.default'
+TMP_CONF='/tmp/linkerd-cni.conf.default'
 # If specified, overwrite the network configuration file.
 : "${CNI_NETWORK_CONFIG_FILE:=}"
 : "${CNI_NETWORK_CONFIG:=}"


### PR DESCRIPTION
Increase container security by making the root file system of the cni
install plugin read-only.

Change the temporary directory used in the cni install script, add a
writable EmptyDir volume and enable readOnlyFileSystem securityContext
in cni plugin helm chart.

Tested this by building the container image of the cni plugin and
installed the chart onto a cluster. Logs looked the same as before this
change.

Fixes #6468
