### PR TITLE
Run lock-threads action once per day

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 1 * * *'
 
 permissions:
   issues: write


### PR DESCRIPTION
Followup to #6484

#2 is the oldest closed issue and it appears that the action has locked
it already, so it's caught up and we can have it run just once per day.
