### PR TITLE
Make privilege escalation configurable through Helm

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -218,6 +218,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.controllerUID}}
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level={{.Values.controllerLogLevel}}
@@ -245,6 +246,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.controllerUID}}
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -289,6 +291,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.controllerUID}}
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -63,4 +63,5 @@ spec:
             {{- end }}
             securityContext:
               runAsUser: {{.Values.controllerUID}}
+              allowPrivilegeEscalation: false
 {{- end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -179,6 +179,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.controllerUID}}
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -97,6 +97,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: {{.Values.controllerUID}}
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1477,6 +1477,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1931,6 +1932,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1955,6 +1957,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1992,6 +1995,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2101,6 +2105,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2280,6 +2285,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1918,6 +1919,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1942,6 +1944,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1979,6 +1982,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2081,6 +2085,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2258,6 +2263,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1557,6 +1557,7 @@ spec:
             memory: "10Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -2065,6 +2066,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -2089,6 +2091,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -2126,6 +2129,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2241,6 +2245,7 @@ spec:
                 memory: "50Mi"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2454,6 +2459,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1557,6 +1557,7 @@ spec:
             memory: "10Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -2065,6 +2066,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -2089,6 +2091,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -2126,6 +2129,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2241,6 +2245,7 @@ spec:
                 memory: "50Mi"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2454,6 +2459,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1407,6 +1407,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1860,6 +1861,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1884,6 +1886,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1921,6 +1924,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2160,6 +2164,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -737,6 +737,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1193,6 +1194,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1217,6 +1219,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1254,6 +1257,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -1365,6 +1369,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 # Source: linkerd-control-plane/templates/proxy-injector.yaml
 ---
@@ -1547,6 +1552,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -818,6 +818,7 @@ spec:
             memory: "10Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1329,6 +1330,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1353,6 +1355,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1390,6 +1393,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -1507,6 +1511,7 @@ spec:
                 memory: "50Mi"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 # Source: linkerd-control-plane/templates/proxy-injector.yaml
 ---
@@ -1723,6 +1728,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -826,6 +826,7 @@ spec:
             memory: "10Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1341,6 +1342,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1365,6 +1367,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1402,6 +1405,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -1523,6 +1527,7 @@ spec:
                 memory: "50Mi"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 # Source: linkerd-control-plane/templates/proxy-injector.yaml
 ---
@@ -1743,6 +1748,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -818,6 +818,7 @@ spec:
             memory: "10Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1329,6 +1330,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1353,6 +1355,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1390,6 +1393,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -1507,6 +1511,7 @@ spec:
                 memory: "50Mi"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 # Source: linkerd-control-plane/templates/proxy-injector.yaml
 ---
@@ -1723,6 +1728,7 @@ spec:
             memory: "50Mi"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1892,6 +1893,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1916,6 +1918,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1953,6 +1956,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2025,6 +2029,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2204,6 +2209,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1473,6 +1473,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1931,6 +1932,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=ControllerLogLevel
@@ -1955,6 +1957,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1998,6 +2001,7 @@ spec:
             memory: "memory-request"
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2109,6 +2113,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2290,6 +2295,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.cluster.local:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1476,6 +1476,7 @@ spec:
             port: 9990
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/issuer
           name: identity-issuer
@@ -1929,6 +1930,7 @@ spec:
             port: 9996
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
       - args:
         - sp-validator
         - -log-level=info
@@ -1953,6 +1955,7 @@ spec:
             port: 9997
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: sp-tls
@@ -1990,6 +1993,7 @@ spec:
         resources:
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
@@ -2099,6 +2103,7 @@ spec:
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.example.com:9090"
             securityContext:
               runAsUser: 2103
+              allowPrivilegeEscalation: false
 ---
 ###
 ### Proxy Injector
@@ -2278,6 +2283,7 @@ spec:
             port: 9995
         securityContext:
           runAsUser: 2103
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/run/linkerd/config
           name: config


### PR DESCRIPTION
Disabling privilege escalation is a security best practice, but
currently this is not supported when installing from Helm.

A parameter called `privilegeEscalationEnabled` is added to the Helm
chart. The default value is `true`to avoid breaking changes to the Helm
chart.

Fixes #7282

Signed-off-by: Kim Christensen <kimworking@gmail.com>