### PR TITLE
Upon rollout timeouts in integration tests, show events

### DIFF
--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -326,9 +326,10 @@ func (h *KubernetesHelper) WaitRollout(t *testing.T, deploys map[string]DeploySp
 	for deploy, deploySpec := range deploys {
 		o, err := h.Kubectl("", "--namespace="+deploySpec.Namespace, "rollout", "status", "--timeout=60m", "deploy/"+deploy)
 		if err != nil {
+			oEvt, _ := h.Kubectl("", "--namespace="+deploySpec.Namespace, "get", "event", "--field-selector", "involvedObject.name="+deploy)
 			AnnotatedFatalf(t,
 				fmt.Sprintf("failed to wait rollout of deploy/%s", deploy),
-				"failed to wait for rollout of deploy/%s: %s: %s", deploy, err, o)
+				"failed to wait for rollout of deploy/%s: %s: %s\nEvents:\n%s", deploy, err, o, oEvt)
 		}
 	}
 }


### PR DESCRIPTION
Sometimes deployments deadlines are reached in integrations tests when
waiting for rollouts, with no additional explanation.

E.g.
https://github.com/linkerd/linkerd2/runs/3123265801?check_suite_focus=true#step:8:161

This change outputs the events related to the deployment, for better
insight.