### PR TITLE
Fix multicluster StatefulSet test

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -460,6 +460,10 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceCreated(ctx context.
 	serviceInfo := fmt.Sprintf("%s/%s", remoteService.Namespace, remoteService.Name)
 	localServiceName := rcsw.mirroredResourceName(remoteService.Name)
 
+	if rcsw.headlessServicesEnabled && remoteService.Spec.ClusterIP == corev1.ClusterIPNone {
+		return nil
+	}
+
 	if err := rcsw.mirrorNamespaceIfNecessary(ctx, remoteService.Namespace); err != nil {
 		return err
 	}
@@ -474,10 +478,6 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceCreated(ctx context.
 		Spec: corev1.ServiceSpec{
 			Ports: remapRemoteServicePorts(remoteService.Spec.Ports),
 		},
-	}
-
-	if rcsw.headlessServicesEnabled && remoteService.Spec.ClusterIP == corev1.ClusterIPNone {
-		return nil
 	}
 
 	rcsw.log.Infof("Creating a new service mirror for %s", serviceInfo)
@@ -1080,6 +1080,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateHeadlessEndpoints(ctx con
 			}
 		}
 	}
+
 	if len(errors) > 0 {
 		return RetryableError{errors}
 	}

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -457,12 +457,12 @@ func remapRemoteServicePorts(ports []corev1.ServicePort) []corev1.ServicePort {
 
 func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceCreated(ctx context.Context, ev *RemoteServiceCreated) error {
 	remoteService := ev.service.DeepCopy()
-	serviceInfo := fmt.Sprintf("%s/%s", remoteService.Namespace, remoteService.Name)
-	localServiceName := rcsw.mirroredResourceName(remoteService.Name)
-
 	if rcsw.headlessServicesEnabled && remoteService.Spec.ClusterIP == corev1.ClusterIPNone {
 		return nil
 	}
+
+	serviceInfo := fmt.Sprintf("%s/%s", remoteService.Namespace, remoteService.Name)
+	localServiceName := rcsw.mirroredResourceName(remoteService.Name)
 
 	if err := rcsw.mirrorNamespaceIfNecessary(ctx, remoteService.Namespace); err != nil {
 		return err


### PR DESCRIPTION
The multicluster StatefulSet test seemed to be a bit flakey. In the actual PR, the check passed, but as soon as it was merged it failed. I had a quick look and noticed that the flakiness in the test came from the logic that mirrors a namespace. Specifically, when we have a headless service, we create it and mirror its namespace here: https://github.com/linkerd/linkerd2/blob/main/multicluster/service-mirror/cluster_watcher.go#L1120

But, every time we process a new service, we do the same thing:
https://github.com/linkerd/linkerd2/blob/main/multicluster/service-mirror/cluster_watcher.go#L463

The tests were failing when a headless service was being created with the following error:
```
time="2021-07-29T20:58:03Z" level=info msg="Err Inner errors:\n\tnamespaces \"ns2\" already exists: " cluster=remote
```

It seems that the namespace was being created twice in a very short span leading to a race condition (hence why it would pass randomly, I assume). An easy way to fix this is to bail out early in `handleRemoteServiceCreated()` if we have a headless service, before we create the namespace.

Signed-off-by: Matei David <matei@buoyant.io>
