### PR TITLE
Consider arch when building policy-controller

### DIFF
--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -4,6 +4,32 @@ set -eu
 
 export OS_ARCH_ALL="linux-amd64 linux-arm64 linux-arm darwin darwin-arm64 windows"
 
+architecture() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64)
+      arch=amd64
+      ;;
+    armv8*)
+      arch=arm64
+      ;;
+    aarch64*)
+      arch=arm64
+      ;;
+    armv*)
+      arch=arm
+      ;;
+    amd64|arm64)
+      arch=$arch
+      ;;
+    *)
+      echo "unsupported architecture: $arch" >&2
+      exit 1
+      ;;
+  esac
+  echo "$arch"
+}
+
 os() {
   os=$(uname -s)
   arch=""
@@ -16,28 +42,7 @@ os() {
       ;;
     Linux)
       os=linux
-      arch=$(uname -m)
-      case $arch in
-        x86_64)
-          arch=amd64
-          ;;
-        armv8*)
-          arch=arm64
-          ;;
-        aarch64*)
-          arch=arm64
-          ;;
-        armv*)
-          arch=arm
-          ;;
-        amd64|arm64)
-          arch=$arch
-          ;;
-        *)
-          echo "unsupported architecture: $arch" >&2
-          exit 1
-          ;;
-      esac
+      arch=architecture
       ;;
     *)
       echo "unsupported os: $os" >&2

--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -42,7 +42,7 @@ os() {
       ;;
     Linux)
       os=linux
-      arch=architecture
+      arch=$(architecture)
       ;;
     *)
       echo "unsupported os: $os" >&2

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 if [ $# -ne 0 ]; then
     echo "no arguments allowed for ${0##*/}, given: $*" >&2

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -20,4 +20,5 @@ if [ "$DOCKER_TARGET" = 'multi-arch' ]; then
 fi
 
 dir=$( cd "$bindir"/../policy-controller && pwd )
-docker_build policy-controller "${TAG:-$(head_root_tag)}" "$dir/amd64.dockerfile"
+arch=$(uname -m)
+docker_build policy-controller "${TAG:-$(head_root_tag)}" "$dir/$arch.dockerfile"

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 if [ $# -ne 0 ]; then
     echo "no arguments allowed for ${0##*/}, given: $*" >&2
@@ -13,6 +13,8 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 . "$bindir"/_docker.sh
 # shellcheck source=_tag.sh
 . "$bindir"/_tag.sh
+# shellcheck source=_os.sh
+. "$bindir"/_os.sh
 
 if [ "$DOCKER_TARGET" = 'multi-arch' ]; then
     echo "DOCKER_TARGET may not be set to 'multi-arch' with $0" >&2
@@ -20,5 +22,5 @@ if [ "$DOCKER_TARGET" = 'multi-arch' ]; then
 fi
 
 dir=$( cd "$bindir"/../policy-controller && pwd )
-arch=$(uname -m)
+arch=$(architecture)
 docker_build policy-controller "${TAG:-$(head_root_tag)}" "$dir/$arch.dockerfile"


### PR DESCRIPTION
When building the policy controller the `amd64.dockerfile` is hardcoded regardless of the arch being used to build the image.

This changes the Dockerfile to consider the arch (`uname -m`) when building the policy controller and use the correct file.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>