### PR TITLE
Don't redirect linkerd uninstall errors to /dev/null

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -26,7 +26,7 @@ echo "cleaning up cluster-scoped resources labelled with test.linkerd.io/is-test
 kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings,mutatingwebhookconfiguration -l test.linkerd.io/is-test-data-plane
 
 echo "cleaning up linkerd resources [${k8s_context}]"
-"$linkerd_path" uninstall 2> /dev/null | kubectl --context="$k8s_context" delete -f -
+"$linkerd_path" uninstall | kubectl --context="$k8s_context" delete -f -
 
 # Helm cleanup. Just the entries in `helm ls` as the resources should have already been cleaned up by the code above.
 releases=$("$bindir/helm" ls -A -q)


### PR DESCRIPTION
The `bin/test-cleanup` script was not working as I expected and realized that we were redirecting `linkerd uninstall` stderr to `/dev/null`. In my case, I had manually injected deployments that were not deleted yet so Linkerd could not uninstall.

With this change, the script output now shows:
```
$ bin/test-cleanup /home/kevin/Projects/linkerd/linkerd2/target/cli/linux-amd64/linkerd
...
cleaning up linkerd resources []
Please uninject the following pods before uninstalling the control-plane:
        * slow-cooker-6bb7d447b8-cblv8
No resources found
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
