### PR TITLE
multicluster gateway: explicitly allow out-of-cluster probes

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -53,6 +53,8 @@ env:
   value: 0.0.0.0:{{.Values.proxy.ports.control}}
 - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
   value: 0.0.0.0:{{.Values.proxy.ports.admin}}
+- name: LINKERD2_PROXY_HEALTH_LISTEN_ADDR
+  value: 0.0.0.0:4192
 - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
   value: 127.0.0.1:{{.Values.proxy.ports.outbound}}
 - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
@@ -134,7 +136,7 @@ imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPol
 livenessProbe:
   httpGet:
     path: /live
-    port: {{.Values.proxy.ports.admin}}
+    port: 4192
   initialDelaySeconds: 10
 name: linkerd-proxy
 ports:
@@ -142,10 +144,12 @@ ports:
   name: linkerd-proxy
 - containerPort: {{.Values.proxy.ports.admin}}
   name: linkerd-admin
+- containerPort: 4192
+  name: linkerd-health
 readinessProbe:
   httpGet:
     path: /ready
-    port: {{.Values.proxy.ports.admin}}
+    port: 4192
   initialDelaySeconds: 2
 {{- if .Values.proxy.resources }}
 {{ include "partials.resources" .Values.proxy.resources }}

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -170,6 +170,10 @@
           "value": "0.0.0.0:4191"
         },
         {
+          "name": "LINKERD2_PROXY_HEALTH_LISTEN_ADDR",
+          "value": "0.0.0.0:4192"
+        },
+        {
           "name": "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR",
           "value": "127.0.0.1:4140"
         },
@@ -228,7 +232,7 @@
       "livenessProbe": {
         "httpGet": {
           "path": "/live",
-          "port": 4191
+          "port": 4192
         },
         "initialDelaySeconds": 10
       },
@@ -246,7 +250,7 @@
       "readinessProbe": {
         "httpGet": {
           "path": "/ready",
-          "port": 4191
+          "port": 4192
         },
         "initialDelaySeconds": 2
       },

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -8,7 +8,7 @@ enableHeadlessServices: false
 gateway:
   probe:
     # -- The port used for liveliness probing
-    port: 4191
+    port: 4192
 # -- Log level for the Multicluster components
 logLevel: info
 # -- Number of times update from the remote cluster is allowed to be requeued

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -16,7 +16,7 @@ gateway:
     # gateway is alive
     path: /ready
     # -- The port used for liveliness probing
-    port: 4191
+    port: 4192
     # nodePort -- Set the probe nodePort (for LoadBalancer or NodePort) to a specific value
     # nodePort:
     # -- The interval (in seconds) between liveness probes


### PR DESCRIPTION
Problem: On Linode Kubernetes Engine (LKE), probes originate from outside the cluster (e.g.: from 45.79.0.0/21), however the
ServerAuthorization policy on the linkerd-gateway is by default as only allowing localhost.

See these trace logs:

```log
# This line edited for readability:
[    29.766629s] TRACE ThreadId(02) daemon:admin{listen.addr=0.0.0.0:4191}:accept{client.addr=45.79.3.202:60606}: linkerd_app_inbound::policy::authorize::http: Authorizing request policy=AllowPolicy { dst: OrigDstAddr(0.0.0.0:4191), 
  server: Receiver { shared: Shared { value: RwLock(RwLock { data: ServerPolicy { protocol: Http1, 
    authorizations: [
      Authorization { networks: [Network { net: 0.0.0.0/0, except: [] }, Network { net: ::/0, except: [] }], authentication: TlsAuthenticated { identities: {}, suffixes: [Suffix { ends_with: "" }] }, name: "linkerd-gateway-probe" }, 
      Authorization { networks: [Network { net: 10.0.0.0/8, except: [] }, Network { net: 100.64.0.0/10, except: [] }, Network { net: 172.16.0.0/12, except: [] }, Network { net: 192.168.0.0/16, except: [] }], authentication: Unauthenticated, name: "proxy-admin" }, 
      Authorization { networks: [Network { net: 127.0.0.1/32, except: [] }, Network { net: ::1/128, except: [] }], authentication: Unauthenticated, name: "default:localhost" }
    ], name: "gateway-proxy-admin" } }), state: AtomicState(2), ref_count_rx: 8, notify_rx: Notify { state: 4, waiters: Mutex(Mutex { data: LinkedList { head: None, tail: None } }) }, notify_tx: Notify { state: 1, waiters: Mutex(Mutex { data: LinkedList { head: Some(0x7fd619cb8d78), tail: Some(0x7fd619cb8d78) } }) } }, version: Version(0) } }
[    29.766730s]  INFO ThreadId(02) daemon:admin{listen.addr=0.0.0.0:4191}:accept{client.addr=45.79.3.202:60606}: linkerd_app_inbound::policy::authorize::http: Request denied server=gateway-proxy-admin tls=None(NoClientHello) client=45.79.3.202:60606
[    29.766757s]  INFO ThreadId(02) daemon:admin{listen.addr=0.0.0.0:4191}:accept{client.addr=45.79.3.202:60606}:rescue{client.addr=45.79.3.202:60606}: linkerd_app_core::errors::respond: Request failed error=unauthorized connection on server gateway-proxy-admin
[    29.766776s] DEBUG ThreadId(02) daemon:admin{listen.addr=0.0.0.0:4191}:accept{client.addr=45.79.3.202:60606}: linkerd_app_core::errors::respond: Handling error on HTTP connection status=403 Forbidden version=HTTP/1.1 close=false
[    29.766794s] TRACE ThreadId(02) daemon:admin{listen.addr=0.0.0.0:4191}:accept{client.addr=45.79.3.202:60606}:encode_headers: hyper::proto::h1::role: Server::encode status=403, body=None, req_method=Some(GET)
```

Solution: Explicitly add a catch-all network.

Validation: This change was deployed on an LKE cluster on 2021-01-02 with the CNI plugin via Helm chart.

Signed-off-by: Aaron Friel <mayreply@aaronfriel.com>

