### PR TITLE
Make headless services support in multicluster link chart configurabl…

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -23,6 +23,7 @@ Kubernetes: `>=1.16.0-0`
 |-----|------|---------|-------------|
 | controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the Service mirror component (uses the Linkerd controller image) |
 | controllerImageVersion | string | `"linkerdVersionValue"` | Tag for the Service Mirror container Docker image |
+| enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | namespace | string | `"linkerd-multicluster"` | Service Mirror component namespace |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -101,6 +101,9 @@ spec:
         - -log-level={{.Values.logLevel}}
         - -event-requeue-limit={{.Values.serviceMirrorRetryLimit}}
         - -namespace={{.Values.namespace}}
+        {{- if .Values.enableHeadlessServices }}
+        - -enable-headless-services
+        {{- end }}
         - {{.Values.targetClusterName}}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion}}
         name: service-mirror

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -3,7 +3,7 @@
 controllerImage: cr.l5d.io/linkerd/controller
 # -- Tag for the Service Mirror container Docker image
 controllerImageVersion: linkerdVersionValue
-# -- Toogle support for mirroring headless services
+# -- Toggle support for mirroring headless services
 enableHeadlessServices: false
 gateway:
   probe:

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -3,6 +3,8 @@
 controllerImage: cr.l5d.io/linkerd/controller
 # -- Tag for the Service Mirror container Docker image
 controllerImageVersion: linkerdVersionValue
+# -- Toogle support for mirroring headless services
+enableHeadlessServices: false
 gateway:
   probe:
     # -- The port used for liveliness probing


### PR DESCRIPTION
Running `linkerd multicluster link --cluster <target> --set "enableHeadlessServices=true"`
should enable the [headless service functionality](https://github.com/linkerd/linkerd2/pull/6090).

Adds the `enableHeadlessServices` flag to the helm chart, which adds the
`-enable-headless-services` container argument to the controller.

Just tested the rendering of the chart. Will test using the chart in a cluster now.

Fixes #6562

Signed-off-by: Knut Götz <knutgoetz@gmail.com>