### PR TITLE
Improve error message when extension is not found

### DIFF
--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -200,7 +200,9 @@ func (kubeAPI *KubernetesAPI) GetNamespaceWithExtensionLabel(ctx context.Context
 			return &ns, err
 		}
 	}
-	return nil, kerrors.NewNotFound(corev1.Resource("namespace"), value)
+	errNotFound := kerrors.NewNotFound(corev1.Resource("namespace"), value)
+	errNotFound.ErrStatus.Message = fmt.Sprintf("namespace with label \"%s: %s\" not found", LinkerdExtensionLabel, value)
+	return nil, errNotFound
 }
 
 // GetPodStatus receives a pod and returns the pod status, based on `kubectl` logic.


### PR DESCRIPTION
Fixes #7264

When the CLI attempts to retrieve an extension namespace by selecting a
label like `linkerd.io/extension: viz` and fails, the error was reading:

```
Cannot connect to Linkerd Viz: namespace "viz" not found
```

which is misleading. Changed that to:

```
Cannot connect to Linkerd Viz: namespace with label "linkerd.io/extension: viz" not found
```
