### PR TITLE
Remove namespace from linkerd2-cni chart

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -32,9 +32,7 @@ Kubernetes: `>=1.16.0-0`
 | ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via iptables |
 | imagePullSecrets | string | `nil` |  |
 | inboundProxyPort | int | `4143` | Inbound port for the proxy container |
-| installNamespace | bool | `true` | Whether to create the CNI plugin plane namespace or not |
 | logLevel | string | `"info"` | Log level for the CNI plugin |
-| namespace | string | `"linkerd-cni"` | CNI plugin plane namespace |
 | outboundProxyPort | int | `4140` | Outbound port for the proxy container |
 | portsToRedirect | string | `""` | Ports to redirect to proxy |
 | priorityClassName | string | `""` | Kubernetes priorityClassName for the CNI plugin's Pods |

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -17,11 +17,11 @@ limitations under the License.
 This file was inspired by
 1) https://github.com/istio/cni/blob/c63a509539b5ed165a6617548c31b686f13c2133/deployments/kubernetes/install/manifests/istio-cni.yaml
 */ -}}
-{{- if .Values.installNamespace -}}
+{{- if eq .Release.Service "CLI" -}}
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{.Values.namespace}}
+  name: {{.Release.Namespace}}
   annotations:
     linkerd.io/inject: disabled
   labels:
@@ -33,7 +33,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/cni-resource: "true"
 {{- if .Values.imagePullSecrets }}
@@ -45,7 +45,7 @@ imagePullSecrets:
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: linkerd-{{.Values.namespace}}-cni
+  name: linkerd-{{.Release.Namespace}}-cni
   labels:
     linkerd.io/cni-resource: "true"
 spec:
@@ -68,21 +68,21 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/cni-resource: "true"
 rules:
 - apiGroups: ['extensions', 'policy']
   resources: ['podsecuritypolicies']
   resourceNames:
-  - linkerd-{{.Values.namespace}}-cni
+  - linkerd-{{.Release.Namespace}}-cni
   verbs: ['use']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/cni-resource: "true"
 roleRef:
@@ -92,7 +92,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ end -}}
 ---
 kind: ClusterRole
@@ -119,13 +119,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -167,7 +167,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -1,7 +1,3 @@
-# -- CNI plugin plane namespace
-namespace: linkerd-cni
-# -- Whether to create the CNI plugin plane namespace or not
-installNamespace: true
 # -- Inbound port for the proxy container
 inboundProxyPort: 4143
 # -- Outbound port for the proxy container

--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -39,7 +39,6 @@ type cniPluginOptions struct {
 	destCNIBinDir       string
 	useWaitFlag         bool
 	priorityClassName   string
-	installNamespace    bool
 }
 
 func (options *cniPluginOptions) validate() error {
@@ -109,7 +108,6 @@ assumes that the 'linkerd install' command will be executed with the
 	cmd.PersistentFlags().StringVar(&options.destCNINetDir, "dest-cni-net-dir", options.destCNINetDir, "Directory on the host where the CNI configuration will be placed")
 	cmd.PersistentFlags().StringVar(&options.destCNIBinDir, "dest-cni-bin-dir", options.destCNIBinDir, "Directory on the host where the CNI binary will be placed")
 	cmd.PersistentFlags().StringVar(&options.priorityClassName, "priority-class-name", options.priorityClassName, "Pod priorityClassName for CNI daemonset's pods")
-	cmd.PersistentFlags().BoolVar(&options.installNamespace, "install-namespace", options.installNamespace, "Whether to create the CNI namespace or not")
 	cmd.PersistentFlags().BoolVar(
 		&options.useWaitFlag,
 		"use-wait-flag",
@@ -140,7 +138,6 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 		destCNIBinDir:       defaults.DestCNIBinDir,
 		useWaitFlag:         defaults.UseWaitFlag,
 		priorityClassName:   defaults.PriorityClassName,
-		installNamespace:    defaults.InstallNamespace,
 	}
 
 	if defaults.IgnoreInboundPorts != "" {
@@ -177,9 +174,7 @@ func (options *cniPluginOptions) buildValues() (*cnicharts.Values, error) {
 	installValues.DestCNINetDir = options.destCNINetDir
 	installValues.DestCNIBinDir = options.destCNIBinDir
 	installValues.UseWaitFlag = options.useWaitFlag
-	installValues.Namespace = cniNamespace
 	installValues.PriorityClassName = options.priorityClassName
-	installValues.InstallNamespace = options.installNamespace
 	return installValues, nil
 }
 
@@ -208,7 +203,7 @@ func renderCNIPlugin(w io.Writer, config *cniPluginOptions) error {
 	chart := &charts.Chart{
 		Name:      helmCNIDefaultChartName,
 		Dir:       helmCNIDefaultChartDir,
-		Namespace: controlPlaneNamespace,
+		Namespace: defaultCNINamespace,
 		RawValues: rawValues,
 		Files:     files,
 		Fs:        static.Templates,

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -1,7 +1,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: other
+  name: linkerd-cni
   annotations:
     linkerd.io/inject: disabled
   labels:
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 ---
@@ -40,13 +40,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -82,7 +82,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -1,7 +1,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: other
+  name: linkerd-cni
   annotations:
     linkerd.io/inject: disabled
   labels:
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 ---
@@ -40,13 +40,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -82,7 +82,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -1,8 +1,18 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: linkerd-cni
+  annotations:
+    linkerd.io/inject: disabled
+  labels:
+    linkerd.io/cni-resource: "true"
+    config.linkerd.io/admission-webhooks: disabled
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 ---
@@ -30,13 +40,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: other
+  namespace: linkerd-cni
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -72,7 +82,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: other
+  namespace: linkerd-cni
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -105,7 +105,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:dev-9f6ee444-alpeb
+        image: cr.l5d.io/linkerd/cni-plugin:dev-undefined
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -1,20 +1,10 @@
 ---
 # Source: linkerd2-cni/templates/cni-plugin.yaml
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
-  labels:
-    linkerd.io/cni-resource: "true"
-    config.linkerd.io/admission-webhooks: disabled
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: linkerd-cni
+  
   labels:
     linkerd.io/cni-resource: "true"
 ---
@@ -42,13 +32,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-cni
-  namespace: linkerd-cni
+  namespace: linkerd-test
 ---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: linkerd-cni
+  
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -84,7 +74,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: linkerd-cni
+  
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"
@@ -115,7 +105,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:dev-undefined
+        image: cr.l5d.io/linkerd/cni-plugin:dev-9f6ee444-alpeb
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -1,20 +1,10 @@
 ---
 # Source: linkerd2-cni/templates/cni-plugin.yaml
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: linkerd-test
-  annotations:
-    linkerd.io/inject: disabled
-  labels:
-    linkerd.io/cni-resource: "true"
-    config.linkerd.io/admission-webhooks: disabled
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: linkerd-cni
-  namespace: linkerd-test
+  
   labels:
     linkerd.io/cni-resource: "true"
 ---
@@ -48,7 +38,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-cni-config
-  namespace: linkerd-test
+  
   labels:
     linkerd.io/cni-resource: "true"
 data:
@@ -84,7 +74,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: linkerd-cni
-  namespace: linkerd-test
+  
   labels:
     k8s-app: linkerd-cni
     linkerd.io/cni-resource: "true"

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -82,6 +82,8 @@ func (c *Chart) render(partialsFiles []*loader.BufferedFile) (bytes.Buffer, erro
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
+	release, _ := valuesToRender["Release"].(map[string]interface{})
+	release["Service"] = "CLI"
 
 	renderedTemplates, err := engine.Render(chart, valuesToRender)
 	if err != nil {

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -17,7 +17,6 @@ const (
 
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
-	Namespace           string `json:"namespace"`
 	InboundProxyPort    uint   `json:"inboundProxyPort"`
 	OutboundProxyPort   uint   `json:"outboundProxyPort"`
 	IgnoreInboundPorts  string `json:"ignoreInboundPorts"`
@@ -32,7 +31,6 @@ type Values struct {
 	DestCNIBinDir       string `json:"destCNIBinDir"`
 	UseWaitFlag         bool   `json:"useWaitFlag"`
 	PriorityClassName   string `json:"priorityClassName"`
-	InstallNamespace    bool   `json:"installNamespace"`
 	ProxyAdminPort      string `json:"proxyAdminPort"`
 	ProxyControlPort    string `json:"proxyControlPort"`
 }


### PR DESCRIPTION
Third part of #6584, followup of #6635 (and based off of alpeb/no-ns-helm-core)

Stop rendering the namespace in the `linkerd2-cni` chart, same as we did in #6635.

This also removes the `install-namespace` option from `linkerd install-cni`,
which isn't found in `linkerd install` nor `linkerd viz install` anyways, and
it would add some complexity to support.
