### PR TITLE
policy-controller: Do not use docker caching

### DIFF
--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -6,9 +6,7 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY . /build
-RUN --mount=type=cache,target=target \
-    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
-    target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
+RUN target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
     cargo build --locked --release --target="$target" --package=linkerd-policy-controller && \
     mv "target/${target}/release/linkerd-policy-controller" /tmp/
 


### PR DESCRIPTION
crazy-max/ghaction-docker-buildx#172 describes a problem with
cross-building docker images--especially 32b ARM images--and docker
caching.

This change removes caching from the policy-controller dockerfile to
avoid this issue.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
