### PR TITLE
Add lock-threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,19 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-lock-inactive-days: '14'
+          pr-lock-inactive-days: '14'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   action:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,5 +15,4 @@ jobs:
       - uses: dessant/lock-threads@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-lock-inactive-days: '14'
-          pr-lock-inactive-days: '14'
+          issue-lock-inactive-days: '30'

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 * * * *'
 
 permissions:
   issues: write
@@ -12,7 +12,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@1621939cecf8586399a6b60d2a7af9469232b5b6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-lock-inactive-days: '30'
+          process-only: 'issues'


### PR DESCRIPTION
Fixes #6479 

Add the lock threads action to lock closed issues and PRs after 14 days of inactivity.  This action runs on a cron once per day to check for issues or PRs that should be locked.

Signed-off-by: Alex Leong <alex@buoyant.io>

