### PR TITLE
viz: add examples for `viz stat <svc>` in CLI

### DIFF
--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -154,11 +154,11 @@ If no resource name is specified, displays stats about all resources of the spec
   # of clients, and thus will not include unmeshed client request metrics.
   linkerd viz stat svc/web
 
-  # Get the web services, and metrics for any traffic coming to the service from the hello1 deployment
+  # Get the web services and metrics for any traffic coming to the service from the hello1 deployment
   # in the test namespace.
   linkerd viz stat svc/web --from deploy/hello1 --from-namespace test
 
-  # Get the web services, and metrics for all the traffic that reaches the web-pod1 pod
+  # Get the web services and metrics for all the traffic that reaches the web-pod1 pod
   # in the test namespace exclusively.
   linkerd viz stat svc/web --to pod/web-pod1 --to-namespace test
 

--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -150,6 +150,18 @@ If no resource name is specified, displays stats about all resources of the spec
   # Get all pods in all namespaces that call the hello1 service in the test namespace.
   linkerd viz stat pods --to svc/hello1 --to-namespace test --all-namespaces
 
+  # Get the web service. With Services, metrics are generated from the outbound metrics
+  # of clients, and thus will not include unmeshed client request metrics.
+  linkerd viz stat svc/web
+
+  # Get the web services, and metrics for any traffic coming to the service from the hello1 deployment
+  # in the test namespace.
+  linkerd viz stat svc/web --from deploy/hello1 --from-namespace test
+
+  # Get the web services, and metrics for all the traffic that reaches the web-pod1 pod
+  # in the test namespace exclusively.
+  linkerd viz stat svc/web --to pod/web-pod1 --to-namespace test
+
   # Get all services in all namespaces that receive calls from hello1 deployment in the test namespace.
   linkerd viz stat services --from deploy/hello1 --from-namespace test --all-namespaces
 


### PR DESCRIPTION
This PR adds examples showcasing the usage of `viz stat` in the CLI,
along with specific explanation on how it differs from other
stats i.e client side metrics, and the usage of `--to` flag.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
