### PR TITLE
fix: helm invocation in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -483,7 +483,7 @@ During development, please use the [`bin/helm`](bin/helm) wrapper script to
 invoke the Helm commands. For example,
 
 ```bash
-bin/helm install charts/linkerd2
+bin/helm install linkerd2 charts/linkerd2
 ```
 
 This ensures that you use the same Helm version as that of the Linkerd CI


### PR DESCRIPTION
Add name to helm install command. The proper usage of helm install is:
```helm install [NAME] [CHART] [flags]```

Fixes #7041

Signed-off-by: Krzysztof Dryś <krzysztofdrys@gmail.com>
