### PR TITLE
Remove reference to "linkerd-sp-validator" service account

### DIFF
--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -98,7 +98,4 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
   namespace: {{.Values.namespace}}
-- kind: ServiceAccount
-  name: linkerd-sp-validator
-  namespace: {{.Values.namespace}}
 {{ end -}}


### PR DESCRIPTION
While reviewing the changes for the 2.11 release, I noticed there was still a reference to the `linkerd-sp-validator` service account in the `linkerd-psp` role binding.

This isn't really an issue as PSPs are deprecated and slated to be removed in Kubernetes 1.25, but figured it would be good to remove the old reference anyway.

Signed-off-by: David Symons <david.symons@onemodel.co>