### PR TITLE
More unit test fixes

### DIFF
--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1844,7 +1844,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1843,7 +1843,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2a3e6d14f91ce9eca2a1c14c52e2a60477136abcca04abff9a27599476be4ea4
+        checksum/config: 3ab0224989104fa7f067f9f96a60adc6d75d1f50aa8b183cf52834abe2c11b45
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1843,7 +1843,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1843,7 +1843,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1843,7 +1843,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1936,7 +1936,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4f845cf3c8e00375a0c4b73f2e53aab468e83dde0f388c4c3aea65a7f7ea2f5d
+        checksum/config: ef7c2923ac9a98ca1098f42a170c5266e3a2ff58fdafd80b83b8711890cb16a0
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1936,7 +1936,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4f845cf3c8e00375a0c4b73f2e53aab468e83dde0f388c4c3aea65a7f7ea2f5d
+        checksum/config: ef7c2923ac9a98ca1098f42a170c5266e3a2ff58fdafd80b83b8711890cb16a0
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1774,7 +1774,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -1836,7 +1836,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c36cb26305670af136b11b2014647c41deef4af151d00bd9abe043eb0fcd636
+        checksum/config: 14940bccd962673f2a2c6bb60f328179e5b4ef7e8ccb051575c43a1192bb2fc4
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -1929,7 +1929,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f6128e06bbada7980ab0fb470c06cd3e33f5d4f02dc76d717476fb56396253b8
+        checksum/config: 13b4b56fa08dfbe21f77d119bb260c44cafa519b34f114ba1b5bc5e30fc9e19b
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1937,7 +1937,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f6128e06bbada7980ab0fb470c06cd3e33f5d4f02dc76d717476fb56396253b8
+        checksum/config: 13b4b56fa08dfbe21f77d119bb260c44cafa519b34f114ba1b5bc5e30fc9e19b
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1929,7 +1929,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fc859f60e32a6a3df7efead92920983eaac2545d381334610cf9ecf4b9839f48
+        checksum/config: 0a447cc95ac5df9d2096fe668509c879b672d1768d4237b2ba84abb18324f6ce
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1805,7 +1805,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1845,7 +1845,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b99ea15980ed7928905400a137930b4a98faea5de4fe7dc67a98a5ab0c007064
+        checksum/config: 3b5f3a12c582fc818fa275981006785e6c8f016637331b7656e15c6f41db6f96
         linkerd.io/created-by: CliVersion
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1843,7 +1843,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b89a4eb8ca4d469047bd79c59eca2822ee472467613f938c7853d24e63e6fe63
+        checksum/config: 3a972809005225b5683a2b27044316fb39690eb989ae38f6259b1602a3c86d18
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1829,7 +1829,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2a3e6d14f91ce9eca2a1c14c52e2a60477136abcca04abff9a27599476be4ea4
+        checksum/config: 3ab0224989104fa7f067f9f96a60adc6d75d1f50aa8b183cf52834abe2c11b45
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version


### PR DESCRIPTION
Policy CRD changes (#6943) merged and changed `destination-rbac.yml`, and didn't have as an ancestor the changes from #6954 that calculate that file's sha. This PR then updates that SHA in the golden files.
