### PR TITLE
proxy-injector: always add the `opaque-ports` annotation

### DIFF
--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -131,6 +131,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         {{- include "partials.proxy.annotations" . | nindent 8}}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        config.linkerd.io/opaque-ports: {{.Values.proxy.opaquePorts}}
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: {{.Values.namespace}}

--- a/charts/linkerd2/templates/identity.yaml
+++ b/charts/linkerd2/templates/identity.yaml
@@ -127,6 +127,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         {{- include "partials.proxy.annotations" . | nindent 8}}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        config.linkerd.io/opaque-ports: {{.Values.proxy.opaquePorts}}
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: {{.Values.namespace}}

--- a/charts/linkerd2/templates/proxy-injector.yaml
+++ b/charts/linkerd2/templates/proxy-injector.yaml
@@ -38,6 +38,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         {{- include "partials.proxy.annotations" . | nindent 8}}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+        config.linkerd.io/opaque-ports: {{.Values.proxy.opaquePorts}}
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: {{.Values.namespace}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1558,6 +1559,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1895,6 +1897,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: l5d
@@ -1557,6 +1558,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: l5d
@@ -1893,6 +1895,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: l5d

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1557,6 +1558,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1893,6 +1895,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1557,6 +1558,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1893,6 +1895,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1557,6 +1558,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1893,6 +1895,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1297,6 +1297,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1650,6 +1651,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -2026,6 +2028,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1297,6 +1297,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1650,6 +1651,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -2026,6 +2028,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1185,6 +1185,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1488,6 +1489,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1775,6 +1777,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1245,6 +1245,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1550,6 +1551,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1890,6 +1892,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1288,6 +1288,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1643,6 +1644,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -2023,6 +2025,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1294,6 +1294,7 @@ spec:
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1653,6 +1654,7 @@ spec:
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -2041,6 +2043,7 @@ spec:
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1288,6 +1288,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1643,6 +1644,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -2023,6 +2025,7 @@ spec:
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1519,6 +1520,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1817,6 +1819,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
+        config.linkerd.io/opaque-ports: 25,443,587,3306,5432,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1559,6 +1560,7 @@ spec:
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
+        config.linkerd.io/opaque-ports: 25,443,587,3306,5432,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1903,6 +1905,7 @@ spec:
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
+        config.linkerd.io/opaque-ports: 25,443,587,3306,5432,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1254,6 +1254,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: linkerd
@@ -1557,6 +1558,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: linkerd
@@ -1893,6 +1895,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1240,6 +1240,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: l5d
@@ -1543,6 +1544,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: l5d
@@ -1879,6 +1881,7 @@ spec:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
+        config.linkerd.io/opaque-ports: 25,443,587,3306,4444,5432,6379,9300,11211
       labels:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: l5d

--- a/controller/proxy-injector/fake/data/default-op-annotation.patch.json
+++ b/controller/proxy-injector/fake/data/default-op-annotation.patch.json
@@ -1,0 +1,12 @@
+[
+    {
+        "op": "add",
+        "path": "/metadata/annotations",
+        "value": {}
+    },
+    {
+        "op": "add",
+        "path": "/metadata/annotations/config.linkerd.io~1opaque-ports",
+        "value": "25,443,587,3306,4444,5432,6379,9300,11211"
+    }
+]

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -93,6 +93,16 @@ func Inject(
 		// If namespace has annotations that do not exist on pod then copy them
 		// over to pod's template.
 		resourceConfig.AppendNamespaceAnnotations()
+
+		// If the pod did not inherit the opaque ports annotation from the
+		// namespace, then add the default value from the config values. This
+		// ensures that the generated patch always sets the opaue ports
+		// annotation.
+		if !resourceConfig.HasPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation) {
+			opaquePorts := resourceConfig.GetValues().Proxy.OpaquePorts
+			resourceConfig.AppendPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation, opaquePorts)
+		}
+
 		patchJSON, err := resourceConfig.GetPodPatch(true)
 		if err != nil {
 			return nil, err
@@ -115,11 +125,31 @@ func Inject(
 	// If the resource is not injectable but does need the opaque ports
 	// annotation added, then admit it after creating a patch that adds the
 	// annotation.
-	if opaquePorts, opaquePortsOk := resourceConfig.GetConfigAnnotation(pkgK8s.ProxyOpaquePortsAnnotation); opaquePortsOk {
-		patchJSON, err := resourceConfig.CreateAnnotationPatch(opaquePorts)
+	// 1. Check if the annotation should be copied down from the namespace.
+	//    If opaquePortsOk is true, then we know the namespace has the
+	//    annotation and the workload does not.
+	// 2. If opaquePortsOk is false, we know either the workload has the
+	//    annotation or both the workload and the namespace does not have
+	//    annotation. In the case of the latter, we must add a default value
+	//    to the pod.
+	var patchJSON []byte
+	opaquePorts, opaquePortsOk := resourceConfig.GetConfigAnnotation(pkgK8s.ProxyOpaquePortsAnnotation)
+	if opaquePortsOk {
+		patchJSON, err = resourceConfig.CreateAnnotationPatch(opaquePorts)
 		if err != nil {
 			return nil, err
 		}
+	} else if !resourceConfig.HasPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation) && resourceConfig.IsPod() {
+		opaquePorts := resourceConfig.GetValues().Proxy.OpaquePorts
+		patchJSON, err = resourceConfig.CreateAnnotationPatch(opaquePorts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// If patchJSON holds a patch after checking 1 and 2 above, then a patch
+	// was generated and we admit the request.
+	if len(patchJSON) != 0 {
 		log.Infof("annotation patch generated for: %s", report.ResName())
 		log.Debugf("annotation patch: %s", patchJSON)
 		proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "", report.InjectAnnotationAt, configLabels)).Inc()

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -353,19 +353,9 @@ func TestGetAnnotationPatch(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				var patchJSON []byte
-				opaquePorts, ok := fullConf.GetConfigAnnotation(pkgK8s.ProxyOpaquePortsAnnotation)
-				if ok {
-					patchJSON, err = fullConf.CreateAnnotationPatch(opaquePorts)
-					if err != nil {
-						t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
-					}
-				} else if !fullConf.HasPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation) && fullConf.IsPod() {
-					opaquePorts := fullConf.GetValues().Proxy.OpaquePorts
-					patchJSON, err = fullConf.CreateAnnotationPatch(opaquePorts)
-					if err != nil {
-						t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
-					}
+				patchJSON, err := fullConf.CreateDefaultOpaquePortsPatch()
+				if err != nil {
+					t.Fatalf("Unexpected error creating default opaque ports patch: %s", err)
 				}
 				if len(testCase.expectedPatchBytes) != 0 && len(patchJSON) == 0 {
 					t.Fatalf("There was no patch, but one was expected: %s", testCase.expectedPatchBytes)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -248,6 +248,11 @@ func (conf *ResourceConfig) ParseMetaAndYAML(bytes []byte) (*Report, error) {
 	return newReport(conf), nil
 }
 
+// GetValues returns the values used for rendering patches.
+func (conf *ResourceConfig) GetValues() *linkerd2.Values {
+	return conf.values
+}
+
 // GetOverriddenValues returns the final Values struct which is created
 // by overriding annotated configuration on top of default Values
 func (conf *ResourceConfig) GetOverriddenValues() (*linkerd2.Values, error) {
@@ -358,6 +363,16 @@ func (conf *ResourceConfig) GetConfigAnnotation(annotationKey string) (string, b
 		return annotation, true
 	}
 	return "", false
+}
+
+// HasPodAnnotation returns true if the pod has the annotation set by the
+// resource config or its metadata.
+func (conf *ResourceConfig) HasPodAnnotation(annotation string) bool {
+	if _, ok := conf.pod.meta.Annotations[annotation]; ok {
+		return true
+	}
+	_, ok := conf.pod.annotations[annotation]
+	return ok
 }
 
 // CreateAnnotationPatch returns a json patch which adds the opaque ports


### PR DESCRIPTION
In order to discover how a workload is configured without knowing the global defaults, the `opaque-ports` annotation is now added by the proxy injector to workloads, regardless of the list being the default or user-specified.

Closes #6689

#### core
Because core control plane components do not go through the proxy injector the annotation is added to the `destination`, `identity`, and `proxy-injector` templates.

#### non-core
All other resources go through the proxy injector; it decides whether or not services or pods (the two resources that it can add annotations to) should get the default list.

For now, we're ignoring adding a default list annotation to services. They still will get the annotation added if they or their namespace has it set.

Pods get the default list of opaque ports added if they and their namespace do not have the annotation already. So this boils down to:
1. If the pod already has the annotation, no patch is created
2. If the namespace has the annotation but the pod does not, a patch is generated
3. If the pod and namespace do not have the annotation, a patch is generated

#### tests
A unit test has been added and I performed the following manual tests:
1. Injected a pod with the annotation: a patch is generated but there is no change to opaque ports
2. Injected a pod with the namespace annotation: a patch is genereted and opaque ports are copied down to the pod
3. Injected a pod with no annotation on it or the namespace: a patch is generated and the default opaque ports are added
4. Created a pod (not injected): a patch is generated (without the proxy) that adds the annotation (this holds true for if the pod having the annotation or the namespace having the annotation)

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
