### PR TITLE
Add release notes for `edge-21.9.1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ in the proxy i.e, terminating TCP connections when a authorization is revoked, i
 in the proxy authorization metrics. In addition, proxy injector has also been updated
 to set the right `opaque-ports` annotation on services with default opaque ports.
 
-* Added a new validating admission controller to validate the proxy resources
+* Added a new validating admission controller to validate the policy resources
 * Updated the proxy-init to remove a rule which caused the packets from the proxy
   with destination != 127.0.0.1 on localhost to be sent to the inbound proxy
 * Added new `LINKERD_DOCKER_REGISTRY` env variable to configure the docker
@@ -22,7 +22,7 @@ to set the right `opaque-ports` annotation on services with default opaque ports
 * Updated tokio to include performance improvements and to enable link-time
   optimizations in the release builds
 * Added DNS name validation to the `proxy-identity` binary which creates the
-  read-only private key required the proxy (thanks @yorkijr!)
+  read-only private key required by the proxy (thanks @yorkijr!)
 * Updated the identity controller's default policy to be `cluster-unauthenticated`
 * Updated the proxy injector to include the correct default ports as opaque with
   services

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,15 +11,13 @@ to set the right `opaque-ports` annotation on services with default opaque ports
 * Added a new validating admission controller to validate the policy resources
 * Updated the proxy-init to remove a rule which caused the packets from the proxy
   with destination != 127.0.0.1 on localhost to be sent to the inbound proxy
-* Added new `LINKERD_DOCKER_REGISTRY` env variable to configure the docker
-  registry in the CLI
 * Updated inbound policy enforcement to interrupt TCP forwarding if a previously
   established authorization is revoked
-* Added new proxy metrics w.r.t Authorization along with traffic target labels
+* Added new proxy metrics to expose authorization decisions
 * Updated inbound TCP metrics to only include a `srv_name` label
 * Updated the proxy to export route-oriented metrics only when a ServiceProfile
-  is enabled.
-* Updated the tokio dependency in the proxy to include performance improvements
+  is enabled
+* Updated the proxy's release build configuration to improve CPU and memory utilization 
 * Added DNS name validation to the `proxy-identity` binary which creates the
   read-only private key required by the proxy (thanks @yorkijr!)
 * Updated the identity controller's default policy to be `cluster-unauthenticated`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,8 +19,7 @@ to set the right `opaque-ports` annotation on services with default opaque ports
 * Updated inbound TCP metrics to only include a `srv_name` label
 * Updated the proxy to export route-oriented metrics only when a ServiceProfile
   is enabled.
-* Updated tokio to include performance improvements and to enable link-time
-  optimizations in the release builds
+* Updated the tokio dependency in the proxy to include performance improvements
 * Added DNS name validation to the `proxy-identity` binary which creates the
   read-only private key required by the proxy (thanks @yorkijr!)
 * Updated the identity controller's default policy to be `cluster-unauthenticated`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,35 @@
 # Changes
 
+## edge-21.9.1
+
+This release includes various improvements and feature additions across the policy
+feature i.e, New validating webhook for policy resources. This also includes changes
+in the proxy i.e, terminating TCP connections when a authorization is revoked, improvements
+in the proxy authorization metrics. In addition, proxy injector has also been updated
+to set the right `opaque-ports` annotation on services with default opaque ports.
+
+* Added a new validating admission controller to validate the proxy resources
+* Updated the proxy-init to remove a rule which caused the packets from the proxy
+  with destination != 127.0.0.1 on localhost to be sent to the inbound proxy
+* Added new `LINKERD_DOCKER_REGISTRY` env variable to configure the docker
+  registry in the CLI
+* Updated inbound policy enforcement to interrupt TCP forwarding if a previously
+  established authorization is revoked
+* Added new proxy metrics w.r.t Authorization along with traffic target labels
+* Updated inbound TCP metrics to only include a `srv_name` label
+* Updated the proxy to export route-oriented metrics only when a ServiceProfile
+  is enabled.
+* Updated tokio to include performance improvements and to enable link-time
+  optimizations in the release builds
+* Added DNS name validation to the `proxy-identity` binary which creates the
+  read-only private key required the proxy (thanks @yorkijr!)
+* Updated the identity controller's default policy to be `cluster-unauthenticated`
+* Updated the proxy injector to include the correct default ports as opaque with
+  services
+* Deprecated the usage of `vis stat ts` and print a warning about the SMI extension
+* Updated various dependencies across the dashboard, policy-controller
+  (thanks @dependabot!)
+
 ## edge-21.8.4
 
 This edge release continues to build on the policy feature by adding support for


### PR DESCRIPTION
This release includes various improvements and feature additions across the policy
feature i.e, New validating webhook for policy resources. This also includes changes
in the proxy i.e, terminating TCP connections when a authorization is revoked, improvements
in the proxy authorization metrics. In addition, proxy injector has also been updated
to set the right `opaque-ports` annotation on services with default opaque ports.

* Added a new validating admission controller to validate the policy resources
* Updated the proxy-init to remove a rule which caused the packets from the proxy
  with destination != 127.0.0.1 on localhost to be sent to the inbound proxy
* Updated inbound policy enforcement to interrupt TCP forwarding if a previously
  established authorization is revoked
* Added new proxy metrics to expose authorization decisions
* Updated inbound TCP metrics to only include a `srv_name` label
* Updated the proxy to export route-oriented metrics only when a ServiceProfile
  is enabled
* Updated the proxy's release build configuration to improve CPU and memory utilization 
* Added DNS name validation to the `proxy-identity` binary which creates the
  read-only private key required by the proxy (thanks @yorkijr!)
* Updated the identity controller's default policy to be `cluster-unauthenticated`
* Updated the proxy injector to include the correct default ports as opaque with
  services
* Deprecated the usage of `vis stat ts` and print a warning about the SMI extension
* Updated various dependencies across the dashboard, policy-controller
  (thanks @dependabot!)