### PR TITLE
Add install error for runtime container check

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -130,7 +130,6 @@ A full list of configurable values can be found at https://www.github.com/linker
 				return err
 			}
 
-			var k8sAPI *k8s.KubernetesAPI
 			if !ignoreCluster {
 				// Ensure k8s is reachable and that Linkerd is not already installed.
 				if err := errAfterRunningChecks(values.CNIEnabled); err != nil {
@@ -144,7 +143,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 
 				// Initialize the k8s API which is used for the proxyInit
 				// runAsRoot check.
-				k8sAPI, err = k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 30*time.Second)
+				k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 30*time.Second)
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -232,8 +232,12 @@ func TestRender(t *testing.T) {
 	for i, tc := range testCases {
 		tc := tc // pin
 		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
+			valuesOverrides, err := tc.options.MergeValues(nil)
+			if err != nil {
+				t.Fatalf("Failed to get values overrides: %v", err)
+			}
 			var buf bytes.Buffer
-			if err := render(&buf, tc.values, "", tc.options); err != nil {
+			if err := render(&buf, tc.values, "", valuesOverrides); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			testDataDiffer.DiffTestdata(t, tc.goldenFileName, buf.String())

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -305,10 +305,11 @@ the 'linkerd repair' command to repair the Linkerd config`)
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
-	runAsRoot := getRunAsRoot(valuesOverrides)
-	err = healthcheck.CheckProxyInitRunsAsRoot(ctx, k, runAsRoot)
-	if err != nil {
-		return bytes.Buffer{}, err
+	if !isRunAsRoot(valuesOverrides) {
+		err = healthcheck.CheckNodesHaveNonDockerRuntime(ctx, k)
+		if err != nil {
+			return bytes.Buffer{}, err
+		}
 	}
 
 	// rendering to a buffer and printing full contents of buffer after

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -300,10 +300,21 @@ the 'linkerd repair' command to repair the Linkerd config`)
 		}
 	}
 
+	// Create values override
+	valuesOverrides, err := options.MergeValues(nil)
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+	runAsRoot := getRunAsRoot(valuesOverrides)
+	err = healthcheck.CheckProxyInitRunsAsRoot(ctx, k, runAsRoot)
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+
 	// rendering to a buffer and printing full contents of buffer after
 	// render is complete, to ensure that okStatus prints separately
 	var buf bytes.Buffer
-	if err = render(&buf, values, stage, options); err != nil {
+	if err = render(&buf, values, stage, valuesOverrides); err != nil {
 		upgradeErrorf("Could not render upgrade configuration: %s", err)
 	}
 

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -560,7 +560,7 @@ func pathMatch(path []string, template []string) bool {
 
 func renderInstall(t *testing.T, values *linkerd2.Values) bytes.Buffer {
 	var installBuf bytes.Buffer
-	if err := render(&installBuf, values, "", valuespkg.Options{}); err != nil {
+	if err := render(&installBuf, values, "", nil); err != nil {
 		t.Fatalf("could not render install manifests: %s", err)
 	}
 	return installBuf

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2121,7 +2121,7 @@ func CheckProxyInitRunsAsRoot(ctx context.Context, k8sAPI *k8s.KubernetesAPI, ru
 		}
 	}
 	if hasDockerNodes && !runAsRoot {
-		return fmt.Errorf("there are nodes using the docker container runtime and proxy-init container must run as root user.\n\tTry installing linkerd via --set proxyInit.runAsRoot=true")
+		return fmt.Errorf("there are nodes using the docker container runtime and proxy-init container must run as root user.\ntry installing linkerd via --set proxyInit.runAsRoot=true")
 	}
 	return nil
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2095,10 +2095,9 @@ func (hc *HealthChecker) checkValidatingWebhookConfigurations(ctx context.Contex
 // CheckProxyInitRunsAsRoot checks that proxyInit will run as root if cluster
 // uses the Docker container runtime.
 func CheckProxyInitRunsAsRoot(ctx context.Context, k8sAPI *k8s.KubernetesAPI, runAsRoot bool) error {
-	// If the cluster is ignored (and the k8s API is not initialized) or the
-	// proxyInit container will run as root, there is no validation that needs
-	// to take place.
-	if k8sAPI == nil || runAsRoot {
+	// If proxyInit will run as root, no validation needs to take place
+	// because it will work regardless of the container runtime.
+	if runAsRoot {
 		return nil
 	}
 	hasDockerNodes := false

--- a/test/integration/testdata/check.pre.golden
+++ b/test/integration/testdata/check.pre.golden
@@ -24,7 +24,6 @@ pre-kubernetes-setup
 √ can read Secrets
 √ can read extension-apiserver-authentication configmap
 √ no clock skew detected
-√ proxy-init container runs as root user if docker container runtime is used
 
 linkerd-version
 ---------------

--- a/test/integration/uninstall/testdata/check.pre.golden
+++ b/test/integration/uninstall/testdata/check.pre.golden
@@ -24,7 +24,6 @@ pre-kubernetes-setup
 √ can read Secrets
 √ can read extension-apiserver-authentication configmap
 √ no clock skew detected
-√ proxy-init container runs as root user if docker container runtime is used
 
 linkerd-version
 ---------------


### PR DESCRIPTION
When installing Linkerd on a cluster with the Docker container runtime, `proxyInit.runAsRoot` but be set to `true` in order for Linkerd to operate. This is checked two different ways: `linkerd check --pre` and `linkerd check`.

#7457 discussed if it's better to emit this as a warning or error, but after some further discussion it makes more sense as a `linkerd install` runtime error so that a user cannot miss this configuration.

It still remains as part of `linkerd check` in case more nodes are added that do not satisfy this condition, or Linkerd is installed through Helm.

```sh
$ linkerd install
there are nodes using the docker container runtime and proxy-init container must run as root user.
try installing linkerd via --set proxyInit.runAsRoot=true

$ linkerd install --set proxyInit.runAsRoot=false
there are nodes using the docker container runtime and proxy-init container must run as root user.
try installing linkerd via --set proxyInit.runAsRoot=true

$ linkerd install --set proxyInit.runAsRoot=""
there are nodes using the docker container runtime and proxy-init container must run as root user.
try installing linkerd via --set proxyInit.runAsRoot=true

$ linkerd install --set proxyInit.runAsRoot=true
...

$ linkerd install --set proxyInit.runAsRoot=1
...
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>