### PR TITLE
Update test for ports bound on localhost

### DIFF
--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -86,8 +86,8 @@ func TestLocalhostServer(t *testing.T) {
 				return fmt.Errorf("expected non-zero RPS from slowcooker to nginx: %s", out)
 			}
 
-            // Requests sent to a port which is only bound to localhost should
-            // fail.
+			// Requests sent to a port which is only bound to localhost should
+			// fail.
 			if *stats[0].Success >= 1.0 {
 				return fmt.Errorf("expected zero success-rate from slowcooker to nginx: %s", out)
 			}

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -86,9 +86,8 @@ func TestLocalhostServer(t *testing.T) {
 				return fmt.Errorf("expected non-zero RPS from slowcooker to nginx: %s", out)
 			}
 
-			// TODO: Update this test to expect these requests to fail once
-			// https://github.com/linkerd/linkerd2/issues/6495 is fixed.  Requests
-			// sent to a port which is only bound to localhost should fail.
+            // Requests sent to a port which is only bound to localhost should
+            // fail.
 			if *stats[0].Success >= 1.0 {
 				return fmt.Errorf("expected zero success-rate from slowcooker to nginx: %s", out)
 			}

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -89,11 +89,11 @@ func TestLocalhostServer(t *testing.T) {
 			// TODO: Update this test to expect these requests to fail once
 			// https://github.com/linkerd/linkerd2/issues/6495 is fixed.  Requests
 			// sent to a port which is only bound to localhost should fail.
-			if *stats[0].Success != 1.0 {
-				return fmt.Errorf("expected perfect success-rate from slowcooker to nginx: %s", out)
+			if *stats[0].Success >= 1.0 {
+				return fmt.Errorf("expected zero success-rate from slowcooker to nginx: %s", out)
 			}
-			if *stats[0].TCPOpenConnections == 0 {
-				return fmt.Errorf("expected tcp connection from slowcooker to nginx: %s", out)
+			if *stats[0].TCPOpenConnections > 0 {
+				return fmt.Errorf("expected no tcp connection from slowcooker to nginx: %s", out)
 			}
 
 			return nil


### PR DESCRIPTION
Should be merged after [#1161](https://github.com/linkerd/linkerd2-proxy/pull/1161), marked as draft until then. 

When a connection is forwarded to a port bound on localhost instead of the original IP, the connection should be rejected. For more details, see [#6495](https://github.com/linkerd/linkerd2/issues/6495)


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
