### PR TITLE
Fix Create Release step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,19 +240,14 @@ jobs:
     - name: Create release
       id: create_release
       uses: softprops/action-gh-release@fb0163a75bee697a9cfec2c931801de7c7f10042
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         draft: false
         prerelease: false
         body_path: NOTES.md
         files: |
           ./target/release/linkerd2-cli-*-darwin*
-          ./target/release/linkerd2-cli-*-darwin*.sha256
           ./target/release/linkerd2-cli-*-linux-*
-          ./target/release/linkerd2-cli-*-linux-*.sha256
-          ./target/release/linkerd2-cli-*-windows.exe
-          ./target/release/linkerd2-cli-*-windows.exe.sha256
+          ./target/release/linkerd2-cli-*-windows.*
           ./target/release/linkerd2-cli-*.nupkg
   website_publish:
     name: Linkerd website publish


### PR DESCRIPTION
We had glob patterns in the Create Release step which resulted in
the same files being uploaded more than once, which since the last
`action-gh-release` version results in an error (see softprops/action-gh-release#131).

Also removed the GITHUB_TOKEN env var which is not required.

This step still outputs some deprecation messages, which is being
addressed upstream (see softprops/action-gh-release#129)