### PR TITLE
Add support for `cli-version-override` flag in viz check

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -258,7 +258,7 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 func getExtensionCheckFlags(lf *pflag.FlagSet) []string {
 	extensionFlags := []string{
 		"api-addr", "context", "as", "as-group", "kubeconfig", "linkerd-namespace", "verbose",
-		"namespace", "proxy", "wait",
+		"namespace", "proxy", "wait", "cli-version-override",
 	}
 	cmdLineFlags := []string{}
 	for _, flag := range extensionFlags {

--- a/viz/cmd/check.go
+++ b/viz/cmd/check.go
@@ -8,15 +8,17 @@ import (
 
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/version"
 	vizHealthCheck "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	"github.com/spf13/cobra"
 )
 
 type checkOptions struct {
-	proxy     bool
-	wait      time.Duration
-	namespace string
-	output    string
+	proxy              bool
+	wait               time.Duration
+	namespace          string
+	output             string
+	cliVersionOverride string
 }
 
 func newCheckOptions() *checkOptions {
@@ -58,6 +60,8 @@ code.`,
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+	cmd.Flags().StringVar(&options.cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (for testing)")
+	cmd.Flags().MarkHidden("cli-version-override")
 
 	pkgcmd.ConfigureNamespaceFlagCompletion(
 		cmd, []string{"namespace"},
@@ -69,6 +73,10 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, options *checkOptions
 	err := options.validate()
 	if err != nil {
 		return fmt.Errorf("Validation error when executing check command: %v", err)
+	}
+
+	if options.cliVersionOverride != "" {
+		version.Version = options.cliVersionOverride
 	}
 
 	hc := vizHealthCheck.NewHealthChecker([]healthcheck.CategoryID{}, &healthcheck.Options{


### PR DESCRIPTION
... so that `linkerd viz check` can have a static output in integration tests. This flag is marked as hidden.
