### PR TITLE
Don't upgrade react-router to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,10 @@ updates:
     directory: "/web/app"
     schedule:
       interval: "daily"
+    ignore:
+      # v6 is backwards-incompatible and requires lots of changes.
+      # A compatibility layer should come out at some point
+      # see https://reactrouter.com/docs/en/v6/upgrading/v5
+      - dependency-name: "react-router-dom"
+        update-type: "semver-major"
 


### PR DESCRIPTION
The upgrade requires manual intervention, and they promised a
compatibility layer, so let's wait for that.
See https://reactrouter.com/docs/en/v6/upgrading/v5
