### PR TITLE
override docker registry in install-pr script

### DIFF
--- a/bin/install-pr
+++ b/bin/install-pr
@@ -127,6 +127,9 @@ case $(uname) in
     ;;
 esac
 
+# Images created based off PRs use the ghcr.io registry, so override the
+# default here when pulling the binary.
+export DOCKER_REGISTRY=ghcr.io/linkerd
 linkerd=$("$bindir"/docker-pull-binaries "$tag" | awk -v platform=$platform '$0 ~ platform')
 
 echo ""


### PR DESCRIPTION
Images created based off PRs now use the `ghcr.io/linkerd` registry. `bin/docker-pull-binaries` which is used by this script uses the default `cr.l5d.io/linkerd`. This results in no binary being pulled because `bin/install-pr` is using the incorrect image name.

This change overrides the `DOCKER_REGISTRY` in `bin/install-pr` so that the correct name is used when pulling the binary.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>