### PR TITLE
ci: Split rust test execution into its own step

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -65,8 +65,9 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       # Check each crate independently to ensure its Cargo.toml is sufficient.
       - run: |
-          for d in $(for toml in $(find . -mindepth 2 -name Cargo.toml) ; do echo ${toml%/*} ; done | sort -r )
+          for toml in $(find . -mindepth 2 -name Cargo.toml | sort -r)
           do
+            d=$(dirname "$toml")
             echo "# $d"
             (cd $d ; cargo check --all-targets)
           done
@@ -79,4 +80,5 @@ jobs:
       image: docker://rust:1.56.0
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: cargo test --workspace --no-run
       - run: cargo test --workspace


### PR DESCRIPTION
In the proxy repo, we've split test execution into a distinct step that
follows building the tests (as suggested by [matklad's excellent blog
post][frb]). This allows us to separate the build phase from the text
execution phase (i.e., in the Actions UI).

This change also simplifies the `check` workflow for readability.

[frb]: https://matklad.github.io/2021/09/04/fast-rust-builds.html

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
