### PR TITLE
actions: Do not run tests on push to main

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,13 +1,6 @@
 name: Integration tests
 on:
   pull_request: {}
-  push:
-    paths-ignore:
-    - '*.md'
-    - '**/*.md'
-    - 'web/app/package.json'
-    branches:
-    - main
 permissions:
   contents: read
 env:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -3,11 +3,6 @@ on:
   pull_request:
     paths-ignore:
     - 'web/app/package.json'
-  push:
-    paths-ignore:
-    - 'web/app/package.json'
-    branches:
-    - main
 permissions: 
   contents: read
 jobs:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,12 +1,6 @@
 name: Unit tests
 on:
   pull_request: {}
-  push:
-    paths-ignore:
-    - '*.md'
-    - '**/*.md'
-    branches:
-    - main
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Each time we push to the main branch, we run a full set of unit and
integration tests, even though the branch has already passed CI before
merging. When we have many branches in-flight, this work chews into our
actions usage, delaying actions for open PRs that are more important to
run expediently.

This change disables running these tests on push to `main`. We continue
to run `CodeQL` checks on main, as these checks appear to be necessary.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
