### PR TITLE
policy-controller: Use jemalloc on x86_64 gnu/linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "futures"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +667,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +850,7 @@ dependencies = [
  "drain",
  "futures",
  "hyper",
+ "jemallocator",
  "kube",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-grpc",

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -26,3 +26,6 @@ tokio = { version = "1", features = ["macros", "parking_lot", "rt", "rt-multi-th
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"] }
 warp = { version = "0.3", default-features = false, features = ["tls"] }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+jemallocator = "0.3"

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -12,6 +12,10 @@ use tokio::{sync::watch, time};
 use tracing::{debug, info, info_span, instrument, Instrument};
 use tracing_subscriber::{fmt::format, prelude::*, EnvFilter};
 
+#[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[derive(Debug, StructOpt)]
 #[structopt(name = "policy", about = "A policy resource prototype")]
 struct Args {


### PR DESCRIPTION
While testing the proxy with various allocators, we've seen that
jemalloc generally uses less memory without incurring CPU or latency
costs.

This change updates the policy-controller to use jemalloc on x86_64
gnu/linux. We continue to use the system allocator on other platforms
(especially arm), since the jemalloc tests do not pass on these
platforms (according to the jemallocator readme).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
