### PR TITLE
Filter default opaque ports for pods and services

### DIFF
--- a/controller/proxy-injector/fake/data/filter-pod-opaque-ports.yaml
+++ b/controller/proxy-injector/fake/data/filter-pod-opaque-ports.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+  labels:
+    app: test
+spec:
+  containers:
+  - name: foo
+    image: mysql
+    ports:
+    - containerPort: 3306

--- a/controller/proxy-injector/fake/data/filter-service-opaque-ports.yaml
+++ b/controller/proxy-injector/fake/data/filter-service-opaque-ports.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: kube-public
+spec:
+  selector:
+    app: test
+  ports:
+  - name: foo
+    port: 9090
+    targetPort: 3306
+  - name: bar
+    port: 5432
+    targetPort: 9091
+  - name: baz
+    port: 9092
+    targetPort: not-an-int

--- a/controller/proxy-injector/fake/data/filter-service-opaque-ports.yaml
+++ b/controller/proxy-injector/fake/data/filter-service-opaque-ports.yaml
@@ -7,12 +7,19 @@ spec:
   selector:
     app: test
   ports:
-  - name: foo
+    # 9090 should be set since it targets an opaque port.
+  - name: a
     port: 9090
     targetPort: 3306
-  - name: bar
+    # 5432 should not be set since it does not target an opaque port.
+  - name: b
     port: 5432
     targetPort: 9091
-  - name: baz
-    port: 9092
+    # 3306 should be set since it does not have a target port and is opaque.
+  - name: c
+    port: 3306
+    # 9093 should not be set since it targets a named port and we don't know
+    # what port number it is exposed on.
+  - name: d
+    port: 9093
     targetPort: not-an-int

--- a/controller/proxy-injector/fake/data/filtered-pod-opaque-ports.json
+++ b/controller/proxy-injector/fake/data/filtered-pod-opaque-ports.json
@@ -1,0 +1,12 @@
+[
+    {
+        "op": "add",
+        "path": "/metadata/annotations",
+        "value": {}
+    },
+    {
+        "op": "add",
+        "path": "/metadata/annotations/config.linkerd.io~1opaque-ports",
+        "value": "3306"
+    }
+]

--- a/controller/proxy-injector/fake/data/filtered-service-opaque-ports.json
+++ b/controller/proxy-injector/fake/data/filtered-service-opaque-ports.json
@@ -7,6 +7,6 @@
     {
         "op": "add",
         "path": "/metadata/annotations/config.linkerd.io~1opaque-ports",
-        "value": "25,443,587,3306,4444,5432,6379,9300,11211"
+        "value": "9090,5432"
     }
 ]

--- a/controller/proxy-injector/fake/data/filtered-service-opaque-ports.json
+++ b/controller/proxy-injector/fake/data/filtered-service-opaque-ports.json
@@ -7,6 +7,6 @@
     {
         "op": "add",
         "path": "/metadata/annotations/config.linkerd.io~1opaque-ports",
-        "value": "9090,5432"
+        "value": "9090,3306"
     }
 ]

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -128,9 +128,9 @@ func Inject(
 		}, nil
 	}
 
-	// Create an annotation patch that would set the list of default opaque
-	// ports if is needed.
-	patchJSON, err := resourceConfig.CreateDefaultOpaquePortsPatch()
+	// Create a patch which adds the opaque ports annotation if the workload
+	// does already have it set.
+	patchJSON, err := resourceConfig.CreateOpaquePortsPatch()
 	if err != nil {
 		return nil, err
 	}

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -99,8 +99,14 @@ func Inject(
 		// ensures that the generated patch always sets the opaue ports
 		// annotation.
 		if !resourceConfig.HasWorkloadAnnotation(pkgK8s.ProxyOpaquePortsAnnotation) {
-			opaquePorts := resourceConfig.GetValues().Proxy.OpaquePorts
-			resourceConfig.AppendPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation, opaquePorts)
+			defaultPorts := strings.Split(resourceConfig.GetValues().Proxy.OpaquePorts, ",")
+			filteredPorts := resourceConfig.FilterPodOpaquePorts(defaultPorts)
+			// Only add the annotation if there are ports that the pod exposes
+			// that are in the default opaque ports list.
+			if len(filteredPorts) != 0 {
+				ports := strings.Join(filteredPorts, ",")
+				resourceConfig.AppendPodAnnotation(pkgK8s.ProxyOpaquePortsAnnotation, ports)
+			}
 		}
 
 		patchJSON, err := resourceConfig.GetPodPatch(true)

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -267,11 +267,19 @@ func TestGetAnnotationPatch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
-		defaultOPBytes, err := factory.FileContents("default-op-annotation.patch.json")
+		filteredServiceBytes, err := factory.FileContents("filtered-service-opaque-ports.json")
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
-		defaultOPPatch, err := unmarshalPatch(defaultOPBytes)
+		filteredServicePatch, err := unmarshalPatch(filteredServiceBytes)
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		filteredPodBytes, err := factory.FileContents("filtered-pod-opaque-ports.json")
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+		filteredPodPatch, err := unmarshalPatch(filteredPodBytes)
 		if err != nil {
 			t.Fatalf("Unexpected error: %s", err)
 		}
@@ -304,12 +312,10 @@ func TestGetAnnotationPatch(t *testing.T) {
 				conf:     confNsWithoutOpaquePorts(),
 			},
 			{
-				name:               "service without opaque ports and namespace without",
-				filename:           "service-without-opaque-ports.yaml",
-				ns:                 nsWithoutOpaquePorts,
-				conf:               confNsWithoutOpaquePorts(),
-				expectedPatchBytes: defaultOPBytes,
-				expectedPatch:      defaultOPPatch,
+				name:     "service without opaque ports and namespace without",
+				filename: "service-without-opaque-ports.yaml",
+				ns:       nsWithoutOpaquePorts,
+				conf:     confNsWithoutOpaquePorts(),
 			},
 			{
 				name:               "pod without opaque ports and namespace with",
@@ -332,12 +338,26 @@ func TestGetAnnotationPatch(t *testing.T) {
 				conf:     confNsWithoutOpaquePorts(),
 			},
 			{
-				name:               "pod without opaque ports and namespace without",
-				filename:           "pod-without-opaque-ports.yaml",
+				name:     "pod without opaque ports and namespace without",
+				filename: "pod-without-opaque-ports.yaml",
+				ns:       nsWithoutOpaquePorts,
+				conf:     confNsWithoutOpaquePorts(),
+			},
+			{
+				name:               "service opaque ports are filtered",
+				filename:           "filter-service-opaque-ports.yaml",
 				ns:                 nsWithoutOpaquePorts,
 				conf:               confNsWithoutOpaquePorts(),
-				expectedPatchBytes: defaultOPBytes,
-				expectedPatch:      defaultOPPatch,
+				expectedPatchBytes: filteredServiceBytes,
+				expectedPatch:      filteredServicePatch,
+			},
+			{
+				name:               "pod opaque ports are filtered",
+				filename:           "filter-pod-opaque-ports.yaml",
+				ns:                 nsWithoutOpaquePorts,
+				conf:               confNsWithoutOpaquePorts(),
+				expectedPatchBytes: filteredPodBytes,
+				expectedPatch:      filteredPodPatch,
 			},
 		}
 		for _, testCase := range testCases {

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -375,7 +375,7 @@ func TestGetAnnotationPatch(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				patchJSON, err := fullConf.CreateDefaultOpaquePortsPatch()
+				patchJSON, err := fullConf.CreateOpaquePortsPatch()
 				if err != nil {
 					t.Fatalf("Unexpected error creating default opaque ports patch: %s", err)
 				}

--- a/pkg/healthcheck/healthcheck_labels.go
+++ b/pkg/healthcheck/healthcheck_labels.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -75,7 +76,7 @@ func getMisconfiguredLabels(objectMeta metav1.ObjectMeta) []string {
 
 	for label := range objectMeta.Labels {
 		if hasAnyPrefix(label, validAsAnnotationPrefixOnly) ||
-			containsString(label, validAsAnnotationOnly) {
+			util.ContainsString(label, validAsAnnotationOnly) {
 			invalid = append(invalid, label)
 		}
 	}
@@ -87,7 +88,7 @@ func getMisconfiguredAnnotations(objectMeta metav1.ObjectMeta) []string {
 	var invalid []string
 
 	for ann := range objectMeta.Annotations {
-		if containsString(ann, validAsLabelOnly) {
+		if util.ContainsString(ann, validAsLabelOnly) {
 			invalid = append(invalid, ann)
 		}
 	}
@@ -98,15 +99,6 @@ func getMisconfiguredAnnotations(objectMeta metav1.ObjectMeta) []string {
 func hasAnyPrefix(str string, prefixes []string) bool {
 	for _, pref := range prefixes {
 		if strings.HasPrefix(str, pref) {
-			return true
-		}
-	}
-	return false
-}
-
-func containsString(str string, collection []string) bool {
-	for _, e := range collection {
-		if str == e {
 			return true
 		}
 	}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -395,18 +395,20 @@ func (conf *ResourceConfig) CreateDefaultOpaquePortsPatch() ([]byte, error) {
 		if conf.IsPod() {
 			for _, c := range conf.pod.spec.Containers {
 				for _, p := range c.Ports {
-					if util.ContainsString(strconv.Itoa(int(p.ContainerPort)), defaultPorts) {
-						filteredPorts = append(filteredPorts, strconv.Itoa(int(p.ContainerPort)))
+					port := strconv.Itoa(int(p.ContainerPort))
+					if util.ContainsString(port, defaultPorts) {
+						filteredPorts = append(filteredPorts, port)
 					}
 				}
 			}
 		} else if conf.IsService() {
 			service := conf.workload.obj.(*corev1.Service)
 			for _, p := range service.Spec.Ports {
-				if util.ContainsString(strconv.Itoa(int(p.Port)), defaultPorts) {
-					filteredPorts = append(filteredPorts, strconv.Itoa(int(p.Port)))
+				port := strconv.Itoa(int(p.Port))
+				if util.ContainsString(port, defaultPorts) {
+					filteredPorts = append(filteredPorts, port)
 				} else if util.ContainsString(strconv.Itoa(int(p.TargetPort.IntVal)), defaultPorts) {
-					filteredPorts = append(filteredPorts, strconv.Itoa(int(p.Port)))
+					filteredPorts = append(filteredPorts, port)
 				}
 			}
 		}

--- a/pkg/util/parsing.go
+++ b/pkg/util/parsing.go
@@ -80,3 +80,13 @@ func isNamed(pr string, containers []corev1.Container) (int32, bool) {
 	}
 	return 0, false
 }
+
+// ContainsString checks if a string collections contains the given string.
+func ContainsString(str string, collection []string) bool {
+	for _, e := range collection {
+		if str == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#6719 changed the proxy injector so that it adds the `config.linkerd.io/opaque-ports` annotation to all pods and services if they or their namespace do not already contain the annotation. The value used is the default list of opaque ports—which is `25,443,587,3306,4444,5432,6379,9300,11211` unless otherwise specified by the user during installation.

Closes #6729

The main issue with this is that if a service exposes a service port `9090` that targets `3306`, the service _should_ have `9090` set as opaque since it targets a default opaque port, but it does not. This change ensures that services with this situation have `9090` set as opaque.

Additionally, services and pods do not need an annotation for with the entire default opaque ports list if they don't expose those ports in the first place. This change will filter out ports from the default list if the service or pod does not expose them.

### tests
I've added some unit tests that demonstrate the change in behavior and explained in the original issue #6729.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
