### PR TITLE
Avoid potentially incorrect integer conversions

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2341,7 +2341,7 @@ func misconfiguredOpaqueAnnotation(service *corev1.Service, pod *corev1.Pod) err
 
 func checkPodPorts(service *corev1.Service, pod *corev1.Pod, podPorts []string, port int) error {
 	for _, sp := range service.Spec.Ports {
-		if sp.Port == int32(port) {
+		if int(sp.Port) == port {
 			for _, c := range pod.Spec.Containers {
 				for _, cp := range c.Ports {
 					if cp.ContainerPort == sp.TargetPort.IntVal || cp.Name == sp.TargetPort.StrVal {
@@ -2368,13 +2368,13 @@ func checkPodPorts(service *corev1.Service, pod *corev1.Pod, podPorts []string, 
 func checkServiceIntPorts(service *corev1.Service, svcPorts []string, port int) (bool, error) {
 	for _, p := range service.Spec.Ports {
 		if p.TargetPort.Type == 0 && p.TargetPort.IntVal == 0 {
-			if p.Port == int32(port) {
+			if int(p.Port) == port {
 				// The service does not have a target port, so its service
 				// port should be marked as opaque.
 				return false, fmt.Errorf("service %s targets the opaque port %d; add it to its %s annotation", service.Name, port, k8s.ProxyOpaquePortsAnnotation)
 			}
 		}
-		if p.TargetPort.IntVal == int32(port) {
+		if int(p.TargetPort.IntVal) == port {
 			svcPort := strconv.Itoa(int(p.Port))
 			if util.ContainsString(svcPort, svcPorts) {
 				// The service exposes svcPort which targets p and svcPort
@@ -2396,7 +2396,7 @@ func checkServiceNamePorts(service *corev1.Service, pod *corev1.Pod, port int, s
 		}
 		for _, c := range pod.Spec.Containers {
 			for _, cp := range c.Ports {
-				if cp.ContainerPort == int32(port) {
+				if int(cp.ContainerPort) == port {
 					// This is the containerPort that maps to the opaque port
 					// we are currently checking.
 					if cp.Name == p.TargetPort.StrVal {


### PR DESCRIPTION
CodeQL has flagged a few integer conversions in healthcheck as
potentially incorrect:

> Incorrect conversion of an integer with architecture-dependent bit size
> from `strconv.Atoi` to a lower bit size type `int32` without an upper
> bound check.

This change updates these comparisons by converting `int32` to `int`
instead of converting the other way.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
