### PR TITLE
ci: remove dependency on viz for some deep tests

### DIFF
--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -22,70 +22,48 @@ func TestMain(m *testing.M) {
 
 func TestGoodEndpoints(t *testing.T) {
 	ctx := context.Background()
-	nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
-	if err != nil {
-		testutil.AnnotatedFatal(t, "unexpected error", err)
+	nginxNs := "linkerd-endpoints-test"
+	controlNs := TestHelper.GetLinkerdNamespace()
+	testDataPath := "testdata"
+	cmd := []string{
+		"diagnostics",
+		"endpoints",
+		fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", controlNs),
+		fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", controlNs),
+		fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", controlNs),
 	}
 
-	TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
-		controlNs := TestHelper.GetLinkerdNamespace()
-		nginxNs := ns
-		testDataPath := "testdata"
-
-		out, err := TestHelper.KubectlApply(nginx, ns)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
-		}
-
-		err = TestHelper.CheckPods(ctx, ns, "nginx", 1)
-		if err != nil {
-			if rce, ok := err.(*testutil.RestartCountError); ok {
-				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
-			} else {
-				testutil.AnnotatedError(t, "CheckPods timed-out", err)
-			}
-		}
-
-		cmd := []string{
-			"diagnostics",
-			"endpoints",
-			fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", controlNs),
-			fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", controlNs),
-			fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", controlNs),
-			fmt.Sprintf("nginx.%s.svc.cluster.local:8080", nginxNs),
-		}
-
-		if !TestHelper.ExternalPrometheus() {
-			cmd = append(cmd, fmt.Sprintf("prometheus.%s.svc.cluster.local:9090", nginxNs))
-		} else {
-			cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
-			testDataPath += "/external_prometheus"
-		}
-
+	if !TestHelper.ExternalPrometheus() {
+		cmd = append(cmd, fmt.Sprintf("nginx.%s.svc.cluster.local:8080", nginxNs))
 		cmd = append(cmd, "-ojson")
-		out, err = TestHelper.LinkerdRun(cmd...)
-		if err != nil {
-			testutil.AnnotatedFatal(t, "unexpected error", err)
-		}
+		TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
+			nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
+			if err != nil {
+				testutil.AnnotatedFatal(t, "unexpected error", err)
+			}
 
-		tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
-		vars := struct {
-			Ns      string
-			NginxNs string
-		}{
-			controlNs,
-			nginxNs,
-		}
-		var b bytes.Buffer
-		if err := tpl.Execute(&b, vars); err != nil {
-			testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
-		}
+			out, err := TestHelper.KubectlApply(nginx, ns)
+			if err != nil {
+				testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
+			}
 
-		r := regexp.MustCompile(b.String())
-		if !r.MatchString(out) {
-			testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
-		}
-	})
+			err = TestHelper.CheckPods(ctx, ns, "nginx", 1)
+			if err != nil {
+				if rce, ok := err.(*testutil.RestartCountError); ok {
+					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+				} else {
+					testutil.AnnotatedError(t, "CheckPods timed-out", err)
+				}
+			}
+
+		})
+	} else {
+		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
+		cmd = append(cmd, "-ojson")
+		testDataPath += "/external_prometheus"
+		checkEndpoints(t, cmd, testDataPath, controlNs, "external-prometheus")
+	}
+
 }
 
 // TODO: when #3004 gets fixed, add a negative test for mismatched ports
@@ -100,5 +78,30 @@ func TestBadEndpoints(t *testing.T) {
 	}
 	if stderrOut[0] != "Destination API error: Invalid authority: foo" {
 		testutil.AnnotatedErrorf(t, "unexpected error string", "unexpected error string: %s", stderrOut[0])
+	}
+}
+
+func checkEndpoints(t *testing.T, cmd []string, testDataPath, controlNs, endpointNs string) {
+	out, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		testutil.AnnotatedFatal(t, "unexpected error", err)
+	}
+
+	tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
+	vars := struct {
+		Ns         string
+		EndpointNs string
+	}{
+		controlNs,
+		endpointNs,
+	}
+	var b bytes.Buffer
+	if err := tpl.Execute(&b, vars); err != nil {
+		testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
+	}
+
+	r := regexp.MustCompile(b.String())
+	if !r.MatchString(out) {
+		testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
 	}
 }

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -2,14 +2,14 @@ package endpoints
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"github.com/linkerd/linkerd2/testutil"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"text/template"
-
-	"github.com/linkerd/linkerd2/testutil"
 )
 
 var TestHelper *testutil.TestHelper
@@ -20,50 +20,71 @@ func TestMain(m *testing.M) {
 }
 
 func TestGoodEndpoints(t *testing.T) {
-	ns := TestHelper.GetLinkerdNamespace()
-	vizNs := TestHelper.GetVizNamespace()
-	testDataPath := "testdata"
-	cmd := []string{
-		"diagnostics",
-		"endpoints",
-		fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", ns),
-		fmt.Sprintf("grafana.%s.svc.cluster.local:3000", vizNs),
-		fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", ns),
-		fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", ns),
-		fmt.Sprintf("tap.%s.svc.cluster.local:8088", vizNs),
-		fmt.Sprintf("web.%s.svc.cluster.local:8084", vizNs),
-	}
-
-	if !TestHelper.ExternalPrometheus() {
-		cmd = append(cmd, fmt.Sprintf("prometheus.%s.svc.cluster.local:9090", vizNs))
-	} else {
-		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
-		testDataPath += "/external_prometheus"
-	}
-
-	cmd = append(cmd, "-ojson")
-	out, err := TestHelper.LinkerdRun(cmd...)
+	ctx := context.Background()
+	nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
 	if err != nil {
 		testutil.AnnotatedFatal(t, "unexpected error", err)
 	}
 
-	tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
-	vars := struct {
-		Ns    string
-		VizNs string
-	}{
-		ns,
-		vizNs,
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, vars); err != nil {
-		testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
-	}
+	TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
+		controlNs := TestHelper.GetLinkerdNamespace()
+		nginxNs := ns
+		testDataPath := "testdata"
 
-	r := regexp.MustCompile(b.String())
-	if !r.MatchString(out) {
-		testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
-	}
+		out, err := TestHelper.KubectlApply(nginx, ns)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
+		}
+
+		err = TestHelper.CheckPods(ctx, ns, "nginx", 1)
+		if err != nil {
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
+		}
+
+		cmd := []string{
+			"diagnostics",
+			"endpoints",
+			fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", controlNs),
+			fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", controlNs),
+			fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", controlNs),
+			fmt.Sprintf("nginx.%s.svc.cluster.local:8080", nginxNs),
+		}
+
+		if !TestHelper.ExternalPrometheus() {
+			cmd = append(cmd, fmt.Sprintf("prometheus.%s.svc.cluster.local:9090", nginxNs))
+		} else {
+			cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
+			testDataPath += "/external_prometheus"
+		}
+
+		cmd = append(cmd, "-ojson")
+		out, err = TestHelper.LinkerdRun(cmd...)
+		if err != nil {
+			testutil.AnnotatedFatal(t, "unexpected error", err)
+		}
+
+		tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
+		vars := struct {
+			Ns      string
+			NginxNs string
+		}{
+			controlNs,
+			nginxNs,
+		}
+		var b bytes.Buffer
+		if err := tpl.Execute(&b, vars); err != nil {
+			testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
+		}
+
+		r := regexp.MustCompile(b.String())
+		if !r.MatchString(out) {
+			testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
+		}
+	})
 }
 
 // TODO: when #3004 gets fixed, add a negative test for mismatched ports

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -35,7 +35,6 @@ func TestGoodEndpoints(t *testing.T) {
 
 	if !TestHelper.ExternalPrometheus() {
 		cmd = append(cmd, fmt.Sprintf("nginx.%s.svc.cluster.local:8080", nginxNs))
-		cmd = append(cmd, "-ojson")
 		TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
 			nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
 			if err != nil {
@@ -56,10 +55,11 @@ func TestGoodEndpoints(t *testing.T) {
 				}
 			}
 
+            checkEndpoints(t, cmd, testDataPath, controlNs, ns)
+
 		})
 	} else {
 		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
-		cmd = append(cmd, "-ojson")
 		testDataPath += "/external_prometheus"
 		checkEndpoints(t, cmd, testDataPath, controlNs, "external-prometheus")
 	}
@@ -82,6 +82,7 @@ func TestBadEndpoints(t *testing.T) {
 }
 
 func checkEndpoints(t *testing.T, cmd []string, testDataPath, controlNs, endpointNs string) {
+	cmd = append(cmd, "-ojson")
 	out, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		testutil.AnnotatedFatal(t, "unexpected error", err)

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/linkerd/linkerd2/testutil"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/linkerd/linkerd2/testutil"
 )
 
 var TestHelper *testutil.TestHelper

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -30,38 +30,48 @@ func TestGoodEndpoints(t *testing.T) {
 		fmt.Sprintf("linkerd-dst.%s.svc.cluster.local:8086", controlNs),
 		fmt.Sprintf("linkerd-identity.%s.svc.cluster.local:8080", controlNs),
 		fmt.Sprintf("linkerd-proxy-injector.%s.svc.cluster.local:443", controlNs),
+		fmt.Sprintf("nginx.%s.svc.cluster.local:8080", "linkerd-endpoints-test"),
+		"-ojson",
 	}
 
-	if !TestHelper.ExternalPrometheus() {
-		cmd = append(cmd, fmt.Sprintf("nginx.%s.svc.cluster.local:8080", "linkerd-endpoints-test"))
-		TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
-			nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
-			if err != nil {
-				testutil.AnnotatedFatal(t, "unexpected error", err)
+	TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
+		out, err := TestHelper.Kubectl("", "apply", "-f", fmt.Sprintf("%s/%s", testDataPath, "nginx.yaml"), "-n", ns)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
+		}
+
+		err = TestHelper.CheckPods(ctx, ns, "nginx", 1)
+		if err != nil {
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
 			}
+		}
 
-			out, err := TestHelper.KubectlApply(nginx, ns)
-			if err != nil {
-				testutil.AnnotatedFatalf(t, "unexpected error", "unexpected error: %v output:\n%s", err, out)
-			}
+		out, err = TestHelper.LinkerdRun(cmd...)
+		if err != nil {
+			testutil.AnnotatedFatal(t, "unexpected error", err)
+		}
 
-			err = TestHelper.CheckPods(ctx, ns, "nginx", 1)
-			if err != nil {
-				if rce, ok := err.(*testutil.RestartCountError); ok {
-					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
-				} else {
-					testutil.AnnotatedError(t, "CheckPods timed-out", err)
-				}
-			}
+		tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
+		vars := struct {
+			Ns         string
+			EndpointNs string
+		}{
+			controlNs,
+			ns,
+		}
+		var b bytes.Buffer
+		if err := tpl.Execute(&b, vars); err != nil {
+			testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
+		}
 
-			checkEndpoints(t, cmd, testDataPath, controlNs, ns)
-		})
-	} else {
-		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")
-		testDataPath += "/external_prometheus"
-		checkEndpoints(t, cmd, testDataPath, controlNs, "external-prometheus")
-	}
-
+		r := regexp.MustCompile(b.String())
+		if !r.MatchString(out) {
+			testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
+		}
+	})
 }
 
 // TODO: when #3004 gets fixed, add a negative test for mismatched ports
@@ -76,31 +86,5 @@ func TestBadEndpoints(t *testing.T) {
 	}
 	if stderrOut[0] != "Destination API error: Invalid authority: foo" {
 		testutil.AnnotatedErrorf(t, "unexpected error string", "unexpected error string: %s", stderrOut[0])
-	}
-}
-
-func checkEndpoints(t *testing.T, cmd []string, testDataPath, controlNs, endpointNs string) {
-	cmd = append(cmd, "-ojson")
-	out, err := TestHelper.LinkerdRun(cmd...)
-	if err != nil {
-		testutil.AnnotatedFatal(t, "unexpected error", err)
-	}
-
-	tpl := template.Must(template.ParseFiles(testDataPath + "/linkerd_endpoints.golden"))
-	vars := struct {
-		Ns         string
-		EndpointNs string
-	}{
-		controlNs,
-		endpointNs,
-	}
-	var b bytes.Buffer
-	if err := tpl.Execute(&b, vars); err != nil {
-		testutil.AnnotatedFatalf(t, "failed to parse linkerd_endpoints.golden template", "failed to parse linkerd_endpoints.golden template: %s", err)
-	}
-
-	r := regexp.MustCompile(b.String())
-	if !r.MatchString(out) {
-		testutil.AnnotatedErrorf(t, "unexpected output", "expected output:\n%s\nactual:\n%s", b.String(), out)
 	}
 }

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -22,7 +22,6 @@ func TestMain(m *testing.M) {
 
 func TestGoodEndpoints(t *testing.T) {
 	ctx := context.Background()
-	nginxNs := "linkerd-endpoints-test"
 	controlNs := TestHelper.GetLinkerdNamespace()
 	testDataPath := "testdata"
 	cmd := []string{
@@ -34,7 +33,7 @@ func TestGoodEndpoints(t *testing.T) {
 	}
 
 	if !TestHelper.ExternalPrometheus() {
-		cmd = append(cmd, fmt.Sprintf("nginx.%s.svc.cluster.local:8080", nginxNs))
+		cmd = append(cmd, fmt.Sprintf("nginx.%s.svc.cluster.local:8080", "linkerd-endpoints-test"))
 		TestHelper.WithDataPlaneNamespace(ctx, "endpoints-test", map[string]string{}, t, func(t *testing.T, ns string) {
 			nginx, err := TestHelper.LinkerdRun("inject", "testdata/nginx.yaml")
 			if err != nil {
@@ -55,8 +54,7 @@ func TestGoodEndpoints(t *testing.T) {
 				}
 			}
 
-            checkEndpoints(t, cmd, testDataPath, controlNs, ns)
-
+			checkEndpoints(t, cmd, testDataPath, controlNs, ns)
 		})
 	} else {
 		cmd = append(cmd, "prometheus.external-prometheus.svc.cluster.local:9090")

--- a/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/external_prometheus/linkerd_endpoints.golden
@@ -26,26 +26,5 @@
     "port": 8443,
     "pod": "linkerd\-proxy\-injector-[a-f0-9]+\-[a-z0-9]+",
     "service": "linkerd\-proxy\-injector\.{{.Ns}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 3000,
-    "pod": "grafana\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "grafana\.{{.VizNs}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 8088,
-    "pod": "tap\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "tap\.{{.VizNs}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 8084,
-    "pod": "web\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "web\.{{.VizNs}}"
   \}
 \]

--- a/test/integration/endpoints/testdata/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/linkerd_endpoints.golden
@@ -21,10 +21,10 @@
     "service": "linkerd\-proxy\-injector\.{{.Ns}}"
   \},
   \{
-    "namespace": "{{.NginxNs}}",
+    "namespace": "{{.EndpointNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
     "port": 8080,
     "pod": "nginx\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "nginx\.{{.NginxNs}}"
+    "service": "nginx\.{{.EndpointNs}}"
   \}
 \]

--- a/test/integration/endpoints/testdata/linkerd_endpoints.golden
+++ b/test/integration/endpoints/testdata/linkerd_endpoints.golden
@@ -21,31 +21,10 @@
     "service": "linkerd\-proxy\-injector\.{{.Ns}}"
   \},
   \{
-    "namespace": "{{.VizNs}}",
+    "namespace": "{{.NginxNs}}",
     "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 3000,
-    "pod": "grafana\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "grafana\.{{.VizNs}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 9090,
-    "pod": "prometheus-[a-f0-9]+\-[a-z0-9]+",
-    "service": "prometheus\.{{.VizNs}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 8088,
-    "pod": "tap\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "tap\.{{.VizNs}}"
-  \},
-  \{
-    "namespace": "{{.VizNs}}",
-    "ip": "\d+\.\d+\.\d+\.\d+",
-    "port": 8084,
-    "pod": "web\-[a-f0-9]+\-[a-z0-9]+",
-    "service": "web\.{{.VizNs}}"
+    "port": 8080,
+    "pod": "nginx\-[a-f0-9]+\-[a-z0-9]+",
+    "service": "nginx\.{{.NginxNs}}"
   \}
 \]

--- a/test/integration/endpoints/testdata/nginx.yaml
+++ b/test/integration/endpoints/testdata/nginx.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: service
+    port: 8080
+  selector:
+    app: nginx 

--- a/test/integration/endpoints/testdata/nginx.yaml
+++ b/test/integration/endpoints/testdata/nginx.yaml
@@ -11,6 +11,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
       labels:
         app: nginx
     spec:

--- a/test/integration/localhost/localhost_test.go
+++ b/test/integration/localhost/localhost_test.go
@@ -11,14 +11,6 @@ import (
 	"github.com/linkerd/linkerd2/testutil"
 )
 
-type jsonStats struct {
-	Namespace          string   `json:"namespace"`
-	Name               string   `json:"name"`
-	Success            *float64 `json:"success"`
-	Rps                *float64 `json:"rps"`
-	TCPOpenConnections *int     `json:"tcp_open_connections"`
-}
-
 var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Closes #7402 

Currently, we're trying to lower the time it takes for tests to run. As part of this effort, it would be great to remove the dependency our `deep` suite has on viz. Some tests can be moved out (particularly those that test viz functionality), while others can be changed to use `linkerd diagnostics` instead of viz counterparts to assert correct behavior w.r.t to connectivity.

Two viz dependent tests in our deep suite are `localhost_test` and `endpoints_test`. The former uses viz to get some metrics while the latter asserts endpoints exist for viz components.

For `localhost` through this change we would use regex and `linkerd diagnostics` to check the metrics. `endpoints_test` had its viz endpoints replaced with `nginx`.

Quick note for reviewers; for `endpoints_test` this change adds a bit of overhead, the assumption before in the test was that viz is already installed and running. Now, however, we have to install nginx and that adds a few seconds. I'd be in favour of removing nginx and only asserting that our control plane endpoints exist. For consistency, I wanted to check more than one namespace so I made the change, but I'm open to taking nginx out of the equation here.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
