### PR TITLE
edge-21.11.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,9 @@ default tokens injected by Kubernetes which are overly permissive.
 Note that this edge release updates the minimum supported kubernetes version to 1.20.
 
 * Updated the minimum supported kubernetes version to 1.20
-* Use Service Account Token Volume Projections to set up the pods' identities
+* Use Service Account Token Volume Projections to set up the pods' identities;
+  now injection also works on pods with `automountServiceAccountToken` set to
+  `false`
 * Updated proxy-init's Alpine base image to fix some CVEs (not affecting
   Linkerd)
 * Updated the Prometheus image in linkerd-viz to 2.30.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # Changes
 
+## edge-21.11.1
+
+In this edge, we're very excited to introduce Service Account Token Volume
+Projections, used to set up the pod's identities. These tokens are bounded
+specifically for this use case and are rotated daily, replacing the usage of the
+default tokens injected by Kubernetes which are overly permissive and not
+rotated.
+
+Note that this edge release updates the minimum supported kubernetes version to 1.20.
+
+* Updated the minimum supported kubernetes version to 1.20
+* Use Service Account Token Volume Projections to set up the pods identities
+* Updated proxy-init's Alpine base image to fix some CVEs (not affecting
+  Linkerd)
+* Updated the Prometheus image in viz to 2.30.3
+* Changed the proxy and policy controller to use jemalloc on x86_64 gnu/linux to
+  reduce memory usage
+* Improved retries so that requests without a `content-length` can be retried
+  (e.g. for `grpc-go` clients)
+* Promoted service discovery updates entries in the proxy's log from TRACE to
+  DEBUG, for improved discovery diagnostics
+* Fixed output for `linkerd check -o json`
+* Added ability to configure ephemeral-storage resources for each component
+  (thanks @michaellzc!)
+
 ## edge-21.10.3
 
 This edge release fixes a bug in the proxy that could cause it to be killed in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,10 +16,6 @@ Note that this edge release updates the minimum supported kubernetes version to 
 * Updated the Prometheus image in linkerd-viz to 2.30.3
 * Changed the proxy and policy controller to use jemalloc on x86_64 gnu/linux to
   reduce memory usage
-* Improved retries so that requests without a `content-length` can be retried
-  (e.g. for `grpc-go` clients)
-* Promoted service discovery updates entries in the proxy's log from TRACE to
-  DEBUG, for improved discovery diagnostics
 * Fixed output for `linkerd check -o json`
 * Added ability to configure ephemeral-storage resources for each component
   (thanks @michaellzc!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## edge-21.11.1
 
 In this edge, we're very excited to introduce Service Account Token Volume
-Projections, used to set up the pod's identities. These tokens are bounded
+Projections, used to set up the pods' identities. These tokens are bounded
 specifically for this use case and are rotated daily, replacing the usage of the
 default tokens injected by Kubernetes which are overly permissive and not
 rotated.
@@ -11,10 +11,10 @@ rotated.
 Note that this edge release updates the minimum supported kubernetes version to 1.20.
 
 * Updated the minimum supported kubernetes version to 1.20
-* Use Service Account Token Volume Projections to set up the pods identities
+* Use Service Account Token Volume Projections to set up the pods' identities
 * Updated proxy-init's Alpine base image to fix some CVEs (not affecting
   Linkerd)
-* Updated the Prometheus image in viz to 2.30.3
+* Updated the Prometheus image in linkerd-viz to 2.30.3
 * Changed the proxy and policy controller to use jemalloc on x86_64 gnu/linux to
   reduce memory usage
 * Improved retries so that requests without a `content-length` can be retried

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,7 @@
 In this edge, we're very excited to introduce Service Account Token Volume
 Projections, used to set up the pods' identities. These tokens are bounded
 specifically for this use case and are rotated daily, replacing the usage of the
-default tokens injected by Kubernetes which are overly permissive and not
-rotated.
+default tokens injected by Kubernetes which are overly permissive.
 
 Note that this edge release updates the minimum supported kubernetes version to 1.20.
 


### PR DESCRIPTION
## edge-21.11.1

In this edge, we're very excited to introduce Service Account Token Volume
Projections, used to set up the pods' identities. These tokens are bounded
specifically for this use case and are rotated daily, replacing the usage of the
default tokens injected by Kubernetes which are overly permissive.

Note that this edge release updates the minimum supported kubernetes version to 1.20.

* Updated the minimum supported kubernetes version to 1.20
* Use Service Account Token Volume Projections to set up the pods' identities;
  now injection also works on pods with `automountServiceAccountToken` set to
  `false`
* Updated proxy-init's Alpine base image to fix some CVEs (not affecting
  Linkerd)
* Updated the Prometheus image in linkerd-viz to 2.30.3
* Changed the proxy and policy controller to use jemalloc on x86_64 gnu/linux to
  reduce memory usage
* Fixed output for `linkerd check -o json`
* Added ability to configure ephemeral-storage resources for each component
  (thanks @michaellzc!)
