### PR TITLE
Fix some grafana links

### DIFF
--- a/grafana/dashboards/authority.json
+++ b/grafana/dashboards/authority.json
@@ -1256,6 +1256,6 @@
   },
   "timezone": "",
   "title": "Linkerd Authority",
-  "uid": "authority",
+  "uid": "linkerd-authority",
   "version": 1
 }

--- a/grafana/dashboards/cronjob.json
+++ b/grafana/dashboards/cronjob.json
@@ -2294,7 +2294,7 @@
     },
     "timezone": "",
     "title": "Linkerd CronJob",
-    "uid": "cronjob",
+    "uid": "linkerd-cronjob",
     "version": 1
   }
   

--- a/grafana/dashboards/daemonset.json
+++ b/grafana/dashboards/daemonset.json
@@ -2294,6 +2294,6 @@
   },
   "timezone": "",
   "title": "Linkerd DaemonSet",
-  "uid": "daemonset",
+  "uid": "linkerd-daemonset",
   "version": 1
 }

--- a/grafana/dashboards/deployment.json
+++ b/grafana/dashboards/deployment.json
@@ -2294,6 +2294,6 @@
   },
   "timezone": "",
   "title": "Linkerd Deployment",
-  "uid": "deployment",
+  "uid": "linkerd-deployment",
   "version": 1
 }

--- a/grafana/dashboards/job.json
+++ b/grafana/dashboards/job.json
@@ -2294,6 +2294,6 @@
   },
   "timezone": "",
   "title": "Linkerd Job",
-  "uid": "job",
+  "uid": "linkerd-job",
   "version": 1
 }

--- a/grafana/dashboards/replicaset.json
+++ b/grafana/dashboards/replicaset.json
@@ -2340,6 +2340,6 @@
     },
     "timezone": "",
     "title": "Linkerd ReplicaSet",
-    "uid": "replicaset",
+    "uid": "linkerd-replicaset",
     "version": 1
   }

--- a/grafana/dashboards/replicationcontroller.json
+++ b/grafana/dashboards/replicationcontroller.json
@@ -2294,6 +2294,6 @@
   },
   "timezone": "",
   "title": "Linkerd ReplicationController",
-  "uid": "replicationcontroller",
+  "uid": "linkerd-replicationcontroller",
   "version": 1
 }

--- a/grafana/dashboards/statefulset.json
+++ b/grafana/dashboards/statefulset.json
@@ -2294,6 +2294,6 @@
   },
   "timezone": "",
   "title": "Linkerd StatefulSet",
-  "uid": "statefulset",
+  "uid": "linkerd-statefulset",
   "version": 1
 }


### PR DESCRIPTION
As per how links to grafana charts are [built](https://github.com/linkerd/linkerd2/blob/b0a799eee7be2e9b5c46226f4b1d3a68f16dc745/web/app/js/components/GrafanaLink.jsx#L7), all the chart's UUIDs should be prefixed by `linkerd-`. So this fixes the broken links to charts for deployments, cronjobs, jobs, daemonsets, replicasets, replicationcontrollers and statefulsets.
