### PR TITLE
tests: remove the policy checks removal with upgrade

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -955,14 +955,6 @@ func testCheckCommand(t *testing.T, stage, expectedVersion, namespace, cliVersio
 	}
 
 	expected := getCheckOutput(t, golden, TestHelper.GetLinkerdNamespace())
-
-	// When performing the check before upgrading, the policy-validator will not be installed yet.
-	if (TestHelper.UpgradeFromVersion() != "" && expectedVersion == TestHelper.UpgradeFromVersion()) ||
-		(TestHelper.UpgradeHelmFromVersion() != "" && expectedVersion == TestHelper.UpgradeHelmFromVersion()) {
-		expected = strings.ReplaceAll(expected, "√ policy-validator webhook has valid cert\n", "")
-		expected = strings.ReplaceAll(expected, "√ policy-validator cert is valid for at least 60 days\n", "")
-	}
-
 	timeout := time.Minute * 5
 	err := TestHelper.RetryFor(timeout, func() error {
 		if cliVersionOverride != "" {


### PR DESCRIPTION
FIxes the `helm-upgrade` integration test being failed on main.

As these are present even with upgrades now, we don't have
to remove it and perform the check before we upgrade.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
