### PR TITLE
actions: Only run releases on edge/stable tags

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript' ]
+        language:
+        - go
+        - javascript
 
     steps:
     - name: Checkout

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,10 +69,10 @@ jobs:
         - external-resources
         - helm-deep
         - helm-upgrade
+        - uninstall
         - multicluster
         - upgrade-edge
         - upgrade-stable
-        - uninstall
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -19,7 +19,18 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        component: [proxy, controller, policy-controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
+        component:
+        - cli-bin
+        - cni-plugin
+        - controller
+        - debug
+        - grafana
+        - jaeger-webhook
+        - metrics-api
+        - policy-controller
+        - proxy
+        - tap
+        - web
     name: Docker build (${{ matrix.component }})
     timeout-minutes: 30
     steps:
@@ -50,18 +61,18 @@ jobs:
       matrix:
         integration_test:
         - cluster-domain
+        - cni-calico-deep
         - deep
+        - default-policy-deny
         - external-issuer
         - external-prometheus-deep
         - external-resources
         - helm-deep
         - helm-upgrade
         - multicluster
-        - uninstall
         - upgrade-edge
         - upgrade-stable
-        - cni-calico-deep
-        - default-policy-deny
+        - uninstall
     needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
     runs-on: ubuntu-20.04

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,8 +69,8 @@ jobs:
         - external-resources
         - helm-deep
         - helm-upgrade
-        - uninstall
         - multicluster
+        - uninstall
         - upgrade-edge
         - upgrade-stable
     needs: [docker_build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,35 @@
 name: Release
+
 on:
   push:
     tags:
-    - "*"
+    - "edge-*"
+    - "stable-*"
+
 permissions:
   contents: read
+
 env:
   GH_ANNOTATION: true
   DOCKER_REGISTRY: ghcr.io/linkerd
+
 jobs:
 
   docker_build:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        component: [proxy, controller, metrics-api, web, cni-plugin, debug, cli-bin, grafana, jaeger-webhook, tap]
+        component:
+        - cli-bin
+        - cni-plugin
+        - controller
+        - debug
+        - grafana
+        - jaeger-webhook
+        - metrics-api
+        - proxy
+        - tap
+        - web
     name: Docker build (${{ matrix.component }})
     timeout-minutes: 30
     steps:
@@ -54,7 +69,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        arch: [amd64, arm64, arm]
+        arch:
+        - amd64
+        - arm
+        - arm64
     name: Policy controller build (${{ matrix.arch }})
     steps:
     - name: Set up Docker Buildx
@@ -139,17 +157,17 @@ jobs:
       matrix:
         integration_test:
         - cluster-domain
+        - cni-calico-deep
         - deep
+        - default-policy-deny
         - external-issuer
         - external-prometheus-deep
         - external-resources
         - helm-deep
         - helm-upgrade
-        - uninstall
         - upgrade-edge
         - upgrade-stable
-        - cni-calico-deep
-        - default-policy-deny
+        - uninstall
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,9 +165,9 @@ jobs:
         - external-resources
         - helm-deep
         - helm-upgrade
+        - uninstall
         - upgrade-edge
         - upgrade-stable
-        - uninstall
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60


### PR DESCRIPTION
If we for some reason push other tags to the repo, they shouldn't cause
a release.

This changes the actions triggers to only run on edge/stable tags.

This change also expands/sorts matrix fields for readability.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
