### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 set -eu
 
-lintversion=1.25.1
+lintversion=1.43.0
 
 cd "$(pwd -P)"
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -217,7 +217,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 func newCmdInstall() *cobra.Command {
 	values, err := l5dcharts.NewValues()
 	if err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 	var options valuespkg.Options

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -216,6 +216,10 @@ A full list of configurable values can be found at https://www.github.com/linker
 
 func newCmdInstall() *cobra.Command {
 	values, err := l5dcharts.NewValues()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 	var options valuespkg.Options
 
 	allStageFlags, allStageFlagSet := makeAllStageFlags(values)

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -55,7 +55,7 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 						extensionNames = append(extensionNames, fmt.Sprintf("* %s", v))
 					}
 
-					fmt.Fprintln(os.Stderr, fmt.Sprintf("Please uninstall the following extensions before uninstalling the control-plane:\n\t%s", strings.Join(extensionNames, "\n\t")))
+					fmt.Fprintf(os.Stderr, "Please uninstall the following extensions before uninstalling the control-plane:\n\t%s\n", strings.Join(extensionNames, "\n\t"))
 					fail = true
 				}
 
@@ -73,7 +73,7 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 				}
 
 				if len(injectedPods) > 0 {
-					fmt.Fprintln(os.Stderr, fmt.Sprintf("Please uninject the following pods before uninstalling the control-plane:\n\t%s", strings.Join(injectedPods, "\n\t")))
+					fmt.Fprintf(os.Stderr, "Please uninject the following pods before uninstalling the control-plane:\n\t%s\n", strings.Join(injectedPods, "\n\t"))
 					fail = true
 				}
 

--- a/test/integration/smimetrics/smi-metrics_test.go
+++ b/test/integration/smimetrics/smi-metrics_test.go
@@ -14,6 +14,7 @@ import (
 
 var TestHelper *testutil.TestHelper
 
+//nolint // The test that uses this is currently skipped.
 type testCase struct {
 	name string
 	kind string

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -437,7 +437,7 @@ func renderTapEventJSON(event *tapPb.TapEvent, _ string) string {
 	if err != nil {
 		return fmt.Sprintf("{\"error marshalling JSON\": \"%s\"}", err)
 	}
-	return fmt.Sprintf("%s", e)
+	return string(e[:])
 }
 
 // Map public API `TapEvent`s to `displayTapEvent`s

--- a/viz/metrics-api/http_server_test.go
+++ b/viz/metrics-api/http_server_test.go
@@ -106,7 +106,8 @@ func getServerVizClient(t *testing.T) (*mockGrpcServer, pb.ApiClient) {
 		}
 		err := http.Serve(listener, handler)
 		if err != nil {
-			t.Fatalf("Could not start server: %v", err)
+			t.Errorf("Could not start server: %v", err)
+			return
 		}
 	}()
 


### PR DESCRIPTION
This upgrades golangci-lint from `v1.25.1` to `v1.43.0` and fixes a few new lint errors.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
