### PR TITLE
Update proxy-init to v1.4.0

### DIFF
--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -209,7 +209,7 @@ Kubernetes: `>=1.16.0-0`
 | proxyInit.ignoreOutboundPorts | string | `"4567,4568"` | Default set of outbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container Docker image |
-| proxyInit.image.version | string | `"v1.3.13"` | Tag for the proxy-init container Docker image |
+| proxyInit.image.version | string | `"v1.4.0"` | Tag for the proxy-init container Docker image |
 | proxyInit.resources.cpu.limit | string | `"100m"` | Maximum amount of CPU units that the proxy-init container can use |
 | proxyInit.resources.cpu.request | string | `"10m"` | Amount of CPU units that the proxy-init container requests |
 | proxyInit.resources.memory.limit | string | `"50Mi"` | Maximum amount of memory that the proxy-init container can use |

--- a/charts/linkerd2/values.yaml
+++ b/charts/linkerd2/values.yaml
@@ -163,7 +163,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container Docker image
-    version: v1.3.13
+    version: v1.4.0
   resources:
     cpu:
       # -- Maximum amount of CPU units that the proxy-init container can use

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -161,7 +161,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -161,7 +161,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -355,7 +355,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -161,7 +161,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -201,7 +201,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -377,7 +377,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -582,7 +582,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -787,7 +787,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -185,7 +185,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -189,7 +189,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -377,7 +377,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -177,7 +177,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -173,7 +173,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -173,7 +173,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -173,7 +173,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -174,7 +174,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -174,7 +174,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -174,7 +174,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+          image: cr.l5d.io/linkerd/proxy-init:v1.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -373,7 +373,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+          image: cr.l5d.io/linkerd/proxy-init:v1.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -174,7 +174,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+          image: cr.l5d.io/linkerd/proxy-init:v1.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -373,7 +373,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+          image: cr.l5d.io/linkerd/proxy-init:v1.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -155,7 +155,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+    image: cr.l5d.io/linkerd/proxy-init:v1.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -158,7 +158,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+    image: cr.l5d.io/linkerd/proxy-init:v1.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -157,7 +157,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+    image: cr.l5d.io/linkerd/proxy-init:v1.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -166,7 +166,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+    image: cr.l5d.io/linkerd/proxy-init:v1.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -173,7 +173,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -174,7 +174,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -381,7 +381,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment.input.yml
+++ b/cli/cmd/testdata/inject_tap_deployment.input.yml
@@ -203,7 +203,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568,443
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1474,7 +1474,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1873,7 +1873,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2160,7 +2160,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1473,7 +1473,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1871,7 +1871,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2158,7 +2158,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1473,7 +1473,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.3.13
+        image: my.custom.registry/linkerd-io/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1871,7 +1871,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.3.13
+        image: my.custom.registry/linkerd-io/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2158,7 +2158,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.3.13
+        image: my.custom.registry/linkerd-io/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1473,7 +1473,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1871,7 +1871,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2158,7 +2158,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1473,7 +1473,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1871,7 +1871,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2158,7 +2158,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1193,7 +1193,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1547,7 +1547,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1995,7 +1995,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2322,7 +2322,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1193,7 +1193,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1547,7 +1547,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1995,7 +1995,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2322,7 +2322,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1106,7 +1106,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1404,7 +1404,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1802,7 +1802,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2040,7 +2040,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1175,7 +1175,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1473,7 +1473,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "5432,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1871,7 +1871,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "5432,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2158,7 +2158,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "5432,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1161,7 +1161,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.3.13
+        version: v1.4.0
       resources:
         cpu:
           limit: 100m
@@ -1459,7 +1459,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1857,7 +1857,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2144,7 +2144,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568,443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.3.13
+        image: cr.l5d.io/linkerd/proxy-init:v1.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.3.13",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -68,7 +68,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.3.13",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.3.13",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/linkerd/linkerd2-proxy-api v0.2.0
-	github.com/linkerd/linkerd2-proxy-init v1.3.13
+	github.com/linkerd/linkerd2-proxy-init v1.4.0
 	github.com/mattn/go-isatty v0.0.13
 	github.com/mattn/go-runewidth v0.0.13
 	github.com/nsf/termbox-go v0.0.0-20180613055208-5c94acc5e6eb

--- a/go.sum
+++ b/go.sum
@@ -574,6 +574,8 @@ github.com/linkerd/linkerd2-proxy-api v0.2.0 h1:bbtx/tSPrajcUvhd8KtwylVKIaUWTvfG
 github.com/linkerd/linkerd2-proxy-api v0.2.0/go.mod h1:EIFzeyjPwmXTq+EgfX4prgVf7GuUKATCIVKeoHA/tKg=
 github.com/linkerd/linkerd2-proxy-init v1.3.13 h1:Y7xKWOAV8F8tvGy28/d3KeFKOfIEyvTMC0Fv/DA+uDE=
 github.com/linkerd/linkerd2-proxy-init v1.3.13/go.mod h1:re7j9P7dBpV+/k23NoFGk8JHC0AbKH6Ww1zRaudaW+w=
+github.com/linkerd/linkerd2-proxy-init v1.4.0 h1:gIzUGPW1FKSF/J1PONc6yc8b0aOkIm0fig6gigBQdkc=
+github.com/linkerd/linkerd2-proxy-init v1.4.0/go.mod h1:re7j9P7dBpV+/k23NoFGk8JHC0AbKH6Ww1zRaudaW+w=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2170,7 +2170,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.3.13","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.4.0","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}`,
 			},
@@ -2216,7 +2216,7 @@ data:
 					},
 					DisableExternalProfiles: true,
 					ProxyVersion:            "install-proxy-version",
-					ProxyInitImageVersion:   "v1.3.13",
+					ProxyInitImageVersion:   "v1.4.0",
 					DebugImage: &configPb.Image{
 						ImageName:  "cr.l5d.io/linkerd/debug",
 						PullPolicy: "IfNotPresent",
@@ -2308,7 +2308,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.3.13","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.4.0","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |
@@ -2470,7 +2470,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.3.13","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.4.0","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init
 // This has to be kept in sync with the constraint version for
 // github.com/linkerd/linkerd2-proxy-init in /go.mod
-var ProxyInitVersion = "v1.3.13"
+var ProxyInitVersion = "v1.4.0"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
Updates `linkerd2-proxy-init` to latest version (`v1.4.0`). 

**List of changes**:
   * Removed `"redirect-non-loopback-traffic"` rule; previously packets with destination != 127.0.0.1 on `lo` originating from proxy process would be sent to the inbound proxy port (assuming application tries to talk to itself). This is no longer the case.

**Non user facing**:
   * `kind` version in integration test bumped to `v.0.11.1`.