### PR TITLE
Fix the svc/linkerd-policy pod selector

### DIFF
--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -65,14 +65,14 @@ metadata:
   name: linkerd-policy
   namespace: {{.Values.namespace}}
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1515,14 +1515,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1514,14 +1514,14 @@ metadata:
   name: linkerd-policy
   namespace: l5d
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: l5d
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1514,14 +1514,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1514,14 +1514,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1514,14 +1514,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1588,14 +1588,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1588,14 +1588,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1445,14 +1445,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1507,14 +1507,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1581,14 +1581,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1589,14 +1589,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1581,14 +1581,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1476,14 +1476,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1516,14 +1516,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: CliVersion
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1514,14 +1514,14 @@ metadata:
   name: linkerd-policy
   namespace: linkerd
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1500,14 +1500,14 @@ metadata:
   name: linkerd-policy
   namespace: l5d
   labels:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: l5d
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 spec:
   clusterIP: None
   selector:
-    linkerd.io/control-plane-component: policy
+    linkerd.io/control-plane-component: destination
   ports:
   - name: grpc
     port: 8090


### PR DESCRIPTION
`svc/linkerd-policy` selects pods on
`linkerd.io/control-plane-component: policy`; but this doesn't actually
select any controller pods.

This change ensures all `control-plane-component` labels use
`destination` instead of `policy`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
