### PR TITLE
policy-controller: Maintain liveness on watch restart

### DIFF
--- a/policy-controller/Cargo.lock
+++ b/policy-controller/Cargo.lock
@@ -809,7 +809,6 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1917,8 +1916,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project 1.0.8",
  "tracing",
 ]

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -16,4 +16,3 @@ serde_json = "1"
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
-tracing-futures = { version = "0.2", default-features = false, features = ["futures-03"] }

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -17,7 +17,6 @@ use kube::api::{Api, ListParams};
 pub use kube::api::{ObjectMeta, ResourceExt};
 use kube_runtime::watcher;
 use tracing::info_span;
-use tracing_futures::Instrument;
 
 /// Resource watches.
 pub struct ResourceWatches {
@@ -46,18 +45,14 @@ impl From<kube::Client> for ResourceWatches {
         let pod_params = params.clone().labels("linkerd.io/control-plane-ns");
 
         Self {
-            nodes_rx: watcher(Api::all(client.clone()), params.clone())
-                .instrument(info_span!("nodes"))
-                .into(),
-            pods_rx: watcher(Api::all(client.clone()), pod_params)
-                .instrument(info_span!("pods"))
-                .into(),
-            servers_rx: watcher(Api::all(client.clone()), params.clone())
-                .instrument(info_span!("servers"))
-                .into(),
-            authorizations_rx: watcher(Api::all(client), params)
-                .instrument(info_span!("serverauthorizations"))
-                .into(),
+            nodes_rx: Watch::from(watcher(Api::all(client.clone()), params.clone()))
+                .instrument(info_span!("nodes")),
+            pods_rx: Watch::from(watcher(Api::all(client.clone()), pod_params))
+                .instrument(info_span!("pods")),
+            servers_rx: Watch::from(watcher(Api::all(client.clone()), params.clone()))
+                .instrument(info_span!("servers")),
+            authorizations_rx: Watch::from(watcher(Api::all(client), params))
+                .instrument(info_span!("serverauthorizations")),
         }
     }
 }

--- a/policy-controller/k8s/api/src/watch.rs
+++ b/policy-controller/k8s/api/src/watch.rs
@@ -51,10 +51,7 @@ impl<T> Watch<T> {
                 .next()
                 .instrument(self.span.clone())
                 .await
-                .expect(&*format!(
-                    "{} stream must not terminate",
-                    std::any::type_name::<T>()
-                ));
+                .expect("stream must not terminate");
 
             match ev {
                 Ok(ev) => {

--- a/policy-controller/k8s/api/src/watch.rs
+++ b/policy-controller/k8s/api/src/watch.rs
@@ -1,13 +1,14 @@
 use futures::prelude::*;
 use std::pin::Pin;
 use tokio::time;
-use tracing::info;
+use tracing::{info, Instrument};
 
 pub use kube_runtime::watcher::{Event, Result};
 
 /// Wraps an event stream that never terminates.
 pub struct Watch<T> {
-    ready: bool,
+    initialized: bool,
+    span: tracing::Span,
     rx: Pin<Box<dyn Stream<Item = Result<Event<T>>> + Send + 'static>>,
 }
 
@@ -18,16 +19,26 @@ where
     W: Stream<Item = Result<Event<T>>> + Send + 'static,
 {
     fn from(watch: W) -> Self {
-        Watch {
-            ready: false,
-            rx: watch.boxed(),
-        }
+        Self::new(watch.boxed())
     }
 }
 
 impl<T> Watch<T> {
-    pub fn ready(&self) -> bool {
-        self.ready
+    pub fn new(rx: Pin<Box<dyn Stream<Item = Result<Event<T>>> + Send + 'static>>) -> Watch<T> {
+        Self {
+            rx,
+            initialized: false,
+            span: tracing::Span::current(),
+        }
+    }
+
+    pub fn instrument(mut self, span: tracing::Span) -> Self {
+        self.span = span;
+        self
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
     }
 
     /// Receive the next event in the stream.
@@ -35,20 +46,25 @@ impl<T> Watch<T> {
     /// If the stream fails, log the error and sleep for 1s before polling for a reset event.
     pub async fn recv(&mut self) -> Event<T> {
         loop {
-            match self
+            let ev = self
                 .rx
                 .next()
+                .instrument(self.span.clone())
                 .await
-                .expect("watch stream must not terminate")
-            {
+                .expect(&*format!(
+                    "{} stream must not terminate",
+                    std::any::type_name::<T>()
+                ));
+
+            match ev {
                 Ok(ev) => {
-                    self.ready = true;
+                    self.initialized = true;
                     return ev;
                 }
                 Err(error) => {
-                    self.ready = false;
-                    info!(%error, "Disconnected");
+                    info!(parent: &self.span, %error, "Failed");
                     time::sleep(time::Duration::from_secs(1)).await;
+                    info!(parent: &self.span, "Restarting");
                 }
             }
         }

--- a/policy-controller/k8s/api/src/watch.rs
+++ b/policy-controller/k8s/api/src/watch.rs
@@ -60,6 +60,11 @@ impl<T> Watch<T> {
                 }
                 Err(error) => {
                     info!(parent: &self.span, %error, "Failed");
+
+                    // TODO(ver) this backoff may not be fully honored if this call to `recv` is
+                    // canceled. Instead, we should track the backoff on the `Watch` and poll it
+                    // before the inner stream. We probably need to use pin-project-lite for this,
+                    // though.
                     time::sleep(time::Duration::from_secs(1)).await;
                     info!(parent: &self.span, "Restarting");
                 }

--- a/policy-controller/k8s/index/src/pod.rs
+++ b/policy-controller/k8s/index/src/pod.rs
@@ -206,7 +206,7 @@ impl PodIndex {
                 let (pod, kubelet) = match nodes.get_kubelet_ips_or_push_pending(pod) {
                     Some((pod, ips)) => (pod, ips),
                     None => {
-                        debug!("Pod cannot yet assigned to a Node");
+                        debug!("Pod cannot yet be assigned to a Node");
                         return Ok(());
                     }
                 };


### PR DESCRIPTION
The policy controller's readiness and liveness admin endpoint is tied to
watch state: the controller only advertises liveness when all watches
have received updates; and after a watch disconnects liveness fails
until a new update is received.

However, in some environments--especially when the API server ends the
stream before the client gracefully reconnects--the watch terminess so
that liveness is not advertises even though the client resumes watching
resources. Because the watch is resumed with a `resourceVersion`, no
updates are provided despite the watch being reestablished, and liveness
checks fail until the pod is terminated (or an update is received).

To fix this, we modify readiness advertisements to fail only until the
initial state is acquired from all watches. After this, the controller
serves cached state indefinitely.

While diagnosing this, logging changes were needed, especially for the
`Watch` type. Watches now properly maintain logging contexts and state
transitions are logged in more cases. The signature and logging context
of `Index::run` has been updated as well. Additionally, node lookup
debug logs have been elaborated to help confirm that 'pending' messages
are benign.
