### PR TITLE
New integration test default-policy-deny

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -6,7 +6,7 @@ set +e
 
 ##### Test setup helpers #####
 
-export default_test_names=(deep external-issuer external-prometheus-deep helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable)
+export default_test_names=(deep external-issuer external-prometheus-deep helm-deep helm-upgrade uninstall upgrade-edge upgrade-stable default-policy-deny)
 export external_resource_test_names=(external-resources)
 export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_test_names[*]}" "${external_resource_test_names[*]}")
 images_load_default=(proxy controller policy-controller web metrics-api grafana tap)
@@ -364,7 +364,7 @@ run_test(){
 
   printf 'Test script: [%s] Params: [%s]\n' "${filename##*/}" "$*"
   # Exit on failure here
-  GO111MODULE=on go test -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --k8s-context="$context" --integration-tests "$@" || exit 1
+  GO111MODULE=on go test -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --default-allow-policy="$default_allow_policy" --k8s-context="$context" --integration-tests "$@" || exit 1
 }
 
 # Returns the latest version for the release channel
@@ -528,6 +528,12 @@ run_deep_test() {
   for test in "${tests[@]}"; do
     run_test "$test"
   done
+}
+
+run_default-policy-deny_test() {
+  local tests=()
+  export default_allow_policy='deny'
+  run_test "$test_directory/install_test.go"
 }
 
 run_cni-calico-deep_test() {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -283,6 +283,10 @@ func TestInstallOrUpgradeCli(t *testing.T) {
 		args = append(args, "--linkerd-cni-enabled")
 	}
 
+	if policy := TestHelper.DefaultAllowPolicy(); policy != "" {
+		args = append(args, "--set", "policyController.defaultAllowPolicy="+policy)
+	}
+
 	if TestHelper.ExternalIssuer() {
 
 		// short cert lifetime to put some pressure on the CSR request, response code path
@@ -832,6 +836,12 @@ func TestOverridesSecret(t *testing.T) {
 
 		if TestHelper.CNI() {
 			knownKeys["cniEnabled"] = true
+		}
+
+		if policy := TestHelper.DefaultAllowPolicy(); policy != "" {
+			knownKeys["policyController"] = tree.Tree{
+				"defaultAllowPolicy": policy,
+			}
 		}
 
 		// Check if the keys in overridesTree match with knownKeys

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -36,6 +36,7 @@ type TestHelper struct {
 	cni                bool
 	calico             bool
 	certsPath          string
+	defaultAllowPolicy string
 	httpClient         http.Client
 	KubernetesHelper
 	helm
@@ -181,6 +182,7 @@ func NewTestHelper() *TestHelper {
 	cni := flag.Bool("cni", false, "whether to install linkerd with CNI enabled")
 	calico := flag.Bool("calico", false, "whether to install calico CNI plugin")
 	certsPath := flag.String("certs-path", "", "if non-empty, 'linkerd install' will use the files ca.crt, issuer.crt and issuer.key under this path in its --identity-* flags")
+	defaultAllowPolicy := flag.String("default-allow-policy", "", "if non-empty, passed to --set policyController.defaultAllowPolicy at linkerd's install time")
 	flag.Parse()
 
 	if !*runTests {
@@ -230,6 +232,7 @@ func NewTestHelper() *TestHelper {
 		calico:             *calico,
 		uninstall:          *uninstall,
 		certsPath:          *certsPath,
+		defaultAllowPolicy: *defaultAllowPolicy,
 	}
 
 	version, err := testHelper.LinkerdRun("version", "--client", "--short")
@@ -347,6 +350,11 @@ func (h *TestHelper) Uninstall() bool {
 // will use in its --identity-* flags
 func (h *TestHelper) CertsPath() string {
 	return h.certsPath
+}
+
+// DefaultAllowPolicy returns the override value for policyController.defaultAllowPolicy
+func (h *TestHelper) DefaultAllowPolicy() string {
+	return h.defaultAllowPolicy
 }
 
 // UpgradeFromVersion returns the base version of the upgrade test.


### PR DESCRIPTION
Closes #6813, followup to #6846

This runs `./test/integration/install_test.go`, installing linkerd with
`--set policyController.defaultAllowPolicy=deny` and subsequently
installing viz, making sure everything is alright.
