### PR TITLE
CI: fix image load issue in k3d

### DIFF
--- a/bin/image-load
+++ b/bin/image-load
@@ -149,5 +149,5 @@ fi
 
 if [ -n "$k3d" ]; then
   printf 'Importing %s...\n' "${images[@]}"
-  "$bin" "${image_sub_cmd[@]}" "${images[@]}"
+  "$bin" "${image_sub_cmd[@]}" "${images[@]}" -m tools-node
 fi


### PR DESCRIPTION
This PR fixes the current CI failures!

`k3d` supports [multiple ways of importing images](https://k3d.io/v5.2.0/usage/importing_images/)
in the latest version of k3d. The default way however fails to import
multiple images from the same command. Hence, there is a need to
either
- load one by one using the `direct` mode
- load all at once using the `tools-node` mode.

I've went ahead with the `tools-node` mode, so that we chan
paralellize the image loads.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
