### PR TITLE
Add missing policy-controller entry in docker_build job for release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Keep in sync with integration_tests.yaml matrix build
-        target: [proxy, controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
+        target: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
     name: Docker build (${{ matrix.target }})
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Thus syncing against `integration_tests.yml`. This should fix the edge build.