### PR TITLE
ci: Only generate test coverage once per week

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,10 +1,13 @@
 name: Coverage
+
+# Run weekly on Sunday at midnight (UTC).
 on:
   schedule:
-  # Run weekly on Sunday at midnight (UTC).
-  - cron: '0 0 * * 7'
+    - cron: '0 0 * * 7'
+
 permissions:
   contents: read
+
 jobs:
   go:
     name: Go
@@ -13,13 +16,14 @@ jobs:
     container:
       image: golang:1.16.4
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - run: go get gotest.tools/gotestsum@v0.4.2
-    - run: gotestsum -- -cover -coverprofile=coverage.out -v -mod=readonly ./...
-    - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
-      with:
-        files: ./coverage.out
-        flags: unittests,golang
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - run: go get gotest.tools/gotestsum@v0.4.2
+      - run: gotestsum -- -cover -coverprofile=coverage.out -v -mod=readonly ./...
+      - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
+        with:
+          files: ./coverage.out
+          flags: unittests,golang
+
   js:
     name: JS
     timeout-minutes: 30
@@ -27,16 +31,16 @@ jobs:
     container:
       image: node:14-stretch
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - name: Yarn setup
-      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
-    - name: Unit tests
-      run: |
-        export PATH="$HOME/.yarn/bin:$PATH"
-        export NODE_ENV=test
-        bin/web --frozen-lockfile
-        bin/web test --reporters="jest-progress-bar-reporter" --reporters="./gh_ann_reporter.js" --coverage
-    - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
-      with:
-        directory: ./web/app/coverage
-        flags: unittests,javascript
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Yarn setup
+        run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
+      - name: Unit tests
+        run: |
+          export PATH="$HOME/.yarn/bin:$PATH"
+          export NODE_ENV=test
+          bin/web --frozen-lockfile
+          bin/web test --reporters="jest-progress-bar-reporter" --reporters="./gh_ann_reporter.js" --coverage
+      - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
+        with:
+          directory: ./web/app/coverage
+          flags: unittests,javascript

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,7 +3,7 @@ name: Coverage
 # Run weekly on Sunday at midnight (UTC).
 on:
   schedule:
-    - cron: '0 0 * * 7'
+    - cron: '0 0 * * 0'
 
 permissions:
   contents: read

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,42 @@
+name: Coverage
+on:
+  schedule:
+  # Run weekly on Sunday at midnight (UTC).
+  - cron: "0 0 * * 7"
+permissions:
+  contents: read
+jobs:
+  go:
+    name: Go
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    container:
+      image: golang:1.16.4
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - run: go get gotest.tools/gotestsum@v0.4.2
+    - run: gotestsum -- -cover -coverprofile=coverage.out -v -mod=readonly ./...
+    - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
+      with:
+        files: ./coverage.out
+        flags: unittests,golang
+  js:
+    name: JS
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    container:
+      image: node:14-stretch
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - name: Yarn setup
+      run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
+    - name: Unit tests
+      run: |
+        export PATH="$HOME/.yarn/bin:$PATH"
+        export NODE_ENV=test
+        bin/web --frozen-lockfile
+        bin/web test --reporters="jest-progress-bar-reporter" --reporters="./gh_ann_reporter.js" --coverage
+    - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
+      with:
+        directory: ./web/app/coverage
+        flags: unittests,javascript

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,7 +2,7 @@ name: Coverage
 on:
   schedule:
   # Run weekly on Sunday at midnight (UTC).
-  - cron: "0 0 * * 7"
+  - cron: '0 0 * * 7'
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,12 +23,7 @@ jobs:
       run: |
         go get gotest.tools/gotestsum@v0.4.2
         # TODO: validate bin/protoc-go.sh does not dirty the repo
-        gotestsum -- -cover -coverprofile=coverage.out -race -v -mod=readonly ./...
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
-      with:
-        files: ./coverage.out
-        flags: unittests,golang
+        gotestsum -- -race -v -mod=readonly ./...
   js_unit_tests:
     name: JS unit tests
     timeout-minutes: 30
@@ -45,9 +40,4 @@ jobs:
         export PATH="$HOME/.yarn/bin:$PATH"
         export NODE_ENV=test
         bin/web --frozen-lockfile
-        bin/web test --reporters="jest-progress-bar-reporter" --reporters="./gh_ann_reporter.js" --coverage
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
-      with:
-        directory: ./web/app/coverage
-        flags: unittests,javascript
+        bin/web test --reporters="jest-progress-bar-reporter" --reporters="./gh_ann_reporter.js"


### PR DESCRIPTION
Codecov reports haven't proven to be actionable on a PR-by-PR basis and
our CI load is already pretty heavy.

This change removes coverage reporting from our PR workflows and moves
them to a dedicated workflow that only runs once per week.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
