### PR TITLE
Enable default-policy-deny tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -61,6 +61,7 @@ jobs:
         - upgrade-edge
         - upgrade-stable
         - cni-calico-deep
+        - default-policy-deny
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
         - upgrade-edge
         - upgrade-stable
         - cni-calico-deep
+        - default-policy-deny
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60


### PR DESCRIPTION
Followup to #6931 where I created the `default-policy-deny` integration
test, but forgot to add it into the GH actions workflows.