### PR TITLE
Defend against nil pointer in localhost test

### DIFF
--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -82,7 +82,7 @@ func TestLocalhostServer(t *testing.T) {
 				return fmt.Errorf("expected 1 row of stat output, got: %s", out)
 			}
 
-			if *stats[0].Rps == 0.0 {
+			if stats[0].Rps == nil || *stats[0].Rps == 0.0 {
 				return fmt.Errorf("expected non-zero RPS from slowcooker to nginx: %s", out)
 			}
 


### PR DESCRIPTION
To avoid panics such as https://github.com/linkerd/linkerd2/runs/3363869247?check_suite_focus=true we defensively do a nil check before dereferencing.  Note that in the case where the Rps is nil, we will still generate an error; however, that error will be retried rather than causing the test to abort with a panic.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
