### PR TITLE
policy: Do not attempt to validate ServerAuthorizations

### DIFF
--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -99,7 +99,7 @@ webhooks:
   failurePolicy: {{.Values.webhookFailurePolicy}}
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -149,10 +149,10 @@ webhooks:
   failurePolicy: {{.Values.webhookFailurePolicy}}
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   {{- if not .Values.omitWebhookSideEffects }}
   sideEffects: None
   {{- end }}

--- a/charts/linkerd2/templates/destination-rbac.yaml
+++ b/charts/linkerd2/templates/destination-rbac.yaml
@@ -99,7 +99,7 @@ webhooks:
   failurePolicy: {{.Values.webhookFailurePolicy}}
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -149,7 +149,7 @@ webhooks:
   failurePolicy: {{.Values.webhookFailurePolicy}}
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,7 +201,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,10 +201,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,10 +201,10 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,7 +201,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,10 +201,10 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,7 +201,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,10 +201,10 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -156,7 +156,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -201,7 +201,7 @@ webhooks:
   failurePolicy: Fail
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: WebhookFailurePolicy
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: WebhookFailurePolicy
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: WebhookFailurePolicy
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: WebhookFailurePolicy
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,10 +195,10 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -150,7 +150,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -195,7 +195,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -136,7 +136,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -181,7 +181,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: [ "CREATE" , "UPDATE" ]
+  - operations: ["CREATE" , "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -184,7 +184,7 @@ webhooks:
   - operations: [ "CREATE" , "UPDATE" ]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
-    resources: ["serverauthorizations", "servers"]
+    resources: ["servers"]
   sideEffects: None
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -136,7 +136,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["linkerd.io"]
     apiVersions: ["v1alpha1", "v1alpha2"]
     resources: ["serviceprofiles"]
@@ -181,7 +181,7 @@ webhooks:
   failurePolicy: Ignore
   admissionReviewVersions: ["v1", "v1beta1"]
   rules:
-  - operations: ["CREATE" , "UPDATE"]
+  - operations: ["CREATE", "UPDATE"]
     apiGroups: ["policy.linkerd.io"]
     apiVersions: ["v1alpha1"]
     resources: ["servers"]


### PR DESCRIPTION
The policy-controller's validating admission controller only handles
`Server` resources; but its webhook configuration processes
`ServerAuthorization` resources as well, which results in errors (and
rejections in HA).

This change modifies the webhook configuration so that
`ServerAuthorization` resources are not validated by the admission
controller. This can be restored if the admission controller grows
the ability to validate these resources.

Fixes #6933

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
