### PR TITLE
Deletes all linkerd extensions during the test cleanup script (#5441)

### DIFF
--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -22,6 +22,9 @@ echo "cleaning up jaeger extension resources, if present [${k8s_context}]"
 echo "cleaning up the all namespaces labelled with test.linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete ns -l test.linkerd.io/is-test-data-plane
 
+echo "cleaning up cluster-scoped resources labelled with linkerd.io/extension"
+kubectl --context="$k8s_context" delete all -l linkerd.io/extension
+
 echo "cleaning up cluster-scoped resources labelled with test.linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings,mutatingwebhookconfiguration -l test.linkerd.io/is-test-data-plane
 

--- a/bin/test-cleanup
+++ b/bin/test-cleanup
@@ -23,7 +23,7 @@ echo "cleaning up the all namespaces labelled with test.linkerd.io/is-test-data-
 kubectl --context="$k8s_context" delete ns -l test.linkerd.io/is-test-data-plane
 
 echo "cleaning up cluster-scoped resources labelled with linkerd.io/extension"
-kubectl --context="$k8s_context" delete all -l linkerd.io/extension
+kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings,ns -l linkerd.io/extension
 
 echo "cleaning up cluster-scoped resources labelled with test.linkerd.io/is-test-data-plane"
 kubectl --context="$k8s_context" delete clusterRole,clusterRoleBindings,mutatingwebhookconfiguration -l test.linkerd.io/is-test-data-plane


### PR DESCRIPTION
Signed-off-by: Alex Lee <westford14@gmail.com>

This addresses issue #5441 where all resources with the label `linkerd.io/extension` get deleted during the test cleanup script. 