### PR TITLE
Add control plane namespace arg to policy controller

### DIFF
--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -251,7 +251,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns={{.Values.namespace}}
+        - --control-plane-namespace={{.Values.namespace}}
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks={{.Values.clusterNetworks}}

--- a/charts/linkerd2/templates/destination.yaml
+++ b/charts/linkerd2/templates/destination.yaml
@@ -251,6 +251,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns={{.Values.namespace}}
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks={{.Values.clusterNetworks}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -2057,7 +2057,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -2057,6 +2057,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -2055,7 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=l5d
+        - --control-plane-namespace=l5d
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -2055,6 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=l5d
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -2055,7 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -2055,6 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -2055,7 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -2055,6 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -2055,6 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.0.0.0/8

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -2055,7 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.0.0.0/8

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -2044,7 +2044,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -2044,6 +2044,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -2191,6 +2191,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -2191,7 +2191,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -2191,6 +2191,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -2191,7 +2191,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1986,7 +1986,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1986,6 +1986,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2048,7 +2048,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -2048,6 +2048,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -2184,7 +2184,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -2184,6 +2184,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -2196,6 +2196,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -2196,7 +2196,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -2184,7 +2184,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -2184,6 +2184,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -2017,7 +2017,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -2017,6 +2017,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -2060,7 +2060,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=ClusterNetworks

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -2060,6 +2060,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=ClusterNetworks

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -2055,7 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=linkerd
+        - --control-plane-namespace=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -2055,6 +2055,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=linkerd
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -2041,7 +2041,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
-        - --control-plane-ns=l5d
+        - --control-plane-namespace=l5d
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -2041,6 +2041,7 @@ spec:
           readOnly: true
       - args:
         - --admin-addr=0.0.0.0:9990
+        - --control-plane-ns=l5d
         - --grpc-addr=0.0.0.0:8090
         - --admission-addr=0.0.0.0:9443
         - --cluster-networks=10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16

--- a/policy-controller/k8s/index/src/authz.rs
+++ b/policy-controller/k8s/index/src/authz.rs
@@ -1,4 +1,4 @@
-use crate::{server::ServerSelector, Errors, Index, SrvIndex};
+use crate::{server::ServerSelector, ClusterInfo, Errors, Index, SrvIndex};
 use anyhow::{anyhow, bail, Result};
 use linkerd_policy_controller_core::{
     ClientAuthentication, ClientAuthorization, IdentityMatch, IpNet, NetworkMatch,
@@ -42,13 +42,7 @@ impl Index {
             .namespaces
             .get_or_default(authz.namespace().expect("namespace required"));
 
-        ns.authzs.apply(
-            authz,
-            &mut ns.servers,
-            &*self.identity_domain,
-            &*self.cluster_networks,
-            &*self.control_plane_ns,
-        )
+        ns.authzs.apply(authz, &mut ns.servers, &self.cluster_info)
     }
 
     #[instrument(
@@ -142,12 +136,10 @@ impl AuthzIndex {
         &mut self,
         authz: policy::ServerAuthorization,
         servers: &mut SrvIndex,
-        domain: &str,
-        cluster_networks: &[IpNet],
-        control_plane_ns: &str,
+        cluster: &ClusterInfo,
     ) -> Result<()> {
         let name = authz.name();
-        let authz = mk_authz(authz, domain, cluster_networks, control_plane_ns)?;
+        let authz = mk_authz(authz, cluster)?;
 
         match self.index.entry(name) {
             HashEntry::Vacant(entry) => {
@@ -173,12 +165,7 @@ impl AuthzIndex {
     }
 }
 
-fn mk_authz(
-    srv: policy::authz::ServerAuthorization,
-    domain: &str,
-    cluster_networks: &[IpNet],
-    control_plane_ns: &str,
-) -> Result<Authz> {
+fn mk_authz(srv: policy::authz::ServerAuthorization, cluster: &ClusterInfo) -> Result<Authz> {
     let policy::authz::ServerAuthorization { metadata, spec, .. } = srv;
 
     let servers = {
@@ -206,7 +193,8 @@ fn mk_authz(
             .collect::<Result<Vec<NetworkMatch>>>()?
     } else {
         // If no networks are specified, the cluster networks are used as the default.
-        cluster_networks
+        cluster
+            .networks
             .iter()
             .copied()
             .map(NetworkMatch::from)
@@ -220,7 +208,7 @@ fn mk_authz(
             .client
             .mesh_tls
             .ok_or_else(|| anyhow!("client mtls missing"))?;
-        mk_mtls_authn(&metadata, mtls, domain, control_plane_ns)?
+        mk_mtls_authn(&metadata, mtls, cluster)?
     };
 
     Ok(Authz {
@@ -235,8 +223,7 @@ fn mk_authz(
 fn mk_mtls_authn(
     metadata: &k8s::ObjectMeta,
     mtls: MeshTls,
-    domain: &str,
-    control_plane_ns: &str,
+    cluster: &ClusterInfo,
 ) -> Result<ClientAuthentication> {
     if mtls.unauthenticated_tls {
         return Ok(ClientAuthentication::TlsUnauthenticated);
@@ -270,7 +257,7 @@ fn mk_mtls_authn(
         debug!(ns = %ns, serviceaccount = %name, "Authenticated");
         let n = format!(
             "{}.{}.serviceaccount.identity.{}.{}",
-            name, ns, control_plane_ns, domain
+            name, ns, cluster.control_plane_ns, cluster.identity_domain
         );
         identities.push(IdentityMatch::Name(n));
     }

--- a/policy-controller/k8s/index/src/authz.rs
+++ b/policy-controller/k8s/index/src/authz.rs
@@ -268,7 +268,10 @@ fn mk_mtls_authn(
             .namespace
             .unwrap_or_else(|| metadata.namespace.clone().unwrap());
         debug!(ns = %ns, serviceaccount = %name, "Authenticated");
-        let n = format!("{}.{}.serviceaccount.identity.{}.{}", name, ns, control_plane_ns, domain);
+        let n = format!(
+            "{}.{}.serviceaccount.identity.{}.{}",
+            name, ns, control_plane_ns, domain
+        );
         identities.push(IdentityMatch::Name(n));
     }
 

--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -82,6 +82,9 @@ pub struct Index {
 
     /// A handle that supports updates to the lookup index.
     lookups: lookup::Writer,
+
+    /// The namespace where the linkerd control plane is deployed
+    control_plane_ns: String,
 }
 
 #[derive(Debug)]
@@ -95,6 +98,7 @@ impl Index {
         identity_domain: String,
         default_policy: DefaultPolicy,
         detect_timeout: time::Duration,
+        control_plane_ns: String,
     ) -> (lookup::Reader, Self) {
         // Create a common set of receivers for all supported default policies.
         let default_policy_watches =
@@ -111,6 +115,7 @@ impl Index {
             identity_domain,
             cluster_networks,
             default_policy_watches,
+            control_plane_ns,
         };
         (reader, idx)
     }

--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -65,8 +65,7 @@ type PodServerTx = watch::Sender<ServerRx>;
 pub struct ClusterInfo {
     /// Networks including PodIPs in this cluster.
     ///
-    /// TODO(ver) this can be discovered dynamically by the node index, but this would complicate
-    /// notifications.
+    /// Unfortunately, there's no way to discover this at runtime.
     pub networks: Vec<IpNet>,
 
     /// The namespace where the linkerd control plane is deployed

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -13,17 +13,20 @@ use tokio::time;
 #[tokio::test]
 async fn incrementally_configure_server() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
     let (lookup_rx, mut idx) = Index::new(
-        vec![cluster_net],
-        "cluster.example.com".into(),
+        cluster,
         DefaultPolicy::Allow {
             authenticated_only: false,
             cluster_only: true,
         },
         detect_timeout,
-        "linkerd".to_string(),
     );
 
     let pod = mk_pod(
@@ -136,19 +139,18 @@ async fn incrementally_configure_server() {
 #[test]
 fn server_update_deselects_pod() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
     let default = DefaultPolicy::Allow {
         authenticated_only: false,
         cluster_only: true,
     };
-    let (lookup_rx, mut idx) = Index::new(
-        vec![cluster_net],
-        "cluster.example.com".into(),
-        default,
-        detect_timeout,
-        "linkerd".to_string(),
-    );
+    let (lookup_rx, mut idx) = Index::new(cluster, default, detect_timeout);
 
     let p = mk_pod(
         "ns-0",
@@ -200,17 +202,16 @@ fn server_update_deselects_pod() {
 #[test]
 fn default_policy_global() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
 
     for default in &DEFAULTS {
-        let (lookup_rx, mut idx) = Index::new(
-            vec![cluster_net],
-            "cluster.example.com".into(),
-            *default,
-            detect_timeout,
-            "linkerd".to_string(),
-        );
+        let (lookup_rx, mut idx) = Index::new(cluster.clone(), *default, detect_timeout);
 
         let p = mk_pod(
             "ns-0",
@@ -244,13 +245,17 @@ fn default_policy_global() {
 #[test]
 fn default_policy_annotated() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
 
     for default in &DEFAULTS {
         let (lookup_rx, mut idx) = Index::new(
-            vec![cluster_net],
-            "cluster.example.com".into(),
+            cluster.clone(),
             // Invert default to ensure override applies.
             match *default {
                 DefaultPolicy::Deny => DefaultPolicy::Allow {
@@ -260,7 +265,6 @@ fn default_policy_annotated() {
                 _ => DefaultPolicy::Deny,
             },
             detect_timeout,
-            "linkerd".to_string(),
         );
 
         let mut p = mk_pod(
@@ -292,6 +296,11 @@ fn default_policy_annotated() {
 #[test]
 fn default_policy_annotated_invalid() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
 
@@ -299,13 +308,7 @@ fn default_policy_annotated_invalid() {
         authenticated_only: false,
         cluster_only: false,
     };
-    let (lookup_rx, mut idx) = Index::new(
-        vec![cluster_net],
-        "cluster.example.com".into(),
-        default,
-        detect_timeout,
-        "linkerd".to_string(),
-    );
+    let (lookup_rx, mut idx) = Index::new(cluster, default, detect_timeout);
 
     let mut p = mk_pod(
         "ns-0",
@@ -343,17 +346,16 @@ fn default_policy_annotated_invalid() {
 #[test]
 fn opaque_annotated() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
 
     for default in &DEFAULTS {
-        let (lookup_rx, mut idx) = Index::new(
-            vec![cluster_net],
-            "cluster.example.com".into(),
-            *default,
-            detect_timeout,
-            "linkerd".to_string(),
-        );
+        let (lookup_rx, mut idx) = Index::new(cluster.clone(), *default, detect_timeout);
 
         let mut p = mk_pod(
             "ns-0",
@@ -382,17 +384,16 @@ fn opaque_annotated() {
 #[test]
 fn authenticated_annotated() {
     let cluster_net = IpNet::from_str("192.0.2.0/24").unwrap();
+    let cluster = ClusterInfo {
+        networks: vec![cluster_net],
+        control_plane_ns: "linkerd".to_string(),
+        identity_domain: "cluster.example.com".into(),
+    };
     let pod_net = IpNet::from_str("192.0.2.2/28").unwrap();
     let detect_timeout = time::Duration::from_secs(1);
 
     for default in &DEFAULTS {
-        let (lookup_rx, mut idx) = Index::new(
-            vec![cluster_net],
-            "cluster.example.com".into(),
-            *default,
-            detect_timeout,
-            "linkerd".to_string(),
-        );
+        let (lookup_rx, mut idx) = Index::new(cluster.clone(), *default, detect_timeout);
 
         let mut p = mk_pod(
             "ns-0",

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -23,6 +23,7 @@ async fn incrementally_configure_server() {
             cluster_only: true,
         },
         detect_timeout,
+        "linkerd".to_string(),
     );
 
     let pod = mk_pod(
@@ -146,6 +147,7 @@ fn server_update_deselects_pod() {
         "cluster.example.com".into(),
         default,
         detect_timeout,
+        "linkerd".to_string(),
     );
 
     let p = mk_pod(
@@ -207,6 +209,7 @@ fn default_policy_global() {
             "cluster.example.com".into(),
             *default,
             detect_timeout,
+            "linkerd".to_string(),
         );
 
         let p = mk_pod(
@@ -257,6 +260,7 @@ fn default_policy_annotated() {
                 _ => DefaultPolicy::Deny,
             },
             detect_timeout,
+            "linkerd".to_string(),
         );
 
         let mut p = mk_pod(
@@ -300,6 +304,7 @@ fn default_policy_annotated_invalid() {
         "cluster.example.com".into(),
         default,
         detect_timeout,
+        "linkerd".to_string(),
     );
 
     let mut p = mk_pod(
@@ -347,6 +352,7 @@ fn opaque_annotated() {
             "cluster.example.com".into(),
             *default,
             detect_timeout,
+            "linkerd".to_string(),
         );
 
         let mut p = mk_pod(
@@ -385,6 +391,7 @@ fn authenticated_annotated() {
             "cluster.example.com".into(),
             *default,
             detect_timeout,
+            "linkerd".to_string(),
         );
 
         let mut p = mk_pod(

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -53,6 +53,9 @@ struct Args {
 
     #[structopt(long, default_value = "all-unauthenticated")]
     default_policy: DefaultPolicy,
+
+    #[structopt(long)]
+    control_plane_namespace: String,
 }
 
 #[derive(Clone, Debug)]
@@ -72,6 +75,7 @@ async fn main() -> Result<()> {
         default_policy,
         log_level,
         log_format,
+        control_plane_namespace,
     } = Args::from_args();
 
     log_init(log_level, log_format)?;
@@ -97,6 +101,7 @@ async fn main() -> Result<()> {
             identity_domain,
             default_policy,
             DETECT_TIMEOUT,
+            control_plane_namespace,
         );
 
         tokio::spawn(index.run(client.clone(), ready_tx));


### PR DESCRIPTION


## Problem
When using a `serviceAccount` in the `meshTLS` section of a `ServerAuthorization` the policy controller uses the service account name to generate a string that matches the same string that the linkerd-identity service creates. In the case of #7204, using the `web` service account results in the policy controller attempting to match `web.linkerd-viz.serviceaccount.identity.linkerd.svc.cluster.local`.

This works fine when the control plane is deployed to the `linkerd` namespace. However, as described in #7204, deploying the control plane to any other namespace causes `serviceAccount` matches to fail, because the identity that is generated is: `web.linkerd-viz.serviceaccount.identity.<custom-linkerd-namespace>.cluster.local`

## Solution

Add an argument to the policy-controller named `control-plane-ns` which is set to the value of `{{.Values.namespace}}` in the destination.yaml template file. Then use this value when formatting the service account name to the identity format.

## Validation

Tested in a local cluster using the same steps to reproduce that are outlined in #7204.

This change needs tests, so I'm going to put this into a draft until the tests are committed.

Fixes #7204

Signed-off-by: Charles Pretzer <charles@charlespretzer.com>
