### PR TITLE
Fix policy validator namespaceSelector

### DIFF
--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -136,7 +136,7 @@ metadata:
 webhooks:
 - name: linkerd-policy-validator.linkerd.io
   namespaceSelector:
-    {{- toYaml .Values.profileValidator.namespaceSelector | trim | nindent 4 }}
+    {{- toYaml .Values.policyValidator.namespaceSelector | trim | nindent 4 }}
   clientConfig:
     service:
       name: linkerd-policy-validator

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -189,9 +189,9 @@ webhooks:
   namespaceSelector:
     matchExpressions:
     - key: config.linkerd.io/admission-webhooks
-      operator: In
+      operator: NotIn
       values:
-      - enabled
+      - disabled
   clientConfig:
     service:
       name: linkerd-policy-validator


### PR DESCRIPTION
The helm template was making reference to `profileValidator.namespaceSelector` instead of `policyValidator.namespaceSelector`.
