### PR TITLE
codeql: Only run codeql analysis when Go/JS files change

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,17 +5,17 @@ name: CodeQL
 on:
   push:
     branches: [ main, stable-* ]
-    paths-ignore:
-    - '*.md'
-    - '**/*.md'
+    paths:
+    - '**/*.go'
+    - '**/*.js'
+    - '**/*.jsx'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, stable-* ]
-    paths-ignore:
-    - '*.md'
-    - '**/*.md'
-  schedule:
-    - cron: '40 5 * * 3'
+    paths:
+    - '**/*.go'
+    - '**/*.js'
+    - '**/*.jsx'
 
 jobs:
   analyze:


### PR DESCRIPTION
We skip codeql analysis when only markdown files change; but, instead,
we should only run it when Go or JS (or JSX) files change.

This change also removes the scheduled cron run of codeql, as we don't
really get any benefit from it.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
