### PR TITLE
Release notes for edge-21.10.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,14 @@
 
 ## edge-21.10.2
 
-This edge release updates the minimum kubernetes version to 1.17.0, improves
-`check` functionality for extensions by adding the `-oshort` flag, and prevents
-duplicate policy resources from being created for linked multicluster services.
+This edge release fixes linkerd check and the helm charts to explicitly
+indicate that the minimum Kubernetes version is 1.17.0. Prior to this change,
+there was no validation or enforcement from linkerd check or helm to meet this
+minimum requirement.
+
+This edge also improves `check` functionality for extensions by adding the
+`-oshort` flag, and prevents duplicate policy resources from being created for
+linked multicluster services.
 
 * Moved service mirror policy into multicluster base chart
 * Added `-oshort` flag for extension `check` commands


### PR DESCRIPTION
Release notes for edge-21.10.2

## edge-21.10.2

This edge release updates the minimum kubernetes version to 1.17.0, improves
`check` functionality for extensions by adding the `-oshort` flag, and prevents
duplicate policy resources from being created for linked multicluster services.

* Moved service mirror policy into multicluster base chart
* Added `-oshort` flag for extension `check` commands
* Updated minimum kubernetes version to 1.17.0
* Removed unused `crtExpiry` template parameter from helm charts
* Fixed multicluster gateway name for ServerAuthorization
* Added `priorityClassName` to the helm charts to configure control plane
  components

Signed-off-by: Charles Pretzer <charles@buoyant.io>
