### PR TITLE
policy-controller: Use rustls on ARM

### DIFF
--- a/policy-controller/arm.dockerfile
+++ b/policy-controller/arm.dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && \
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
 WORKDIR /build
 COPY Cargo.toml Cargo.lock policy-controller/ /build/
+# XXX(ver) we can't easily cross-compile against openssl, so use rustls on arm.
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.56.0,source=/usr/local/cargo,target=/usr/local/cargo \
-    cargo build --locked --release --target=armv7-unknown-linux-gnueabihf --package=linkerd-policy-controller && \
+    cargo build --locked --release --target=armv7-unknown-linux-gnueabihf \
+        --package=linkerd-policy-controller --no-default-features --features="rustls" && \
     mv target/armv7-unknown-linux-gnueabihf/release/linkerd-policy-controller /tmp/
 
 FROM --platform=linux/arm $RUNTIME_IMAGE

--- a/policy-controller/arm64.dockerfile
+++ b/policy-controller/arm64.dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 WORKDIR /build
 COPY Cargo.toml Cargo.lock policy-controller/ /build/
+# XXX(ver) we can't easily cross-compile against openssl, so use rustls on arm.
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.56.0,source=/usr/local/cargo,target=/usr/local/cargo \
-    cargo build --locked --release --target=aarch64-unknown-linux-gnu --package=linkerd-policy-controller && \
+    cargo build --locked --release --target=aarch64-unknown-linux-gnu \
+        --package=linkerd-policy-controller --no-default-features --features="rustls" && \
     mv target/aarch64-unknown-linux-gnu/release/linkerd-policy-controller /tmp/
 
 FROM --platform=linux/arm64 $RUNTIME_IMAGE


### PR DESCRIPTION
We can't easily cross-compile the policy controller using openssl; so
this change modifies the docker images to forcefully enable the rustls
feature.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
