### PR TITLE
Skip Evicted pods in Pods running check and add test

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2789,15 +2789,12 @@ func CheckPodsRunning(pods []corev1.Pod, podsNotFoundMsg string) error {
 		return fmt.Errorf(podsNotFoundMsg)
 	}
 	for _, pod := range pods {
-		if pod.Status.Phase != corev1.PodRunning {
+		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != "Evicted" {
 			return fmt.Errorf("%s status is %s", pod.Name, pod.Status.Phase)
 		}
 
-		// check for container readiness
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if !containerStatus.Ready {
-				return fmt.Errorf("container %s in pod %s is not ready ", pod.Name, containerStatus.Name)
-			}
+		if !k8s.GetProxyReady(pod) {
+			return fmt.Errorf("container %s in pod %s is not ready", k8s.ProxyContainerName, pod.Name)
 		}
 	}
 	return nil

--- a/viz/pkg/healthcheck/healthcheck_test.go
+++ b/viz/pkg/healthcheck/healthcheck_test.go
@@ -1,0 +1,33 @@
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHealthChecker(t *testing.T) {
+	t.Run("Does not return an error if the pod is Evicted", func(t *testing.T) {
+		pods := []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-1"},
+				Status: v1.PodStatus{
+					Phase: "Evicted",
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  k8s.ProxyContainerName,
+							Ready: true,
+						},
+					},
+				},
+			},
+		}
+		err := healthcheck.CheckPodsRunning(pods, "")
+		if err != nil {
+			t.Fatalf("Expected success, got %s", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #7326.

Both `linkerd viz check` and `linkerd jaeger check` use `healthcheck.CheckPodsRunning` to check that status of their deployments Pods. If one of those Pods is Evicted, this can result in an error and therefore retries until a timeout.

Similar to [healtcheck.validateDataPlanePods](https://github.com/linkerd/linkerd2/blob/4612adacac1e9510a6d41592248f21933dbb0106/pkg/healthcheck/healthcheck.go#L2722-L2723), this skips pods that are Evicted.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
