### PR TITLE
Add services to web dashboard

### DIFF
--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -10,6 +10,7 @@ import SuccessRateMiniChart from './util/SuccessRateMiniChart.jsx';
 import { Trans } from '@lingui/macro';
 import _cloneDeep from 'lodash/cloneDeep';
 import _each from 'lodash/each';
+import _some from 'lodash/some';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import { processedMetricsPropType } from './util/MetricUtils.jsx';
@@ -186,7 +187,7 @@ const gatewayColumns = [
   },
 ];
 
-const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, PrefixedLink, isTcpTable, grafana, jaeger) => {
+const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, PrefixedLink, isTcpTable, hasTsStats, grafana, jaeger) => {
   const isAuthorityTable = resource === 'authority';
   const isTrafficSplitTable = resource === 'trafficsplit';
   const isServicesTable = resource === 'service';
@@ -284,7 +285,7 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
   if (showNameColumn) {
     columns = [nameColumn];
   }
-  if (isServicesTable) {
+  if (isServicesTable && hasTsStats) {
     columns = columns.concat(serviceDetailsColumns(PrefixedLink));
   }
   if (isTrafficSplitTable) {
@@ -335,7 +336,8 @@ const MetricsTable = ({ metrics, resource, showNamespaceColumn, showName, title,
   const showNameColumn = resource !== 'trafficsplit' ? true : showName;
   let orderBy = 'name';
   if (resource === 'trafficsplit' && !showNameColumn) { orderBy = 'leaf'; }
-  const columns = columnDefinitions(resource, showNsColumn, showNameColumn, api.PrefixedLink, isTcpTable, grafana, jaeger);
+  const hasTsStats = _some(metrics, m => m.tsStats);
+  const columns = columnDefinitions(resource, showNsColumn, showNameColumn, api.PrefixedLink, isTcpTable, hasTsStats, grafana, jaeger);
   const rows = preprocessMetrics(metrics);
   return (
     <BaseTable

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -94,13 +94,28 @@ const trafficSplitWeightColumn = {
   },
 };
 
-const serviceDetailsColumns = [
+const serviceDetailsColumns = PrefixedLink => [
   {
     title: <Trans>columnTitleDestination</Trans>,
-    dataIndex: 'leaf',
+    dataIndex: 'DST',
     isNumeric: false,
     filter: d => !d.tsStats ? null : d.tsStats.leaf,
-    render: d => !d.tsStats ? null : d.tsStats.leaf,
+    render: d => {
+      if (!d.tsStats) {
+        return null;
+      }
+      const nameContents = (
+        <PrefixedLink to={`/namespaces/${d.namespace}/services/${d.tsStats.leaf}`}>
+          {d.tsStats.leaf}
+        </PrefixedLink>
+      );
+      return (
+        <Grid container alignItems="center" spacing={1}>
+          <Grid item>{nameContents}</Grid>
+          {_isEmpty(d.errors) ? null : <Grid item><ErrorModal errors={d.errors} resourceName={d.name} resourceType={d.type} /></Grid>}
+        </Grid>
+      );
+    },
     sorter: d => !d.tsStats ? null : d.tsStats.leaf,
   },
   trafficSplitWeightColumn,
@@ -270,7 +285,7 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
     columns = [nameColumn];
   }
   if (isServicesTable) {
-    columns = columns.concat(serviceDetailsColumns);
+    columns = columns.concat(serviceDetailsColumns(PrefixedLink));
   }
   if (isTrafficSplitTable) {
     columns = columns.concat(trafficSplitDetailColumns);

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -160,6 +160,7 @@ const gatewayColumns = [
 const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, PrefixedLink, isTcpTable, grafana, jaeger) => {
   const isAuthorityTable = resource === 'authority';
   const isTrafficSplitTable = resource === 'trafficsplit';
+  const isServicesTable = resource === 'service';
   const isMultiResourceTable = resource === 'multi_resource';
   const isGatewayTable = resource === 'gateway';
   const getResourceDisplayName = isMultiResourceTable ? displayName : d => d.name;
@@ -230,7 +231,7 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
       let nameContents;
       if (resource === 'namespace') {
         nameContents = <PrefixedLink to={`/namespaces/${d.name}`}>{d.name}</PrefixedLink>;
-      } else if (!d.added && (!isTrafficSplitTable || isAuthorityTable)) {
+      } else if (!d.added && (!isTrafficSplitTable || isAuthorityTable) && !isServicesTable) {
         nameContents = getResourceDisplayName(d);
       } else {
         nameContents = (
@@ -265,7 +266,7 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
     columns = columns.concat(httpStatColumns);
   }
 
-  if (!isAuthorityTable && !isTrafficSplitTable && !isGatewayTable) {
+  if (!isAuthorityTable && !isTrafficSplitTable && !isGatewayTable && !isServicesTable) {
     columns.splice(1, 0, meshedColumn);
   }
 

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -94,17 +94,15 @@ const trafficSplitWeightColumn = {
   },
 };
 
-const trafficSplitLeafColumn = {
-  title: <Trans>columnTitleLeafService</Trans>,
-  dataIndex: 'leaf',
-  isNumeric: false,
-  filter: d => !d.tsStats ? null : d.tsStats.leaf,
-  render: d => !d.tsStats ? null : d.tsStats.leaf,
-  sorter: d => !d.tsStats ? null : d.tsStats.leaf,
-};
-
 const serviceDetailsColumns = [
-  trafficSplitLeafColumn,
+  {
+    title: <Trans>columnTitleDestination</Trans>,
+    dataIndex: 'leaf',
+    isNumeric: false,
+    filter: d => !d.tsStats ? null : d.tsStats.leaf,
+    render: d => !d.tsStats ? null : d.tsStats.leaf,
+    sorter: d => !d.tsStats ? null : d.tsStats.leaf,
+  },
   trafficSplitWeightColumn,
 ];
 
@@ -117,7 +115,14 @@ const trafficSplitDetailColumns = [
     render: d => !d.tsStats ? null : d.tsStats.apex,
     sorter: d => !d.tsStats ? null : d.tsStats.apex,
   },
-  trafficSplitLeafColumn,
+  {
+    title: <Trans>columnTitleLeafService</Trans>,
+    dataIndex: 'leaf',
+    isNumeric: false,
+    filter: d => !d.tsStats ? null : d.tsStats.leaf,
+    render: d => !d.tsStats ? null : d.tsStats.leaf,
+    sorter: d => !d.tsStats ? null : d.tsStats.leaf,
+  },
   trafficSplitWeightColumn,
 ];
 

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -78,6 +78,26 @@ const httpStatColumns = [
 
 ];
 
+const trafficSplitWeightColumn = {
+  title: <Trans>columnTitleWeight</Trans>,
+  dataIndex: 'weight',
+  isNumeric: true,
+  filter: d => !d.tsStats ? null : d.tsStats.weight,
+  render: d => !d.tsStats ? null : d.tsStats.weight,
+  sorter: d => {
+    if (!d.tsStats) { return -1; }
+    if (parseInt(d.tsStats.weight, 10)) {
+      return parseInt(d.tsStats.weight, 10);
+    } else {
+      return d.tsStats.weight;
+    }
+  },
+};
+
+const serviceDetailsColumns = [
+  trafficSplitWeightColumn,
+];
+
 const trafficSplitDetailColumns = [
   {
     title: <Trans>columnTitleApexService</Trans>,
@@ -95,21 +115,7 @@ const trafficSplitDetailColumns = [
     render: d => !d.tsStats ? null : d.tsStats.leaf,
     sorter: d => !d.tsStats ? null : d.tsStats.leaf,
   },
-  {
-    title: <Trans>columnTitleWeight</Trans>,
-    dataIndex: 'weight',
-    isNumeric: true,
-    filter: d => !d.tsStats ? null : d.tsStats.weight,
-    render: d => !d.tsStats ? null : d.tsStats.weight,
-    sorter: d => {
-      if (!d.tsStats) { return -1; }
-      if (parseInt(d.tsStats.weight, 10)) {
-        return parseInt(d.tsStats.weight, 10);
-      } else {
-        return d.tsStats.weight;
-      }
-    },
-  },
+  trafficSplitWeightColumn,
 ];
 
 const gatewayColumns = [
@@ -264,6 +270,9 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
     columns = columns.concat(gatewayColumns);
   } else {
     columns = columns.concat(httpStatColumns);
+  }
+  if (isServicesTable) {
+    columns = columns.concat(serviceDetailsColumns);
   }
 
   if (!isAuthorityTable && !isTrafficSplitTable && !isGatewayTable && !isServicesTable) {

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -219,7 +219,7 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
     key: 'grafanaDashboard',
     isNumeric: true,
     render: row => {
-      if (!isAuthorityTable && (!row.added || _get(row, 'pods.totalPods') === '0')) {
+      if (!isAuthorityTable && !isServicesTable && (!row.added || _get(row, 'pods.totalPods') === '0')) {
         return null;
       }
 

--- a/web/app/js/components/MetricsTable.jsx
+++ b/web/app/js/components/MetricsTable.jsx
@@ -94,7 +94,17 @@ const trafficSplitWeightColumn = {
   },
 };
 
+const trafficSplitLeafColumn = {
+  title: <Trans>columnTitleLeafService</Trans>,
+  dataIndex: 'leaf',
+  isNumeric: false,
+  filter: d => !d.tsStats ? null : d.tsStats.leaf,
+  render: d => !d.tsStats ? null : d.tsStats.leaf,
+  sorter: d => !d.tsStats ? null : d.tsStats.leaf,
+};
+
 const serviceDetailsColumns = [
+  trafficSplitLeafColumn,
   trafficSplitWeightColumn,
 ];
 
@@ -107,14 +117,7 @@ const trafficSplitDetailColumns = [
     render: d => !d.tsStats ? null : d.tsStats.apex,
     sorter: d => !d.tsStats ? null : d.tsStats.apex,
   },
-  {
-    title: <Trans>columnTitleLeafService</Trans>,
-    dataIndex: 'leaf',
-    isNumeric: false,
-    filter: d => !d.tsStats ? null : d.tsStats.leaf,
-    render: d => !d.tsStats ? null : d.tsStats.leaf,
-    sorter: d => !d.tsStats ? null : d.tsStats.leaf,
-  },
+  trafficSplitLeafColumn,
   trafficSplitWeightColumn,
 ];
 
@@ -261,6 +264,9 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
   if (showNameColumn) {
     columns = [nameColumn];
   }
+  if (isServicesTable) {
+    columns = columns.concat(serviceDetailsColumns);
+  }
   if (isTrafficSplitTable) {
     columns = columns.concat(trafficSplitDetailColumns);
   }
@@ -270,9 +276,6 @@ const columnDefinitions = (resource, showNamespaceColumn, showNameColumn, Prefix
     columns = columns.concat(gatewayColumns);
   } else {
     columns = columns.concat(httpStatColumns);
-  }
-  if (isServicesTable) {
-    columns = columns.concat(serviceDetailsColumns);
   }
 
   if (!isAuthorityTable && !isTrafficSplitTable && !isGatewayTable && !isServicesTable) {

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -524,6 +524,8 @@ class NavigationBase extends React.Component {
 
           { this.menuItem(`/namespaces/${selectedNamespace}/deployments`, <Trans>menuItemDeployments</Trans>, deploymentIcon) }
 
+          { this.menuItem(`/namespaces/${selectedNamespace}/services`, <Trans>menuItemServices</Trans>, deploymentIcon) }
+
           { this.menuItem(`/namespaces/${selectedNamespace}/jobs`, <Trans>menuItemJobs</Trans>, jobIcon) }
 
           { this.menuItem(`/namespaces/${selectedNamespace}/pods`, <Trans>menuItemPods</Trans>, podIcon) }

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -1,4 +1,17 @@
-import { cronJobIcon, daemonsetIcon, deploymentIcon, githubIcon, jobIcon, linkerdWordLogo, namespaceIcon, podIcon, replicaSetIcon, slackIcon, statefulSetIcon } from './util/SvgWrappers.jsx';
+import {
+  cronJobIcon,
+  daemonsetIcon,
+  deploymentIcon,
+  githubIcon,
+  jobIcon,
+  linkerdWordLogo,
+  namespaceIcon,
+  podIcon,
+  replicaSetIcon,
+  serviceIcon,
+  slackIcon,
+  statefulSetIcon,
+} from './util/SvgWrappers.jsx';
 import { handlePageVisibility, withPageVisibility } from './util/PageVisibility.jsx';
 import AppBar from '@material-ui/core/AppBar';
 import Autocomplete from '@material-ui/lab/Autocomplete';
@@ -524,7 +537,7 @@ class NavigationBase extends React.Component {
 
           { this.menuItem(`/namespaces/${selectedNamespace}/deployments`, <Trans>menuItemDeployments</Trans>, deploymentIcon) }
 
-          { this.menuItem(`/namespaces/${selectedNamespace}/services`, <Trans>menuItemServices</Trans>, deploymentIcon) }
+          { this.menuItem(`/namespaces/${selectedNamespace}/services`, <Trans>menuItemServices</Trans>, serviceIcon) }
 
           { this.menuItem(`/namespaces/${selectedNamespace}/jobs`, <Trans>menuItemJobs</Trans>, jobIcon) }
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -366,7 +366,6 @@ export class ResourceDetailBase extends React.Component {
           upstreams={upstreams}
           api={this.api}
           upstreamDisplayMetrics={upstreamDisplayMetrics}
-          downstreamDisplayMetrics={downstreamDisplayMetrics}
           pathPrefix={pathPrefix}
           isTcpOnly={isTcpOnly}
           resourceMetrics={resourceMetrics}

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -10,6 +10,7 @@ import MetricsTable from './MetricsTable.jsx';
 import Octopus from './Octopus.jsx';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ServiceDetail from './ServiceDetail.jsx';
 import SimpleChip from './util/Chip.jsx';
 import Spinner from './util/Spinner.jsx';
 import TopRoutesTabs from './TopRoutesTabs.jsx';
@@ -255,7 +256,6 @@ export class ResourceDetailBase extends React.Component {
         }
 
         const isTcpOnly = !hasHttp && hasTcp;
-        const isTrafficSplit = resourceType === 'trafficsplit';
 
         // figure out when the last traffic this resource received was so we can show a no traffic message
         let newLastMetricReceivedTime = lastMetricReceivedTime;
@@ -273,7 +273,6 @@ export class ResourceDetailBase extends React.Component {
           edges,
           lastMetricReceivedTime: newLastMetricReceivedTime,
           isTcpOnly,
-          isTrafficSplit,
           loaded: true,
           pendingRequests: false,
           error: null,
@@ -317,7 +316,6 @@ export class ResourceDetailBase extends React.Component {
       resourceIsMeshed,
       lastMetricReceivedTime,
       isTcpOnly,
-      isTrafficSplit,
       loaded,
       error,
       upstreamMetrics,
@@ -352,13 +350,29 @@ export class ResourceDetailBase extends React.Component {
 
     const showNoTrafficMsg = resourceIsMeshed && (Date.now() - lastMetricReceivedTime > showNoTrafficMsgDelayMs);
 
-    if (isTrafficSplit) {
+    if (resourceType === 'trafficsplit') {
       return (
         <TrafficSplitDetail
           resourceType={resourceType}
           resourceName={resourceName}
           resourceMetrics={resourceMetrics}
           resourceRsp={resourceRsp} />
+      );
+    }
+    if (resourceType === 'service') {
+      return (
+        <ServiceDetail
+          resourceName={resourceName}
+          upstreams={upstreams}
+          api={this.api}
+          upstreamDisplayMetrics={upstreamDisplayMetrics}
+          downstreamDisplayMetrics={downstreamDisplayMetrics}
+          pathPrefix={pathPrefix}
+          isTcpOnly={isTcpOnly}
+          resourceMetrics={resourceMetrics}
+          unmeshedSources={unmeshedSources}
+          query={query}
+          updateUnmeshedSources={this.updateUnmeshedSources} />
       );
     }
     return (

--- a/web/app/js/components/ServiceDetail.jsx
+++ b/web/app/js/components/ServiceDetail.jsx
@@ -1,0 +1,77 @@
+import Grid from '@material-ui/core/Grid';
+import MetricsTable from './MetricsTable.jsx';
+import Octopus from './Octopus.jsx';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Trans } from '@lingui/macro';
+import Typography from '@material-ui/core/Typography';
+import TopRoutesTabs from './TopRoutesTabs.jsx';
+import _isEmpty from 'lodash/isEmpty';
+
+const ServiceDetail = ({
+  api,
+  resourceMetrics,
+  resourceName,
+  query,
+  isTcpOnly,
+  pathPrefix,
+  upstreamDisplayMetrics,
+  downstreamDisplayMetrics,
+  unmeshedSources,
+  updateUnmeshedSources,
+  upstreams,
+}) => {
+  return (
+    <div>
+      <Grid container justifyContent="space-between" alignItems="center">
+        <Grid item><Typography variant="h5">service/{resourceName}</Typography></Grid>
+      </Grid>
+
+      <Octopus
+        resource={resourceMetrics[0]}
+        neighbors={{ upstream: upstreamDisplayMetrics, downstream: downstreamDisplayMetrics }}
+        unmeshedSources={Object.values(unmeshedSources)}
+        api={api} />
+
+      {isTcpOnly ? null : <TopRoutesTabs
+        query={query}
+        pathPrefix={pathPrefix}
+        updateUnmeshedSources={updateUnmeshedSources}
+        disableTop="false" />
+      }
+
+      {_isEmpty(upstreams) ? null :
+      <MetricsTable
+        resource="multi_resource"
+        title={<Trans>tableTitleInbound</Trans>}
+        metrics={upstreamDisplayMetrics} />
+      }
+
+      {_isEmpty(downstreamDisplayMetrics) ? null :
+      <MetricsTable
+        resource="multi_resource"
+        title={<Trans>tableTitleOutbound</Trans>}
+        metrics={downstreamDisplayMetrics} />
+      }
+
+    </div>
+  );
+};
+
+ServiceDetail.propTypes = {
+  api: PropTypes.shape({
+    PrefixedLink: PropTypes.func.isRequired,
+  }).isRequired,
+  resourceMetrics: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  resourceName: PropTypes.string.isRequired,
+  query: PropTypes.string.isRequired,
+  isTcpOnly: PropTypes.bool.isRequired,
+  pathPrefix: PropTypes.string.isRequired,
+  upstreamDisplayMetrics: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  downstreamDisplayMetrics: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  unmeshedSources: PropTypes.shape({}).isRequired,
+  updateUnmeshedSources: PropTypes.func.isRequired,
+  upstreams: PropTypes.shape({}).isRequired,
+};
+
+export default ServiceDetail;

--- a/web/app/js/components/TopRoutesTabs.jsx
+++ b/web/app/js/components/TopRoutesTabs.jsx
@@ -107,22 +107,24 @@ class TopRoutesTabs extends React.Component {
   }
 }
 
-TopRoutesTabs.propTypes = {
-  disableTop: PropTypes.bool,
-  pathPrefix: PropTypes.string.isRequired,
-  query: PropTypes.shape({
-    namespace: PropTypes.string,
-    resourceType: PropTypes.string,
-    resourceName: PropTypes.string,
-  }),
-  theme: PropTypes.shape({}).isRequired,
-  updateUnmeshedSources: PropTypes.func,
-};
-
 TopRoutesTabs.defaultProps = {
   disableTop: false,
   query: {},
   updateUnmeshedSources: _noop,
+};
+
+export const topRoutesQueryPropType = PropTypes.shape({
+  namespace: PropTypes.string,
+  resourceType: PropTypes.string,
+  resourceName: PropTypes.string,
+});
+
+TopRoutesTabs.propTypes = {
+  disableTop: PropTypes.bool,
+  pathPrefix: PropTypes.string.isRequired,
+  query: topRoutesQueryPropType,
+  theme: PropTypes.shape({}).isRequired,
+  updateUnmeshedSources: PropTypes.func,
 };
 
 export default withStyles(styles, { withTheme: true })(TopRoutesTabs);

--- a/web/app/js/components/util/MetricUtils.jsx
+++ b/web/app/js/components/util/MetricUtils.jsx
@@ -196,9 +196,10 @@ export const processMultiResourceRollup = (rawMetrics, resourceType) => {
     // selected resource in the Octopus graph.
 
     // The below line checks if the statTable contains trafficsplit data and
-    // returns early if the selected resource is not "all" or "trafficsplit",
+    // returns early if the selected resource is not "all" or "trafficsplit" or "service",
     // since any other resource should not include trafficsplit metrics.
-    if (table.podGroup.rows[0].tsStats && resourceType !== 'all' && resourceType !== 'trafficsplit') {
+    const isTrafficSplit = table.podGroup.rows[0].resource.type === 'trafficsplit';
+    if (isTrafficSplit && resourceType !== 'all' && resourceType !== 'trafficsplit') {
       return;
     }
 
@@ -312,4 +313,7 @@ export const processedMetricsPropType = PropTypes.shape({
   totalRequests: PropTypes.number,
   requestRate: PropTypes.number,
   successRate: PropTypes.number,
+  tsStats: PropTypes.shape({
+    weight: PropTypes.string,
+  }),
 });

--- a/web/app/js/components/util/SvgWrappers.jsx
+++ b/web/app/js/components/util/SvgWrappers.jsx
@@ -608,6 +608,109 @@ export const deploymentIcon = (
   </svg>
 );
 
+export const serviceIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    width="24px"
+    height="24px"
+    viewBox="0 0 18 18">
+    <g
+      transform="translate(-0.99262638,-1.174181)"
+      id="layer1">
+      <g
+        transform="matrix(1.0148887,0,0,1.0148887,16.902146,-2.698726)"
+        id="g70">
+        <path
+          fill="#757575"
+          fillOpacity="1"
+          stroke="none"
+          strokeWidth="0"
+          strokeMiterlimit="4"
+          strokeDasharray="none"
+          strokeOpacity="1"
+          d="m -6.8492015,4.2724668 a 1.1191255,1.1099671 0 0 0 -0.4288818,0.1085303 l -5.8524037,2.7963394 a 1.1191255,1.1099671 0 0 0 -0.605524,0.7529759 l -1.443828,6.2812846 a 1.1191255,1.1099671 0 0 0 0.151943,0.851028 1.1191255,1.1099671 0 0 0 0.06362,0.08832 l 4.0508,5.036555 a 1.1191255,1.1099671 0 0 0 0.874979,0.417654 l 6.4961011,-0.0015 a 1.1191255,1.1099671 0 0 0 0.8749788,-0.416906 L 1.3818872,15.149453 A 1.1191255,1.1099671 0 0 0 1.5981986,14.210104 L 0.15212657,7.9288154 A 1.1191255,1.1099671 0 0 0 -0.45339794,7.1758396 L -6.3065496,4.3809971 A 1.1191255,1.1099671 0 0 0 -6.8492015,4.2724668 Z"
+          id="path3055" />
+        <path d="M -6.8523435,3.8176372 A 1.1814304,1.171762 0 0 0 -7.3044284,3.932904 l -6.1787426,2.9512758 a 1.1814304,1.171762 0 0 0 -0.639206,0.794891 l -1.523915,6.6308282 a 1.1814304,1.171762 0 0 0 0.160175,0.89893 1.1814304,1.171762 0 0 0 0.06736,0.09281 l 4.276094,5.317236 a 1.1814304,1.171762 0 0 0 0.92363,0.440858 l 6.8576188,-0.0015 a 1.1814304,1.171762 0 0 0 0.9236308,-0.44011 l 4.2745966,-5.317985 a 1.1814304,1.171762 0 0 0 0.228288,-0.990993 L 0.53894439,7.6775738 A 1.1814304,1.171762 0 0 0 -0.10026101,6.8834313 L -6.2790037,3.9321555 A 1.1814304,1.171762 0 0 0 -6.8523435,3.8176372 Z m 0.00299,0.4550789 a 1.1191255,1.1099671 0 0 1 0.5426517,0.1085303 l 5.85315169,2.7948425 A 1.1191255,1.1099671 0 0 1 0.15197811,7.9290648 L 1.598051,14.21035 a 1.1191255,1.1099671 0 0 1 -0.2163123,0.939348 l -4.0493032,5.037304 a 1.1191255,1.1099671 0 0 1 -0.8749789,0.416906 l -6.4961006,0.0015 a 1.1191255,1.1099671 0 0 1 -0.874979,-0.417652 l -4.0508,-5.036554 a 1.1191255,1.1099671 0 0 1 -0.06362,-0.08832 1.1191255,1.1099671 0 0 1 -0.151942,-0.851028 l 1.443827,-6.2812853 a 1.1191255,1.1099671 0 0 1 0.605524,-0.7529758 l 5.8524036,-2.7963395 a 1.1191255,1.1099671 0 0 1 0.4288819,-0.1085303 z" id="path3054-2-9" />
+      </g>
+      <g
+        transform="translate(0.09238801,0.66897746)"
+        id="g3345">
+        <path
+          id="path964"
+          d="m 4.4949896,11.260826 2.9083311,0 0,2.041667 -2.9083311,0 z"
+          fill="#ffffff"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="0.26458332"
+          strokeLinecap="square"
+          strokeMiterlimit="10" />
+        <path
+          id="path966"
+          d="m 8.4637407,11.260826 2.9083303,0 0,2.041667 -2.9083303,0 z"
+          fill="#ffffff"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="0.26458332"
+          strokeLinecap="square"
+          strokeMiterlimit="10" />
+        <path
+          id="path968"
+          d="m 12.432491,11.260826 2.90833,0 0,2.041667 -2.90833,0 z"
+          fill="#ffffff"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="0.26458332"
+          strokeLinecap="square"
+          strokeMiterlimit="10" />
+        <path
+          id="path970"
+          d="m 7.6137407,5.2082921 4.6083303,0 0,2.041667 -4.6083303,0 z"
+          fill="#ffffff"
+          fillRule="evenodd"
+          stroke="none"
+          strokeWidth="0.26458332"
+          strokeLinecap="square"
+          strokeMiterlimit="10" />
+        <path
+          id="path978"
+          d="m 9.9179005,7.2499601 0,2.005449 -3.966671,0 0,2.0028859"
+          fill="none"
+          fillRule="evenodd"
+          stroke="#ffffff"
+          strokeWidth="0.52916664"
+          strokeLinecap="butt"
+          strokeLinejoin="round"
+          strokeMiterlimit="10"
+          strokeOpacity="1" />
+        <path
+          id="path986"
+          d="m 9.9179005,7.2499601 0,2.005449 3.9666705,0 0,2.0028859"
+          fill="none"
+          fillRule="evenodd"
+          stroke="#ffffff"
+          strokeWidth="0.52899998"
+          strokeLinecap="butt"
+          strokeLinejoin="round"
+          strokeMiterlimit="10"
+          strokeDasharray="none"
+          strokeOpacity="1" />
+        <path
+          id="path982"
+          d="m 9.9095538,7.2512251 0,2.005449 0.0167,0 0,2.0028859"
+          fill="none"
+          fillRule="evenodd"
+          stroke="#ffffff"
+          strokeWidth="0.52916664"
+          strokeLinecap="butt"
+          strokeLinejoin="round"
+          strokeMiterlimit="10"
+          strokeOpacity="1" />
+      </g>
+    </g>
+  </svg>
+);
+
 export const jobIcon = (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -126,6 +126,7 @@ function AppHTML() {
               <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/namespaces`} />
               <Redirect exact from={`${pathPrefix}/overview`} to={`${pathPrefix}/namespaces`} />
               <Redirect exact from={`${pathPrefix}/deployments`} to={`${pathPrefix}/namespaces/_all/deployments`} />
+              <Redirect exact from={`${pathPrefix}/services`} to={`${pathPrefix}/namespaces/_all/services`} />
               <Redirect exact from={`${pathPrefix}/trafficsplits`} to={`${pathPrefix}/namespaces/_all/trafficsplits`} />
               <Redirect exact from={`${pathPrefix}/daemonsets`} to={`${pathPrefix}/namespaces/_all/daemonsets`} />
               <Redirect exact from={`${pathPrefix}/statefulsets`} to={`${pathPrefix}/namespaces/_all/statefulsets`} />
@@ -177,8 +178,14 @@ function AppHTML() {
                 path={`${pathPrefix}/namespaces/:namespace/deployments/:deployment`}
                 render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
               <Route
+                path={`${pathPrefix}/namespaces/:namespace/services/:services`}
+                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+              <Route
                 path={`${pathPrefix}/namespaces/:namespace/deployments`}
                 render={props => <Navigation {...props} ChildComponent={ResourceList} resource="deployment" />} />
+              <Route
+                path={`${pathPrefix}/namespaces/:namespace/services`}
+                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="service" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers/:replicationcontroller`}
                 render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -178,7 +178,7 @@ function AppHTML() {
                 path={`${pathPrefix}/namespaces/:namespace/deployments/:deployment`}
                 render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
               <Route
-                path={`${pathPrefix}/namespaces/:namespace/services/:services`}
+                path={`${pathPrefix}/namespaces/:namespace/services/:service`}
                 render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/deployments`}

--- a/web/app/js/locales/en/messages.json
+++ b/web/app/js/locales/en/messages.json
@@ -114,6 +114,7 @@
   "menuItemCronJobs": "Cron Jobs",
   "menuItemDaemonSets": "Daemon Sets",
   "menuItemDeployments": "Deployments",
+  "menuItemServices": "Services",
   "menuItemDocumentation": "Documentation",
   "menuItemExtension": "Extensions",
   "menuItemGateway": "Gateway",

--- a/web/srv/api_handlers.go
+++ b/web/srv/api_handlers.go
@@ -407,6 +407,8 @@ func (h *handler) handleAPIResourceDefinition(w http.ResponseWriter, req *http.R
 		resource, err = h.k8sAPI.AppsV1().DaemonSets(namespace).Get(req.Context(), resourceName, options)
 	case k8s.Deployment:
 		resource, err = h.k8sAPI.AppsV1().Deployments(namespace).Get(req.Context(), resourceName, options)
+	case k8s.Service:
+		resource, err = h.k8sAPI.CoreV1().Services(namespace).Get(req.Context(), resourceName, options)
 	case k8s.Job:
 		resource, err = h.k8sAPI.BatchV1().Jobs(namespace).Get(req.Context(), resourceName, options)
 	case k8s.Pod:

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -144,6 +144,7 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/trafficsplits", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/jobs", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/deployments", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/services", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/replicationcontrollers", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/pods", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/cronjobs", handler.handleIndex)
@@ -156,6 +157,7 @@ func NewServer(
 	server.router.GET("/trafficsplits", handler.handleIndex)
 	server.router.GET("/jobs", handler.handleIndex)
 	server.router.GET("/deployments", handler.handleIndex)
+	server.router.GET("/services", handler.handleIndex)
 	server.router.GET("/replicationcontrollers", handler.handleIndex)
 	server.router.GET("/pods", handler.handleIndex)
 
@@ -166,6 +168,7 @@ func NewServer(
 	server.router.GET("/namespaces/:namespace/statefulsets/:statefulset", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/trafficsplits/:trafficsplit", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/deployments/:deployment", handler.handleIndex)
+	server.router.GET("/namespaces/:namespace/services/:deployment", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/jobs/:job", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/replicationcontrollers/:replicationcontroller", handler.handleIndex)
 	server.router.GET("/namespaces/:namespace/cronjobs/:cronjob", handler.handleIndex)


### PR DESCRIPTION
Adds services as a new screan on a web dashboard. Services screen is
implemented as a separate func, because it is different from
pods/jobs/etc.

Services view will not have pods or edges section because this
information is not available.

Fixes #6648

Signed-off-by: Krzysztof Dryś <krzysztofdrys@gmail.com>
