### PR TITLE
Fix unit tests fixtures for proxy-init 1.5.0

### DIFF
--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -166,7 +166,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v1.5.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1376,7 +1376,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.4.1
+        version: v1.5.0
       resources:
         cpu:
           limit: 100m
@@ -1684,7 +1684,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v1.5.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2081,7 +2081,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v1.5.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2369,7 +2369,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v1.5.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:


### PR DESCRIPTION
A couple of new golden files didn't get the v1.5.0 proxy-init tag, which broke unit tests in `main`.
