### PR TITLE
Remove new label from mc gateway and service-mirror

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/templates/proxy-admin-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/proxy-admin-policy.yaml
@@ -3,15 +3,13 @@ apiVersion: policy.linkerd.io/v1beta1
 kind: Server
 metadata:
   namespace: {{.Values.namespace}}
-  name: gateway-proxy-admin
+  name: service-mirror-proxy-admin
   labels:
     linkerd.io/extension: multicluster
-  annotations:
-    {{ include "partials.annotations.created-by" . }}
 spec:
   podSelector:
     matchLabels:
-      app: {{.Values.gateway.name}}
+      linkerd.io/control-plane-component: linkerd-service-mirror
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
@@ -19,14 +17,12 @@ apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization
 metadata:
   namespace: {{.Values.namespace}}
-  name: proxy-admin
+  name: service-mirror-proxy-admin
   labels:
     linkerd.io/extension: multicluster
-  annotations:
-    {{ include "partials.annotations.created-by" . }}
 spec:
   server:
-    name: gateway-proxy-admin
+    name: service-mirror-proxy-admin
   client:
     # for kubelet probes
     unauthenticated: true

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -91,7 +91,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: multicluster
       linkerd.io/control-plane-component: linkerd-service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   template:
@@ -99,7 +98,6 @@ spec:
       annotations:
         linkerd.io/inject: enabled
       labels:
-        linkerd.io/extension: multicluster
         linkerd.io/control-plane-component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
     spec:

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -18,7 +18,6 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/extension: multicluster
       app: {{.Values.gateway.name}}
   template:
     metadata:
@@ -28,7 +27,6 @@ spec:
         config.linkerd.io/proxy-require-identity-inbound-ports: "{{.Values.gateway.port}}"
         config.linkerd.io/enable-gateway: "true"
       labels:
-        linkerd.io/extension: multicluster
         app: {{.Values.gateway.name}}
     spec:
       containers:

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -262,6 +262,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				{Name: "templates/service-mirror-policy.yaml"},
 				{Name: "templates/psp.yaml"},
 				{Name: "templates/gateway-mirror.yaml"},
+				{Name: "templates/proxy-admin-policy.yaml"},
 			}
 
 			// Load all multicluster link chart files into buffer


### PR DESCRIPTION
In #6846 we added the `linkerd.io/extension: multicluster` label to the
gateway and service-mirror pods, for completeness sake, and to use them
in the server podSelector. But it turns out that a deployment's selector
is immutable so we can't have smooth rollouts and this would cause
downtime when upgrading the multicluster resources. So we're removing
those labels and updating the gateway policy accordingly. This also
means we had to add a separate policy for the service-mirror proxy-admin
because we don't have a global label to address the gateway _and_ the
service-mirror through a single saz.
