### PR TITLE
stat: support `-ojson` option with srv resources

### DIFF
--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -763,6 +763,7 @@ type jsonStats struct {
 	Leaf           string   `json:"leaf,omitempty"`
 	Dst            string   `json:"dst,omitempty"`
 	Weight         string   `json:"weight,omitempty"`
+	Unauthorized   *float64 `json:"unauthorized,omitempty"`
 }
 
 func printStatJSON(statTables map[string]map[string]*row, w *tabwriter.Writer) {
@@ -802,6 +803,12 @@ func printStatJSON(statTables map[string]map[string]*row, w *tabwriter.Writer) {
 				} else if stats[key].dstStats != nil {
 					entry.Dst = stats[key].dstStats.dst
 					entry.Weight = stats[key].dstStats.weight
+				}
+
+				if resourceType == k8s.Server {
+					if stats[key].srvStats != nil {
+						entry.Unauthorized = &stats[key].srvStats.unauthorizedRate
+					}
 				}
 				entries = append(entries, entry)
 			}


### PR DESCRIPTION
Policy resources are already supported just like
any other resources. For `srv`, the newly `unauthorized`
field is missed in the json response.

This PR tries to fix that.

## Output

```bash
on ⛵ kind-kind  linkerd2 on 🌱 taru [📦📝🤷‍] via 🐼 v1.16.8 via  via ⚙️ v1.55.0
➜ ./bin/go-run cli viz stat srv -n emojivoto -ojson                                                                      ~/work/linkerd2
[
  {
    "namespace": "emojivoto",
    "kind": "server",
    "name": "emoji-grpc",
    "success": 1,
    "rps": 2,
    "latency_ms_p50": 1,
    "latency_ms_p95": 1,
    "latency_ms_p99": 1,
    "tcp_open_connections": 0,
    "tcp_read_bytes_rate": 0,
    "tcp_write_bytes_rate": 0,
    "unauthorized": 0
  },
  {
    "namespace": "emojivoto",
    "kind": "server",
    "name": "prom",
    "success": null,
    "rps": null,
    "latency_ms_p50": null,
    "latency_ms_p95": null,
    "latency_ms_p99": null
  },
  {
    "namespace": "emojivoto",
    "kind": "server",
    "name": "voting-grpc",
    "success": 0.8833333333333333,
    "rps": 1,
    "latency_ms_p50": 1,
    "latency_ms_p95": 1,
    "latency_ms_p99": 1,
    "tcp_open_connections": 0,
    "tcp_read_bytes_rate": 0,
    "tcp_write_bytes_rate": 0,
    "unauthorized": 0
  },
  {
    "namespace": "emojivoto",
    "kind": "server",
    "name": "web-http",
    "success": 0.9576271186440678,
    "rps": 1.9666666666666666,
    "latency_ms_p50": 1,
    "latency_ms_p95": 5,
    "latency_ms_p99": 9,
    "tcp_open_connections": 0,
    "tcp_read_bytes_rate": 0,
    "tcp_write_bytes_rate": 0,
    "unauthorized": 0
  }
]

on ⛵ kind-kind  linkerd2 on 🌱 taru [📦📝🤷‍] via 🐼 v1.16.8 via  via ⚙️ v1.55.0took 2s
➜ ./bin/go-run cli viz stat saz -n emojivoto -ojson                                                                      ~/work/linkerd2
[
  {
    "namespace": "emojivoto",
    "kind": "serverauthorization",
    "name": "emoji-grpc",
    "success": 0.9666666666666667,
    "rps": 4,
    "latency_ms_p50": 1,
    "latency_ms_p95": 3,
    "latency_ms_p99": 5
  },
  {
    "namespace": "emojivoto",
    "kind": "serverauthorization",
    "name": "prom-prometheus",
    "success": null,
    "rps": null,
    "latency_ms_p50": null,
    "latency_ms_p95": null,
    "latency_ms_p99": null
  },
  {
    "namespace": "emojivoto",
    "kind": "serverauthorization",
    "name": "voting-grpc",
    "success": 0.8666666666666667,
    "rps": 1,
    "latency_ms_p50": 1,
    "latency_ms_p95": 1,
    "latency_ms_p99": 1
  },
  {
    "namespace": "emojivoto",
    "kind": "serverauthorization",
    "name": "web-public",
    "success": null,
    "rps": null,
    "latency_ms_p50": null,
    "latency_ms_p95": null,
    "latency_ms_p99": null
  }
]


```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
