### PR TITLE
Add caching to policy controller image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,26 @@ jobs:
     - run: |
         . bin/_tag.sh
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
+        echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
+    - name: Cache docker layers
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+      with:
+        path: ${{ env.DOCKER_BUILDKIT_CACHE }}
+        key: policy-controller-${{ matrix.arch }}-${{ env.TAG }}
+        restore-keys: policy-controller-
     - name: Build ${{ matrix.arch }}
       run: |
         echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
         docker buildx build --push . \
           -f ./policy-controller/${{ matrix.arch }}.dockerfile \
-          -t $DOCKER_REGISTRY/policy-controller:$TAG-${{ matrix.arch }}
+          -t $DOCKER_REGISTRY/policy-controller:$TAG-${{ matrix.arch }} \
+          --cache-from type=local,src=${DOCKER_BUILDKIT_CACHE} \
+          --cache-to type=local,dest=${DOCKER_BUILDKIT_CACHE},mode=max
+    - name: Prune docker layers cache
+      # changes generate new images while the existing ones don't get removed
+      # so we manually do that to avoid bloating the cache
+      shell: bash
+      run: bin/docker-cache-prune
 
   policy_controller_manifest:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Replicated what we do for other images, in the release workflow. No
longer have to wait for full builds in CI! Note the cache key needs to
incorporate the arch. Tested successfully in a fork.
