### PR TITLE
Enables helm log format config (#6871)

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -86,6 +86,7 @@ Kubernetes: `>=1.16.0-0`
 | dashboard.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the  web component |
 | dashboard.image.registry | string | defaultRegistry | Docker registry for the web instance |
 | dashboard.image.tag | string | linkerdVersion | Docker image tag for the web instance |
+| dashboard.logFormat | string | defaultLogFormat | log format of the dashboard component |
 | dashboard.logLevel | string | defaultLogLevel | log level of the dashboard component |
 | dashboard.proxy | string | `nil` |  |
 | dashboard.replicas | int | `1` | Number of replicas of dashboard |
@@ -95,6 +96,7 @@ Kubernetes: `>=1.16.0-0`
 | dashboard.resources.memory.request | string | `nil` | Amount of memory that the web container requests |
 | dashboard.restrictPrivileges | bool | `false` | Restrict the Linkerd Dashboard's default privileges to disallow Tap and Check |
 | defaultImagePullPolicy | string | `"IfNotPresent"` | Docker imagePullPolicy for all viz components |
+| defaultLogFormat | string | `"plain"` | Log format (`plain` or `json`) for all the viz components. |
 | defaultLogLevel | string | `"info"` | Log level for all the viz components |
 | defaultRegistry | string | `"cr.l5d.io/linkerd"` | Docker registry for all viz components |
 | defaultUID | int | `2103` | UID for all the viz components |
@@ -124,6 +126,7 @@ Kubernetes: `>=1.16.0-0`
 | metricsAPI.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the metrics-api component |
 | metricsAPI.image.registry | string | defaultRegistry | Docker registry for the metrics-api component |
 | metricsAPI.image.tag | string | linkerdVersion | Docker image tag for the metrics-api component |
+| metricsAPI.logFormat | string | defaultLogFormat | log format of the metrics-api component |
 | metricsAPI.logLevel | string | defaultLogLevel | log level of the metrics-api component |
 | metricsAPI.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | metricsAPI.proxy | string | `nil` |  |
@@ -166,6 +169,7 @@ Kubernetes: `>=1.16.0-0`
 | tap.image.registry | string | defaultRegistry | Docker registry for the tap instance |
 | tap.image.tag | string | linkerdVersion | Docker image tag for the tap instance |
 | tap.keyPEM | string | `""` | Certificate key for Tap component. If not provided then Helm will generate one. |
+| tap.logFormat | string | defaultLogFormat | log format of the tap component |
 | tap.logLevel | string | defaultLogLevel | log level of the tap component |
 | tap.proxy | string | `nil` |  |
 | tap.replicas | int | `1` | Number of tap component replicas |
@@ -183,6 +187,7 @@ Kubernetes: `>=1.16.0-0`
 | tapInjector.image.registry | string | defaultRegistry | Docker registry for the tapInjector instance |
 | tapInjector.image.tag | string | linkerdVersion | Docker image tag for the tapInjector instance |
 | tapInjector.keyPEM | string | `""` | Certificate key for the tapInjector. If not provided then Helm will generate one. |
+| tapInjector.logFormat | string | defaultLogFormat | log format of the tapInjector component |
 | tapInjector.logLevel | string | defaultLogLevel | log level of the tapInjector |
 | tapInjector.namespaceSelector | string | `nil` |  |
 | tapInjector.objectSelector | string | `nil` |  |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -107,8 +107,8 @@ Kubernetes: `>=1.16.0-0`
 | grafana.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the grafana instance |
 | grafana.image.registry | string | defaultRegistry | Docker registry for the grafana instance |
 | grafana.image.tag | string | linkerdVersion | Docker image tag for the grafana instance |
-| grafana.logFormat | string | text | log format (text, json) of the grafana instance |
-| grafana.logLevel | string | info | log level of the grafana instance |
+| grafana.logFormat | string | defaultLogFormat | log format (plain, json) of the grafana instance |
+| grafana.logLevel | string | defaultLogLevel | log level of the grafana instance |
 | grafana.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | grafana.proxy | string | `nil` |  |
 | grafana.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the grafana container can use |
@@ -149,7 +149,7 @@ Kubernetes: `>=1.16.0-0`
 | prometheus.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the prometheus instance |
 | prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
 | prometheus.image.tag | string | `"v2.19.3"` | Docker image tag for the prometheus instance |
-| prometheus.logFormat | string | logfmt | log format (logfmt, json) of the prometheus instance |
+| prometheus.logFormat | string | defaultLogLevel | log format (plain, json) of the prometheus instance |
 | prometheus.logLevel | string | defaultLogLevel | log level of the prometheus instance |
 | prometheus.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.proxy | string | `nil` |  |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -107,6 +107,8 @@ Kubernetes: `>=1.16.0-0`
 | grafana.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the grafana instance |
 | grafana.image.registry | string | defaultRegistry | Docker registry for the grafana instance |
 | grafana.image.tag | string | linkerdVersion | Docker image tag for the grafana instance |
+| grafana.logFormat | string | text | log format (text, json) of the grafana instance |
+| grafana.logLevel | string | info | log level of the grafana instance |
 | grafana.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | grafana.proxy | string | `nil` |  |
 | grafana.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the grafana container can use |
@@ -147,6 +149,7 @@ Kubernetes: `>=1.16.0-0`
 | prometheus.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the prometheus instance |
 | prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
 | prometheus.image.tag | string | `"v2.19.3"` | Docker image tag for the prometheus instance |
+| prometheus.logFormat | string | logfmt | log format (logfmt, json) of the prometheus instance |
 | prometheus.logLevel | string | defaultLogLevel | log level of the prometheus instance |
 | prometheus.nodeSelector | object | `{"beta.kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.proxy | string | `nil` |  |

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -33,8 +33,8 @@ data:
     [log]
     mode = console
     [log.console]
-    format = {{ .Values.grafana.logFormat | default "text" }}
-    level = {{ .Values.grafana.logLevel | default "info" }}
+    format = {{ .Values.grafana.logFormat | default .Values.defaultLogFormat | replace "plain" "text" }}
+    level = {{ .Values.grafana.logLevel | default .Values.defaultLogLevel }}
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.grafana.enabled -}}
-{{$rand := randAlpha 8 | lower -}}
 ---
 ###
 ### Grafana
@@ -7,7 +6,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: grafana-config-{{ $rand }}
+  name: grafana-config
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/extension: viz
@@ -15,7 +14,6 @@ metadata:
     namespace: {{.Values.namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
-immutable: true
 data:
   grafana.ini: |-
     instance_name = grafana
@@ -174,6 +172,6 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: grafana-config-{{ $rand }}
+          name: grafana-config
         name: grafana-config
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.grafana.enabled -}}
+{{$rand := randAlpha 8 | lower -}}
 ---
 ###
 ### Grafana
@@ -6,7 +7,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: grafana-config
+  name: grafana-config-{{ $rand }}
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/extension: viz
@@ -14,6 +15,7 @@ metadata:
     namespace: {{.Values.namespace}}
   annotations:
     {{ include "partials.annotations.created-by" . }}
+immutable: true
 data:
   grafana.ini: |-
     instance_name = grafana
@@ -172,6 +174,6 @@ spec:
             path: provisioning/datasources/datasources.yaml
           - key: dashboards.yaml
             path: provisioning/dashboards/dashboards.yaml
-          name: grafana-config
+          name: grafana-config-{{ $rand }}
         name: grafana-config
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/grafana.yaml
+++ b/viz/charts/linkerd-viz/templates/grafana.yaml
@@ -30,6 +30,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = {{ .Values.grafana.logFormat | default "text" }}
+    level = {{ .Values.grafana.logLevel | default "info" }}
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -69,6 +69,7 @@ spec:
       - args:
         - -controller-namespace={{.Values.linkerdNamespace}}
         - -log-level={{.Values.metricsAPI.logLevel | default .Values.defaultLogLevel}}
+        - -log-format={{.Values.metricsAPI.logFormat | default .Values.defaultLogFormat}}
         - -cluster-domain={{.Values.clusterDomain}}
         {{- if .Values.prometheusUrl }}
         - -prometheus-url={{.Values.prometheusUrl}}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -246,7 +246,7 @@ spec:
         - --log.level={{.Values.prometheus.logLevel | default .Values.defaultLogLevel}}
         {{- end }}
         {{- if not (hasKey .Values.prometheus.args "log.format") }}
-        - --log.format={{.Values.prometheus.logFormat | default "logfmt" }}
+        - --log.format={{.Values.prometheus.logFormat | default .Values.defaultLogFormat | replace "plain" "logfmt" }}
         {{- end }}
         {{- range $key, $value := .Values.prometheus.args}}
         - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -245,6 +245,9 @@ spec:
         {{- if not (hasKey .Values.prometheus.args "log.level") }}
         - --log.level={{.Values.prometheus.logLevel | default .Values.defaultLogLevel}}
         {{- end }}
+        {{- if not (hasKey .Values.prometheus.args "log.format") }}
+        - --log.format={{.Values.prometheus.logFormat | default "logfmt" }}
+        {{- end }}
         {{- range $key, $value := .Values.prometheus.args}}
         - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
         {{- end }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -73,6 +73,7 @@ spec:
         - injector
         - -tap-service-name=tap.{{.Values.namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain | default .Values.clusterDomain}}
         - -log-level={{.Values.tapInjector.logLevel | default .Values.defaultLogLevel}}
+        - -log-format={{.Values.tapInjector.logFormat | default .Values.defaultLogFormat}}
         image: {{.Values.tapInjector.image.registry | default .Values.defaultRegistry}}/{{.Values.tapInjector.image.name}}:{{.Values.tapInjector.image.tag | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.tapInjector.image.pullPolicy | default .Values.defaultImagePullPolicy}}
         livenessProbe:

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -82,6 +82,7 @@ spec:
         - api
         - -api-namespace={{.Values.linkerdNamespace}}
         - -log-level={{.Values.tap.logLevel | default .Values.defaultLogLevel}}
+        - -log-format={{.Values.tap.logFormat | default .Values.defaultLogFormat}}
         - -identity-trust-domain={{.Values.identityTrustDomain | default .Values.clusterDomain}}
         image: {{.Values.tap.image.registry | default .Values.defaultRegistry}}/{{.Values.tap.image.name}}:{{.Values.tap.image.tag | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.tap.image.pullPolicy | default .Values.defaultImagePullPolicy}}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -80,6 +80,7 @@ spec:
         - -controller-namespace={{.Values.linkerdNamespace}}
         - -viz-namespace={{.Values.namespace}}
         - -log-level={{.Values.dashboard.logLevel | default .Values.defaultLogLevel}}
+        - -log-format={{.Values.dashboard.logFormat | default .Values.defaultLogFormat}}
         {{- if .Values.dashboard.enforcedHostRegexp }}
         - -enforced-host={{.Values.dashboard.enforcedHostRegexp}}
         {{- else -}}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -296,6 +296,12 @@ dashboard:
 grafana:
   # -- toggle field to enable or disable grafana
   enabled: true
+  # -- log level of the grafana instance
+  # @default -- info
+  logLevel: ""
+  # -- log format (text, json) of the grafana instance
+  # @default -- text
+  logFormat: ""  
   image:
     # -- Docker registry for the grafana instance
     # @default -- defaultRegistry
@@ -351,6 +357,9 @@ prometheus:
   # -- log level of the prometheus instance
   # @default -- defaultLogLevel
   logLevel: ""
+  # -- log format (logfmt, json) of the prometheus instance
+  # @default -- logfmt
+  logFormat: ""
   # -- Command line options for Prometheus binary
   args:
     storage.tsdb.path: /data

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -18,6 +18,8 @@ defaultRegistry: cr.l5d.io/linkerd
 defaultImagePullPolicy: IfNotPresent
 # -- Log level for all the viz components
 defaultLogLevel: info
+# -- Log format (`plain` or `json`) for all the viz components.
+defaultLogFormat: plain
 # -- UID for all the viz components
 defaultUID: 2103
 
@@ -71,6 +73,9 @@ metricsAPI:
   # -- log level of the metrics-api component
   # @default -- defaultLogLevel
   logLevel: ""
+  # -- log format of the metrics-api component
+  # @default -- defaultLogFormat
+  logFormat: ""
   image:
     # -- Docker registry for the metrics-api component
     # @default -- defaultRegistry
@@ -119,6 +124,9 @@ tap:
   # -- log level of the tap component
   # @default -- defaultLogLevel
   logLevel: ""
+  # -- log format of the tap component
+  # @default -- defaultLogFormat
+  logFormat: ""
   image:
     # -- Docker registry for the tap instance
     # @default -- defaultRegistry
@@ -175,6 +183,9 @@ tapInjector:
   # -- log level of the tapInjector
   # @default -- defaultLogLevel
   logLevel: ""
+  # -- log format of the tapInjector component
+  # @default -- defaultLogFormat
+  logFormat: ""
   image:
     # -- Docker registry for the tapInjector instance
     # @default -- defaultRegistry
@@ -239,6 +250,9 @@ dashboard:
   # -- log level of the dashboard component
   # @default -- defaultLogLevel
   logLevel: ""
+  # -- log format of the dashboard component
+  # @default -- defaultLogFormat
+  logFormat: ""
   image:
     # -- Docker registry for the web instance
     # @default -- defaultRegistry

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -297,10 +297,10 @@ grafana:
   # -- toggle field to enable or disable grafana
   enabled: true
   # -- log level of the grafana instance
-  # @default -- info
+  # @default -- defaultLogLevel
   logLevel: ""
-  # -- log format (text, json) of the grafana instance
-  # @default -- text
+  # -- log format (plain, json) of the grafana instance
+  # @default -- defaultLogFormat
   logFormat: ""  
   image:
     # -- Docker registry for the grafana instance
@@ -357,8 +357,8 @@ prometheus:
   # -- log level of the prometheus instance
   # @default -- defaultLogLevel
   logLevel: ""
-  # -- log format (logfmt, json) of the prometheus instance
-  # @default -- logfmt
+  # -- log format (plain, json) of the prometheus instance
+  # @default -- defaultLogLevel
   logFormat: ""
   # -- Command line options for Prometheus binary
   args:

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -608,6 +608,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = text
+    level = info
   datasources.yaml: |-
     apiVersion: 1
     datasources:
@@ -976,6 +981,7 @@ spec:
       containers:
       - args:
         - --log.level=info
+        - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -515,6 +515,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
@@ -1081,6 +1082,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1279,6 +1281,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=info
+        - -log-format=plain
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1412,6 +1415,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -612,7 +612,7 @@ data:
     mode = console
     [log.console]
     format = text
-    level = info
+    level = debug
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -608,6 +608,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = text
+    level = info
   datasources.yaml: |-
     apiVersion: 1
     datasources:
@@ -976,6 +981,7 @@ spec:
       containers:
       - args:
         - --log.level=debug
+        - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -515,6 +515,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=debug
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: gcr.io/linkerd/metrics-api:dev-undefined
@@ -1081,6 +1082,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:stable-9.2
         imagePullPolicy: IfNotPresent
@@ -1279,6 +1281,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=debug
+        - -log-format=plain
         image: gcr.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1412,6 +1415,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=debug
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: gcr.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -762,6 +762,7 @@ spec:
       containers:
       - args:
         - --log.level=info
+        - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h

--- a/viz/cmd/testdata/install_grafana_disabled.golden
+++ b/viz/cmd/testdata/install_grafana_disabled.golden
@@ -502,6 +502,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
@@ -867,6 +868,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1065,6 +1067,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=info
+        - -log-format=plain
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1198,6 +1201,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -568,6 +568,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = text
+    level = info
   datasources.yaml: |-
     apiVersion: 1
     datasources:

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -475,6 +475,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=external-prom.com
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
@@ -794,6 +795,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -992,6 +994,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=info
+        - -log-format=plain
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1125,6 +1128,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -515,6 +515,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
@@ -1081,6 +1082,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1279,6 +1281,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=info
+        - -log-format=plain
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1412,6 +1415,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -608,6 +608,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = text
+    level = info
   datasources.yaml: |-
     apiVersion: 1
     datasources:
@@ -975,6 +980,7 @@ spec:
         fsGroup: 65534
       containers:
       - args:
+        - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=debug
         - --storage.tsdb.path=/data

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -515,6 +515,7 @@ spec:
       - args:
         - -controller-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -cluster-domain=cluster.local
         - -prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090
         image: cr.l5d.io/linkerd/metrics-api:dev-undefined
@@ -1093,6 +1094,7 @@ spec:
         - api
         - -api-namespace=linkerd
         - -log-level=info
+        - -log-format=plain
         - -identity-trust-domain=cluster.local
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
@@ -1291,6 +1293,7 @@ spec:
         - injector
         - -tap-service-name=tap.linkerd-viz.serviceaccount.identity.linkerd.cluster.local
         - -log-level=info
+        - -log-format=plain
         image: cr.l5d.io/linkerd/tap:dev-undefined
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -1428,6 +1431,7 @@ spec:
         - -controller-namespace=linkerd
         - -viz-namespace=linkerd-viz
         - -log-level=info
+        - -log-format=plain
         - -enforced-host=^(localhost|127\.0\.0\.1|web\.linkerd-viz\.svc\.cluster\.local|web\.linkerd-viz\.svc|\[::1\])(:\d+)?$
         image: cr.l5d.io/linkerd/web:dev-undefined
         imagePullPolicy: IfNotPresent

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -608,6 +608,11 @@ data:
     check_for_updates = false
     [panels]
     disable_sanitize_html = true
+    [log]
+    mode = console
+    [log.console]
+    format = text
+    level = info
   datasources.yaml: |-
     apiVersion: 1
     datasources:
@@ -984,6 +989,7 @@ spec:
       containers:
       - args:
         - --log.level=info
+        - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h


### PR DESCRIPTION
Although linkerd-viz components (tap, tap-injector, api-metrics and web) accepts by default a log format configuration for `plain` and `json` modes, there was no way to set this configuration on helm charts.

This commit adds chart values, defaults and docs to allow such behavior for all linkerd-viz components.

Once merged, it should be possible  to configure any individual component through `<component>.logFormat` or globally through `defaultLogFormat`

Old behavior (`plain` format) is the default option.

Fixes #6871

Signed-off-by: Gustavo Carvalho <gusfcarvalho@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
