### PR TITLE
Add integration test for servers bound to localhost

### DIFF
--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -16,7 +16,7 @@ type jsonStats struct {
 	Name               string   `json:"name"`
 	Success            *float64 `json:"success"`
 	Rps                *float64 `json:"rps"`
-	TcpOpenConnections *int     `json:"tcp_open_connections"`
+	TCPOpenConnections *int     `json:"tcp_open_connections"`
 }
 
 var TestHelper *testutil.TestHelper
@@ -92,7 +92,7 @@ func TestLocalhostServer(t *testing.T) {
 			if *stats[0].Success != 1.0 {
 				return fmt.Errorf("expected perfect success-rate from slowcooker to nginx: %s", out)
 			}
-			if *stats[0].TcpOpenConnections == 0 {
+			if *stats[0].TCPOpenConnections == 0 {
 				return fmt.Errorf("expected tcp connection from slowcooker to nginx: %s", out)
 			}
 

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -1,0 +1,101 @@
+package localhost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/linkerd/linkerd2/testutil"
+)
+
+type jsonStats struct {
+	Namespace string   `json:"namespace"`
+	Name      string   `json:"name"`
+	Success   *float64 `json:"success"`
+	Rps       *float64 `json:"rps"`
+}
+
+var TestHelper *testutil.TestHelper
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	os.Exit(m.Run())
+}
+
+// TestLocalhostServer creates an nginx deployment which listens on localhost
+// and a slow-cooker which attempts to send traffic to the nginx.  Since
+// slow-cooker should not be able to connect to nginx's localhost address,
+// these requests should fail.
+func TestLocalhostServer(t *testing.T) {
+	ctx := context.Background()
+	nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
+	if err != nil {
+		testutil.AnnotatedFatal(t, "unexpected error", err)
+	}
+	slowcooker, err := TestHelper.LinkerdRun("inject", "testdata/slow-cooker.yaml")
+	if err != nil {
+		testutil.AnnotatedFatal(t, "unexpected error", err)
+	}
+
+	TestHelper.WithDataPlaneNamespace(ctx, "localhost-test", map[string]string{}, t, func(t *testing.T, ns string) {
+
+		out, err := TestHelper.KubectlApply(nginx, ns)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
+		}
+		out, err = TestHelper.KubectlApply(slowcooker, ns)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
+		}
+
+		for _, deploy := range []string{"nginx", "slow-cooker"} {
+			err = TestHelper.CheckPods(ctx, ns, deploy, 1)
+			if err != nil {
+				if rce, ok := err.(*testutil.RestartCountError); ok {
+					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+				} else {
+					testutil.AnnotatedError(t, "CheckPods timed-out", err)
+				}
+			}
+		}
+
+		err = TestHelper.RetryFor(20*time.Second, func() error {
+			// Use a short time window so that transient errors at startup
+			// fall out of the window.
+			out, err := TestHelper.LinkerdRun("viz", "stat", "-n", ns, "deploy/slow-cooker", "--to", "deploy/nginx", "-t", "30s", "-o", "json")
+			if err != nil {
+				testutil.AnnotatedFatalf(t, "unexpected stat error",
+					"unexpected stat error: %s\n%s", err, out)
+			}
+
+			var stats []jsonStats
+			err = json.Unmarshal([]byte(out), &stats)
+			if err != nil {
+				return fmt.Errorf("failed to parse json stat output: %s\n%s", err, out)
+			}
+
+			if len(stats) != 1 {
+				return fmt.Errorf("expected 1 row of stat output, got: %s", out)
+			}
+
+			if *stats[0].Rps == 0.0 {
+				return fmt.Errorf("expected non-zero RPS from slowcooker to nginx: %s", out)
+			}
+
+			// TODO: Update this test to expect these requests to fail once
+			// https://github.com/linkerd/linkerd2/issues/6495 is fixed.  Requests
+			// sent to a port which is only bound to localhost should fail.
+			if *stats[0].Success != 1.0 {
+				return fmt.Errorf("expected perfect success-rate from slowcooker to nginx: %s", out)
+			}
+
+			return nil
+		})
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "unexpected stat output", "unexpected stat output: %v", err)
+		}
+	})
+}

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 type jsonStats struct {
-	Namespace string   `json:"namespace"`
-	Name      string   `json:"name"`
-	Success   *float64 `json:"success"`
-	Rps       *float64 `json:"rps"`
+	Namespace          string   `json:"namespace"`
+	Name               string   `json:"name"`
+	Success            *float64 `json:"success"`
+	Rps                *float64 `json:"rps"`
+	TcpOpenConnections *int     `json:"tcp_open_connections"`
 }
 
 var TestHelper *testutil.TestHelper
@@ -90,6 +91,9 @@ func TestLocalhostServer(t *testing.T) {
 			// sent to a port which is only bound to localhost should fail.
 			if *stats[0].Success != 1.0 {
 				return fmt.Errorf("expected perfect success-rate from slowcooker to nginx: %s", out)
+			}
+			if *stats[0].TcpOpenConnections == 0 {
+				return fmt.Errorf("expected tcp connection from slowcooker to nginx: %s", out)
 			}
 
 			return nil

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -62,7 +62,7 @@ func TestLocalhostServer(t *testing.T) {
 			}
 		}
 
-		err = TestHelper.RetryFor(20*time.Second, func() error {
+		err = TestHelper.RetryFor(50*time.Second, func() error {
 			// Use a short time window so that transient errors at startup
 			// fall out of the window.
 			out, err := TestHelper.LinkerdRun("viz", "stat", "-n", ns, "deploy/slow-cooker", "--to", "deploy/nginx", "-t", "30s", "-o", "json")

--- a/test/integration/localhost/testdata/nginx.yaml
+++ b/test/integration/localhost/testdata/nginx.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+ nginx.conf: |-
+    events {}
+    http {
+        server {
+          listen 127.0.0.1:8080;
+            location / {
+                return 200;
+            }
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: service
+    port: 8080
+  selector:
+    app: nginx

--- a/test/integration/localhost/testdata/slow-cooker.yaml
+++ b/test/integration/localhost/testdata/slow-cooker.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slow-cooker
+  template:
+    metadata:
+      labels:
+        app: slow-cooker
+    spec:
+      containers:
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.3.0
+        command:
+        - "/bin/sh"
+        args:
+        - "-c"
+        - |
+          sleep 15 # wait for pods to start
+          /slow_cooker/slow_cooker -metric-addr 0.0.0.0:9999 http://nginx:8080
+        ports:
+        - containerPort: 9999


### PR DESCRIPTION
TestLocalhostServer creates an nginx deployment which listens on localhost
and a slow-cooker which attempts to send traffic to the nginx.  Since
slow-cooker should not be able to connect to nginx's localhost address,
these requests should fail.

This test currently asserts that these requests should succeed.  Once https://github.com/linkerd/linkerd2/issues/6495 is fixed, this test should be updated to assert that these requests should fail.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
