### PR TITLE
drop svc `linkerd-sp-validator` opaque ports annotation

### DIFF
--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -50,7 +50,6 @@ metadata:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1573,7 +1573,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1572,7 +1572,6 @@ metadata:
     linkerd.io/control-plane-ns: l5d
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1572,7 +1572,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1572,7 +1572,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1572,7 +1572,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1646,7 +1646,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1646,7 +1646,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1503,7 +1503,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1565,7 +1565,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1639,7 +1639,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1647,7 +1647,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1639,7 +1639,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1534,7 +1534,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1574,7 +1574,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: CliVersion
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1572,7 +1572,6 @@ metadata:
     linkerd.io/control-plane-ns: linkerd
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1558,7 +1558,6 @@ metadata:
     linkerd.io/control-plane-ns: l5d
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    config.linkerd.io/opaque-ports: "443"
 spec:
   type: ClusterIP
   selector:

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2355,7 +2355,7 @@ func checkPodPorts(service *corev1.Service, pod *corev1.Pod, podPorts []string, 
 						if util.ContainsString(strPort, podPorts) {
 							return nil
 						}
-						return fmt.Errorf("service %s expects %d to be opaque; add it to pod %s's %s annotation", service.Name, port, pod.Name, k8s.ProxyOpaquePortsAnnotation)
+						return fmt.Errorf("service %s expects target port %s to be opaque; add it to pod %s %s annotation", service.Name, strPort, pod.Name, k8s.ProxyOpaquePortsAnnotation)
 					}
 				}
 			}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -3418,7 +3418,7 @@ subsets:
     protocol: TCP
 `,
 			},
-			expected: fmt.Errorf("\t* service svc expects 9200 to be opaque; add it to pod pod's config.linkerd.io/opaque-ports annotation"),
+			expected: fmt.Errorf("\t* service svc expects target port 9200 to be opaque; add it to pod pod config.linkerd.io/opaque-ports annotation"),
 		},
 		{
 			resources: []string{`


### PR DESCRIPTION
#6887 dropped `8443` from deploy `linkerd-destination` opaque ports annotation. The service that targets this port—`linkerd-sp-validator`—still expects this port to be opaque because of it's annotation (`443` which targets `8443`).

This port should be treated as opaque so this change removes `443` from svc `linkerd-sp-validator` which makes `linkerd check --proxy` pass again.

I also noticed that in the warning message we hint the incorrect port should be added to a pod
```
* service linkerd-sp-validator expects 443 to be opaque; add it to pod linkerd-destination-8596887999-msrlx's config.linkerd.io/opaque-ports annotation
```

This message _should_ advise `8443` being added to the pod, not the service's port.

With the change in messaging this warning now is corrrect
```
* service linkerd-sp-validator expects 8443 to be opaque; add it to pod linkerd-destination-8596887999-msrlx config.linkerd.io/opaque-ports annotation
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>