### PR TITLE
Add Salt Security as an adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -54,6 +54,7 @@
 - [PriceKinetics (GVC Australia)](https://www.pricekinetics.com.au/)
 - [Projector](https://projector.com)
 - [Purdue University Global](https://www.purdueglobal.edu/)
+- [Salt Security](https://salt.security/)
 - [SCA](https://sca.com.au)
 - [Search365](https://search365.ai/)
 - [StackPulse](https://stackpulse.com)


### PR DESCRIPTION
Salt Security is using Linkerd 2 in production and would like to be added to the list of adopters.
