### PR TITLE
Fix warning in dashboard

### DIFF
--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/dynamic"
@@ -138,7 +137,7 @@ func (kubeAPI *KubernetesAPI) CheckVersion(versionInfo *version.Info) error {
 // NamespaceExists validates whether a given namespace exists.
 func (kubeAPI *KubernetesAPI) NamespaceExists(ctx context.Context, namespace string) (bool, error) {
 	ns, err := kubeAPI.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-	if kerrors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		return false, nil
 	}
 	if err != nil {

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -23,6 +23,7 @@ import (
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	tappkg "github.com/linkerd/linkerd2/viz/tap/pkg"
 	log "github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -447,7 +448,7 @@ func (h *handler) handleGetExtensions(w http.ResponseWriter, req *http.Request, 
 	resp := map[string]interface{}{}
 	if extensionName != "" {
 		ns, err := h.k8sAPI.GetNamespaceWithExtensionLabel(ctx, extensionName)
-		if err != nil && strings.HasPrefix(err.Error(), "could not find") {
+		if err != nil && kerrors.IsNotFound(err) {
 			renderJSON(w, resp)
 			return
 		} else if err != nil {


### PR DESCRIPTION
This fixes this error seen in the dashboard:
```
api/extensions?extension_name=multicluster:1 Failed to load resource: the server responded with a status of 500 (Internal Server Error)
```

The issue was #6684 had changed the shape of the error returned by
`GetNamespaceWithExtensionLabel` and the `handleGetExtensions` function
wasn't adapted to it.
