### PR TITLE
Add release notes for `edge-21.11.4`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,8 +22,6 @@ contributors for their continued support and involvement.
 * Deprecated `v1alpha1` version of the policy APIs
 * Removed newline from `linkerd check` header text (thanks @mikutas!)
 * Replaced deprecated `beta.kubernetes.io/os` label with `kubernetes.io/os`
-* Replaced the use of unstructured types for interacting with policy API in
-  `k8s` pkg with a typed client.
 
 ## edge-21.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,11 +5,9 @@
 This edge release introduces a change in the destination service to honor
 opaque ports set in the `proxyProtocol` field of `Server` resources. This
 change makes it possible to set opaque ports directly in `Server` resources
-without needing the opaque ports annotation on pods. Version `v1alpha1` of the
-policy API has been officially deprecated; `v1alpha1` variants of the resource
-will now emit warnings when used with `kubectl`. The release also features a
-number of fixes and improvements, a big thank you to our external contributors
-for their continued support and involvement.
+without needing the opaque ports annotation on pods. The release also features
+a number of fixes and improvements, a big thank you to our external
+contributors for their continued support and involvement.
 
 * Added support in the destination service for honoring opaque ports marked in
   `Server` resources; ports can now be marked as opaque directly in `Server`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changes
 
+## edge-21.11.4
+
+This edge release introduces a change in the destination service to honor
+opaque ports set in the `proxyProtocol` field of `Server` resources. This
+change makes it possible to set opaque ports directly in `Server` resources
+without needing the opaque ports annotation on pods. Version `v1alpha1` of the
+policy API has been officially deprecated; `v1alpha1` variants of the resource
+will now emit warnings when used with `kubectl`. The release also features a
+number of fixes and improvements, a big thank you to our external contributors
+for their continued support and involvement.
+
+* Added support in the destination service for honoring opaque ports marked in
+  `Server` resources; ports can now be marked as opaque directly in `Server`
+  resources through the `proxyProtocol` field.
+* Added support to override default behavior and run `proxyInit` as root
+  (thanks @alex-berger!)
+* Added multicluster `Link` CRD to code generation script; consumers of the
+  multicluster API can now use a typed API to interact with multicluster links
+  (thanks @zaharidichev!)
+* Added a multicluster integration test for exported headless services (thanks
+  @importhuman!)
+* Deprecated `v1alpha1` version of the policy APIs
+* Removed newline from `linkerd check` header text (thanks @mikutas!)
+* Replaced deprecated `beta.kubernetes.io/os` label with `kubernetes.io/os`
+* Replaced the use of unstructured types for interacting with policy API in
+  `k8s` pkg with a typed client.
+
 ## edge-21.11.3
 
 This edge releases fixes a compatibility issue that prevented the policy


### PR DESCRIPTION
This edge release introduces a change in the destination service to honor
opaque ports set in the `proxyProtocol` field of `Server` resources. This
change makes it possible to set opaque ports directly in `Server` resources
without needing the opaque ports annotation on pods. Version `v1alpha1` of the
policy API has been officially deprecated; `v1alpha1` variants of the resource
will now emit warnings when used with `kubectl`. The release also features a
number of fixes and improvements, a big thank you to our external contributors
for their continued support and involvement.

* Added support in the destination service for honoring opaque ports marked in
  `Server` resources; ports can now be marked as opaque directly in `Server`
  resources through the `proxyProtocol` field.
* Added support to override default behavior and run `proxyInit` as root
  (thanks @alex-berger!)
* Added multicluster `Link` CRD to code generation script; consumers of the
  multicluster API can now use a typed API to interact with multicluster links
  (thanks @zaharidichev!)
* Added a multicluster integration test for exported headless services (thanks
  @importhuman!)
* Deprecated `v1alpha1` version of the policy APIs
* Removed newline from `linkerd check` header text (thanks @mikutas!)
* Replaced deprecated `beta.kubernetes.io/os` label with `kubernetes.io/os`
* Replaced the use of unstructured types for interacting with policy API in
  `k8s` pkg with a typed client.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
