### PR TITLE
viz: support custom HTTP request methods

### DIFF
--- a/viz/cmd/profile.go
+++ b/viz/cmd/profile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	pb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
 	log "github.com/sirupsen/logrus"
@@ -245,7 +246,7 @@ func getPathDataFromTap(event *pb.TapEvent) *sp.RouteSpec {
 		return profiles.MkRouteSpec(
 			path,
 			profiles.PathToRegex(path), // for now, no path consolidation
-			ev.RequestInit.GetMethod().GetRegistered().String(),
+			vizutil.HTTPMethodToString(ev.RequestInit.GetMethod()),
 			nil)
 	default:
 		return nil

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	metricsPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
 	log "github.com/sirupsen/logrus"
@@ -372,7 +373,7 @@ func renderTapEvent(event *tapPb.TapEvent, resource string) string {
 			ev.RequestInit.GetId().GetBase(),
 			ev.RequestInit.GetId().GetStream(),
 			flow,
-			ev.RequestInit.GetMethod().GetRegistered().String(),
+			vizutil.HTTPMethodToString(ev.RequestInit.GetMethod()),
 			ev.RequestInit.GetAuthority(),
 			ev.RequestInit.GetPath(),
 			resources,

--- a/viz/cmd/top.go
+++ b/viz/cmd/top.go
@@ -19,6 +19,7 @@ import (
 	metricsAPI "github.com/linkerd/linkerd2/viz/metrics-api"
 	metricsPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
 	runewidth "github.com/mattn/go-runewidth"
@@ -585,7 +586,7 @@ func newRow(req topRequest) (tableRow, error) {
 	if route == "" {
 		route = metricsAPI.DefaultRouteName
 	}
-	method := req.reqInit.GetMethod().GetRegistered().String()
+
 	source := stripPort(addr.PublicAddressToString(req.event.GetSource()))
 	if pod := req.event.SourceMeta.Labels["pod"]; pod != "" {
 		source = pod
@@ -631,7 +632,7 @@ func newRow(req topRequest) (tableRow, error) {
 
 	return tableRow{
 		path:        path,
-		method:      method,
+		method:      vizutil.HTTPMethodToString(req.reqInit.GetMethod()),
 		route:       route,
 		source:      source,
 		destination: destination,

--- a/viz/pkg/util/util.go
+++ b/viz/pkg/util/util.go
@@ -163,3 +163,12 @@ func buildResource(namespace string, resType string, name string) (*pb.Resource,
 		Name:      name,
 	}, nil
 }
+
+func HTTPMethodToString(method *pb.HttpMethod) string {
+	// Check Unregistered first as Registered (being an enum) defaults
+	// to GET when empty
+	if method.GetUnregistered() != "" {
+		return method.GetUnregistered()
+	}
+	return method.GetRegistered().String()
+}

--- a/viz/pkg/util/util.go
+++ b/viz/pkg/util/util.go
@@ -164,6 +164,8 @@ func buildResource(namespace string, resType string, name string) (*pb.Resource,
 	}, nil
 }
 
+// HTTPMethodtoString returns the HTTP request method
+// from the HTTPMethod protobuf type
 func HTTPMethodToString(method *pb.HttpMethod) string {
 	// Check Unregistered first as Registered (being an enum) defaults
 	// to GET when empty

--- a/viz/pkg/util/util.go
+++ b/viz/pkg/util/util.go
@@ -164,7 +164,7 @@ func buildResource(namespace string, resType string, name string) (*pb.Resource,
 	}, nil
 }
 
-// HTTPMethodtoString returns the HTTP request method
+// HTTPMethodToString returns the HTTP request method
 // from the HTTPMethod protobuf type
 func HTTPMethodToString(method *pb.HttpMethod) string {
 	// Check Unregistered first as Registered (being an enum) defaults


### PR DESCRIPTION
Fixes #7461

This PR updates the viz components to also consider the `Unregistered`
HTTP request methods when parsing the HTTP request methods from tap
responses. As this is a common functionality used across tap, top, etc
It is moved into a separate func.

## Output

### TAP

```
\# a request with KEEP method
req id=17:0 proxy=in  src=10.244.0.1:40532 dst=10.244.0.22:80 tls=no_tls_from_remote :method=KEEP :authority=10.244.0.22 :path=/
rsp id=17:0 proxy=in  src=10.244.0.1:40532 dst=10.244.0.22:80 tls=no_tls_from_remote :status=405 latency=449µs
end id=17:0 proxy=in  src=10.244.0.1:40532 dst=10.244.0.22:80 tls=no_tls_from_remote duration=29µs response-length=157B
req id=17:1 proxy=in  src=10.244.0.1:40572 dst=10.244.0.22:80 tls=no_tls_from_remote :method=KEEP :authority=10.244.0.22 :path=/
rsp id=17:1 proxy=in  src=10.244.0.1:40572 dst=10.244.0.22:80 tls=no_tls_from_remote :status=405 latency=521µs
end id=17:1 proxy=in  src=10.244.0.1:40572 dst=10.244.0.22:80 tls=no_tls_from_remote duration=35µs response-length=157B
req id=17:2 proxy=in  src=10.244.0.1:40676 dst=10.244.0.22:80 tls=no_tls_from_remote :method=XYZ :authority=10.244.0.22 :path=/
rsp id=17:2 proxy=in  src=10.244.0.1:40676 dst=10.244.0.22:80 tls=no_tls_from_remote :status=405 latency=532µs
end id=17:2 proxy=in  src=10.244.0.1:40676 dst=10.244.0.22:80 tls=no_tls_from_remote duration=51µs response-length=157B
```

### TOP

```
Source      Destination  Method      Path   Count    Best   Worst    Last  Success Rate
10.244.0.1  poddd        XYZ         /          2   184µs   663µs   663µs       100.00%
10.244.0.1  poddd        POST        /          1   573µs   573µs   573µs       100.00%
10.244.0.1  poddd        TRACE       /          1   283µs   283µs   283µs       100.00%
10.244.0.1  poddd        PATCH       /          1     1ms     1ms     1ms       100.00%
```

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
