### PR TITLE
Fix recommended value formatting for '--set clusterNetworks'

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1880,7 +1880,9 @@ func (hc *HealthChecker) checkClusterNetworks(ctx context.Context) error {
 		return &SkipError{Reason: podCIDRUnavailableSkipReason}
 	}
 	if len(badPodCIDRS) > 0 {
-		return fmt.Errorf("node has podCIDR(s) %v which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=%s", badPodCIDRS, strings.Join(badPodCIDRS, ","))
+		sort.Strings(badPodCIDRS)
+		return fmt.Errorf("node has podCIDR(s) %v which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=\"%s\"",
+			badPodCIDRS, strings.Join(badPodCIDRS, "\\,"))
 	}
 	return nil
 }

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1164,6 +1164,14 @@ spec:
   podCIDR: 90.10.90.24/24
 `,
 				`
+apiVersion: v1
+kind: Node
+metadata:
+  name: linkerd-test-ns-identity2
+spec:
+  podCIDR: 242.3.64.0/25
+`,
+				`
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -1177,7 +1185,7 @@ data:
 `,
 			},
 			expected: []string{
-				"linkerd-existence cluster networks contains all node podCIDRs: node has podCIDR(s) [90.10.90.24/24] which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=90.10.90.24/24",
+				"linkerd-existence cluster networks contains all node podCIDRs: node has podCIDR(s) [242.3.64.0/25 90.10.90.24/24] which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=\"242.3.64.0/25\\,90.10.90.24/24\"",
 			},
 		},
 		{


### PR DESCRIPTION
The solution `linkerd check` suggests for setting a correct
`clusterNetworks` value does not work when there are more than
one podCIDR. Here's an example recommendation by that command:

```
× cluster networks contains all node podCIDRs
    node has podCIDR(s) [242.3.68.0/25 242.3.68.128/25 242.3.66.0/25 242.3.67.128/25 242.3.69.0/25 242.3.66.128/25 242.3.64.128/25 242.3.65.128/25 242.3.67.0/25 242.3.65.0/25 242.3.64.0/25] which are not contained in the Linkerd clusterNetworks.
	Try installing linkerd via --set clusterNetworks=242.3.68.0/25,242.3.68.128/25,242.3.66.0/25,242.3.67.128/25,242.3.69.0/25,242.3.66.128/25,242.3.64.128/25,242.3.65.128/25,242.3.67.0/25,242.3.65.0/25,242.3.64.0/25
    see https://linkerd.io/2.11/checks/#l5d-cluster-networks-cidr for hints
```

If you follow that suggestion and run

```
linkerd install --set clusterNetworks=242.3.68.0/25,242.3.68.128/25,242.3.66.0/25,242.3.67.128/25,242.3.69.0/25,242.3.66.128/25,242.3.64.128/25,242.3.65.128/25,242.3.67.0/25,242.3.65.0/25,242.3.64.0/25
```

you will get the following error:

```
Error: failed parsing --set data: key "128/25" has no value (cannot end with ,)
```

Once merged, this change will make sure the list of recommended podCIDRS
are separated with escaped comma (i.e `\,`) and enclosed with `"`.

Signed-off-by: Elvin Efendi <elvin.efendiyev@gmail.com>