### PR TITLE
ci: Schedule dependabot updates to avoid contention

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,21 +9,21 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "3:00"
+      time: "03:00"
       timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
-      time: "3:30"
+      time: "03:30"
       timezone: "UTC"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-      time: "4:00"
+      time: "04:00"
       timezone: "UTC"
 
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,40 @@
+# Dependabot are scheduled to avoid contention with normal workday CI usage. We
+# start running updates at 3AM UTC (7PM PST, 8AM IST) and stagger each
+# subsequent update by 30m.
+#
+# JS updates are run weekly.
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "3:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
+      time: "3:30"
+      timezone: "UTC"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+      time: "4:00"
+      timezone: "UTC"
 
   - package-ecosystem: "npm"
     directory: "/web/app"
     schedule:
-      interval: "daily"
+      # JS dependencies tend to be pretty noisy, so only check once per week.
+      interval: "weekly"
+      day: "sunday"
     ignore:
       # v6 is backwards-incompatible and requires lots of changes.
       # A compatibility layer should come out at some point
       # see https://reactrouter.com/docs/en/v6/upgrading/v5
       - dependency-name: "react-router-dom"
         update-types: ["version-update:semver-major"]
-


### PR DESCRIPTION
Our dependabot CI can run at inconvenient times, like when we're trying
to do a release. Also, the JS depedendencies seem to update ~constantly,
which clogs up the review pipeline.

This change moves Go, Rust, and Actions dependency updates to run
off-hours for most of our dev team. It changes JS dependency updates to
run weekly.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
