### PR TITLE
Fix and re-enable cni-calico-deep integration test

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -60,7 +60,7 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
-        #- cni-calico-deep # XXX currently broken
+        - cni-calico-deep
         - default-policy-deny
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -169,37 +169,17 @@ func TestInstallCalico(t *testing.T) {
 		return
 	}
 
-	// Install calico CNI plug-in from the official manifests
-	// Calico operator and custom resource definitions.
-	out, err := TestHelper.Kubectl("", []string{"apply", "-f", "https://docs.projectcalico.org/manifests/tigera-operator.yaml"}...)
+	out, err := TestHelper.Kubectl("", []string{"apply", "-f", "https://k3d.io/usage/guides/calico.yaml"}...)
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 			"kubectl apply command failed\n%s", out)
 	}
 
-	// wait for the tigera-operator deployment
-	name := "tigera-operator"
-	ns := "tigera-operator"
-	o, err := TestHelper.Kubectl("", "--namespace="+ns, "wait", "--for=condition=available", "--timeout=120s", "deploy/"+name)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for deploy/%s in namespace %s", name, ns),
-			"failed to wait for condition=available for deploy/%s in namespace %s: %s: %s", name, ns, err, o)
-	}
-
-	// creating the necessary custom resource
-	out, err = TestHelper.Kubectl("", []string{"apply", "-f", "https://docs.projectcalico.org/manifests/custom-resources.yaml"}...)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
-			"kubectl apply command failed\n%s", out)
-	}
-
-	// Wait for Calico CNI Installation, which is created by the operator based on the custom resource applied above
 	time.Sleep(10 * time.Second)
-	ns = "calico-system"
-	o, err = TestHelper.Kubectl("", "--namespace="+ns, "wait", "--for=condition=available", "--timeout=120s", "deploy/calico-kube-controllers", "deploy/calico-typha")
+	o, err := TestHelper.Kubectl("", "--namespace=kube-system", "wait", "--for=condition=available", "--timeout=120s", "deploy/calico-kube-controllers")
 	if err != nil {
-		testutil.AnnotatedFatalf(t, fmt.Sprintf("failed to wait for condition=available for resources in namespace %s", ns),
-			"failed to wait for condition=available for resources in namespace %s: %s: %s", ns, err, o)
+		testutil.AnnotatedFatalf(t, "failed to wait for condition=available for calico resources",
+			"failed to wait for condition=available for calico resources: %s: %s", err, o)
 	}
 }
 


### PR DESCRIPTION
Replaced the tigera-operator setup with the calico manifest
preconfigured for k3d (see https://k3d.io/usage/guides/calico/).
I couldn't find what was wrong with the former, but the latter works
just fine, and is simpler.
