### PR TITLE
tests: manually inject `external-prometheus`

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -442,7 +442,7 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 	if TestHelper.ExternalPrometheus() {
 
 		// Install external prometheus
-		out, err := TestHelper.LinkerdRun("inject", "testdata/external_prometheus.yaml")
+		out, err := TestHelper.LinkerdRun("inject", "testdata/external_prometheus.yaml", "--manual")
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'linkerd inject' command failed", "'linkerd inject' command failed: %s", err)
 		}


### PR DESCRIPTION
Looked at the CI failures after https://github.com/linkerd/linkerd2/pull/6627
was merged, and in all the cases the external prometheus pod
wasn't injected.

This updates the `external-prometheus-deep` test to manually
inject the `external-prometheus` deployment instead of having
the injection be nondeterministic.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>
