### PR TITLE
Set `webhookFailurePolicy` as `Ignore` in HA

### DIFF
--- a/charts/linkerd2/values-ha.yaml
+++ b/charts/linkerd2/values-ha.yaml
@@ -36,7 +36,7 @@ heartbeatResources: *controller_resources
 
 # proxy injector configuration
 proxyInjectorResources: *controller_resources
-webhookFailurePolicy: Fail
+webhookFailurePolicy: Ignore
 
 # service profile validator configuration
 spValidatorResources: *controller_resources


### PR DESCRIPTION
`webhookFailurePolicy` is set to `Fail` in the Helm charts of the HA mode, this causes a full failure  (sometimes a partial failure in the proxy injector) of  Linkerd2 deployment with Helm.

So doing the following steps manually fixed the issue in the cluster:
```bash
kubectl edit mutatingwebhookconfigurations linkerd-proxy-injector-webhook-config # and changed the failurePolicy to Ignore instead of Fail
kubectl rollout restart -n linkerd deploy/linkerd-proxy-injector
```
This value is already set by default as `Ignore` in the "normal" mode, also in the Helm Chart documentation it is mentioned that the default value is `Ignore` however this was `Fail` in the `values-ha.yaml` and that made some confusing and made it harder to debug the failed deployments.

Fixes #6530 

Signed-off-by: Aymen Segni <segniaymen1@gmail.com>