### PR TITLE
use easymode api for subscriber initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,6 @@ dependencies = [
  "structopt",
  "tokio",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "warp",
 ]

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -24,6 +24,5 @@ serde_json = "1"
 structopt = "0.3"
 tokio = { version = "1", features = ["macros", "parking_lot", "rt", "rt-multi-thread", "signal", "sync"] }
 tracing = "0.1"
-tracing-log = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"] }
 warp = { version = "0.3", default-features = false, features = ["tls"] }


### PR DESCRIPTION
If we use the [`SubscriberInitExt` trait][1] from the
`tracing-subscriber` prelude, the `log` compatibility code is set up
automagically (as long as the "tracing-log" feature flag is enabled).

This code golfs the function for setting up logging a little bit.

[1]: https://docs.rs/tracing-subscriber/0.2.22/tracing_subscriber/util/trait.SubscriberInitExt.html

Signed-off-by: Eliza Weisman <eliza@buoyant.io>