### PR TITLE
Make opaque ports check a warning

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1357,6 +1357,7 @@ func (hc *HealthChecker) allCategories() []*Category {
 				{
 					description: "opaque ports are properly annotated",
 					hintAnchor:  "linkerd-opaque-ports-definition",
+					warning:     true,
 					check: func(ctx context.Context) error {
 						return hc.checkMisconfiguredOpaquePortAnnotations(ctx)
 					},


### PR DESCRIPTION
Currently the `linkerd check` opaque ports check issues an error if services or pods are misconfigured.

`linkerd check` errors have previously occurred when there is an actual error with the Linkerd installation and the user needs to take some action to correct that. In this case, there is nothing inherently broken with the Linkerd installation; it's just that injected services or pods are misconfigured which lead to detection timeouts.

This changes the check from error to warning.

Sample app
```
apiVersion: v1
kind: Service
metadata:
  name: svc
spec:
  selector:
    app: test
  ports:
  - name: http
    port: 8080
---
apiVersion: v1
kind: Pod
metadata:
  name: pod
  labels:
    app: test
  annotations:
    config.linkerd.io/opaque-ports: "8080"
spec:
  containers:
  - name: test
    image: nginx
    ports:
    - name: test
      containerPort: 8080
```

`linkerd check --proxy`
```
❯ bin/linkerd check --proxy
Linkerd core checks
===================

...

linkerd-data-plane
------------------
...
‼ opaque ports are properly annotated
        * service svc targets the opaque port 8080 through 8080; add 8080 to its config.linkerd.io/opaque-ports annotation
    see https://linkerd.io/2/checks/#linkerd-opaque-ports-definition for hints

Status check results are √
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
