### PR TITLE
Remove issue checkbox and some other cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,17 +2,12 @@ name: "🐛 Bug Report"
 description: "If something isn't working as expected 🤔."
 labels: ["bug"]
 body:
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
-      options:
-      - label: I have searched the existing issues
-        required: true
-
   - type: markdown
     attributes:
-      value: Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+
+        Please search to see if an issue already exists for the bug you encountered.
 
   - type: textarea
     attributes:
@@ -68,8 +63,7 @@ body:
   - type: dropdown
     attributes:
       label: Would you like to work on fixing this bug?
-      description: |
-        **NOTE**: Let us know if you would like to submit a PR for this. We are more than happy to help you through the process.
+      description: We are more than happy to help you through the process.
       options:
         - "yes"
         - "no"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,25 +2,18 @@ name: 💡 Feature Request"
 description: I have a suggestion (and may want to implement it 🙂)!
 labels: ["enhancement"]
 body:
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the feature you want to request.
-      options:
-      - label: I have searched the existing issues
-        required: true
-
   - type: markdown
     attributes:
-      value: Thanks for taking the time to suggest a new feature! Please fill out this form as completely as possible.
+      value: |
+        Thanks for taking the time to suggest a new feature! Please fill out this form as completely as possible.
+
+        Please search to see if an issue already exists for the feature you are suggesting.
 
   - type: textarea
     attributes:
       label: What problem are you trying to solve?
-      description: |
-        A concise description of what the problem is.
-      placeholder: |
-        I have an issue when [...]
+      description: A concise description of what the problem is.
+      placeholder: I have an issue when [...]
     validations:
       required: true
 
@@ -41,14 +34,12 @@ body:
   - type: textarea
     attributes:
       label: How would users interact with this feature?
-      description: |
-        If you can, explain how users will be able to use this. Maybe come sample CLI output?
+      description: If you can, explain how users will be able to use this. Maybe come sample CLI output?
 
   - type: dropdown
     attributes:
       label: Would you like to work on this feature?
-      description: |
-        **NOTE**: Let us know if you would like to submit a PR for this. We are more than happy to help you through the process.
+      description: We are more than happy to help you through the process.
       options:
         - "yes"
         - "no"


### PR DESCRIPTION
Both the bug and feature issue forms begin with the user indicating they have searched for existing issues with a checkbox.

While we do want users to check this, it does feel a little uncessary to have it as the _first_ thing we see in issues. Additionally, GitHub interprets this as a task for the issue, so it always shows `1 task done` now.

We remove this checkbox and instead just ask the user to double check before submitting a new issue.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>