### PR TITLE
Disable calico tests temporarily

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -60,7 +60,7 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
-        - cni-calico-deep
+          #- cni-calico-deep
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -60,6 +60,9 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
+          # temporarily disabled; 
+          # image used in manifests for calico-operator
+          # does not exist in image repository yet
           #- cni-calico-deep
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,9 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
+          # temporarily disabled; 
+          # image used in manifests for calico-operator
+          # does not exist in image repository yet
           #- cni-calico-deep
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
-        - cni-calico-deep
+          #- cni-calico-deep
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60


### PR DESCRIPTION
Calico CNI integration tests are currently blocking the release so this temporarily disables the test from being run on merges and on release.

A new version of the calico operator has been released, however the image isn't in their repository (but they have updated the manifests to use the new version). The test fails because the image cannot be pulled.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
