### PR TITLE
Update the policy-controller release build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
-    - name: Set up a small filesystem for Docker
+    - name: Set up a Docker filesystem
       if: matrix.target == 'policy-controller'
       # See crazy-max/ghaction-docker-buildx#172
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
     - "*"
-    branches:
-    - 'ver/dockerfs'
 permissions:
   contents: read
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
     - "*"
+    branches:
+    - 'ver/dockerfs'
 permissions:
   contents: read
 env:
@@ -37,6 +39,21 @@ jobs:
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
+    - name: Set up a small filesystem for Docker
+      # See crazy-max/ghaction-docker-buildx#172
+      run: |
+        df -h
+        sudo swapon --show
+        sudo dd if=/dev/zero of=/dockerfs bs=1M count=6K
+        sudo chmod 600 /dockerfs
+        sudo mkswap /dockerfs
+        sudo swapon /dockerfs
+        sudo swapon --show
+        sudo free -h
+        sudo systemctl stop docker
+        sudo mount -t tmpfs -o size=9G tmpfs /var/lib/docker
+        df -h
+        sudo systemctl start docker
     - name: Build & Push Multi Arch Images
       env:
         DOCKER_MULTIARCH: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
     name: Static CLI tests (windows)
     timeout-minutes: 30
     runs-on: windows-latest
-    needs: [docker_build, policy_controller_manifest]
+    needs: [docker_build]
     steps:
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -240,7 +240,7 @@ jobs:
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
     timeout-minutes: 30
-    needs: [integration_tests, arm64_integration_tests]
+    needs: [integration_tests]
     runs-on: windows-2019
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64, arm]
-    name: Policy controller build (${{ matrix.target }})
+    name: Policy controller build (${{ matrix.arch }})
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
@@ -104,12 +104,14 @@ jobs:
     - run: |
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
-    - name: Setup multiarch manifest
+    - name: Create multiarch manifest
       run: |
         docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
             ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
             ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
             ghcr.io/linkerd/policy-controller:${TAG}-arm
+    - name: Annotate multiarch manifest
+      run: |
         docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
             ghcr.io/linkerd/policy-controller:${TAG}-amd64 --os=linux --arch=amd64
         docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,14 @@ jobs:
     - run: |
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
-    - run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+    - name: Build ${{ matrix.arch }}
+      run: |
         docker build ./policy-controller/ \
           -f ./policy-controller/${{ matrix.arch }}.dockerfile \
           -t ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
+    - name: Push ${{ matrix.arch }}
+      run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
         docker push ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
 
   policy_controller_manifest:
@@ -42,8 +45,8 @@ jobs:
     - run: |
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
-    - run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+    - name: Setup multiarch manifest
+      run: |
         docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
             ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
             ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
@@ -54,6 +57,9 @@ jobs:
             ghcr.io/linkerd/policy-controller:${TAG}-arm64 --os=linux --arch=arm64
         docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
             ghcr.io/linkerd/policy-controller:${TAG}-arm --os=linux --arch=arm
+    - name: Push multiarch manifest
+      run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
         docker manifest push ghcr.io/linkerd/policy-controller:$TAG
 
   docker_build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,63 +10,12 @@ permissions:
 env:
   GH_ANNOTATION: true
 jobs:
-  policy_controller_build:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        arch: [amd64, arm64, arm]
-    steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
-    - name: Checkout code
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - run: |
-        . bin/_tag.sh
-        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
-    - name: Build ${{ matrix.arch }}
-      run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
-        docker buildx build --push ./policy-controller/ \
-          -f ./policy-controller/${{ matrix.arch }}.dockerfile \
-          -t ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
-
-  policy_controller_manifest:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
-    needs: [policy_controller_build]
-    strategy:
-      matrix:
-        arch: [amd64, arm64, arm]
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - run: |
-        . bin/_tag.sh
-        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
-    - name: Setup multiarch manifest
-      run: |
-        docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
-            ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
-            ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
-            ghcr.io/linkerd/policy-controller:${TAG}-arm
-        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
-            ghcr.io/linkerd/policy-controller:${TAG}-amd64 --os=linux --arch=amd64
-        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
-            ghcr.io/linkerd/policy-controller:${TAG}-arm64 --os=linux --arch=arm64
-        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
-            ghcr.io/linkerd/policy-controller:${TAG}-arm --os=linux --arch=arm
-    - name: Push multiarch manifest
-      run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
-        docker manifest push ghcr.io/linkerd/policy-controller:$TAG
-
   docker_build:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
         # Keep in sync with integration_tests.yaml matrix build
-        target: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
+        target: [proxy, controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
     name: Docker build (${{ matrix.target }})
     timeout-minutes: 30
     steps:
@@ -122,12 +71,62 @@ jobs:
         name: image-archives
         path: /home/runner/archives
 
+  policy_controller_build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: [amd64, arm64, arm]
+    name: Policy controller build (${{ matrix.target }})
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
+    - name: Checkout code
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - run: |
+        . bin/_tag.sh
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+    - name: Build ${{ matrix.arch }}
+      run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+        docker buildx build --push ./policy-controller/ \
+          -f ./policy-controller/${{ matrix.arch }}.dockerfile \
+          -t ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
+
+  policy_controller_manifest:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    needs: [policy_controller_build]
+    name: Policy controller manifest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - run: |
+        . bin/_tag.sh
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+    - name: Setup multiarch manifest
+      run: |
+        docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-amd64 --os=linux --arch=amd64
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm64 --os=linux --arch=arm64
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm --os=linux --arch=arm
+    - name: Push multiarch manifest
+      run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+        docker manifest push ghcr.io/linkerd/policy-controller:$TAG
+
   # todo: Keep in sync with `integration_tests.yml`
   windows_static_cli_tests:
     name: Static CLI tests (windows)
     timeout-minutes: 30
     runs-on: windows-latest
-    needs: [docker_build]
+    needs: [docker_build, policy_controller_manifest]
     steps:
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -190,7 +189,7 @@ jobs:
     name: ARM64 integration tests
     timeout-minutes: 60
     runs-on: ubuntu-20.04
-    needs: [docker_build]
+    needs: [docker_build, policy_controller_manifest]
     steps:
     - name: Checkout code
       #if: startsWith(github.ref, 'refs/tags/stable')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
     - name: Set up a small filesystem for Docker
+      if: matrix.target == 'policy-controller'
       # See crazy-max/ghaction-docker-buildx#172
       run: |
         df -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Keep in sync with integration_tests.yaml matrix build
-        target: [proxy, controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
+        target: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
     name: Docker build (${{ matrix.target }})
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         arch: [amd64, arm64, arm]
     steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - run: |
@@ -24,13 +26,10 @@ jobs:
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
     - name: Build ${{ matrix.arch }}
       run: |
-        docker build ./policy-controller/ \
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+        docker buildx build --push ./policy-controller/ \
           -f ./policy-controller/${{ matrix.arch }}.dockerfile \
           -t ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
-    - name: Push ${{ matrix.arch }}
-      run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
-        docker push ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
 
   policy_controller_manifest:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,52 @@ permissions:
 env:
   GH_ANNOTATION: true
 jobs:
+  policy_controller_build:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: [amd64, arm64, arm]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - run: |
+        . bin/_tag.sh
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+    - run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+        docker build ./policy-controller/ \
+          -f ./policy-controller/${{ matrix.arch }}.dockerfile \
+          -t ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
+        docker push ghcr.io/linkerd/policy-controller:$TAG-${{ matrix.arch }}
+
+  policy_controller_manifest:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    needs: [policy_controller_build]
+    strategy:
+      matrix:
+        arch: [amd64, arm64, arm]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - run: |
+        . bin/_tag.sh
+        echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+    - run: |
+        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
+        docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-amd64 --os=linux --arch=amd64
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm64 --os=linux --arch=arm64
+        docker manifest annotate ghcr.io/linkerd/policy-controller:$TAG \
+            ghcr.io/linkerd/policy-controller:${TAG}-arm --os=linux --arch=arm
+        docker manifest push ghcr.io/linkerd/policy-controller:$TAG
+
   docker_build:
     runs-on: ubuntu-20.04
     strategy:
@@ -17,7 +63,7 @@ jobs:
         # Keep in sync with integration_tests.yaml matrix build
         target: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
     name: Docker build (${{ matrix.target }})
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -39,22 +85,6 @@ jobs:
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@abe5d8f79a1606a2d3e218847032f3f2b1726ab0
-    - name: Set up a Docker filesystem
-      if: matrix.target == 'policy-controller'
-      # See crazy-max/ghaction-docker-buildx#172
-      run: |
-        df -h
-        sudo swapon --show
-        sudo dd if=/dev/zero of=/dockerfs bs=1M count=6K
-        sudo chmod 600 /dockerfs
-        sudo mkswap /dockerfs
-        sudo swapon /dockerfs
-        sudo swapon --show
-        sudo free -h
-        sudo systemctl stop docker
-        sudo mount -t tmpfs -o size=9G tmpfs /var/lib/docker
-        df -h
-        sudo systemctl start docker
     - name: Build & Push Multi Arch Images
       env:
         DOCKER_MULTIARCH: 1
@@ -86,6 +116,7 @@ jobs:
       with:
         name: image-archives
         path: /home/runner/archives
+
   # todo: Keep in sync with `integration_tests.yml`
   windows_static_cli_tests:
     name: Static CLI tests (windows)
@@ -149,6 +180,7 @@ jobs:
         # Validate the CLI version matches the current build tag.
         [[ "$TAG" == "$($CMD version --short --client)" ]]
         bin/tests --images preload --name ${{ matrix.integration_test }} "$CMD"
+
   arm64_integration_tests:
     name: ARM64 integration tests
     timeout-minutes: 60
@@ -198,6 +230,7 @@ jobs:
       if: ${{ always() }}
       # will fail if other steps didn't run, so ignore error
       run: bin/test-cleanup "$CMD" || true
+
   choco_pack:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
@@ -225,6 +258,7 @@ jobs:
       with:
         name: choco
         path: ./linkerd.*.nupkg
+
   gh_release:
     name: Create GH release
     timeout-minutes: 30
@@ -267,6 +301,7 @@ jobs:
           ./target/release/linkerd2-cli-*-linux-*
           ./target/release/linkerd2-cli-*-windows.*
           ./target/release/linkerd2-cli-*.nupkg
+
   website_publish:
     name: Linkerd website publish
     timeout-minutes: 30
@@ -282,6 +317,7 @@ jobs:
         token: ${{ secrets.RELEASE_TOKEN }}
         repository: linkerd/website
         event-type: release
+
   website_publish_check:
     name: Linkerd website publish check
     timeout-minutes: 30
@@ -312,6 +348,7 @@ jobs:
           echo "::error::The version '$TAG' was NOT found published in the website"
           exit 1
         fi
+
   chart_deploy:
     name: Helm chart deploy
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
     - name: Create multiarch manifest
       run: |
-        docker manifest create ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
+        docker manifest create ghcr.io/linkerd/policy-controller:${TAG} \
             ghcr.io/linkerd/policy-controller:${TAG}-amd64 \
             ghcr.io/linkerd/policy-controller:${TAG}-arm64 \
             ghcr.io/linkerd/policy-controller:${TAG}-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         # Keep in sync with integration_tests.yaml matrix build
         target: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
     name: Docker build (${{ matrix.target }})
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
     - name: Checkout code
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
         - upgrade-edge
         - upgrade-stable
         - cni-calico-deep
-    needs: [docker_build]
+    needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60
     runs-on: ubuntu-20.04

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -7,17 +7,17 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
-if [ -n "$DOCKER_MULTIARCH" ]; then
-    echo "DOCKER_MULTIARCH may not be set with $0" >&2
-    exit 1
-fi
-
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
 # shellcheck source=_docker.sh
 . "$bindir"/_docker.sh
 # shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
+
+if [ -n "$DOCKER_MULTIARCH" ]; then
+    echo "DOCKER_MULTIARCH may not be set with $0" >&2
+    exit 1
+fi
 
 tag=$(head_root_tag)
 ROOTDIR=$( cd "$bindir"/../policy-controller && pwd )

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -7,6 +7,11 @@ if [ $# -ne 0 ]; then
     exit 64
 fi
 
+if [ -n "$DOCKER_MULTIARCH" ]; then
+    echo "DOCKER_MULTIARCH may not be set with $0" >&2
+    exit 1
+fi
+
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
 # shellcheck source=_docker.sh
@@ -16,4 +21,4 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 
 tag=$(head_root_tag)
 ROOTDIR=$( cd "$bindir"/../policy-controller && pwd )
-docker_build policy-controller "$tag" "$ROOTDIR/Dockerfile"
+docker_build policy-controller "$tag" "$ROOTDIR/amd64.dockerfile"

--- a/policy-controller/Cargo.lock
+++ b/policy-controller/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "darling"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +511,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +658,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-timeout",
  "hyper-tls",
  "jsonpath_lib",
@@ -642,6 +669,7 @@ dependencies = [
  "pem",
  "pin-project 1.0.8",
  "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -652,6 +680,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "webpki",
 ]
 
 [[package]]
@@ -1325,6 +1354,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1746,17 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]

--- a/policy-controller/Cargo.lock
+++ b/policy-controller/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "js-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json-patch"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +641,7 @@ dependencies = [
  "openssl",
  "pem",
  "pin-project 1.0.8",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1280,6 +1296,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1368,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1475,6 +1529,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1850,6 +1910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1948,80 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+
+[[package]]
+name = "web-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "which"

--- a/policy-controller/Cargo.lock
+++ b/policy-controller/Cargo.lock
@@ -1862,6 +1862,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1885,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -22,7 +22,7 @@ linkerd-policy-controller-k8s-index = { path = "./k8s/index" }
 structopt = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "parking_lot", "signal", "sync"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt", "tracing-log"] }
 
 [workspace]
 resolver = "2"

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -5,12 +5,17 @@ edition = "2018"
 license = "Apache-2.0"
 publish = false
 
+[features]
+default = ["rustls"]
+native-tls = ["kube/native-tls"]
+rustls = ["kube/rustls"]
+
 [dependencies]
 anyhow = "1"
 drain = "0.1"
 futures = "0.3"
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
-kube = { version = "0.58", default-features = false, features = ["client", "derive", "native-tls"] }
+kube = { version = "0.58", default-features = false, features = ["client", "derive"] }
 linkerd-policy-controller-core = { path = "./core" }
 linkerd-policy-controller-grpc = { path = "./grpc" }
 linkerd-policy-controller-k8s-index = { path = "./k8s/index" }

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [features]
 default = ["rustls"]
 native-tls = ["kube/native-tls"]
-rustls = ["kube/rustls"]
+rustls = ["kube/rustls-tls"]
 
 [dependencies]
 anyhow = "1"

--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -6,7 +6,9 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY . /build
-RUN target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
+    target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
     cargo build --locked --release --target="$target" --package=linkerd-policy-controller && \
     mv "target/${target}/release/linkerd-policy-controller" /tmp/
 

--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -6,9 +6,7 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY . /build
-RUN --mount=type=cache,target=target \
-    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
-    target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
+RUN target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
     cargo build --locked --release --target="$target" --package=linkerd-policy-controller && \
     mv "target/${target}/release/linkerd-policy-controller" /tmp/
 

--- a/policy-controller/amd64.dockerfile
+++ b/policy-controller/amd64.dockerfile
@@ -6,9 +6,10 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY . /build
-RUN target=$(rustup show | sed -n 's/^Default host: \(.*\)/\1/p') ; \
-    cargo build --locked --release --target="$target" --package=linkerd-policy-controller && \
-    mv "target/${target}/release/linkerd-policy-controller" /tmp/
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
+    cargo build --locked --target=x86_64-unknown-linux-gnu --release --package=linkerd-policy-controller && \
+    mv target/x86_64-unknown-linux-gnu/release/linkerd-policy-controller /tmp/
 
 # Creates a minimal runtime image with the controller binary.
 FROM $RUNTIME_IMAGE

--- a/policy-controller/arm.dockerfile
+++ b/policy-controller/arm.dockerfile
@@ -1,0 +1,19 @@
+ARG RUST_IMAGE=docker.io/library/rust:1.54.0-buster
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+
+FROM $RUST_IMAGE as build
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends g++-arm-linux-gnueabihf libc6-dev-armhf-cross && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ && \
+    rustup target add armv7-unknown-linux-gnueabihf
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
+WORKDIR /build
+COPY . /build
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
+    cargo build --locked --release --target=armv7-unknown-linux-gnueabihf --package=linkerd-policy-controller && \
+    mv target/armv7-unknown-linux-gnueabihf/release/linkerd-policy-controller /tmp/
+
+FROM --platform=linux/arm $RUNTIME_IMAGE
+COPY --from=build /tmp/linkerd-policy-controller /bin/
+ENTRYPOINT ["/bin/linkerd-policy-controller"]

--- a/policy-controller/arm64.dockerfile
+++ b/policy-controller/arm64.dockerfile
@@ -1,0 +1,19 @@
+ARG RUST_IMAGE=docker.io/library/rust:1.54.0-buster
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+
+FROM $RUST_IMAGE as build
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends g++-aarch64-linux-gnu libc6-dev-arm64-cross && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/ && \
+    rustup target add aarch64-unknown-linux-gnu
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+WORKDIR /build
+COPY . /build
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.54.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
+    cargo build --locked --release --target=aarch64-unknown-linux-gnu --package=linkerd-policy-controller && \
+    mv target/aarch64-unknown-linux-gnu/release/linkerd-policy-controller /tmp/
+
+FROM --platform=linux/arm64 $RUNTIME_IMAGE
+COPY --from=build /tmp/linkerd-policy-controller /bin/
+ENTRYPOINT ["/bin/linkerd-policy-controller"]

--- a/policy-controller/deny.toml
+++ b/policy-controller/deny.toml
@@ -15,13 +15,23 @@ ignore = []
 
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "BSD-3-Clause", "MIT"]
+allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT"]
 deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"
 confidence-threshold = 0.8
-exceptions = []
+exceptions = [
+    { allow = ["ISC", "MIT", "OpenSSL"], name = "ring", version = "*" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+version = "*"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [bans]
 multiple-versions = "deny"
@@ -46,6 +56,3 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
-
-[sources.allow-org]
-github = ["linkerd"]

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 k8s-openapi = { version = "0.12.0", default-features = false, features = ["v1_20"] }
-kube = { version = "0.58.1", default-features = false, features = ["client", "derive", "native-tls"] }
+kube = { version = "0.58.1", default-features = false, features = ["client", "derive"] }
 kube-runtime = { version = "0.58.1", default-features = false }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
We can't use the typical multiarch docker build with the proxy:
qemu-hosted arm64/arm builds take 45+ minutes before failing due to
missing tooling--specifically `protoc`. (While there is a `protoc`
binary available for arm64, there are no binaries available for 32-bit
arm hosts).

To fix this, this change updates the release process to cross-build the
policy-controller on an amd64 host to the target architecture. We
separate the policy-controller's dockerfiles as `amd64.dockerfile`,
`arm64.dockerfile`, and `arm.dockerfile`. Then, in CI we build and push
each of these images individually (in parallel, via a build matrix).
Once all of these are complete, we use the `docker manifest` CLI tools
to unify these images into a single multi-arch manifest.

This cross-building approach requires that we move from using
`native-tls` to `rustls`, as we cannot build against the platform-
appropriate native TLS libraries. The policy-controller is now feature-
flagged to use `rustls` by default, though it may be necessary to use
`native-tls` in local development, as `rustls` cannot validate TLS
connections that target IP addresses.

The policy-controller has also been updated to pull in `tracing-log` for
compatibility with crates that do not use `tracing` natively. This was
helpful while debugging connectivity issue with the Kubernetes cluster.

The `bin/docker-build-policy-controller` helper script now *only* builds
the amd64 variant of the policy controller. It fails when asked to build
multiarch images.