### PR TITLE
Expose service metadata from source service to mirrored service

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -193,7 +193,9 @@ func (rcsw *RemoteClusterServiceWatcher) originalResourceName(mirroredName strin
 }
 
 // Provides labels for mirrored service.
-// "remoteService" is an optional parameter. If provided, copies all labels from the remote service to mirrored service (except labels with the "SvcMirrorPrefix").
+// "remoteService" is an optional parameter. If provided, copies all labels
+// from the remote service to mirrored service (except labels with the
+// "SvcMirrorPrefix").
 func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceLabels(remoteService *corev1.Service) map[string]string {
 	labels := map[string]string{
 		consts.MirroredResourceLabel:  "true",

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -206,7 +206,10 @@ func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceLabels() map[string]s
 }
 
 func (rcsw *RemoteClusterServiceWatcher) getMirroredServiceAnnotations(remoteService *corev1.Service) map[string]string {
-	annotations := remoteService.ObjectMeta.Annotations
+	annotations := make(map[string]string)
+	for i, v := range remoteService.ObjectMeta.Annotations {
+		annotations[i] = v
+	}
 	annotations[consts.RemoteResourceVersionAnnotation] = remoteService.ResourceVersion // needed to detect real changes
 	annotations[consts.RemoteServiceFqName] = fmt.Sprintf("%s.%s.svc.%s", remoteService.Name, remoteService.Namespace, rcsw.link.TargetClusterDomain)
 

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -777,7 +777,6 @@ func mirrorService(name, namespace, resourceVersion string, ports []corev1.Servi
 			Labels: map[string]string{
 				consts.RemoteClusterNameLabel: clusterName,
 				consts.MirroredResourceLabel:  "true",
-				// consts.DefaultExportedServiceSelector: "true",
 			},
 			Annotations: annotations,
 		},

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -777,6 +777,7 @@ func mirrorService(name, namespace, resourceVersion string, ports []corev1.Servi
 			Labels: map[string]string{
 				consts.RemoteClusterNameLabel: clusterName,
 				consts.MirroredResourceLabel:  "true",
+				// consts.DefaultExportedServiceSelector: "true",
 			},
 			Annotations: annotations,
 		},


### PR DESCRIPTION
@mateiidavid I've modified `getMirroredServiceAnnotations()` to copy all the annotations from the remote service and then add the custom fields wherever required. Other than the function itself, I've only changed some code in `createEndpointMirrorService()`, as everywhere else the function is called directly. Some doubts about the code and the PR process:
- I've left the annotations for the "endpoints" type as they were, only updating for those of type "service" since that was what was mentioned in #5561. Should I modify for the endpoints as well?
- I tried adding a parameter to `getMirroredServiceLabels()`, but it is used is the `cleanupMirroredResources()` method, which is called by `processNextEvent()` in the case `*ClusterUnregistered`. This is an empty struct, so I'm unsure how to proceed. 

Edit: Other than `processNextEvent`, this struct is only used in a `Stop()` method, but I'm unable to find where this method is being used. 

- Is the commit message convention to be followed for all commits, or the final one?
- Should I squash all future commits and force push, or wait till the changes are decided, and then do one force push?