### PR TITLE
check: pull trust anchor certificate from linkerd-identity-trust-roots

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1776,6 +1776,13 @@ func (hc *HealthChecker) fetchWebhookCaBundle(ctx context.Context, webhook strin
 	return caBundle, nil
 }
 
+// FetchTrustBundle retrieves the ca-bundle from the config-map linkerd-identity-trust-roots
+func FetchTrustBundle(ctx context.Context, kubeAPI k8s.KubernetesAPI, controlPlaneNamespace string) (string, error) {
+	configMap, err := kubeAPI.CoreV1().ConfigMaps(controlPlaneNamespace).Get(ctx, "linkerd-identity-trust-roots", metav1.GetOptions{})
+
+	return configMap.Data["ca-bundle.crt"], err
+}
+
 // FetchCredsFromSecret retrieves the TLS creds given a secret name
 func (hc *HealthChecker) FetchCredsFromSecret(ctx context.Context, namespace string, secretName string) (*tls.Cred, error) {
 	secret, err := hc.kubeAPI.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
@@ -2170,12 +2177,11 @@ func checkPodsProxiesCertificate(ctx context.Context, kubeAPI k8s.KubernetesAPI,
 		return err
 	}
 
-	_, values, err := FetchCurrentConfiguration(ctx, kubeAPI, controlPlaneNamespace)
+	trustAnchorsPem, err := FetchTrustBundle(ctx, kubeAPI, controlPlaneNamespace)
 	if err != nil {
 		return err
 	}
 
-	trustAnchorsPem := values.IdentityTrustAnchorsPEM
 	offendingPods := []string{}
 	for _, pod := range meshedPods {
 		// Skip control plane pods since they load their trust anchors from the linkerd-identity-trust-anchors configmap.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1276,16 +1276,15 @@ func TestCheckDataPlaneProxiesCertificate(t *testing.T) {
 	const currentCertificate = "current-certificate"
 	const oldCertificate = "old-certificate"
 
-	linkerdConfigMap := fmt.Sprintf(`
+	linkerdIdentityTrustRoots := fmt.Sprintf(`
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: %s
 data:
-  values: |
-    identityTrustAnchorsPEM: %s
+  ca-bundle.crt: %s
 
-`, k8s.ConfigConfigMapName, currentCertificate)
+`, "linkerd-identity-trust-roots", currentCertificate)
 
 	var testCases = []struct {
 		checkDescription string
@@ -1338,7 +1337,7 @@ data:
 			hc.DataPlaneNamespace = testCase.namespace
 
 			var err error
-			hc.kubeAPI, err = k8s.NewFakeAPI(append(testCase.resources, linkerdConfigMap)...)
+			hc.kubeAPI, err = k8s.NewFakeAPI(append(testCase.resources, linkerdIdentityTrustRoots)...)
 			if err != nil {
 				t.Fatalf("Unexpected error: %q", err)
 			}


### PR DESCRIPTION
Fixes #7449 

This PR updates the health checker to use the trust root from the config map `linkerd-identity-trust-roots`. This will prevent a certificate mismatch, when linkerd is installed without manually passing in the certificates.

Signed-off-by: Wim de Groot <34519486+degrootwim@users.noreply.github.com>
