### PR TITLE
Support non-pod endpoints in GetProfile responses

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -315,9 +315,22 @@ func toAddr(address watcher.Address) (*net.TcpAddress, error) {
 }
 
 func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}, enableH2Upgrade bool, identityTrustDomain string, controllerNS string, log *logging.Entry) (*pb.WeightedAddr, error) {
-	// When converting an address to a weighted addr, it should be backed by a Pod.
+
+	tcpAddr, err := toAddr(address)
+	if err != nil {
+		return nil, err
+	}
+
+	weightedAddr := pb.WeightedAddr{
+		Addr:         tcpAddr,
+		Weight:       defaultWeight,
+		MetricLabels: map[string]string{},
+	}
+
+	// If the address is not backed by a pod, there is no additional metadata
+	// to add.
 	if address.Pod == nil {
-		return nil, fmt.Errorf("endpoint not backed by Pod: %s:%d", address.IP, address.Port)
+		return &weightedAddr, nil
 	}
 
 	skippedInboundPorts, err := getPodSkippedInboundPortsAnnotations(address.Pod)
@@ -327,16 +340,16 @@ func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}
 
 	controllerNSLabel := address.Pod.Labels[k8s.ControllerNSLabel]
 	sa, ns := k8s.GetServiceAccountAndNS(address.Pod)
-	labels := k8s.GetPodLabels(address.OwnerKind, address.OwnerName, address.Pod)
+	weightedAddr.MetricLabels = k8s.GetPodLabels(address.OwnerKind, address.OwnerName, address.Pod)
 	_, isSkippedInboundPort := skippedInboundPorts[address.Port]
 
 	// If the pod is controlled by any Linkerd control plane, then it can be
 	// hinted that this destination knows H2 (and handles our orig-proto
 	// translation)
-	hint := &pb.ProtocolHint{}
+	weightedAddr.ProtocolHint = &pb.ProtocolHint{}
 	if controllerNSLabel != "" && !isSkippedInboundPort {
 		if enableH2Upgrade {
-			hint.Protocol = &pb.ProtocolHint_H2_{
+			weightedAddr.ProtocolHint.Protocol = &pb.ProtocolHint_H2_{
 				H2: &pb.ProtocolHint_H2{},
 			}
 		}
@@ -349,7 +362,7 @@ func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}
 			if err != nil {
 				log.Error(err)
 			} else {
-				hint.OpaqueTransport = &pb.ProtocolHint_OpaqueTransport{
+				weightedAddr.ProtocolHint.OpaqueTransport = &pb.ProtocolHint_OpaqueTransport{
 					InboundPort: port,
 				}
 			}
@@ -361,14 +374,13 @@ func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}
 	//
 	// TODO this should be relaxed to match a trust domain annotation so that
 	// multiple meshes can participate in identity if they share trust roots.
-	var identity *pb.TlsIdentity
 	if identityTrustDomain != "" &&
 		controllerNSLabel == controllerNS &&
 		address.Pod.Annotations[k8s.IdentityModeAnnotation] == k8s.IdentityModeDefault &&
 		!isSkippedInboundPort {
 
 		id := fmt.Sprintf("%s.%s.serviceaccount.identity.%s.%s", sa, ns, controllerNSLabel, identityTrustDomain)
-		identity = &pb.TlsIdentity{
+		weightedAddr.TlsIdentity = &pb.TlsIdentity{
 			Strategy: &pb.TlsIdentity_DnsLikeIdentity_{
 				DnsLikeIdentity: &pb.TlsIdentity_DnsLikeIdentity{
 					Name: id,
@@ -377,18 +389,7 @@ func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}
 		}
 	}
 
-	tcpAddr, err := toAddr(address)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pb.WeightedAddr{
-		Addr:         tcpAddr,
-		Weight:       defaultWeight,
-		MetricLabels: labels,
-		TlsIdentity:  identity,
-		ProtocolHint: hint,
-	}, nil
+	return &weightedAddr, nil
 }
 
 func getNodeTopologyZone(nodes coreinformers.NodeInformer, srcNode string) (string, error) {

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -259,11 +259,11 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 		// name. When we fetch the profile using a pod's DNS name, we want to
 		// return an endpoint in the profile response.
 		if hostname != "" {
-			address, pod, err := s.getEndpointByHostname(s.k8sAPI, hostname, service, port)
+			address, err := s.getEndpointByHostname(s.k8sAPI, hostname, service, port)
 			if err != nil {
 				return fmt.Errorf("failed to get pod for hostname %s: %v", hostname, err)
 			}
-			opaquePorts, err := getAnnotatedOpaquePorts(pod, s.defaultOpaquePorts)
+			opaquePorts, err := getAnnotatedOpaquePorts(address.Pod, s.defaultOpaquePorts)
 			if err != nil {
 				return fmt.Errorf("failed to get opaque ports for pod: %s", err)
 			}
@@ -272,19 +272,19 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 			if err != nil {
 				return fmt.Errorf("failed to create endpoint: %s", err)
 			}
-			translator := newEndpointProfileTranslator(pod, port, endpoint, stream, s.log)
+			translator := newEndpointProfileTranslator(address.Pod, port, endpoint, stream, s.log)
 
 			// If the endpoint's port is annotated as opaque, we don't need to
 			// subscribe for updates because it will always be opaque
 			// regardless of any Servers that may select it.
 			if _, ok := opaquePorts[port]; ok {
 				translator.UpdateProtocol(true)
-			} else if pod == nil {
+			} else if address.Pod == nil {
 				translator.UpdateProtocol(false)
 			} else {
 				translator.UpdateProtocol(address.OpaqueProtocol)
-				s.servers.Subscribe(pod, port, translator)
-				defer s.servers.Unsubscribe(pod, port, translator)
+				s.servers.Subscribe(address.Pod, port, translator)
+				defer s.servers.Unsubscribe(address.Pod, port, translator)
 			}
 			select {
 			case <-s.shutdown:
@@ -427,10 +427,10 @@ func getSvcID(k8sAPI *k8s.API, clusterIP string, log *logging.Entry) (*watcher.S
 // instanceID). The hostname is generally the prefix of the pod's DNS name;
 // since it may be arbitrary we need to look at the corresponding service's
 // Endpoints object to see whether the hostname matches a pod.
-func (s *server) getEndpointByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID, port uint32) (*watcher.Address, *corev1.Pod, error) {
+func (s *server) getEndpointByHostname(k8sAPI *k8s.API, hostname string, svcID watcher.ServiceID, port uint32) (*watcher.Address, error) {
 	ep, err := k8sAPI.Endpoint().Lister().Endpoints(svcID.Namespace).Get(svcID.Name)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	for _, subset := range ep.Subsets {
@@ -442,24 +442,24 @@ func (s *server) getEndpointByHostname(k8sAPI *k8s.API, hostname string, svcID w
 					podNamespace := addr.TargetRef.Namespace
 					pod, err := k8sAPI.Pod().Lister().Pods(podNamespace).Get(podName)
 					if err != nil {
-						return nil, nil, err
+						return nil, err
 					}
 					address, err := s.createAddress(pod, port)
 					if err != nil {
-						return nil, nil, err
+						return nil, err
 					}
-					return &address, pod, nil
+					return &address, nil
 				}
 				return &watcher.Address{
 					IP:   addr.IP,
 					Port: port,
-				}, nil, nil
+				}, nil
 
 			}
 		}
 	}
 
-	return nil, nil, fmt.Errorf("no pod found in Endpoints %s/%s for hostname %s", svcID.Namespace, svcID.Name, hostname)
+	return nil, fmt.Errorf("no pod found in Endpoints %s/%s for hostname %s", svcID.Namespace, svcID.Name, hostname)
 }
 
 // getPodByIP returns a pod that maps to the given IP address. The pod can either


### PR DESCRIPTION
Fixes #6337

GetProfile can be called with a FQDN for a specific member of a service e.g.

```
web-0.foo.ns.svc.cluster.local
```

If that endpoint is not backed by a pod, `GetProfile` will not return an endpoint in the response.

We update the logic to return an endpoint in the response even when the endpoint is not backed by a pod.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
