### PR TITLE
When `edges` command tests fail print all pods for additional debugging information.

### DIFF
--- a/test/integration/edges/edges_test.go
+++ b/test/integration/edges/edges_test.go
@@ -134,16 +134,14 @@ func TestDirectEdges(t *testing.T) {
 			testDataPath += "/external_prometheus"
 		}
 		err = TestHelper.RetryFor(timeout, func() error {
+			// Start by sleeping each try to give Prometheus time to scrape
+			// slow-cooker. This fixes some flakiness when 50 seconds is not
+			// long enough for this to be the case and the test fails.
+			time.Sleep(10 * time.Second)
+
 			out, err = TestHelper.LinkerdRun("-n", testNamespace, "-o", "json", "viz", "edges", "deploy")
 			if err != nil {
 				return err
-			}
-
-			// If Prometheus has not scraped any workloads yet then the
-			// expected Prometheus edges will not be found; we fail so that
-			// the test is retried.
-			if !strings.Contains(out, "prometheus") {
-				return fmt.Errorf("Expected Prometheus edges but found none:\n%s", out)
 			}
 
 			tpl := template.Must(template.ParseFiles(testDataPath + "/direct_edges.golden"))

--- a/test/integration/edges/edges_test.go
+++ b/test/integration/edges/edges_test.go
@@ -139,6 +139,13 @@ func TestDirectEdges(t *testing.T) {
 				return err
 			}
 
+			// If Prometheus has not scraped any workloads yet then the
+			// expected Prometheus edges will not be found; we fail so that
+			// the test is retried.
+			if !strings.Contains(out, "prometheus") {
+				return fmt.Errorf("Expected Prometheus edges but found none:\n%s", out)
+			}
+
 			tpl := template.Must(template.ParseFiles(testDataPath + "/direct_edges.golden"))
 			vars := struct {
 				Ns    string


### PR DESCRIPTION
After #6574 recently merging the `TestDirectEdges` test has been flaky. Occasionally the test fails for the following error:
```
2021-08-05T22:08:06.2860090Z --- FAIL: TestDirectEdges (73.39s)
2021-08-05T22:08:06.2860719Z     edges_test.go:161: Expected output:
2021-08-05T22:08:06.2861172Z         \[
2021-08-05T22:08:06.2861480Z           \{
2021-08-05T22:08:06.2861884Z             "src": "prometheus",
2021-08-05T22:08:06.2862642Z             "src_namespace": "external\-prometheus",
2021-08-05T22:08:06.2863356Z             "dst": "slow-cooker",
2021-08-05T22:08:06.2864211Z             "dst_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2865267Z             "client_id": "prometheus.external\-prometheus",
2021-08-05T22:08:06.2866374Z             "server_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2867120Z             "no_tls_reason": ""
2021-08-05T22:08:06.2867492Z           \},
2021-08-05T22:08:06.2867804Z           \{
2021-08-05T22:08:06.2868211Z             "src": "prometheus",
2021-08-05T22:08:06.2868933Z             "src_namespace": "external\-prometheus",
2021-08-05T22:08:06.2869481Z             "dst": "terminus",
2021-08-05T22:08:06.2870311Z             "dst_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2871318Z             "client_id": "prometheus.external\-prometheus",
2021-08-05T22:08:06.2872435Z             "server_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2873180Z             "no_tls_reason": ""
2021-08-05T22:08:06.2873563Z           \},
2021-08-05T22:08:06.2873888Z           \{
2021-08-05T22:08:06.2874421Z             "src": "slow-cooker",
2021-08-05T22:08:06.2875282Z             "src_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2875936Z             "dst": "terminus",
2021-08-05T22:08:06.2876751Z             "dst_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2877906Z             "client_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2879151Z             "server_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2879887Z             "no_tls_reason": ""
2021-08-05T22:08:06.2880258Z           \}
2021-08-05T22:08:06.2880579Z         \]
2021-08-05T22:08:06.2880885Z         
2021-08-05T22:08:06.2881227Z         actual:
2021-08-05T22:08:06.2881560Z         [
2021-08-05T22:08:06.2881876Z           {
2021-08-05T22:08:06.2882429Z             "src": "slow-cooker",
2021-08-05T22:08:06.2883268Z             "src_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2883925Z             "dst": "terminus",
2021-08-05T22:08:06.2884759Z             "dst_namespace": "linkerd-direct-edges-test",
2021-08-05T22:08:06.2885901Z             "client_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2887153Z             "server_id": "default.linkerd-direct-edges-test",
2021-08-05T22:08:06.2887896Z             "no_tls_reason": ""
2021-08-05T22:08:06.2888250Z           }
2021-08-05T22:08:06.2888572Z         ]
2021-08-05T22:08:06.2888870Z
```

What is happening is Prometheus has not scraped workloads yet, so there is no edge to or from Prometheus and slow-cooker.

While it's remains unclear why exactly this happens, this change addresses two potential problems:

1. Print the cluster's pods so that we can determine if the Prometheus pod is injected. If it's not injected, we'll be able to debug further with that information.
2. Introduce retries to the `TestEdges` test. As we already have retries in the `TestDirectEdges`, this makes a similar change to `TestEdges`.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>