### PR TITLE
Update links to support grafana 7.2+

### DIFF
--- a/web/app/js/components/GrafanaLink.jsx
+++ b/web/app/js/components/GrafanaLink.jsx
@@ -4,7 +4,7 @@ import _isEmpty from 'lodash/isEmpty';
 import { grafanaIcon } from './util/SvgWrappers.jsx';
 
 const GrafanaLink = ({ PrefixedLink, name, namespace, resource }) => {
-  let link = `/grafana/dashboard/db/linkerd-${resource}?var-${resource}=${name}`;
+  let link = `/grafana/d/linkerd-${resource}?var-${resource}=${name}`;
   if (!_isEmpty(namespace)) {
     link += `&var-namespace=${namespace}`;
   }


### PR DESCRIPTION
Subject
Update links to support grafana 7.2+

Problem
With grafana >7.2, the dashboards links don't work.

Solution
Updated links to support grafana 7.2+

Validation

Fixes https://github.com/linkerd/linkerd2/issues/6579


