### PR TITLE
stable-2.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,86 @@
 # Changes
 
+## stable-2.11.0
+
+This release introduces access control policies. Default policies may be
+configured at the cluster- and workspace-levels; and fine grained policies may
+be instrumented via via the new `policy.linkerd.io/v1beta1` CRDs: `Server` and
+`ServerAuthorization`. These resources may be created to define how individual
+ports accept connections; and the `Server` resource will be a building block for
+future features that configure inbound proxy behavior.
+
+Furthermore, `ServiceProfile` retry configurations can now instrument retries
+for requests with bodies. This unlocks retry behavior for gRPC services.
+
+**Upgrade notes**: Please see the [upgrade instructions][ugprade-2110].
+
+* Proxy
+  * Reduced CPU & Memory usage by up to 30% in some load tests
+  * Updated retries to support requests with bodies up to 64KB. ServiceProfiles
+    may now configure retries for gRPC services
+  * The proxy's container image is now based on `gcr.io/distroless/cc` to
+    contain a minimal OS footprint that should not trigger unnecessary alerts in
+    security scanners
+  * Added the `inbound_http_errors_total` and `outbound_http_errors_total`
+    metrics to reflect errors that caused the proxy to respond with errors
+  * Added an `l5d-proxy-error` header that is included on responses on trusted
+    connections for debugging purposes
+  * Added a `l5d-client-id` header on mutually-authenticated inbound requests so
+    that applications can discover the client's identity
+  * Added metrics to reflect TCP and HTTP authorization decisions
+  * Added `srv_name` and `saz_name` labels to inbound HTTP metrics
+  * Fixed an issue that could cause the proxy to continually reconnect to
+    defunct service endpoints
+  * Dropped support for non-HTTP outbound services when `linkerd.io/inject:
+    ingress` is used
+  * Instrumented fuzz testing to help guard against unexpected panics
+
+* Control Plane
+  * Added a new `policy-controller` container to the `linkerd-destination`
+    pod--the first control plane component implemented in Rust
+  * Added a new admission controller to validate that multiple `Server`
+    resources do not reference the same port
+  * Added a `linkerd-identity-trust-roots` ConfigMap which configures the trust
+    root bundle for all pods in the core control plane namespace
+  * Eliminated the `linkerd-controller` deployment so that Linkerd's core
+    control plane now consists of only 3 deployments
+  * Updated the proxy injector to configure the `proxy-init` container with
+    `NET_RAW` and `NET_ADMIN` capabilities so that the container does not fail
+    when the pod drops these capabilities
+
+* CLI
+  * Enhanced `linkerd completion` to expand Kubernetes resources from the current
+    kubectl context
+  * Added an `authz` subcommand to display the authorization policies that
+    impact a workload
+  * Added a _short_ output mode for `linkerd check` that only prints failed checks
+  * Added support for `ReplicaSets` to `linkerd stat` so that pods created by
+    Argo `Rollout` resources can be inspected
+
+* Helm: please see the [upgrade instructions][ugprade-2110].
+
+* Extensions:
+  * Introduced a new (optional) `linkerd-smi` extension responsible for reading
+    `specs.smi-spec.io` resources and converting them to Linkerd resources.
+    * In `stable-2.12`, this extension will be required to use `TrafficSplit`
+      resources with Linkerd
+
+  * Viz
+    * Added `Server` and `ServerAuthorization` resources for all ports
+    * Added JSON log formatting
+    * Added an extensions page to the Linkerd Web UI
+
+  * Multicluster
+    * Added experimental support for `StatefulSet` workloads
+    * Added an extensions page to the Linkerd Web UI
+
+This release includes changes from a massive list of contributors. A special
+thank-you to everyone who helped make this release possible:
+
+* TODO: list contributors
+
+[upgrade-2110]: https://linkerd.io/2/tasks/upgrade/#upgrade-notice-stable-2110
+
 ## edge-21.9.5
 
 This edge is a release candidate for `stable-2.11.0`, containing a couple of

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,10 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
     * Added JSON log formatting
     * Added an extensions page to the Linkerd Web UI
 
+  * Jaeger
+    * Added OpenTelemetry collector instead of OpenCensus
+    * Added an extensions page to the Linkerd Web UI
+    
   * Multicluster
     * Added experimental support for `StatefulSet` workloads
     * Added an extensions page to the Linkerd Web UI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,8 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
     kubectl context
   * Added an `authz` subcommand to display the authorization policies that
     impact a workload
-  * Added a _short_ output mode for `linkerd check` that only prints failed checks
+  * Added a _short_ output mode for `linkerd check` that only prints failed
+    checks
   * Added support for `ReplicaSets` to `linkerd stat` so that pods created by
     Argo `Rollout` resources can be inspected
 
@@ -62,21 +63,19 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
 * Extensions:
   * Introduced a new (optional) SMI extension responsible for reading
     `specs.smi-spec.io` resources and converting them to Linkerd resources
-    * In `stable-2.12`, this extension will be required to use `TrafficSplit`
-      resources with Linkerd
+  * In `stable-2.12`, this extension will be required to use `TrafficSplit`
+    resources with Linkerd
+  * Added an extensions page to the Linkerd Web UI
 
   * Viz
     * Added `Server` and `ServerAuthorization` resources for all ports
     * Added JSON log formatting
-    * Added an extensions page to the Linkerd Web UI
 
   * Jaeger
     * Added OpenTelemetry collector instead of OpenCensus
-    * Added an extensions page to the Linkerd Web UI
     
   * Multicluster
     * Added experimental support for `StatefulSet` workloads
-    * Added an extensions page to the Linkerd Web UI
 
 This release includes changes from a massive list of contributors. A special
 thank-you to everyone who helped make this release possible:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,7 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
 
   * Jaeger
     * Added OpenTelemetry collector instead of OpenCensus
-    
+
   * Multicluster
     * Added experimental support for `StatefulSet` workloads
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 This release introduces access control policies. Default policies may be
 configured at the cluster- and workspace-levels; and fine grained policies may
-be instrumented via via the new `policy.linkerd.io/v1beta1` CRDs: `Server` and
+be instrumented via the new `policy.linkerd.io/v1beta1` CRDs: `Server` and
 `ServerAuthorization`. These resources may be created to define how individual
 ports accept connections; and the `Server` resource will be a building block for
 future features that configure inbound proxy behavior.
@@ -77,7 +77,34 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
 This release includes changes from a massive list of contributors. A special
 thank-you to everyone who helped make this release possible:
 
-* TODO: list contributors
+Gustavo Fernandes de Carvalho @gusfcarvalho
+Oleg Vorobev @olegy2008
+Bart Peeters @bartpeeters
+Stepan Rabotkin @EpicStep
+LiuDui @xichengliudui
+Andrew Hemming @drewhemm
+Ujjwal Goyal @importhuman
+Knut Götz @knutgoetz
+Sanni Michael @sannimichaelse
+Brandon Sorgdrager @bsord
+Gerald Pape @ubergesundheit
+Alexey Kostin @rumanzo
+rdileep13 @rdileep13
+Takumi Sue @mikutas
+Akshit Grover @akshitgrover
+Sanskar Jaiswal @aryan9600
+Aleksandr Tarasov @aatarasoff
+Taylor @skinn
+Miguel Ángel Pastor Olivar @migue
+wangchenglong01 @wangchenglong01
+Josh Soref @jsoref
+Carol Chen @kipply
+Peter Smit @psmit
+Tarvi Pillessaar @tarvip
+James Roper @jroper
+Dominik Münch @muenchdo
+Szymon Gibała @Szymongib
+Mitch Hulscher @mhulscher
 
 [upgrade-2110]: https://linkerd.io/2/tasks/upgrade/#upgrade-notice-stable-2110
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ future features that configure inbound proxy behavior.
 Furthermore, `ServiceProfile` retry configurations can now instrument retries
 for requests with bodies. This unlocks retry behavior for gRPC services.
 
-**Upgrade notes**: Please see the [upgrade instructions][ugprade-2110].
+**Upgrade notes**: Please see the [upgrade instructions][upgrade-2110].
 
 * Proxy
   * Reduced CPU & Memory usage by up to 30% in some load tests
@@ -57,11 +57,11 @@ for requests with bodies. This unlocks retry behavior for gRPC services.
   * Added support for `ReplicaSets` to `linkerd stat` so that pods created by
     Argo `Rollout` resources can be inspected
 
-* Helm: please see the [upgrade instructions][ugprade-2110].
+* Helm: please see the [upgrade instructions][upgrade-2110].
 
 * Extensions:
-  * Introduced a new (optional) `linkerd-smi` extension responsible for reading
-    `specs.smi-spec.io` resources and converting them to Linkerd resources.
+  * Introduced a new (optional) SMI extension responsible for reading
+    `specs.smi-spec.io` resources and converting them to Linkerd resources
     * In `stable-2.12`, this extension will be required to use `TrafficSplit`
       resources with Linkerd
 


### PR DESCRIPTION
This release introduces access control policies. Default policies may be
configured at the cluster- and workspace-levels; and fine grained policies may
be instrumented via via the new `policy.linkerd.io/v1beta1` CRDs: `Server` and
`ServerAuthorization`. These resources may be created to define how individual
ports accept connections; and the `Server` resource will be a building block for
future features that configure inbound proxy behavior.

Furthermore, `ServiceProfile` retry configurations can now instrument retries
for requests with bodies. This unlocks retry behavior for gRPC services.

**Upgrade notes**: Please see the [upgrade instructions][upgrade-2110].

* Proxy
  * Reduced CPU & Memory usage by up to 30% in some load tests
  * Updated retries to support requests with bodies up to 64KB. ServiceProfiles
    may now configure retries for gRPC services
  * The proxy's container image is now based on `gcr.io/distroless/cc` to
    contain a minimal OS footprint that should not trigger unnecessary alerts in
    security scanners
  * Added the `inbound_http_errors_total` and `outbound_http_errors_total`
    metrics to reflect errors that caused the proxy to respond with errors
  * Added an `l5d-proxy-error` header that is included on responses on trusted
    connections for debugging purposes
  * Added a `l5d-client-id` header on mutually-authenticated inbound requests so
    that applications can discover the client's identity
  * Added metrics to reflect TCP and HTTP authorization decisions
  * Added `srv_name` and `saz_name` labels to inbound HTTP metrics
  * Fixed an issue that could cause the proxy to continually reconnect to
    defunct service endpoints
  * Dropped support for non-HTTP outbound services when `linkerd.io/inject:
    ingress` is used
  * Instrumented fuzz testing to help guard against unexpected panics

* Control Plane
  * Added a new `policy-controller` container to the `linkerd-destination`
    pod--the first control plane component implemented in Rust
  * Added a new admission controller to validate that multiple `Server`
    resources do not reference the same port
  * Added a `linkerd-identity-trust-roots` ConfigMap which configures the trust
    root bundle for all pods in the core control plane namespace
  * Eliminated the `linkerd-controller` deployment so that Linkerd's core
    control plane now consists of only 3 deployments
  * Updated the proxy injector to configure the `proxy-init` container with
    `NET_RAW` and `NET_ADMIN` capabilities so that the container does not fail
    when the pod drops these capabilities

* CLI
  * Enhanced `linkerd completion` to expand Kubernetes resources from the current
    kubectl context
  * Added an `authz` subcommand to display the authorization policies that
    impact a workload
  * Added a _short_ output mode for `linkerd check` that only prints failed checks
  * Added support for `ReplicaSets` to `linkerd stat` so that pods created by
    Argo `Rollout` resources can be inspected

* Helm: please see the [upgrade instructions][upgrade-2110].

* Extensions:
  * Introduced a new (optional) `linkerd-smi` extension responsible for reading
    `specs.smi-spec.io` resources and converting them to Linkerd resources.
    * In `stable-2.12`, this extension will be required to use `TrafficSplit`
      resources with Linkerd

  * Viz
    * Added `Server` and `ServerAuthorization` resources for all ports
    * Added JSON log formatting
    * Added an extensions page to the Linkerd Web UI

  * Multicluster
    * Added experimental support for `StatefulSet` workloads
    * Added an extensions page to the Linkerd Web UI

This release includes changes from a massive list of contributors. A special
thank-you to everyone who helped make this release possible:

* TODO: list contributors
