### PR TITLE
fix wrong group names in fake client

### DIFF
--- a/bin/update-codegen.sh
+++ b/bin/update-codegen.sh
@@ -34,3 +34,7 @@ GO111MODULE='on' "${codegen_pkg}/generate-groups.sh" \
 
 # copy generated code out of GOPATH
 cp -R "${GOPATH}/src/${ROOT_PACKAGE}/controller/gen" 'controller/'
+
+# Temporary fix for https://github.com/kubernetes/code-generator/issues/135
+sed -i 's/Group: \"server\"/Group: \"policy.linkerd.io\"/g' "${rootdir}/controller/gen/client/clientset/versioned/typed/server/v1beta1/fake/fake_server.go"
+sed -i 's/Group: \"serverauthorization\"/Group: \"policy.linkerd.io\"/g' "${rootdir}/controller/gen/client/clientset/versioned/typed/serverauthorization/v1beta1/fake/fake_serverauthorization.go"

--- a/controller/gen/apis/server/v1beta1/types.go
+++ b/controller/gen/apis/server/v1beta1/types.go
@@ -9,7 +9,6 @@ import (
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +groupName=policy.linkerd.io
-// +groupGoName=server
 
 type Server struct {
 	// TypeMeta is the metadata for the resource, like kind and apiversion

--- a/controller/gen/apis/serverauthorization/v1beta1/types.go
+++ b/controller/gen/apis/serverauthorization/v1beta1/types.go
@@ -8,7 +8,6 @@ import (
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +groupName=policy.linkerd.io
-// +groupGoName=serverauthorization
 
 type ServerAuthorization struct {
 	// TypeMeta is the metadata for the resource, like kind and apiversion

--- a/controller/gen/client/clientset/versioned/typed/server/v1beta1/fake/fake_server.go
+++ b/controller/gen/client/clientset/versioned/typed/server/v1beta1/fake/fake_server.go
@@ -36,9 +36,9 @@ type FakeServers struct {
 	ns   string
 }
 
-var serversResource = schema.GroupVersionResource{Group: "server", Version: "v1beta1", Resource: "servers"}
+var serversResource = schema.GroupVersionResource{Group: "policy.linkerd.io", Version: "v1beta1", Resource: "servers"}
 
-var serversKind = schema.GroupVersionKind{Group: "server", Version: "v1beta1", Kind: "Server"}
+var serversKind = schema.GroupVersionKind{Group: "policy.linkerd.io", Version: "v1beta1", Kind: "Server"}
 
 // Get takes name of the server, and returns the corresponding server object, and an error if there is any.
 func (c *FakeServers) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.Server, err error) {

--- a/controller/gen/client/clientset/versioned/typed/serverauthorization/v1beta1/fake/fake_serverauthorization.go
+++ b/controller/gen/client/clientset/versioned/typed/serverauthorization/v1beta1/fake/fake_serverauthorization.go
@@ -36,9 +36,9 @@ type FakeServerAuthorizations struct {
 	ns   string
 }
 
-var serverauthorizationsResource = schema.GroupVersionResource{Group: "serverauthorization", Version: "v1beta1", Resource: "serverauthorizations"}
+var serverauthorizationsResource = schema.GroupVersionResource{Group: "policy.linkerd.io", Version: "v1beta1", Resource: "serverauthorizations"}
 
-var serverauthorizationsKind = schema.GroupVersionKind{Group: "serverauthorization", Version: "v1beta1", Kind: "ServerAuthorization"}
+var serverauthorizationsKind = schema.GroupVersionKind{Group: "policy.linkerd.io", Version: "v1beta1", Kind: "ServerAuthorization"}
 
 // Get takes name of the serverAuthorization, and returns the corresponding serverAuthorization object, and an error if there is any.
 func (c *FakeServerAuthorizations) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ServerAuthorization, err error) {

--- a/pkg/k8s/policy.go
+++ b/pkg/k8s/policy.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"strings"
 
+	serverv1beta1 "github.com/linkerd/linkerd2/controller/gen/apis/server/v1beta1"
+	serverauthorizationv1beta1 "github.com/linkerd/linkerd2/controller/gen/apis/serverauthorization/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -22,18 +23,10 @@ type ServerAndAuthorization struct {
 type id struct{ name, namespace string }
 
 // SazGVR is the GroupVersionResource for the ServerAuthorization resource.
-var SazGVR = schema.GroupVersionResource{
-	Group:    "policy.linkerd.io",
-	Version:  "v1alpha1",
-	Resource: "serverauthorizations",
-}
+var SazGVR = serverauthorizationv1beta1.SchemeGroupVersion.WithResource("serverauthorizations")
 
 // ServerGVR is the GroupVersionResource for the Server resource.
-var ServerGVR = schema.GroupVersionResource{
-	Group:    "policy.linkerd.io",
-	Version:  "v1alpha1",
-	Resource: "servers",
-}
+var ServerGVR = serverv1beta1.SchemeGroupVersion.WithResource("servers")
 
 // ServerAuthorizationsForResource returns a list of Server-ServerAuthorization
 // pairs which select pods belonging to the given resource.


### PR DESCRIPTION
The `Group` attribute of the`GroupVersionResource` is wrong for the fake clients.
This leads to tests failing as types are not registered and keyed correctly.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
