### PR TITLE
policy-controller: Update kube, k8s-openapi dependencies

### DIFF
--- a/policy-controller/Cargo.lock
+++ b/policy-controller/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
+checksum = "748acc444200aa3528dc131a8048e131a9e75a611a52d152e276e99199313d1a"
 dependencies = [
  "base64",
  "bytes",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
+checksum = "f2bfa22c305a6d817b57a7afcd2e6ee23c80c6c93933edb02f210fdf73f837cc"
 dependencies = [
  "base64",
  "bytes",
@@ -640,14 +640,15 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
+checksum = "9c33d2272d8e530938bafc6cf4ac76f2a6f6c9ca684defcfab6c357913a43bcc"
 dependencies = [
  "form_urlencoded",
  "http",
  "json-patch",
  "k8s-openapi",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror",
@@ -655,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a28be5ca4f233b5dd872f426fdc75d6765c34576b590c44564982c05fdb400"
+checksum = "53dc9fa719dd21d1a4c155cf8936f618a687f3590885e09d9261727cd5dc56a5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -668,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
+checksum = "cb40d5730a3ac47b7153c7ad0494a66881bbdf0c17ead478b714dd82c9dba259"
 dependencies = [
  "dashmap",
  "derivative",

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 drain = "0.1"
 futures = "0.3"
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
-kube = { version = "0.58", default-features = false, features = ["client", "derive", "native-tls"] }
+kube = { version = "0.59", default-features = false, features = ["client", "derive", "native-tls"] }
 linkerd-policy-controller-core = { path = "./core" }
 linkerd-policy-controller-grpc = { path = "./grpc" }
 linkerd-policy-controller-k8s-index = { path = "./k8s/index" }

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-k8s-openapi = { version = "0.12.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.58.1", default-features = false, features = ["client", "derive", "native-tls"] }
-kube-runtime = { version = "0.58.1", default-features = false }
+k8s-openapi = { version = "0.13", default-features = false, features = ["v1_16"] }
+kube = { version = "0.59", default-features = false, features = ["client", "derive", "native-tls"] }
+kube-runtime = { version = "0.59", default-features = false }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/policy-controller/k8s/api/src/labels.rs
+++ b/policy-controller/k8s/api/src/labels.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone, Debug, Eq, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Labels(Arc<Map>);
 
 pub type Map = BTreeMap<String, String>;
@@ -95,6 +95,13 @@ impl std::iter::FromIterator<Expression> for Selector {
 
 // === Labels ===
 
+impl From<Option<Map>> for Labels {
+    #[inline]
+    fn from(labels: Option<Map>) -> Self {
+        labels.unwrap_or_default().into()
+    }
+}
+
 impl From<Map> for Labels {
     #[inline]
     fn from(labels: Map) -> Self {
@@ -109,10 +116,20 @@ impl AsRef<Map> for Labels {
     }
 }
 
-impl<T: AsRef<Map>> std::cmp::PartialEq<T> for Labels {
+impl std::cmp::PartialEq<Self> for Labels {
     #[inline]
-    fn eq(&self, t: &T) -> bool {
+    fn eq(&self, t: &Self) -> bool {
         self.0.as_ref().eq(t.as_ref())
+    }
+}
+
+impl std::cmp::PartialEq<Option<Map>> for Labels {
+    #[inline]
+    fn eq(&self, t: &Option<Map>) -> bool {
+        match t {
+            None => self.0.is_empty(),
+            Some(t) => t.eq(self.0.as_ref()),
+        }
     }
 }
 

--- a/policy-controller/k8s/index/src/default_allow.rs
+++ b/policy-controller/k8s/index/src/default_allow.rs
@@ -33,12 +33,14 @@ impl DefaultAllow {
     pub const ANNOTATION: &'static str = "policy.linkerd.io/default-allow";
 
     pub fn from_annotation(meta: &k8s::ObjectMeta) -> Result<Option<Self>> {
-        if let Some(v) = meta.annotations.get(Self::ANNOTATION) {
-            let mode = v.parse()?;
-            Ok(Some(mode))
-        } else {
-            Ok(None)
+        if let Some(ann) = meta.annotations.as_ref() {
+            if let Some(v) = ann.get(Self::ANNOTATION) {
+                let mode = v.parse()?;
+                return Ok(Some(mode));
+            }
         }
+
+        Ok(None)
     }
 }
 

--- a/policy-controller/k8s/index/src/pod.rs
+++ b/policy-controller/k8s/index/src/pod.rs
@@ -260,7 +260,7 @@ impl PodIndex {
                 // labels have changed, then we relink servers to pods in case label selections have
                 // changed.
                 let p = entry.get_mut();
-                if p.labels.as_ref() != &pod.metadata.labels {
+                if p.labels != pod.metadata.labels {
                     p.labels = pod.metadata.labels.into();
                     p.link_servers(servers);
                 }
@@ -281,7 +281,7 @@ impl PodIndex {
         let mut lookups = HashMap::new();
 
         for container in spec.containers.into_iter() {
-            for p in container.ports.into_iter() {
+            for p in container.ports.into_iter().flatten() {
                 if p.protocol.map(|p| p == "TCP").unwrap_or(true) {
                     let port = p.container_port as u16;
                     if ports.by_port.contains_key(&port) {

--- a/policy-controller/k8s/index/src/server.rs
+++ b/policy-controller/k8s/index/src/server.rs
@@ -210,7 +210,7 @@ impl SrvIndex {
             HashEntry::Occupied(mut entry) => {
                 // If something about the server changed, we need to update the config to reflect
                 // the change.
-                let new_labels = if entry.get().labels.as_ref() != &srv.metadata.labels {
+                let new_labels = if entry.get().labels != srv.metadata.labels {
                     Some(k8s::Labels::from(srv.metadata.labels))
                 } else {
                     None

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -462,7 +462,7 @@ fn mk_node(name: impl Into<String>, pod_net: IpNet) -> k8s::Node {
         },
         spec: Some(k8s::api::core::v1::NodeSpec {
             pod_cidr: Some(pod_net.to_string()),
-            pod_cidrs: vec![pod_net.to_string()],
+            pod_cidrs: Some(vec![pod_net.to_string()]),
             ..Default::default()
         }),
         status: Some(k8s::api::core::v1::NodeStatus::default()),
@@ -488,22 +488,24 @@ fn mk_pod(
                 .into_iter()
                 .map(|(name, ports)| k8s::api::core::v1::Container {
                     name: name.into(),
-                    ports: ports
-                        .into_iter()
-                        .map(|p| k8s::api::core::v1::ContainerPort {
-                            container_port: p as i32,
-                            ..Default::default()
-                        })
-                        .collect(),
+                    ports: Some(
+                        ports
+                            .into_iter()
+                            .map(|p| k8s::api::core::v1::ContainerPort {
+                                container_port: p as i32,
+                                ..Default::default()
+                            })
+                            .collect(),
+                    ),
                     ..Default::default()
                 })
                 .collect(),
             ..Default::default()
         }),
         status: Some(k8s::api::core::v1::PodStatus {
-            pod_ips: vec![k8s::api::core::v1::PodIP {
+            pod_ips: Some(vec![k8s::api::core::v1::PodIP {
                 ip: Some(pod_ip.to_string()),
-            }],
+            }]),
             ..Default::default()
         }),
     }
@@ -522,10 +524,12 @@ fn mk_server(
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.into()),
             name: Some(name.into()),
-            labels: srv_labels
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
+            labels: Some(
+                srv_labels
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
             ..Default::default()
         },
         spec: k8s::policy::ServerSpec {


### PR DESCRIPTION
kube v0.59 depends on k8s-openapi v0.13, which includes breaking
changes.

This change updates these dependencies and modifies our code to account
for these changes.

Furthermore, we now use the k8s-openapi feature `v1_16` so that we use
an API version that is compatible with Linkerd's minimum support
kubernetes version.

Closes #6657 #6658 #6659

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
