### PR TITLE
feat(cli): add default-inbound-policy to inject flags

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -486,6 +486,10 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 		}
 	}
 
+	if proxy.DefaultInboundPolicy != baseProxy.DefaultInboundPolicy {
+		overrideAnnotations[k8s.ProxyDefaultInboundPolicyAnnotation] = proxy.DefaultInboundPolicy
+	}
+
 	// Set fields that can't be converted into annotations
 	values.Namespace = controlPlaneNamespace
 

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -310,6 +310,28 @@ func TestUninjectAndInject(t *testing.T) {
 			injectProxy:      true,
 			testInjectConfig: ingressConfig,
 		},
+		{
+			inputFileName:  "inject_emojivoto_deployment.input.yml",
+			goldenFileName: "inject_emojivoto_deployment_default_inbound_policy.golden.yml",
+			reportFileName: "inject_emojivoto_deployment_default_inbound_policy.golden.report",
+			injectProxy:    false,
+			testInjectConfig: func() *linkerd2.Values {
+				values := defaultConfig()
+				values.Proxy.DefaultInboundPolicy = k8s.AllAuthenticated
+				return values
+			}(),
+		},
+		{
+			inputFileName:  "inject_emojivoto_pod.input.yml",
+			goldenFileName: "inject_emojivoto_pod_default_inbound_policy.golden.yml",
+			reportFileName: "inject_emojivoto_pod_default_inbound_policy.golden.report",
+			injectProxy:    false,
+			testInjectConfig: func() *linkerd2.Values {
+				values := defaultConfig()
+				values.Proxy.DefaultInboundPolicy = k8s.AllAuthenticated
+				return values
+			}(),
+		},
 	}
 
 	for i, tc := range testCases {

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -397,6 +397,12 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 
+		flag.NewStringFlag(proxyFlags, "default-inbound-policy", defaults.Proxy.DefaultInboundPolicy, "Inbound policy to use to control inbound access to the proxy",
+			func(values *l5dcharts.Values, value string) error {
+				values.Proxy.DefaultInboundPolicy = value
+				return nil
+			}),
+
 		// Deprecated flags
 
 		flag.NewStringFlag(proxyFlags, "proxy-memory", defaults.Proxy.Resources.Memory.Request, "Amount of Memory that the proxy sidecar requests",

--- a/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report
@@ -1,0 +1,3 @@
+
+deployment "web" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report.verbose
@@ -1,0 +1,10 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+√ at least one resource can be injected or annotated
+√ pod specs do not include UDP ports
+√ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
+
+deployment "web" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: emojivoto
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      annotations:
+        config.linkerd.io/default-inbound-policy: all-authenticated
+        linkerd.io/inject: enabled
+      labels:
+        app: web-svc
+    spec:
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "80"
+        - name: EMOJISVC_HOST
+          value: emoji-svc.emojivoto:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc.emojivoto:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: buoyantio/emojivoto-web:v10
+        name: web-svc
+        ports:
+        - containerPort: 80
+          name: http
+---

--- a/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report
@@ -1,0 +1,3 @@
+
+pod "vote-bot" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report.verbose
@@ -1,0 +1,10 @@
+
+√ pods do not use host networking
+√ pods do not have a 3rd party proxy or initContainer already injected
+√ pods are not annotated to disable injection
+√ at least one resource can be injected or annotated
+√ pod specs do not include UDP ports
+√ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
+
+pod "vote-bot" injected
+

--- a/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    config.linkerd.io/default-inbound-policy: all-authenticated
+    linkerd.io/inject: enabled
+  labels:
+    app: vote-bot
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v10
+    name: vote-bot
+---


### PR DESCRIPTION
PR #6750 adds the config.linkerd.io/default-inbound-policy annotation for setting the default inbound policy for an injected proxy.

This commit adds support for a default-inbound-policy flag in makeProxyFlags so that it can be set with the linkerd inject command.

Closes #6754

Signed-off-by: ahmedalhulaibi <ahmed.alhulaibi41@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
