### PR TITLE
`check`: fix incorrect opaque ports warning

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2389,6 +2389,11 @@ func checkServiceIntPorts(service *corev1.Service, svcPorts []string, port int) 
 
 func checkServiceNamePorts(service *corev1.Service, pod *corev1.Pod, port int, svcPorts []string) error {
 	for _, p := range service.Spec.Ports {
+		if p.TargetPort.StrVal == "" {
+			// The target port is not named so there is no named container
+			// port to check.
+			continue
+		}
 		for _, c := range pod.Spec.Containers {
 			for _, cp := range c.Ports {
 				if cp.ContainerPort == int32(port) {


### PR DESCRIPTION
This fixes an incorrect opaque ports warning. The incorrect warning happens from the following:
1. A service has a target port that is not named. This means that `servicePort.StrVal == ""`

```
- port: 80
  targetPort: 6502
```
2. The service selects a pod with an opaque port that is also not named. This means that `containerPort.Name == ""`

```
ports:
- containerPort: 5432
```
3. Then when doing the opaque ports check, the comparison is currently not strict enough and only compares `servicePort.StrVal == containerPort.Name`. Because of this, it thinks that the target port `6502` is targeting the container port `5432` which is not actually the case.

To fix this, we only want to compare the port names when `servicePort.StrVal != ""`.

A check has been added to to make sure we only make this comparison when dealing a target port that is _actually_ named.

This fixes `linkerd check --proxy` for the following manifest:

```
apiVersion: v1
kind: Service
metadata:
  name: svc
spec:
  selector:
    app: test
  ports:
  - port: 80
    targetPort: 6502
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: deploy
spec:
  selector:
    matchLabels:
      app: test
  template:
    metadata:
      annotations:
        linkerd.io/inject: enabled
      labels:
        app: test
    spec:
      containers:
      - image: nginx
        name: app-1
        ports:
        - containerPort: 6502
      - image: nginx
        name: app-2
        ports:
        - containerPort: 5432
```

```
$ linkerd check --proxy
...
√ data plane service annotations are configured correctly
√ opaque ports are properly annotated

Status check results are √
```

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
