### PR TITLE
opaque ports check: consider service and pod ports when checking annotation values

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2258,7 +2258,7 @@ func (hc *HealthChecker) checkMisconfiguredOpaquePortAnnotations(ctx context.Con
 	return nil
 }
 
-// getEndpointsPods takes a collection of endpoints and returns a map of all
+// getEndpointsPods takes a collection of endpoints and returns the set of all
 // the pods that they target.
 func getEndpointsPods(endpoints *corev1.Endpoints, kubeAPI *controllerK8s.API, namespace string) (map[*corev1.Pod]struct{}, error) {
 	pods := make(map[*corev1.Pod]struct{})

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2357,9 +2357,8 @@ func checkPodPorts(service *corev1.Service, pod *corev1.Pod, podPorts []string, 
 						}
 						if util.ContainsString(strPort, podPorts) {
 							return nil
-						} else {
-							return fmt.Errorf("service %s expects %d to be opaque; add it to pod %s's %s annotation", service.Name, port, pod.Name, k8s.ProxyOpaquePortsAnnotation)
 						}
+						return fmt.Errorf("service %s expects %d to be opaque; add it to pod %s's %s annotation", service.Name, port, pod.Name, k8s.ProxyOpaquePortsAnnotation)
 					}
 				}
 			}
@@ -2383,9 +2382,8 @@ func checkServiceIntPorts(service *corev1.Service, svcPorts []string, port int) 
 				// The service exposes svcPort which targets p and svcPort
 				// is properly as opaque.
 				return true, nil
-			} else {
-				return false, fmt.Errorf("service %s targets the opaque port %d through %d; add %d to its %s annotation", service.Name, port, p.Port, p.Port, k8s.ProxyOpaquePortsAnnotation)
 			}
+			return false, fmt.Errorf("service %s targets the opaque port %d through %d; add %d to its %s annotation", service.Name, port, p.Port, p.Port, k8s.ProxyOpaquePortsAnnotation)
 		}
 	}
 	return false, nil
@@ -2404,9 +2402,8 @@ func checkServiceNamePorts(service *corev1.Service, pod *corev1.Pod, port int, s
 							// The service targets the container port by name
 							// and is marked as opaque.
 							return nil
-						} else {
-							return fmt.Errorf("service %s targets the opaque port %s through %d; add %d to its %s annotation", service.Name, cp.Name, p.Port, p.Port, k8s.ProxyOpaquePortsAnnotation)
 						}
+						return fmt.Errorf("service %s targets the opaque port %s through %d; add %d to its %s annotation", service.Name, cp.Name, p.Port, p.Port, k8s.ProxyOpaquePortsAnnotation)
 					}
 				}
 			}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3370,7 +3370,7 @@ subsets:
   ports:
   - name: http-port
     port: 8080
-    protocol: TCP			
+    protocol: TCP
 `,
 			},
 			expected: nil,
@@ -3434,7 +3434,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* pod/my-service-deployment has the annotation %s but service/test-service-1 doesn't", k8s.ProxyOpaquePortsAnnotation),
+			expected: fmt.Errorf("\t* service test-service-1 which targets the opaque port 9200 should have its service port 9200 marked as opaque"),
 		},
 		{
 			resources: []string{`
@@ -3492,10 +3492,10 @@ subsets:
   ports:
   - name: http-port
     port: 8080
-    protocol: TCP		
+    protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service/test-service-1 has the annotation %s but pod/my-service-deployment doesn't", k8s.ProxyOpaquePortsAnnotation),
+			expected: fmt.Errorf("\t* service test-service-1 has the annotation config.linkerd.io/opaque-ports but pod my-service-deployment does not"),
 		},
 		{
 			resources: []string{`
@@ -3560,6 +3560,167 @@ subsets:
 			},
 			expected: fmt.Errorf("\t* pod/my-service-deployment and service/test-service-1 have the annotation %s but values don't match", k8s.ProxyOpaquePortsAnnotation),
 		},
+		{
+			resources: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  selector:
+    app: test
+  ports:
+  - name: svc-1
+    port: 2001
+`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  namespace: test-ns
+  annotations:
+    config.linkerd.io/opaque-ports: "2001"
+  labels:
+    app: test
+spec:
+  containers:
+  - name: test
+    image: nginx
+    ports:
+    - name: pod-1
+      containerPort: 2001
+`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: test-ns
+subsets:
+- addresses:
+  - ip: 10.42.0.110
+    nodeName: node
+    targetRef:
+      kind: Pod
+      name: pod-1
+  ports:
+  - name: svc-1
+    port: 2001
+    protocol: TCP
+`,
+			},
+			expected: fmt.Errorf("\t* service svc which targets the opaque port 2001 should have its service port 2001 marked as opaque"),
+		},
+		{
+			resources: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  selector:
+    app: test
+  ports:
+  - name: svc-2
+    port: 1002
+    targetPort: 2002
+`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  namespace: test-ns
+  annotations:
+    config.linkerd.io/opaque-ports: "2002"
+  labels:
+    app: test
+spec:
+  containers:
+  - name: test
+    image: nginx
+    ports:
+    - name: pod-2
+      containerPort: 2002
+`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: test-ns
+subsets:
+- addresses:
+  - ip: 10.42.0.111
+    nodeName: node
+    targetRef:
+      kind: Pod
+      name: pod-2
+  ports:
+  - name: svc-2
+    port: 2002
+    protocol: TCP
+`,
+			},
+			expected: fmt.Errorf("\t* service svc which targets the opaque port 2002 should have its service port 1002 marked as opaque"),
+		},
+		{
+			resources: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: test-ns
+spec:
+  selector:
+    app: test
+  ports:
+  - name: svc-3
+    port: 1003
+    targetPort: pod-3
+`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  namespace: test-ns
+  annotations:
+    config.linkerd.io/opaque-ports: "2003"
+  labels:
+    app: test
+spec:
+  containers:
+  - name: test
+    image: nginx
+    ports:
+    - name: pod-3
+      containerPort: 2003
+`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: test-ns
+subsets:
+- addresses:
+  - ip: 10.42.0.112
+    nodeName: node
+    targetRef:
+      kind: Pod
+      name: pod-3
+  ports:
+  - name: svc-3
+    port: 2003
+    protocol: TCP
+`,
+			},
+			expected: fmt.Errorf("\t* service svc which targets the opaque port pod-3 should have its service port 1003 marked as opaque"),
+		},
 	}
 
 	for i, tc := range testCases {
@@ -3577,6 +3738,9 @@ subsets:
 				if err.Error() != tc.expected.Error() {
 					t.Fatalf("Expected error: %s, received: %s", tc.expected, err)
 				}
+			}
+			if err != nil && tc.expected == nil {
+				t.Fatalf("Did not expect error but got: %s", err.Error())
 			}
 		})
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3363,7 +3363,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc which targets the opaque port 9200 should have its service port 9200 marked as opaque"),
+			expected: fmt.Errorf("\t* service svc targets the opaque port 9200 through 9200; add 9200 to its config.linkerd.io/opaque-ports annotation"),
 		},
 		{
 			resources: []string{`
@@ -3418,7 +3418,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc expects 9200 to be opaque, but pod pod does not have it marked"),
+			expected: fmt.Errorf("\t* service svc expects 9200 to be opaque; add it to pod pod's config.linkerd.io/opaque-ports annotation"),
 		},
 		{
 			resources: []string{`
@@ -3528,7 +3528,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc which targets the opaque port 2002 should have its service port 1002 marked as opaque"),
+			expected: fmt.Errorf("\t* service svc targets the opaque port 2002 through 1002; add 1002 to its config.linkerd.io/opaque-ports annotation"),
 		},
 		{
 			resources: []string{`
@@ -3582,7 +3582,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc which targets the opaque port pod-test should have its service port 1003 marked as opaque"),
+			expected: fmt.Errorf("\t* service svc targets the opaque port pod-test through 1003; add 1003 to its config.linkerd.io/opaque-ports annotation"),
 		},
 	}
 

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3259,306 +3259,56 @@ func TestCheckOpaquePortAnnotations(t *testing.T) {
 apiVersion: v1
 kind: Service
 metadata:
-  name: test-service-1
+  name: svc
   namespace: test-ns
+  annotations:
+    config.linkerd.io/opaque-ports: "9200"
 spec:
-  ports:
-    - name: elasticsearch
-      port: 9200
-      protocol: TCP
-      targetPort: 9200
   selector:
-    service: service-1
+    app: test
+  ports:
+  - name: test
+    port: 9200
+    targetPort: 9200
 `,
 				`
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-service-deployment
+  name: pod
   namespace: test-ns
   labels:
-    service: service-1
+    app: test
+  annotations:
+    config.linkerd.io/opaque-ports: "9200"
 spec:
   containers:
+  - name: test
+    image: test
+    ports:
     - name: test
-      image: "test-service"
+      containerPort: 9200
 `,
 				`
 apiVersion: v1
 kind: Endpoints
 metadata:
-  annotations:
-    endpoints.kubernetes.io/last-change-trigger-time: "2021-06-08T08:38:16Z"
-  creationTimestamp: "2021-06-08T08:38:03Z"
-  labels:
-    service: test-service-1
-  name: test-service-1
+  name: svc
   namespace: test-ns
 subsets:
 - addresses:
   - ip: 10.244.3.12
-    nodeName: nodename-1
+    nodeName: nod
     targetRef:
       kind: Pod
-      name: my-service-deployment
+      name: pod
       namespace: test-ns
-      resourceVersion: "20661"
-      uid: b37782aa-1458-4153-8399-dabc2b29aaae
   ports:
-  - name: http-port
-    port: 8080
+  - name: test
+    port: 9200
     protocol: TCP
 `,
 			},
-			expected: nil,
-		},
-		{
-			resources: []string{`
-apiVersion: v1
-kind: Service
-metadata:
-  name: test-service-1
-  namespace: test-ns
-  annotations:
-    config.linkerd.io/opaque-ports: "9200"
-spec:
-  ports:
-    - name: elasticsearch
-      port: 9200
-      protocol: TCP
-      targetPort: 9200
-  selector:
-    service: service-1
-`,
-				`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-service-deployment
-  namespace: test-ns
-  service: service-1
-  labels:
-    service: service-1
-  annotations:
-    config.linkerd.io/opaque-ports: "9200"
-spec:
-  containers:
-    - name: test
-      image: "test-service"
-`,
-				`
-apiVersion: v1
-kind: Endpoints
-metadata:
-  annotations:
-    endpoints.kubernetes.io/last-change-trigger-time: "2021-06-08T08:38:16Z"
-  creationTimestamp: "2021-06-08T08:38:03Z"
-  labels:
-    service: test-service-1
-  name: test-service-1
-  namespace: test-ns
-subsets:
-- addresses:
-  - ip: 10.244.3.12
-    nodeName: nodename-1
-    targetRef:
-      kind: Pod
-      name: my-service-deployment
-      namespace: test-ns
-      resourceVersion: "20661"
-      uid: b37782aa-1458-4153-8399-dabc2b29aaae
-  ports:
-  - name: http-port
-    port: 8080
-    protocol: TCP
-`,
-			},
-			expected: nil,
-		},
-		{
-			resources: []string{`
-apiVersion: v1
-kind: Service
-metadata:
-  name: test-service-1
-  namespace: test-ns
-spec:
-  ports:
-    - name: http
-      port: 9200
-      protocol: TCP
-      targetPort: 9200
-  selector:
-    service: service-1
-`,
-				`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-service-deployment
-  namespace: test-ns
-  service: service-1
-  labels:
-    service: service-1
-  annotations:
-    config.linkerd.io/opaque-ports: "9200"
-spec:
-  containers:
-    - name: test
-      image: "test-service"
-`,
-				`
-apiVersion: v1
-kind: Endpoints
-metadata:
-  annotations:
-    endpoints.kubernetes.io/last-change-trigger-time: "2021-06-08T08:38:16Z"
-  creationTimestamp: "2021-06-08T08:38:03Z"
-  labels:
-    service: test-service-1
-  name: test-service-1
-  namespace: test-ns
-subsets:
-- addresses:
-  - ip: 10.244.3.12
-    nodeName: nodename-1
-    targetRef:
-      kind: Pod
-      name: my-service-deployment
-      namespace: test-ns
-      resourceVersion: "20661"
-      uid: b37782aa-1458-4153-8399-dabc2b29aaae
-  ports:
-  - name: http-port
-    port: 8080
-    protocol: TCP
-`,
-			},
-			expected: fmt.Errorf("\t* service test-service-1 which targets the opaque port 9200 should have its service port 9200 marked as opaque"),
-		},
-		{
-			resources: []string{`
-apiVersion: v1
-kind: Service
-metadata:
-  name: test-service-1
-  namespace: test-ns
-  annotations:
-    config.linkerd.io/opaque-ports: "9200"
-spec:
-  ports:
-    - name: http
-      port: 9200
-      protocol: TCP
-      targetPort: 9200
-  selector:
-    service: service-1
-`,
-				`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-service-deployment
-  namespace: test-ns
-  service: service-1
-  labels:
-    service: service-1
-spec:
-  containers:
-    - name: test
-      image: "test-service"
-`,
-				`
-apiVersion: v1
-kind: Endpoints
-metadata:
-  annotations:
-    endpoints.kubernetes.io/last-change-trigger-time: "2021-06-08T08:38:16Z"
-  creationTimestamp: "2021-06-08T08:38:03Z"
-  labels:
-    service: test-service-1
-  name: test-service-1
-  namespace: test-ns
-subsets:
-- addresses:
-  - ip: 10.244.3.12
-    nodeName: nodename-1
-    targetRef:
-      kind: Pod
-      name: my-service-deployment
-      namespace: test-ns
-      resourceVersion: "20661"
-      uid: b37782aa-1458-4153-8399-dabc2b29aaae
-  ports:
-  - name: http-port
-    port: 8080
-    protocol: TCP
-`,
-			},
-			expected: fmt.Errorf("\t* service test-service-1 has the annotation config.linkerd.io/opaque-ports but pod my-service-deployment does not"),
-		},
-		{
-			resources: []string{`
-apiVersion: v1
-kind: Service
-metadata:
-  name: test-service-1
-  namespace: test-ns
-  annotations:
-    config.linkerd.io/opaque-ports: "9200"
-spec:
-  ports:
-    - name: elasticsearch
-      port: 9200
-      protocol: TCP
-      targetPort: 9200
-  selector:
-    service: service-1
-`,
-				`
-apiVersion: v1
-kind: Pod
-metadata:
-  name: my-service-deployment
-  namespace: test-ns
-  service: service-1
-  labels:
-    service: service-1
-  annotations:
-    config.linkerd.io/opaque-ports: "9300"
-spec:
-  containers:
-    - name: test
-      image: "test-service"
-`,
-				`
-apiVersion: v1
-kind: Endpoints
-metadata:
-  annotations:
-    endpoints.kubernetes.io/last-change-trigger-time: "2021-06-08T08:38:16Z"
-  creationTimestamp: "2021-06-08T08:38:03Z"
-  labels:
-    service: test-service-1
-  name: test-service-1
-  namespace: test-ns
-subsets:
-- addresses:
-  - ip: 10.244.3.12
-    nodeName: nodename-1
-    targetRef:
-      kind: Pod
-      name: my-service-deployment
-      namespace: test-ns
-      resourceVersion: "20661"
-      uid: b37782aa-1458-4153-8399-dabc2b29aaae
-  ports:
-  - name: http-port
-    port: 8080
-    protocol: TCP
-`,
-			},
-			expected: fmt.Errorf("\t* pod/my-service-deployment and service/test-service-1 have the annotation %s but values don't match", k8s.ProxyOpaquePortsAnnotation),
 		},
 		{
 			resources: []string{`
@@ -3571,26 +3321,82 @@ spec:
   selector:
     app: test
   ports:
-  - name: svc-1
-    port: 2001
+  - name: http
+    port: 9200
+    targetPort: 9200
 `,
 				`
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-1
+  name: pod
+  namespace: test-ns
+  labels:
+    app: test
+  annotations:
+    config.linkerd.io/opaque-ports: "9200"
+spec:
+  containers:
+  - name: test
+    image: test
+    ports:
+    - name: test
+      containerPort: 9200
+`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: test-ns
+subsets:
+- addresses:
+  - ip: 10.244.3.12
+    nodeName: nod
+    targetRef:
+      kind: Pod
+      name: pod
+      namespace: test-ns
+  ports:
+  - name: test
+    port: 9200
+    protocol: TCP
+`,
+			},
+			expected: fmt.Errorf("\t* service svc which targets the opaque port 9200 should have its service port 9200 marked as opaque"),
+		},
+		{
+			resources: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
   namespace: test-ns
   annotations:
-    config.linkerd.io/opaque-ports: "2001"
+    config.linkerd.io/opaque-ports: "9200"
+spec:
+  selector:
+    app: test
+  ports:
+  - name: test
+    port: 9200
+    targetPort: 9200
+`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: test-ns
   labels:
     app: test
 spec:
   containers:
   - name: test
-    image: nginx
+    image: test
     ports:
-    - name: pod-1
-      containerPort: 2001
+    - name: test
+      containerPort: 9200
 `,
 				`
 apiVersion: v1
@@ -3600,18 +3406,75 @@ metadata:
   namespace: test-ns
 subsets:
 - addresses:
-  - ip: 10.42.0.110
-    nodeName: node
+  - ip: 10.244.3.12
+    nodeName: nod
     targetRef:
       kind: Pod
-      name: pod-1
+      name: pod
+      namespace: test-ns
   ports:
-  - name: svc-1
-    port: 2001
+  - name: test
+    port: 9200
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc which targets the opaque port 2001 should have its service port 2001 marked as opaque"),
+			expected: fmt.Errorf("\t* service svc expects 9200 to be opaque, but pod pod does not have it marked"),
+		},
+		{
+			resources: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: test-ns
+  annotations:
+    config.linkerd.io/opaque-ports: "9200"
+spec:
+  selector:
+    app: test
+  ports:
+    - name: test
+      port: 9200
+      targetPort: 9200
+`,
+				`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod
+  namespace: test-ns
+  labels:
+    app: test
+  annotations:
+    config.linkerd.io/opaque-ports: "9300"
+spec:
+  containers:
+  - name: test
+    image: test
+    ports:
+    - name: test
+      containerPort: 9300
+`,
+				`
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: svc
+  namespace: test-ns
+subsets:
+- addresses:
+  - ip: 10.244.3.12
+    nodeName: node
+    targetRef:
+      kind: Pod
+      name: pod
+      namespace: test-ns
+  ports:
+  - name: test
+    port: 9200
+    protocol: TCP
+`,
+			},
 		},
 		{
 			resources: []string{`
@@ -3624,7 +3487,7 @@ spec:
   selector:
     app: test
   ports:
-  - name: svc-2
+  - name: test
     port: 1002
     targetPort: 2002
 `,
@@ -3632,7 +3495,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-2
+  name: pod
   namespace: test-ns
   annotations:
     config.linkerd.io/opaque-ports: "2002"
@@ -3641,9 +3504,9 @@ metadata:
 spec:
   containers:
   - name: test
-    image: nginx
+    image: test
     ports:
-    - name: pod-2
+    - name: test
       containerPort: 2002
 `,
 				`
@@ -3658,9 +3521,9 @@ subsets:
     nodeName: node
     targetRef:
       kind: Pod
-      name: pod-2
+      name: pod
   ports:
-  - name: svc-2
+  - name: test
     port: 2002
     protocol: TCP
 `,
@@ -3678,15 +3541,15 @@ spec:
   selector:
     app: test
   ports:
-  - name: svc-3
+  - name: test
     port: 1003
-    targetPort: pod-3
+    targetPort: pod-test
 `,
 				`
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-3
+  name: pod
   namespace: test-ns
   annotations:
     config.linkerd.io/opaque-ports: "2003"
@@ -3695,9 +3558,9 @@ metadata:
 spec:
   containers:
   - name: test
-    image: nginx
+    image: test
     ports:
-    - name: pod-3
+    - name: pod-test
       containerPort: 2003
 `,
 				`
@@ -3712,14 +3575,14 @@ subsets:
     nodeName: node
     targetRef:
       kind: Pod
-      name: pod-3
+      name: pod
   ports:
-  - name: svc-3
+  - name: test
     port: 2003
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc which targets the opaque port pod-3 should have its service port 1003 marked as opaque"),
+			expected: fmt.Errorf("\t* service svc which targets the opaque port pod-test should have its service port 1003 marked as opaque"),
 		},
 	}
 


### PR DESCRIPTION
After #6719 merged the proxy injector started adding a default list for the `config.linkerd.io/opaque-ports` annotation to pods and services if they and their namespace do not have the annotation already.

Addresses part of #6783

For the control plane, the default list that pods get can be different than the services that select them. For example, the `linkerd-sp-validator` exposes `443`—which is opaque by default—but it targets `8443` on `linkerd-destination` pods which is not opaque by default. Therefore, `linkerd-sp-validator`'s default list is `443` and `linkerd-destination`'s default list is `8443`.

The way that the opaque ports check currently works is it naively issues warnings when a service and a pod that it selects have different values for the annotation. With this change, it now accounts for the service's `port` and `targetPort` and the pod's `containerPort`.

---

The main change about the opaque ports check is it now considers `service.Spec.Ports` and `pod.Spec.Containers.Ports`. Using those port lists, it can now figure out when a service targets—by integer or name—an opaque port on a pod and warn the user if it is not annotated on the pod.

Additionally, it can look at a pods's opaque port list and warn the user if a service that targets any of the ports—again by integer or name—does not have that port marked as opaque.

This solves the problem above about a service marking `443` as opaque, but a pod that it selects marking `8443` as opaque. The check can now see that `443 == sp-validator`, and `sp-validator == 8443`  on the pod.

I've updated the unit tests and added some additional ones that exercise the named port behavior.


Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
