### PR TITLE
Relax extension checks

### DIFF
--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -95,7 +95,7 @@ func jaegerCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
 	checkers = append(checkers,
 		*healthcheck.NewChecker("jaeger extension pods are running").
 			WithHintAnchor("l5d-jaeger-pods-running").
-			Fatal().
+			Warning().
 			WithRetryDeadline(hc.RetryDeadline).
 			SurfaceErrorOnRetry().
 			WithCheck(func(ctx context.Context) error {
@@ -117,7 +117,7 @@ func jaegerCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
 	checkers = append(checkers,
 		*healthcheck.NewChecker("jaeger extension proxies are healthy").
 			WithHintAnchor("l5d-jaeger-proxy-healthy").
-			Fatal().
+			Warning().
 			WithRetryDeadline(hc.RetryDeadline).
 			SurfaceErrorOnRetry().
 			WithCheck(func(ctx context.Context) error {

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -227,7 +227,7 @@ func multiclusterCategory(hc *healthChecker) *healthcheck.Category {
 	checkers = append(checkers,
 		*healthcheck.NewChecker("multicluster extension proxies are healthy").
 			WithHintAnchor("l5d-multicluster-proxy-healthy").
-			Fatal().
+			Warning().
 			WithRetryDeadline(hc.RetryDeadline).
 			SurfaceErrorOnRetry().
 			WithCheck(func(ctx context.Context) error {

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -90,11 +90,16 @@ func TestTracing(t *testing.T) {
 		}
 
 		tpl := template.Must(template.ParseFiles("testdata" + "/" + golden))
+		versionErr := healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{})
+		versionErrMsg := ""
+		if versionErr != nil {
+			versionErrMsg = versionErr.Error()
+		}
 		vars := struct {
 			ProxyVersionErr string
 			HintURL         string
 		}{
-			healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{}).Error(),
+			versionErrMsg,
 			healthcheck.HintBaseURL(TestHelper.GetVersion()),
 		}
 

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -168,7 +168,7 @@ func (hc *HealthChecker) VizCategory() *healthcheck.Category {
 			}),
 		*healthcheck.NewChecker("viz extension proxies are healthy").
 			WithHintAnchor("l5d-viz-proxy-healthy").
-			Fatal().
+			Warning().
 			WithCheck(func(ctx context.Context) (err error) {
 				return hc.CheckProxyHealth(ctx, hc.ControlPlaneNamespace, hc.vizNamespace)
 			}),


### PR DESCRIPTION
Fixes #7385

If an extension pod is not running, this does not necessarily mean that the extension is unable to function since there may be other replicas which are healthy.  We want to be conservative about only blocking CLI functionality when we are absolutely sure that it won't work.  Thus, we relax these checks to the warning level so that they don't block access to CLI functionality.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
