### PR TITLE
Docker cache cleanup

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -35,7 +35,6 @@ runs:
     with:
       path: ${{ env.DOCKER_BUILDKIT_CACHE }}
       key: ${{ runner.os }}-buildx-${{ inputs.component }}-${{ env.TAG }}
-      restore-keys: ${{ runner.os }}-buildx-${{ inputs.component }}-
   - name: Set up QEMU
     uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
   - name: Set up Docker Buildx


### PR DESCRIPTION
Do not merge. This just writes a fresh cache for all the docker images,
to unblock #6873

