### PR TITLE
Remove namespace from linkerd2-viz chart

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -31,7 +31,8 @@ echo "cleaning up linkerd resources [${k8s_context}]"
 # Helm cleanup. Just the entries in `helm ls` as the resources should have already been cleaned up by the code above.
 releases=$("$bindir/helm" ls -A -q)
 if [[ "${releases[*]}" =~ 'l5d-viz' ]]; then
-  "$bindir/helm" --kube-context="$k8s_context" delete l5d-viz
+  "$bindir/helm" --kube-context="$k8s_context" --namespace linkerd-viz delete l5d-viz
+  kubectl delete ns linkerd-viz
 fi
 if [[ "${releases[*]}" =~ 'helm-test' ]]; then
   "$bindir/helm" --kube-context="$k8s_context" --namespace linkerd delete helm-test

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -507,6 +507,8 @@ func helmOverridesEdge(root *tls.CA) ([]string, []string) {
 		"--set", "identity.issuer.crtExpiry=" + root.Cred.Crt.Certificate.NotAfter.Format(time.RFC3339),
 	}
 	vizArgs := []string{
+		"--namespace", TestHelper.GetVizNamespace(),
+		"--create-namespace",
 		"--set", "linkerdVersion=" + TestHelper.GetVersion(),
 	}
 	return coreArgs, vizArgs

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -115,7 +115,6 @@ Kubernetes: `>=1.16.0-0`
 | grafanaUrl | string | `""` | url of external grafana instance with reverse proxy configured. |
 | identityTrustDomain | string | clusterDomain | Trust domain used for identity |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
-| installNamespace | bool | `true` | Set to false when installing in a custom namespace. |
 | jaegerUrl | string | `""` | url of external jaeger instance Set this to `jaeger.linkerd-jaeger.svc.<clusterDomain>` if you plan to use jaeger extension |
 | linkerdNamespace | string | `"linkerd"` | Namespace of the Linkerd core control-plane install |
 | linkerdVersion | string | `"linkerdVersionValue"` | control plane version. See Proxy section for proxy version |
@@ -133,7 +132,6 @@ Kubernetes: `>=1.16.0-0`
 | metricsAPI.resources.memory.limit | string | `nil` | Maximum amount of memory that metrics-api container can use |
 | metricsAPI.resources.memory.request | string | `nil` | Amount of memory that the metrics-api container requests |
 | metricsAPI.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
-| namespace | string | `"linkerd-viz"` | Namespace in which the Linkerd Viz extension has to be installed |
 | nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.alertRelabelConfigs | string | `nil` | Alert relabeling is applied to alerts before they are sent to the Alertmanager. |
 | prometheus.alertmanagers | string | `nil` | Alertmanager instances the Prometheus server sends alerts to configured via the static_configs parameter. |

--- a/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana-rbac.yaml
@@ -7,10 +7,10 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: grafana
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: grafana
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -7,11 +7,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: grafana-config
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: grafana
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -40,7 +40,7 @@ data:
       {{- if .Values.prometheusUrl }}
       url: {{.Values.prometheusUrl}}
       {{- else }}
-      url: http://prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
+      url: http://prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:9090
       {{- end }}
       isDefault: true
       jsonData:
@@ -65,13 +65,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: grafana
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: grafana
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -93,16 +94,16 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: grafana
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   name: grafana
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       linkerd.io/extension: viz
       component: grafana
-      namespace: {{.Values.namespace}}
+      namespace: {{.Release.Namespace}}
   template:
     metadata:
       annotations:
@@ -111,10 +112,11 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
-        namespace: {{.Values.namespace}}
+        namespace: {{.Release.Namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- if .Values.grafana.tolerations -}}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -88,6 +88,8 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana

--- a/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
@@ -5,7 +5,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-metrics-api
+  name: linkerd-{{.Release.Namespace}}-metrics-api
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -29,24 +29,24 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-metrics-api
+  name: linkerd-{{.Release.Namespace}}-metrics-api
   labels:
     linkerd.io/extension: viz
     component: metrics-api
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-metrics-api
+  name: linkerd-{{.Release.Namespace}}-metrics-api
 subjects:
 - kind: ServiceAccount
   name: metrics-api
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: metrics-api
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: metrics-api

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -6,12 +6,13 @@ kind: Service
 apiVersion: v1
 metadata:
   name: metrics-api
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: metrics-api
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -34,7 +35,7 @@ metadata:
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: metrics-api
   name: metrics-api
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.metricsAPI.replicas}}
   selector:
@@ -52,6 +53,7 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -73,7 +75,7 @@ spec:
         {{- if .Values.prometheusUrl }}
         - -prometheus-url={{.Values.prometheusUrl}}
         {{- else if .Values.prometheus.enabled }}
-        - -prometheus-url=http://prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:9090
+        - -prometheus-url=http://prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:9090
         {{- else }}
         {{ fail "Please enable `linkerd-prometheus` or provide `prometheusUrl` for the viz extension to function properly"}}
         {{- end }}

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -28,6 +28,8 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api

--- a/viz/charts/linkerd-viz/templates/namespace-metadata-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata-rbac.yaml
@@ -1,0 +1,43 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "patch"]
+  resourceNames: ["{{.Release.Namespace}}"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+roleRef:
+  kind: Role
+  name: namespace-metadata
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/name: namespace-metadata
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
+  name: namespace-metadata
+spec:
+  template:
+    metadata:
+      annotations:
+        {{ include "partials.annotations.created-by" . }}
+      labels:
+        app.kubernetes.io/name: namespace-metadata
+        app.kubernetes.io/part-of: Linkerd
+        app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: namespace-metadata
+      containers:
+      - name: namespace-metadata
+        image: curlimages/curl:7.78.0
+        imagePullPolicy: {{.Values.defaultImagePullPolicy}}
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          ops=''
+          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          ns=$(curl -kfv -H "Authorization: Bearer $token" \
+            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
+
+          if echo "$ns" | grep -vq 'labels'; then
+            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
+          fi
+          if echo "$ns" | grep -vq 'annotations'; then
+            ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {}},"
+          fi
+
+          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"viz\"},"
+          {{- if .Values.prometheusUrl }}
+          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/viz.linkerd.io~1external-prometheus\", \"value\": \"{{.Values.prometheusUrl}}\"},"
+          {{- end }}
+          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/config.linkerd.io~1proxy-await\", \"value\": \"enabled\"}"
+
+          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
+            -d "[$ops]" \
+            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -43,11 +43,10 @@ spec:
             ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {}},"
           fi
 
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"viz\"},"
           {{- if .Values.prometheusUrl }}
           ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/viz.linkerd.io~1external-prometheus\", \"value\": \"{{.Values.prometheusUrl}}\"},"
           {{- end }}
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/config.linkerd.io~1proxy-await\", \"value\": \"enabled\"}"
+          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"viz\"}"
 
           curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
             -d "[$ops]" \

--- a/viz/charts/linkerd-viz/templates/namespace.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.installNamespace) -}}
+{{- if eq .Release.Service "CLI" -}}
 ---
 ###
 ### Linkerd Viz Extension Namespace
@@ -6,7 +6,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{.Values.namespace}}
+  name: {{.Release.Namespace}}
   labels:
     linkerd.io/extension: viz
   annotations:

--- a/viz/charts/linkerd-viz/templates/namespace.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace.yaml
@@ -13,6 +13,4 @@ metadata:
     {{- if .Values.prometheusUrl }}
     viz.linkerd.io/external-prometheus: {{.Values.prometheusUrl}}
     {{- end }}
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
@@ -6,7 +6,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-prometheus
+  name: linkerd-{{.Release.Namespace}}-prometheus
   labels:
     linkerd.io/extension: viz
     component: prometheus
@@ -18,27 +18,27 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-prometheus
+  name: linkerd-{{.Release.Namespace}}-prometheus
   labels:
     linkerd.io/extension: viz
     component: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-prometheus
+  name: linkerd-{{.Release.Namespace}}-prometheus
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -7,11 +7,11 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -35,7 +35,7 @@ data:
       kubernetes_sd_configs:
       - role: pod
         namespaces:
-          names: ['{{.Values.namespace}}']
+          names: ['{{.Release.Namespace}}']
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_name
@@ -75,7 +75,7 @@ data:
         namespaces:
           names:
           - '{{.Values.linkerdNamespace}}'
-          - '{{.Values.namespace}}'
+          - '{{.Release.Namespace}}'
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_container_port_name
@@ -175,13 +175,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -203,9 +204,9 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: prometheus
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   name: prometheus
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: 1
   {{- if .Values.prometheus.persistence }}
@@ -216,7 +217,7 @@ spec:
     matchLabels:
       linkerd.io/extension: viz
       component: prometheus
-      namespace: {{.Values.namespace}}
+      namespace: {{.Release.Namespace}}
   template:
     metadata:
       annotations:
@@ -225,10 +226,11 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
-        namespace: {{.Values.namespace}}
+        namespace: {{.Release.Namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- if .Values.prometheus.tolerations -}}
@@ -315,7 +317,7 @@ metadata:
     app.kubernetes.io/version: {{default .Values.linkerdVersion}}
     component: prometheus
   name: prometheus
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   accessModes:
     - {{ .Values.prometheus.persistence.accessMode | quote }}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -198,6 +198,8 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus

--- a/viz/charts/linkerd-viz/templates/psp.yaml
+++ b/viz/charts/linkerd-viz/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
 rules:
@@ -18,10 +18,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 roleRef:
   kind: Role
   name: psp
@@ -29,24 +29,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tap
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 - kind: ServiceAccount
   name: web
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ if .Values.grafana.enabled -}}
 - kind: ServiceAccount
   name: grafana
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ end -}}
 {{ if .Values.prometheus.enabled -}}
 - kind: ServiceAccount
   name: prometheus
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ end -}}
 - kind: ServiceAccount
   name: metrics-api
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 - kind: ServiceAccount
   name: tap-injector
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/service-profiles.yaml
+++ b/viz/charts/linkerd-viz/templates/service-profiles.yaml
@@ -2,8 +2,8 @@
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: metrics-api.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}
-  namespace: {{.Values.namespace}}
+  name: metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}
+  {{ include "partials.namespace" . }}
 spec:
   routes:
   - name: POST /api/v1/StatSummary
@@ -39,8 +39,8 @@ spec:
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: prometheus.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}
-  namespace: {{.Values.namespace}}
+  name: prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}
+  {{ include "partials.namespace" . }}
 spec:
   routes:
   - name: POST /api/v1/query
@@ -61,8 +61,8 @@ spec:
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
-  name: grafana.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}
-  namespace: {{.Values.namespace}}
+  name: grafana.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}
+  {{ include "partials.namespace" . }}
 spec:
   routes:
   - name: GET /api/annotations

--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -22,7 +22,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: tap-injector
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 roleRef:
   kind: ClusterRole
   name: linkerd-tap-injector
@@ -32,17 +32,17 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: tap-injector
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
-{{- $host := printf "tap-injector.%s.svc" .Values.namespace }}
+{{- $host := printf "tap-injector.%s.svc" .Release.Namespace }}
 {{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.tapInjector.externalSecret) }}
 kind: Secret
 apiVersion: v1
 metadata:
   name: tap-injector-k8s-tls
-  namespace: {{ .Values.namespace }}
+  {{ include "partials.namespace" . }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
@@ -72,7 +72,7 @@ webhooks:
   clientConfig:
     service:
       name: tap-injector
-      namespace: {{ .Values.namespace }}
+      namespace: {{ .Release.Namespace }}
       path: "/"
 {{- if and (.Values.tapInjector.externalSecret) (empty .Values.tapInjector.caBundle) }}
   {{- fail "If tapInjector.externalSecret is true then you need to provide tapInjector.caBundle" }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -6,12 +6,13 @@ kind: Service
 apiVersion: v1
 metadata:
   name: tap-injector
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap-injector
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -33,7 +34,7 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     component: tap-injector
   name: tap-injector
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.tapInjector.replicas}}
   selector:
@@ -55,6 +56,7 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -71,7 +73,7 @@ spec:
       containers:
       - args:
         - injector
-        - -tap-service-name=tap.{{.Values.namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
+        - -tap-service-name=tap.{{.Release.Namespace}}.serviceaccount.identity.$(_l5d_ns).$(_l5d_trustdomain)
         - -log-level={{.Values.tapInjector.logLevel | default .Values.defaultLogLevel}}
         image: {{.Values.tapInjector.image.registry | default .Values.defaultRegistry}}/{{.Values.tapInjector.image.name}}:{{.Values.tapInjector.image.tag | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.tapInjector.image.pullPolicy | default .Values.defaultImagePullPolicy}}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -28,6 +28,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector

--- a/viz/charts/linkerd-viz/templates/tap-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-rbac.yaml
@@ -5,7 +5,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-tap
+  name: linkerd-{{.Release.Namespace}}-tap
   labels:
     linkerd.io/extension: viz
     component: tap
@@ -23,7 +23,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-tap-admin
+  name: linkerd-{{.Release.Namespace}}-tap-admin
   labels:
     linkerd.io/extension: viz
     component: tap
@@ -38,23 +38,23 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-tap
+  name: linkerd-{{.Release.Namespace}}-tap
   labels:
     linkerd.io/extension: viz
     component: tap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-tap
+  name: linkerd-{{.Release.Namespace}}-tap
 subjects:
 - kind: ServiceAccount
   name: tap
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: linkerd-{{.Values.namespace}}-tap-auth-delegator
+  name: linkerd-{{.Release.Namespace}}-tap-auth-delegator
   labels:
     linkerd.io/extension: viz
     component: tap
@@ -65,28 +65,28 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tap
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: tap
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: linkerd-{{.Values.namespace}}-tap-auth-reader
+  name: linkerd-{{.Release.Namespace}}-tap-auth-reader
   namespace: kube-system
   labels:
     linkerd.io/extension: viz
     component: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -94,20 +94,20 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tap
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
-{{- $host := printf "tap.%s.svc" .Values.namespace }}
+{{- $host := printf "tap.%s.svc" .Release.Namespace }}
 {{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}
 {{- if (not .Values.tap.externalSecret) }}
 kind: Secret
 apiVersion: v1
 metadata:
   name: tap-k8s-tls
-  namespace: {{ .Values.namespace }}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -130,7 +130,7 @@ spec:
   versionPriority: 100
   service:
     name: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 {{- if and (.Values.tap.externalSecret) (empty .Values.tap.caBundle) }}
   {{- fail "If tap.externalSecret is true then you need to provide tap.caBundle" }}
 {{- end }}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -6,13 +6,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: tap
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -37,16 +38,16 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: tap
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   name: tap
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.tap.replicas}}
   selector:
     matchLabels:
       linkerd.io/extension: viz
       component: tap
-      namespace: {{.Values.namespace}}
+      namespace: {{.Release.Namespace}}
   {{- if .Values.enablePodAntiAffinity }}
   strategy:
     rollingUpdate:
@@ -63,10 +64,11 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
-        namespace: {{.Values.namespace}}
+        namespace: {{.Release.Namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- if .Values.tolerations -}}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -32,6 +32,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap

--- a/viz/charts/linkerd-viz/templates/web-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/web-rbac.yaml
@@ -44,13 +44,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: web
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 {{- if not .Values.dashboard.restrictPrivileges }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: linkerd-{{.Values.namespace}}-web-check
+  name: linkerd-{{.Release.Namespace}}-web-check
   labels:
     linkerd.io/extension: viz
     component: web
@@ -77,39 +77,39 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: linkerd-{{.Values.namespace}}-web-check
+  name: linkerd-{{.Release.Namespace}}-web-check
   labels:
     linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-web-check
+  name: linkerd-{{.Release.Namespace}}-web-check
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: web
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: linkerd-{{.Values.namespace}}-web-admin
+  name: linkerd-{{.Release.Namespace}}-web-admin
   labels:
     linkerd.io/extension: viz
     component: web
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-tap-admin
+  name: linkerd-{{.Release.Namespace}}-tap-admin
 subjects:
 - kind: ServiceAccount
   name: web
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: linkerd-{{.Values.namespace}}-web-api
+  name: linkerd-{{.Release.Namespace}}-web-api
   labels:
     linkerd.io/extension: viz
     component: web
@@ -121,27 +121,27 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: linkerd-{{.Values.namespace}}-web-api
+  name: linkerd-{{.Release.Namespace}}-web-api
   labels:
     linkerd.io/extension: viz
     component: web
 roleRef:
   kind: ClusterRole
-  name: linkerd-{{.Values.namespace}}-web-api
+  name: linkerd-{{.Release.Namespace}}-web-api
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: web
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 {{- end}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: web
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: web
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -6,13 +6,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: web
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: web
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -37,16 +38,16 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
     component: web
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
   name: web
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
     matchLabels:
       linkerd.io/extension: viz
       component: web
-      namespace: {{.Values.namespace}}
+      namespace: {{.Release.Namespace}}
   template:
     metadata:
       annotations:
@@ -55,10 +56,11 @@ spec:
         {{- include "partials.proxy.config.annotations" .resources | nindent 8 }}
         {{- end }}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web
-        namespace: {{.Values.namespace}}
+        namespace: {{.Release.Namespace}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- if .Values.tolerations -}}
@@ -67,24 +69,24 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
       - args:
-        - -linkerd-metrics-api-addr=metrics-api.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:8085
+        - -linkerd-metrics-api-addr=metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:8085
         - -cluster-domain={{.Values.clusterDomain}}
         {{- if .Values.grafanaUrl }}
         - -grafana-addr={{.Values.grafanaUrl}}
         {{- else if .Values.grafana.enabled }}
-        - -grafana-addr=grafana.{{.Values.namespace}}.svc.{{.Values.clusterDomain}}:3000
+        - -grafana-addr=grafana.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:3000
         {{- end}}
         {{- if .Values.jaegerUrl }}
         - -jaeger-addr={{.Values.jaegerUrl}}
         {{- end}}
         - -controller-namespace={{.Values.linkerdNamespace}}
-        - -viz-namespace={{.Values.namespace}}
+        - -viz-namespace={{.Release.Namespace}}
         - -log-level={{.Values.dashboard.logLevel | default .Values.defaultLogLevel}}
         {{- if .Values.dashboard.enforcedHostRegexp }}
         - -enforced-host={{.Values.dashboard.enforcedHostRegexp}}
         {{- else -}}
-        {{- $hostFull := replace "." "\\." (printf "web.%s.svc.%s" .Values.namespace .Values.clusterDomain) }}
-        {{- $hostAbbrev := replace "." "\\." (printf "web.%s.svc" .Values.namespace) }}
+        {{- $hostFull := replace "." "\\." (printf "web.%s.svc.%s" .Release.Namespace .Values.clusterDomain) }}
+        {{- $hostAbbrev := replace "." "\\." (printf "web.%s.svc" .Release.Namespace) }}
         - -enforced-host=^(localhost|127\.0\.0\.1|{{ $hostFull }}|{{ $hostAbbrev }}|\[::1\])(:\d+)?$
         {{- end}}
         image: {{.Values.dashboard.image.registry | default .Values.defaultRegistry}}/{{.Values.dashboard.image.name}}:{{.Values.dashboard.image.tag | default .Values.linkerdVersion}}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -32,6 +32,8 @@ kind: Deployment
 metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -23,10 +23,6 @@ defaultUID: 2103
 
 # -- Namespace of the Linkerd core control-plane install
 linkerdNamespace: linkerd
-# -- Set to false when installing in a custom namespace.
-installNamespace: true
-# -- Namespace in which the Linkerd Viz extension has to be installed
-namespace: linkerd-viz
 
 # -- Default nodeSelector section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// this doesn't include the namespace-metadata.* templates, which are Helm-only
 	templatesViz = []string{
 		"templates/namespace.yaml",
 		"templates/metrics-api-rbac.yaml",
@@ -156,8 +157,16 @@ func render(w io.Writer, valuesOverrides map[string]interface{}) error {
 		return err
 	}
 
+	fullValues := map[string]interface{}{
+		"Values": vals,
+		"Release": map[string]interface{}{
+			"Namespace": defaultNamespace,
+			"Service":   "CLI",
+		},
+	}
+
 	// Attach the final values into the `Values` field for rendering to work
-	renderedTemplates, err := engine.Render(chart, map[string]interface{}{"Values": vals})
+	renderedTemplates, err := engine.Render(chart, fullValues)
 	if err != nil {
 		return err
 	}

--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -20,6 +20,7 @@ const (
 	LegacyExtensionName = "linkerd-viz"
 
 	vizChartName            = "linkerd-viz"
+	defaultNamespace        = "linkerd-viz"
 	defaultLinkerdNamespace = "linkerd"
 	maxRps                  = 100.0
 

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -9,8 +9,6 @@ metadata:
   labels:
     linkerd.io/extension: viz
   annotations:
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -418,6 +416,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -557,6 +557,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
@@ -807,6 +809,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
@@ -914,6 +918,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -1084,6 +1090,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -1177,6 +1185,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -402,6 +402,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -436,6 +437,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -539,6 +541,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -574,6 +577,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
@@ -787,6 +791,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -822,6 +827,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
@@ -889,6 +895,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -928,6 +935,7 @@ spec:
       annotations:
         checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -1060,6 +1068,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1092,6 +1101,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -1148,6 +1158,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1186,6 +1197,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -9,8 +9,6 @@ metadata:
   labels:
     linkerd.io/extension: viz
   annotations:
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -418,6 +416,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -557,6 +557,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
@@ -807,6 +809,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
@@ -914,6 +918,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -1084,6 +1090,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -1177,6 +1185,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -402,6 +402,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -436,6 +437,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -539,6 +541,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -574,6 +577,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
@@ -787,6 +791,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -822,6 +827,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
@@ -889,6 +895,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -928,6 +935,7 @@ spec:
       annotations:
         checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -1060,6 +1068,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1092,6 +1101,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -1148,6 +1158,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1186,6 +1197,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -241,7 +241,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -265,7 +265,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -9,8 +9,6 @@ metadata:
   labels:
     linkerd.io/extension: viz
   annotations:
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -405,6 +403,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -626,6 +626,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
@@ -733,6 +735,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -903,6 +907,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -996,6 +1002,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -241,7 +241,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -265,7 +265,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -389,6 +389,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -423,6 +424,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -608,6 +610,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -643,6 +646,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
@@ -710,6 +714,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -749,6 +754,7 @@ spec:
       annotations:
         checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -881,6 +887,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -913,6 +920,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -969,6 +977,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1007,6 +1016,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -238,7 +238,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -10,8 +10,6 @@ metadata:
     linkerd.io/extension: viz
   annotations:
     viz.linkerd.io/external-prometheus: external-prom.com
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -378,6 +376,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -517,6 +517,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
@@ -625,6 +627,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -795,6 +799,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -888,6 +894,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -214,7 +214,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -238,7 +238,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -362,6 +362,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -396,6 +397,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -499,6 +501,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -534,6 +537,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
@@ -602,6 +606,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -641,6 +646,7 @@ spec:
       annotations:
         checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -773,6 +779,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -805,6 +812,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -861,6 +869,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -899,6 +908,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -9,8 +9,6 @@ metadata:
   labels:
     linkerd.io/extension: viz
   annotations:
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -418,6 +416,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -557,6 +557,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
@@ -807,6 +809,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
@@ -914,6 +918,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -1084,6 +1090,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -1177,6 +1185,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -402,6 +402,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -436,6 +437,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -539,6 +541,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -574,6 +577,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
@@ -787,6 +791,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -822,6 +827,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
@@ -889,6 +895,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -928,6 +935,7 @@ spec:
       annotations:
         checksum/config: 2ab0ec921e7f9cb65f62dd4f2ebb77d06827c9621f473c3a9c42ad2741603c3e
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -1060,6 +1068,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1092,6 +1101,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -1148,6 +1158,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1186,6 +1197,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd-viz
+  namespace: linkerd
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -278,7 +278,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: web
-  namespace: linkerd
+  namespace: linkerd-viz
   labels:
     linkerd.io/extension: viz
     component: web
@@ -402,6 +402,7 @@ metadata:
     component: metrics-api
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -436,6 +437,7 @@ spec:
       annotations:
         checksum/config: 0d5b035f4d141dc2c13e1f89046de78fe0fb1208075734c3977400b866f2db51
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: metrics-api
@@ -539,6 +541,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -578,6 +581,7 @@ spec:
         config.linkerd.io/proxy-cpu-limit: "100m"
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: grafana
@@ -791,6 +795,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -830,6 +835,7 @@ spec:
         config.linkerd.io/proxy-cpu-limit: "100m"
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: prometheus
@@ -897,6 +903,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -940,6 +947,7 @@ spec:
         config.linkerd.io/proxy-cpu-limit: "100m"
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap
@@ -1072,6 +1080,7 @@ metadata:
     component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1104,6 +1113,7 @@ spec:
       annotations:
         checksum/config: 954486b77f49f95fc44392cf8ea7672033f74102bab63103d00a61ea7895c281
         linkerd.io/created-by: linkerd/helm dev-undefined
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: tap-injector
@@ -1160,6 +1170,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
 spec:
   type: ClusterIP
   selector:
@@ -1202,6 +1213,7 @@ spec:
         config.linkerd.io/proxy-cpu-limit: "100m"
         config.linkerd.io/proxy-memory-request: "20Mi"
         config.linkerd.io/proxy-memory-limit: "250Mi"
+        linkerd.io/inject: enabled
       labels:
         linkerd.io/extension: viz
         component: web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -9,8 +9,6 @@ metadata:
   labels:
     linkerd.io/extension: viz
   annotations:
-    linkerd.io/inject: enabled
-    config.linkerd.io/proxy-await: "enabled"
 ---
 ###
 ### Metrics API RBAC
@@ -418,6 +416,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: metrics-api
@@ -557,6 +557,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: grafana
@@ -811,6 +813,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: prometheus
@@ -922,6 +926,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap
@@ -1096,6 +1102,8 @@ apiVersion: apps/v1
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: tap-injector
@@ -1189,6 +1197,8 @@ kind: Deployment
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    linkerd.io/inject: enabled
+    config.linkerd.io/proxy-await: "enabled"
   labels:
     linkerd.io/extension: viz
     app.kubernetes.io/name: web


### PR DESCRIPTION
Second part of #6584, followup of #6635 (and based off of alpeb/no-ns-helm-core)

Stop rendering `namespace.yaml` in the `linkerd-viz` chart, same as we did in #6635.

The additional change here is the addition of the `namespace-metadata.yaml` template (and its RBAC), _not_ rendered in CLI installs, which is a Helm `post-install` hook, consisting on a Job that executes a script adding the required annotations and labels to the viz namespace using a PATCH request against kube-api. The script first checks if the namespace doesn't already have an annotations/labels entries, in which case it has to add extra ops in that patch.

The Job uses a multiarch `curlimages/curl` image, which is built by curl.haxx.se. I couldn't find a simple multiarch "kubectl" image that would have allowed us issuing simple kubectl commands. The `curlimages/curl` image is based on Alpine; it won't have as much CVE-related reports noise as a Debian image, but it'd be better to have something slimmer still. Eventually we could build our own scratch-based binary if deemed worthy.

I'll post in followup PRs the same changes for the other extensions and the CNI chart.