### PR TITLE
Fix server name in linkerd-gateway-probe saz

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
@@ -53,7 +53,7 @@ metadata:
     {{ include "partials.annotations.created-by" . }}
 spec:
   server:
-    name: proxy-admin
+    name: gateway-proxy-admin
   client:
     # allows probes from outside the cluster, as long as they have an identity
     meshTLS:


### PR DESCRIPTION
The linkerd-gateway-probe saz refers to a `proxy-admin` Server which does not exist in the linkerd-multicluster namespace.  

We fix the name to `gateway-proxy-admin` which does exist.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
