### PR TITLE
Make destination info logs clearer by changing log level of watchers

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -183,9 +183,9 @@ func (ew *EndpointsWatcher) Subscribe(id ServiceID, port Port, hostname string, 
 	}
 
 	if hostname == "" {
-		ew.log.Infof("Establishing watch on endpoint [%s:%d]", id, port)
+		ew.log.Debugf("Establishing watch on endpoint [%s:%d]", id, port)
 	} else {
-		ew.log.Infof("Establishing watch on endpoint [%s.%s:%d]", hostname, id, port)
+		ew.log.Debugf("Establishing watch on endpoint [%s.%s:%d]", hostname, id, port)
 	}
 
 	sp := ew.getOrNewServicePublisher(id)
@@ -197,9 +197,9 @@ func (ew *EndpointsWatcher) Subscribe(id ServiceID, port Port, hostname string, 
 // Unsubscribe removes a listener from the subscribers list for this authority.
 func (ew *EndpointsWatcher) Unsubscribe(id ServiceID, port Port, hostname string, listener EndpointUpdateListener) {
 	if hostname == "" {
-		ew.log.Infof("Stopping watch on endpoint [%s:%d]", id, port)
+		ew.log.Debugf("Stopping watch on endpoint [%s:%d]", id, port)
 	} else {
-		ew.log.Infof("Stopping watch on endpoint [%s.%s:%d]", hostname, id, port)
+		ew.log.Debugf("Stopping watch on endpoint [%s.%s:%d]", hostname, id, port)
 	}
 
 	sp, ok := ew.getServicePublisher(id)

--- a/controller/api/destination/watcher/opaque_ports_watcher.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher.go
@@ -64,7 +64,7 @@ func (opw *OpaquePortsWatcher) Subscribe(id ServiceID, listener OpaquePortsUpdat
 	if svc != nil && svc.Spec.Type == corev1.ServiceTypeExternalName {
 		return invalidService(id.String())
 	}
-	opw.log.Infof("Starting watch on service %s", id)
+	opw.log.Debugf("Starting watch on service %s", id)
 	ss, ok := opw.subscriptions[id]
 	// If there is no watched service, create a subscription for the service
 	// and no opaque ports
@@ -87,7 +87,7 @@ func (opw *OpaquePortsWatcher) Subscribe(id ServiceID, listener OpaquePortsUpdat
 func (opw *OpaquePortsWatcher) Unsubscribe(id ServiceID, listener OpaquePortsUpdateListener) {
 	opw.Lock()
 	defer opw.Unlock()
-	opw.log.Infof("Stopping watch on service %s", id)
+	opw.log.Debugf("Stopping watch on service %s", id)
 	ss, ok := opw.subscriptions[id]
 	if !ok {
 		opw.log.Errorf("Cannot unsubscribe from unknown service %s", id)

--- a/controller/api/destination/watcher/profile_watcher.go
+++ b/controller/api/destination/watcher/profile_watcher.go
@@ -71,7 +71,7 @@ func NewProfileWatcher(k8sAPI *k8s.API, log *logging.Entry) *ProfileWatcher {
 // The provided listener will be updated each time the service profile for the
 // given authority is changed.
 func (pw *ProfileWatcher) Subscribe(id ProfileID, listener ProfileUpdateListener) error {
-	pw.log.Infof("Establishing watch on profile %s", id)
+	pw.log.Debugf("Establishing watch on profile %s", id)
 
 	publisher := pw.getOrNewProfilePublisher(id, nil)
 
@@ -81,7 +81,7 @@ func (pw *ProfileWatcher) Subscribe(id ProfileID, listener ProfileUpdateListener
 
 // Unsubscribe removes a listener from the subscribers list for this authority.
 func (pw *ProfileWatcher) Unsubscribe(id ProfileID, listener ProfileUpdateListener) error {
-	pw.log.Infof("Stopping watch on profile %s", id)
+	pw.log.Debugf("Stopping watch on profile %s", id)
 
 	publisher, ok := pw.getProfilePublisher(id)
 	if !ok {

--- a/controller/api/destination/watcher/traffic_split_watcher.go
+++ b/controller/api/destination/watcher/traffic_split_watcher.go
@@ -71,7 +71,7 @@ func NewTrafficSplitWatcher(k8sAPI *k8s.API, log *logging.Entry) *TrafficSplitWa
 // Each time a traffic split is updated with the given apex service, the
 // listener will be updated.
 func (tsw *TrafficSplitWatcher) Subscribe(id ServiceID, listener TrafficSplitUpdateListener) error {
-	tsw.log.Infof("Establishing watch on service %s", id)
+	tsw.log.Debugf("Establishing watch on service %s", id)
 
 	publisher := tsw.getOrNewTrafficSplitPublisher(id, nil)
 
@@ -81,7 +81,7 @@ func (tsw *TrafficSplitWatcher) Subscribe(id ServiceID, listener TrafficSplitUpd
 
 // Unsubscribe removes a listener from the subscribers list for this service.
 func (tsw *TrafficSplitWatcher) Unsubscribe(id ServiceID, listener TrafficSplitUpdateListener) error {
-	tsw.log.Infof("Stopping watch on profile %s", id)
+	tsw.log.Debugf("Stopping watch on profile %s", id)
 
 	publisher, ok := tsw.getTrafficSplitPublisher(id)
 	if !ok {


### PR DESCRIPTION
Make destination info logs clearer by changing log level of watchers log messages 'Establishing watch', 'Starting watch' and 'Stopping watch' from info to debug

Signed-off-by: Bart Peeters <birtpeeters@hotmail.com>