### PR TITLE
Remove old build constraints

### DIFF
--- a/jaeger/static/generate.go
+++ b/jaeger/static/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/jaeger/static/templates.go
+++ b/jaeger/static/templates.go
@@ -1,6 +1,5 @@
 //go:generate go run generate.go
 //go:build !prod
-// +build !prod
 
 package static
 

--- a/multicluster/static/generate.go
+++ b/multicluster/static/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/multicluster/static/templates.go
+++ b/multicluster/static/templates.go
@@ -1,6 +1,5 @@
 //go:generate go run generate.go
 //go:build !prod
-// +build !prod
 
 package static
 

--- a/pkg/charts/static/generate.go
+++ b/pkg/charts/static/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/charts/static/templates.go
+++ b/pkg/charts/static/templates.go
@@ -1,6 +1,5 @@
 //go:generate go run generate.go
 //go:build !prod
-// +build !prod
 
 package static
 

--- a/viz/static/generate.go
+++ b/viz/static/generate.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/viz/static/templates.go
+++ b/viz/static/templates.go
@@ -1,6 +1,5 @@
 //go:generate go run generate.go
 //go:build !prod
-// +build !prod
 
 package static
 


### PR DESCRIPTION
#7371 upgraded the Go version which included using the new formats for [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints). This removes the old ones that are no longer used.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>