### PR TITLE
Disable Rust's incremental compilation in CI

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -8,6 +8,7 @@ on:
       - 'deny.toml'
       - 'rust-toolchain'
       - 'policy-controller/**'
+      - '.github/workflows/policy_controller.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
There's no reason to use Rust's incremental compilation in CI. According
to matklad's blog post on [fast Rust builds][fastbuilds]:

> CI builds often are closer to from-scratch builds, as changes are
> typically much bigger than from a local edit-compile cycle. For
> from-scratch builds, incremental adds an extra dependency-tracking
> overhead. It also significantly increases the amount of IO and the
> size of ./target, which make caching less effective.

[fastbuilds]: https://matklad.github.io/2021/09/04/fast-rust-builds.html

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
