### PR TITLE
Use default distroless image in policy

### DIFF
--- a/policy-controller/amd64.dockerfile
+++ b/policy-controller/amd64.dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_IMAGE=docker.io/library/rust:1.54.0-buster
-ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc
 
 # Builds the controller binary.
 FROM $RUST_IMAGE as build

--- a/policy-controller/arm.dockerfile
+++ b/policy-controller/arm.dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_IMAGE=docker.io/library/rust:1.54.0-buster
-ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc
 
 FROM $RUST_IMAGE as build
 RUN apt-get update && \

--- a/policy-controller/arm64.dockerfile
+++ b/policy-controller/arm64.dockerfile
@@ -1,5 +1,5 @@
 ARG RUST_IMAGE=docker.io/library/rust:1.54.0-buster
-ARG RUNTIME_IMAGE=gcr.io/distroless/cc:nonroot
+ARG RUNTIME_IMAGE=gcr.io/distroless/cc
 
 FROM $RUST_IMAGE as build
 RUN apt-get update && \


### PR DESCRIPTION
Fixes #6743

As in #6392 for the proxy image (fixed by #6451), using the
`distroless/cc:nonroot` base image breaks the policy container in some
environments. So we're changing that to `distroless/cc`. The policy
container is already being run using a non-root user, so we're not
compromising on security.