### PR TITLE
changelog for edge-21.7.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## edge-21.7.4
 
-This release continues to focus on dependency updates. It also adds proxy a
-change that add a new `l5d-proxy-error` information header to distinguish
+This release continues to focus on dependency updates. It also adds the
+`l5d-proxy-error` information header to distinguish proxy generated errors
 proxy generated errors from application generated errors.
 
 * Updated several project dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Changes
 
+## edge-21.7.4
+
+This release continues to focus on dependency updates. It also adds proxy a
+change that add a new `l5d-proxy-error` information header to distinguish
+proxy generated errors from application generated errors.
+
+* Updated several project dependencies
+* Added a new `l5d-proxy-error` on responses that allows proxy-generated error
+  responses to be distinguished from application-generated error responses.
+* Removed support for configuring HTTP/2 keepalives via the proxy.
+  Configuring this setting would sometimes cause conflicts with Go gRPC servers
+  and clients
+* Added a new `target_addr` label to `*_tcp_accept_errors` metrics to improve
+  diagnostics, especially for TLS detection timeouts
+
 ## edge-21.7.3
 
 This edge release introduces several changes around metrics. ReplicaSets are now


### PR DESCRIPTION
This release continues to focus on dependency updates. It also adds proxy a
change that add a new `l5d-proxy-error` information header to distinguish
proxy generated errors from application generated errors. It also adds
support for proxies in gateway mode to now have `endpoints` as gateway targets.

* Updated several project dependencies
* Added support for gateway proxies to use `endpoint` targets in addition to
  using logical services
* Added a new `l5d-proxy-error` on responses that allows proxy-generated error
  responses to be distinguished from application-generated error responses.
* Removed support for configuring `HTTP/2` keepalives via the proxy.
  Configuring this setting would sometimes cause conflicts with Go gRPC servers
  and clients
* Added a new `target_addr` label to `*_tcp_accept_errors` metrics to improve
  diagnostics, especially for TLS detection timeouts

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>