### PR TITLE
test: Fix `rabbitmq-server` manifests in `externalresources` test

### DIFF
--- a/test/integration/externalresources/testdata/rabbitmq-server.yaml
+++ b/test/integration/externalresources/testdata/rabbitmq-server.yaml
@@ -19,24 +19,20 @@ spec:
           name: rabbitmq
           livenessProbe:
             exec:
-              command:
-                - rabbitmqctl
-                - status
-            failureThreshold: 6
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
+              command: ["rabbitmq-diagnostics", "status"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 15
           readinessProbe:
             exec:
-              command:
-                - rabbitmqctl
-                - status
-            failureThreshold: 6
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
+              command: ["rabbitmq-diagnostics", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+          ports:
+            - containerPort: 15672
+            - containerPort: 5672
+
 ---
 apiVersion: v1
 kind: Service

--- a/test/integration/externalresources/testdata/rabbitmq-server.yaml
+++ b/test/integration/externalresources/testdata/rabbitmq-server.yaml
@@ -17,12 +17,6 @@ spec:
       containers:
         - image: rabbitmq:3.8.12-rc.3-management
           name: rabbitmq
-          livenessProbe:
-            exec:
-              command: ["rabbitmq-diagnostics", "status"]
-            initialDelaySeconds: 60
-            periodSeconds: 60
-            timeoutSeconds: 15
           readinessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "ping"]


### PR DESCRIPTION
Started to notice the following problems in the `externalresources` tests
that is causing them to retry and take a lot of time:
- liveness and readiness probes doesn't seem to be working causing
  restarts. This is addressed by using the [suggested probes from
  the rabbitmq docs](https://github.com/rabbitmq/diy-kubernetes-examples/blob/master/gke/statefulset.yaml#L118).
- `linkerd-proxy` erroring that `LINKERD2_PROXY_INBOUND_PORTS` is not
  set. This is fixed by adding the container ports that are being
  used.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
