### PR TITLE
Trigger destination restart upon every upgrade

### DIFF
--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -147,6 +147,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if (or (empty .Values.cliVersion) (not (eq (.Values.stage | toString) "control-plane"))) }}
+        checksum/config: {{ include (print $.Template.BasePath "/destination-rbac.yaml") . | sha256sum }}
+        {{- end }}
         {{ include "partials.annotations.created-by" . }}
         {{- include "partials.proxy.annotations" . | nindent 8}}
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1643,6 +1643,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1642,6 +1642,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 2a3e6d14f91ce9eca2a1c14c52e2a60477136abcca04abff9a27599476be4ea4
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1642,6 +1642,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1642,6 +1642,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1642,6 +1642,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1735,6 +1735,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 4f845cf3c8e00375a0c4b73f2e53aab468e83dde0f388c4c3aea65a7f7ea2f5d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1735,6 +1735,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 4f845cf3c8e00375a0c4b73f2e53aab468e83dde0f388c4c3aea65a7f7ea2f5d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1573,6 +1573,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1635,6 +1635,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 7c36cb26305670af136b11b2014647c41deef4af151d00bd9abe043eb0fcd636
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1728,6 +1728,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: f6128e06bbada7980ab0fb470c06cd3e33f5d4f02dc76d717476fb56396253b8
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1736,6 +1736,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: f6128e06bbada7980ab0fb470c06cd3e33f5d4f02dc76d717476fb56396253b8
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1728,6 +1728,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 0dc9c5f091c857267a414fc5917819c51dcf2f8707fd9c607289db1fcc998362
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1604,6 +1604,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1644,6 +1644,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b99ea15980ed7928905400a137930b4a98faea5de4fe7dc67a98a5ab0c007064
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1642,6 +1642,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1628,6 +1628,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 2a3e6d14f91ce9eca2a1c14c52e2a60477136abcca04abff9a27599476be4ea4
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version


### PR DESCRIPTION
Fixes #6940

Upon every upgrade the certs used by the policy controller validator
change, but the controller doesn't detect that, which breaks the webhook
requests. As a temporary solution, we force the pod to restart by adding
a `checksum/config` annotation to the manifest, like the injector
currently has.
