### PR TITLE
policy-controller: Make kubelet IP indexing optional

### DIFF
--- a/policy-controller/k8s/index/src/pod.rs
+++ b/policy-controller/k8s/index/src/pod.rs
@@ -288,7 +288,7 @@ impl PodIndex {
         annotations: &PodAnnotations,
         default_policy: DefaultPolicy,
         default_policy_watches: &mut DefaultPolicyWatches,
-        kubelet: KubeletIps,
+        kubelet: Option<KubeletIps>,
     ) -> (PodPorts, HashMap<u16, lookup::Rx>) {
         let mut ports = PodPorts::default();
         let mut lookups = HashMap::new();


### PR DESCRIPTION
In some cluster environments--namely Amazon EKS, nodes do not include a
`podCIDRs` configuration, so it's impossible to automatically detect a
node's Kubelet IP.

This change modifies node indexing to support this case by handling the
case when neither `podCIDR` nor `podCIDRs` is set. In this case, no
`default:kubelet` authorization is set on authorization responses. This
means that unauthenticated kubelet traffic will need to be explicitly
enabled in these clusters when restrictive default policies are used.

Fixes #6742

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
