### PR TITLE
Remove namespace from multicluster charts

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -30,6 +30,7 @@ rm -f viz/charts/linkerd-viz/charts/*
 
 "$bindir"/helm dep up "$rootdir"/multicluster/charts/linkerd-multicluster
 "$bindir"/helm lint "$rootdir"/multicluster/charts/linkerd-multicluster
+"$bindir"/helm dep up "$rootdir"/multicluster/charts/linkerd-multicluster-link
 "$bindir"/helm lint "$rootdir"/multicluster/charts/linkerd-multicluster-link
 "$bindir"/helm lint "$rootdir"/charts/partials
 "$bindir"/helm dep up "$rootdir"/charts/linkerd2-cni

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -37,6 +37,7 @@ if [[ "${releases[*]}" =~ 'helm-test' ]]; then
   "$bindir/helm" --kube-context="$k8s_context" --namespace linkerd delete helm-test
 fi
 if [[ "${releases[*]}" =~ 'multicluster-test' ]]; then
-  "$bindir/helm" --kube-context="$k8s_context" delete multicluster-test
+  "$bindir/helm" --kube-context="$k8s_context" --namespace linkerd-multicluster delete multicluster-test
+  kubectl delete ns linkerd-multicluster
 fi
 

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -17,6 +17,10 @@ shouldn't be used as-is unless you really know what you're doing ;-)
 
 Kubernetes: `>=1.16.0-0`
 
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../../../charts/partials | partials | 0.1.0 |
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -25,7 +29,6 @@ Kubernetes: `>=1.16.0-0`
 | controllerImageVersion | string | `"linkerdVersionValue"` | Tag for the Service Mirror container Docker image |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
-| namespace | string | `"linkerd-multicluster"` | Service Mirror component namespace |
 | serviceMirrorRetryLimit | int | `3` | Number of times update from the remote cluster is allowed to be requeued (retried) |
 | serviceMirrorUID | int | `2103` | User id under which the Service Mirror shall be ran |
 

--- a/multicluster/charts/linkerd-multicluster-link/requirements.lock
+++ b/multicluster/charts/linkerd-multicluster-link/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: partials
+  repository: file://../../../charts/partials
+  version: 0.1.0
+digest: sha256:e2c1d0d581afb33df46411df7a89fca2628328fc7bd0975167e7812bf128e27f
+generated: "2021-08-11T14:34:45.712339546-05:00"

--- a/multicluster/charts/linkerd-multicluster-link/requirements.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: partials
+    version: 0.1.0
+    repository: file://../../../charts/partials

--- a/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: probe-gateway-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     mirror.linkerd.io/mirrored-gateway: "true"
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}

--- a/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
@@ -3,10 +3,10 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multicluster-link-psp
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -14,4 +14,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -28,13 +28,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-service-mirror-read-remote-creds-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
       linkerd.io/control-plane-component: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
@@ -51,7 +51,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: linkerd-service-mirror-read-remote-creds-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
       linkerd.io/control-plane-component: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
@@ -62,13 +62,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: linkerd-service-mirror-{{.Values.targetClusterName}}
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
@@ -80,7 +80,7 @@ metadata:
     linkerd.io/control-plane-component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: 1
   selector:
@@ -100,7 +100,7 @@ spec:
         - service-mirror
         - -log-level={{.Values.logLevel}}
         - -event-requeue-limit={{.Values.serviceMirrorRetryLimit}}
-        - -namespace={{.Values.namespace}}
+        - -namespace={{.Release.Namespace}}
         - {{.Values.targetClusterName}}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion}}
         name: service-mirror

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -7,8 +7,6 @@ gateway:
   probe:
     # -- The port used for liveliness probing
     port: 4191
-# -- Service Mirror component namespace
-namespace: linkerd-multicluster
 # -- Log level for the Multicluster components
 logLevel: info
 # -- Number of times update from the remote cluster is allowed to be requeued

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -90,10 +90,8 @@ Kubernetes: `>=1.16.0-0`
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
-| installNamespace | bool | `true` | If the namespace should be installed |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
-| namespace | string | `"linkerd-multicluster"` | Service Mirror component namespace |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |
 | remoteMirrorServiceAccount | bool | `true` | If the remote mirror service account should be installed |
 | remoteMirrorServiceAccountName | string | `"linkerd-service-mirror-remote-access-default"` | The name of the service account used to allow remote clusters to mirror local services |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -13,7 +13,7 @@ metadata:
     app: {{.Values.gateway.name}}
     linkerd.io/extension: multicluster
   name: {{.Values.gateway.name}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
 spec:
   replicas: 1
   selector:
@@ -38,11 +38,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{.Values.gateway.name}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
   annotations:
-    mirror.linkerd.io/gateway-identity: {{.Values.gateway.name}}.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
+    mirror.linkerd.io/gateway-identity: {{.Values.gateway.name}}.{{.Release.Namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
     mirror.linkerd.io/probe-period: "{{.Values.gateway.probe.seconds}}"
     mirror.linkerd.io/probe-path: {{.Values.gateway.probe.path}}
     mirror.linkerd.io/multicluster-gateway: "true"
@@ -75,7 +75,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{.Values.gateway.name}}
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
@@ -1,0 +1,42 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "patch"]
+  resourceNames: ["{{.Release.Namespace}}"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: namespace-metadata
+roleRef:
+  kind: Role
+  name: namespace-metadata
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app.kubernetes.io/name: namespace-metadata
+    app.kubernetes.io/part-of: Linkerd
+    app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
+  name: namespace-metadata
+spec:
+  template:
+    metadata:
+      annotations:
+        {{ include "partials.annotations.created-by" . }}
+      labels:
+        app.kubernetes.io/name: namespace-metadata
+        app.kubernetes.io/part-of: Linkerd
+        app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: namespace-metadata
+      containers:
+      - name: namespace-metadata
+        image: curlimages/curl:7.78.0
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          ops=''
+          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          ns=$(curl -kfv -H "Authorization: Bearer $token" \
+            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
+
+          if echo "$ns" | grep -vq 'labels'; then
+            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
+          fi
+
+          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"multicluster\"}"
+
+          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
+            -d "[$ops]" \
+            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"

--- a/multicluster/charts/linkerd-multicluster/templates/namespace.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace.yaml
@@ -1,8 +1,8 @@
-{{if .Values.installNamespace -}}
+{{- if eq .Release.Service "CLI" -}}
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{ .Values.namespace }}
+  name: {{ .Release.Namespace }}
   labels:
     linkerd.io/extension: multicluster
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
 rules:
@@ -18,10 +18,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: multicluster-psp
-  namespace: {{.Values.namespace}}
+  {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
-    namespace: {{.Values.namespace}}
+    namespace: {{.Release.Namespace}}
 roleRef:
   kind: Role
   name: psp
@@ -29,5 +29,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{.Values.gateway.name}}
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
 {{ end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{.}}
-  namespace: {{$.Values.namespace}}
+  {{ include "partials.namespace" $ }}
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -30,7 +30,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{.}}
-  namespace: {{$.Values.namespace}}
+  {{ include "partials.namespace" $ }}
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -40,7 +40,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.}}
-  namespace: {{$.Values.namespace}}
+  {{ include "partials.namespace" $ }}
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -52,6 +52,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{.}}
-  namespace: {{$.Values.namespace}}
+  namespace: {{$.Release.Namespace}}
 {{end -}}
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -24,12 +24,8 @@ gateway:
   # -- Set loadBalancerIP on gateway service
   loadBalancerIP: ""
 
-# -- If the namespace should be installed
-installNamespace: true
 # -- Control plane version
 linkerdVersion: linkerdVersionValue
-# -- Service Mirror component namespace
-namespace: linkerd-multicluster
 # -- The port on which the proxy accepts outbound traffic
 proxyOutboundPort: 4140
 # -- If the remote mirror service account should be installed

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -11,6 +11,7 @@ import (
 	"github.com/linkerd/linkerd2/multicluster/static"
 	multicluster "github.com/linkerd/linkerd2/multicluster/values"
 	"github.com/linkerd/linkerd2/pkg/charts"
+	partials "github.com/linkerd/linkerd2/pkg/charts/static"
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/k8s"
@@ -263,13 +264,25 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				{Name: "templates/gateway-mirror.yaml"},
 			}
 
+			var partialFiles []*chartloader.BufferedFile
+			for _, template := range charts.L5dPartials {
+				partialFiles = append(partialFiles,
+					&chartloader.BufferedFile{Name: template},
+				)
+			}
+
 			// Load all multicluster link chart files into buffer
 			if err := charts.FilesReader(static.Templates, helmMulticlusterLinkDefaultChartName+"/", files); err != nil {
 				return err
 			}
 
+			// Load all partial chart files into buffer
+			if err := charts.FilesReader(partials.Templates, "", partialFiles); err != nil {
+				return err
+			}
+
 			// Create a Chart obj from the files
-			chart, err := chartloader.LoadFiles(files)
+			chart, err := chartloader.LoadFiles(append(files, partialFiles...))
 			if err != nil {
 				return err
 			}
@@ -291,8 +304,16 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				return err
 			}
 
+			fullValues := map[string]interface{}{
+				"Values": vals,
+				"Release": map[string]interface{}{
+					"Namespace": opts.namespace,
+					"Service":   "CLI",
+				},
+			}
+
 			// Attach the final values into the `Values` field for rendering to work
-			renderedTemplates, err := engine.Render(chart, map[string]interface{}{"Values": vals})
+			renderedTemplates, err := engine.Render(chart, fullValues)
 			if err != nil {
 				return err
 			}
@@ -346,7 +367,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 
 	return &linkOptions{
 		controlPlaneVersion:     version.Version,
-		namespace:               defaults.Namespace,
+		namespace:               defaultMulticlusterNamespace,
 		dockerRegistry:          defaultDockerRegistry,
 		serviceMirrorRetryLimit: defaults.ServiceMirrorRetryLimit,
 		logLevel:                defaults.LogLevel,
@@ -366,10 +387,6 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 		return nil, errors.New("you need to specify a namespace")
 	}
 
-	if opts.namespace == controlPlaneNamespace {
-		return nil, errors.New("you need to setup the multicluster addons in a namespace different than the Linkerd one")
-	}
-
 	if _, err := log.ParseLevel(opts.logLevel); err != nil {
 		return nil, fmt.Errorf("--log-level must be one of: panic, fatal, error, warn, info, debug")
 	}
@@ -380,7 +397,6 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 	}
 
 	defaults.TargetClusterName = opts.clusterName
-	defaults.Namespace = opts.namespace
 	defaults.ServiceMirrorRetryLimit = opts.serviceMirrorRetryLimit
 	defaults.LogLevel = opts.logLevel
 	defaults.ControllerImageVersion = opts.controlPlaneVersion

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -23,10 +23,8 @@ type Values struct {
 	ControllerImageVersion         string   `json:"controllerImageVersion"`
 	Gateway                        *Gateway `json:"gateway"`
 	IdentityTrustDomain            string   `json:"identityTrustDomain"`
-	InstallNamespace               bool     `json:"installNamespace"`
 	LinkerdNamespace               string   `json:"linkerdNamespace"`
 	LinkerdVersion                 string   `json:"linkerdVersion"`
-	Namespace                      string   `json:"namespace"`
 	ProxyOutboundPort              uint32   `json:"proxyOutboundPort"`
 	ServiceMirror                  bool     `json:"serviceMirror"`
 	LogLevel                       string   `json:"logLevel"`

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -82,6 +82,8 @@ func (c *Chart) render(partialsFiles []*loader.BufferedFile) (bytes.Buffer, erro
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
+	release, _ := valuesToRender["Release"].(map[string]interface{})
+	release["Service"] = "CLI"
 
 	renderedTemplates, err := engine.Render(chart, valuesToRender)
 	if err != nil {
@@ -122,11 +124,6 @@ func (c *Chart) RenderCNI() (bytes.Buffer, error) {
 		{Name: "charts/partials/templates/_pull-secrets.tpl"},
 	}
 	return c.render(cniPartials)
-}
-
-// RenderNoPartials returns a bytes buffer with the result of rendering a Helm chart with no partials
-func (c *Chart) RenderNoPartials() (bytes.Buffer, error) {
-	return c.render([]*loader.BufferedFile{})
 }
 
 // ReadFile updates the buffered file with the data read from disk

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -583,7 +583,6 @@ func TestInstallMulticluster(t *testing.T) {
 	} else if TestHelper.Multicluster() {
 		exec := append([]string{"multicluster"}, []string{
 			"install",
-			"--namespace", TestHelper.GetMulticlusterNamespace(),
 		}...)
 		out, err := TestHelper.LinkerdRun(exec...)
 		if err != nil {

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -527,7 +527,8 @@ func (h *TestHelper) HelmInstallMulticluster(chart string, arg ...string) (strin
 		h.helm.multiclusterReleaseName,
 		chart,
 		"--kube-context", h.k8sContext,
-		"--set", "namespace=" + h.GetMulticlusterNamespace(),
+		"--namespace", h.GetMulticlusterNamespace(),
+		"--create-namespace",
 		"--set", "linkerdNamespace=" + h.GetLinkerdNamespace(),
 	}, arg...)
 	return combinedOutput("", h.helm.path, withParams...)


### PR DESCRIPTION
Another part of #6584, branched off of #6635 (alpeb/no-ns-helm-core).

Stop rendering the namespace in the `linkerd-multicluster` chart as we
did in #6635.

Also:
- Got rid of the `namespace` values.yaml entry in the
  `linkerd-multicluster` and `linkerd-multicluster-link` charts, and
  also the `installNamespace` entry in the former.
- Added a dependency on the `partials` chart to the
  `linkerd-multicluster-link` chart, so that we can tap on the
  `partials.namespace` helper.
- Added the post-install hook resources to the `linkerd-multicluster`
  chart.
- We don't have any more the restriction on having the muticluster
  objects live in a separate namespace than linkerd. It's still good
  practice, and that's the default for the CLI install, but I removed
  that validation.

Finally, as a side-effect, the `allow` subcommand was fixed; it has been
broken for a while apparently:

```console
$ linkerd mc allow --service-account-name foobar
Error: template: linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml:16:7: executing "linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml" at <include "partials.annotations.created-by" $>: error calling include: template: no template "partials.annotations.created-by" associated with template "gotpl"
```
