### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,5 @@ updates:
       # A compatibility layer should come out at some point
       # see https://reactrouter.com/docs/en/v6/upgrading/v5
       - dependency-name: "react-router-dom"
-        update-type: "semver-major"
+        update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Apparently the syntax was off (maybe I picked that up from an older doc?)
It now conforms to
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore
