### PR TITLE
Remove `windows_static_cli_tests` from `integration_tests.yml`

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,11 +53,6 @@ jobs:
       run: |
         mkdir -p $ARCHIVES
         docker save "cr.l5d.io/linkerd/${{ matrix.target }}:$TAG" > $ARCHIVES/${{ matrix.target }}.tar
-        # windows_static_cli_tests needs this binary to be available in the
-        # image archive.
-        if [ '${{ matrix.target }}' == 'cli-bin' ]; then
-          cp -r ./target/cli/windows/linkerd $ARCHIVES/linkerd-windows.exe
-        fi
     # `with.path` values do not support environment variables yet, so an
     # absolute path is used here.
     #
@@ -68,29 +63,6 @@ jobs:
         name: image-archives
         path: /home/runner/archives
   # todo: Keep in sync with `release.yml`
-  windows_static_cli_tests:
-    name: Static CLI tests (windows)
-    runs-on: windows-latest
-    needs: [docker_build]
-    timeout-minutes: 30
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - name: Try to load cached Go modules
-      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Download image archives
-      uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
-      with:
-        name: image-archives
-        path: image-archives
-    - name: Run CLI Integration tests
-      run: |
-        go test --failfast --mod=readonly ".\test\cli" --linkerd=$PWD\image-archives\linkerd-windows.exe --cli-tests -v
   integration_tests:
     strategy:
       matrix:


### PR DESCRIPTION
Addresses part of #6735

The job remains in the `release.yml` workflow, which should continue
doing more complete checks (yet with lower probability of failure) than
the integration tests.