### PR TITLE
Allow args to be passed to Jaeger (#6587)

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -88,6 +88,7 @@ Kubernetes: `>=1.16.0-0`
 | collector.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | installNamespace | bool | `true` | Set to false when installing in a custom namespace. |
+| jaeger.args | list | `["--query.base-path=/jaeger"]` | CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory) |
 | jaeger.enabled | bool | `true` | Set to false to exclude all-in-one Jaeger installation |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -175,7 +175,9 @@ spec:
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
       containers:
       - args:
-        - --query.base-path=/jaeger
+        {{  range .Values.jaeger.args }}
+        - {{ . }}
+        {{ end }}
         image: {{.Values.jaeger.image.name}}:{{.Values.jaeger.image.version}}
         imagePullPolicy: {{.Values.jaeger.image.pullPolicy}}
         name: jaeger

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -175,8 +175,8 @@ spec:
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
       containers:
       - args:
-        {{  range .Values.jaeger.args }}
-        - {{ . }}
+        {{-  range .Values.jaeger.args }}
+        - {{ . -}}
         {{ end }}
         image: {{.Values.jaeger.image.name}}:{{.Values.jaeger.image.version}}
         imagePullPolicy: {{.Values.jaeger.image.pullPolicy}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -81,6 +81,11 @@ jaeger:
     version: 1.19.2
     pullPolicy: Always
 
+  # -- CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory)
+  args:
+    - --memory.max-traces=200
+    
+
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -82,7 +82,7 @@ jaeger:
     pullPolicy: Always
 
   # -- CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory)
-  args: {}
+  args: []
 
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -82,9 +82,7 @@ jaeger:
     pullPolicy: Always
 
   # -- CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory)
-  args:
-    - --memory.max-traces=200
-    
+  args: {}
 
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -82,7 +82,8 @@ jaeger:
     pullPolicy: Always
 
   # -- CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory)
-  args: []
+  args:
+    - --query.base-path=/jaeger
 
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information


### PR DESCRIPTION
Subject
Allow args to be passed to Jaeger

Problem
The Jaeger-all-in-one deployed by the Linkerd-Jaeger Helm chart has unbounded limits and uses memory as the default storage mechanism. When this chart is deployed and Jaeger is receiving traces, it continues to use memory until there is no free memory on the host as old traces effectively never get purged. Upon looking deeper into Jaeger, I discovered they support passing arguments that allow you to restrict the maximum number of traces jaeger will keep in memory, effectively mitigating this issue. However, the Linkerd-Jaeger helm chart does not support passing arguments to the container, and there for unable to control jaegers memory usage (along with dozens of other arguments Jaeger has available).

Solution
Updating the Linkerd-Jaeger helm chart to support passing args to the Jaeger container from values.yaml.

Validation
```sh
git clone https://github.com/bsord/linkerd2/
git checkout helm-jaeger-aio-args-support
cd linkerd2/jaeger/charts/linkerd-jaeger
helm install -n linkerd-jaeger --set namespace=linkerd-jaeger --set installNamespace=false --set webhook.image.version=stable-2.10.2 --set args={--memory.max-traces=2000} linkerd-jaeger .

Kubectl describe the pod, validate arguments match what was passed. 
```

Fixes #6587



