### PR TITLE
Add Web Summit to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -71,6 +71,7 @@
 - [Tradeshift](https://tradeshift.com/)
 - [Transit](https://transit.app)
 - [Vernacular.ai](https://vernacular.ai/)
+- [Web Summit](https://websummit.com)
 - [xCloud](https://www.xbox.com/en-US/xbox-game-streaming/project-xcloud)
 - [YouMail](https://www.youmail.com)
 - [Zimpler](https://www.zimpler.com/)


### PR DESCRIPTION
Web Summit is a proud adopter of Linkerd for all our Kubernetes clusters we use to run conferences. Also in use for the [Summit Engine](https://summitengine.com) platform that will run CES 2022 in January.

This was long due @wmorgan, thanks for inviting us to the list.

Signed-off-by: João Soares <jsoaresgeral@gmail.com>