### PR TITLE
policy: Detect when a server's protocol changes

### DIFF
--- a/policy-controller/k8s/index/src/server.rs
+++ b/policy-controller/k8s/index/src/server.rs
@@ -178,6 +178,7 @@ impl SrvIndex {
 
     /// Update the index with a server instance.
     fn apply(&mut self, srv: policy::Server, ns_authzs: &AuthzIndex) {
+        trace!(?srv, "Applying server");
         let srv_name = srv.name();
         let port = srv.spec.port;
         let protocol = Self::mk_protocol(srv.spec.proxy_protocol.as_ref());
@@ -209,6 +210,8 @@ impl SrvIndex {
             }
 
             HashEntry::Occupied(mut entry) => {
+                trace!(srv = ?entry.get(), "Updating existing server");
+
                 // If something about the server changed, we need to update the config to reflect
                 // the change.
                 let new_labels = if entry.get().labels != srv.metadata.labels {
@@ -217,7 +220,7 @@ impl SrvIndex {
                     None
                 };
 
-                let new_protocol = if entry.get().protocol == protocol {
+                let new_protocol = if entry.get().protocol != protocol {
                     Some(protocol)
                 } else {
                     None


### PR DESCRIPTION
Currently, the policy controller's indexing does not detect when a
server update changes its protocol (due to an incorrect comparison).
This change fixes this comparison so that protocol hint changes are
properly honored.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
