### PR TITLE
Upgrade Ingress resource used in tests

### DIFF
--- a/test/integration/tracing/testdata/ingress.yaml
+++ b/test/integration/tracing/testdata/ingress.yaml
@@ -71,21 +71,25 @@ subjects:
   name: default
   namespace: ___INGRESS_NAMESPACE___
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-nginx
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:80;
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:
-      - backend:
-          serviceName: web-svc
-          servicePort: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 80
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Ingress version `extensions/v1beta1` will disappear in k8s 1.22, so
this upgrades it to `networking.k8s.io/v1` alongside with other required
Ingress changes, used in the tracing integration test.

The other disappearing APIs in k8s 1.22 (MutatingWebhookConfig, etc)
have already been taken care of.