### PR TITLE
fix: handle error in `multicluster check`

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -93,7 +93,7 @@ non-zero exit code.`,
 			// Get the multicluster extension namespace
 			kubeAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to run multicluster check: %v", err)
+				fmt.Fprintf(os.Stderr, "failed to run multicluster check: %v\n", err)
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
Fixes #7043 

When running `linkerd multicluster check` with an invalid (or inexistent) context, the k8s API client won't be created. We will instead have an error and a nil pointer. The client is subsequently used to check whether multicluster has been installed; when used with an invalid context, we hit a nil pointer dereference.

To fix, we're now handling the error returned from client creation. If we have an error, we exit the process and log the error message.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
