### PR TITLE
tests: add missing cleanup logic

### DIFF
--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1232,19 +1232,6 @@ func TestCheckProxy(t *testing.T) {
 	}
 }
 
-func TestInstallCleanUp(t *testing.T) {
-	ctx := context.Background()
-	for _, tc := range injectionCases {
-		tc := tc // pin
-		t.Run(tc.ns, func(t *testing.T) {
-			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
-			if err := TestHelper.DeleteNamespaceIfExists(ctx, prefixedNs); err != nil {
-				testutil.AnnotatedFatal(t, "Deleting namespace failed", err)
-			}
-		})
-	}
-}
-
 func TestRestarts(t *testing.T) {
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1248,7 +1248,8 @@ func TestRestarts(t *testing.T) {
 	}
 }
 
-func TestInstallCleanUp(t *testing.T) {
+// TestCleanUp deletes the resources used in the above tests
+func TestCleanUp(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range injectionCases {
 		tc := tc // pin

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1248,6 +1248,19 @@ func TestRestarts(t *testing.T) {
 	}
 }
 
+func TestInstallCleanUp(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range injectionCases {
+		tc := tc // pin
+		t.Run(tc.ns, func(t *testing.T) {
+			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
+			if err := TestHelper.DeleteNamespaceIfExists(ctx, prefixedNs); err != nil {
+				testutil.AnnotatedFatal(t, "Deleting namespace failed", err)
+			}
+		})
+	}
+}
+
 func TestCheckMulticluster(t *testing.T) {
 	if TestHelper.GetMulticlusterHelmReleaseName() != "" || TestHelper.Multicluster() {
 		cmd := []string{"multicluster", "check", "--wait=60m"}

--- a/test/integration/install_test.go
+++ b/test/integration/install_test.go
@@ -1232,6 +1232,19 @@ func TestCheckProxy(t *testing.T) {
 	}
 }
 
+func TestInstallCleanUp(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range injectionCases {
+		tc := tc // pin
+		t.Run(tc.ns, func(t *testing.T) {
+			prefixedNs := TestHelper.GetTestNamespace(tc.ns)
+			if err := TestHelper.DeleteNamespaceIfExists(ctx, prefixedNs); err != nil {
+				testutil.AnnotatedFatal(t, "Deleting namespace failed", err)
+			}
+		})
+	}
+}
+
 func TestRestarts(t *testing.T) {
 	expectedDeployments := testutil.LinkerdDeployReplicasEdge
 	if !TestHelper.ExternalPrometheus() {

--- a/test/integration/routes/routes_test.go
+++ b/test/integration/routes/routes_test.go
@@ -82,19 +82,4 @@ func TestRoutes(t *testing.T) {
 				"expected %d occurrences of \"%s\", got %d\n%s", r.c, r.s, count, out)
 		}
 	}
-
-	// smoke test / bb routes
-	prefixedNs := TestHelper.GetTestNamespace("smoke-test")
-	cmd = []string{"viz", "routes", "--namespace", prefixedNs, "deploy"}
-	golden := "routes.smoke.golden"
-
-	out, err = TestHelper.LinkerdRun(cmd...)
-	if err != nil {
-		testutil.AnnotatedFatal(t, "'linkerd routes' command failed", err)
-	}
-
-	err = TestHelper.ValidateOutput(out, golden)
-	if err != nil {
-		testutil.AnnotatedFatalf(t, "received unexpected output", "received unexpected output\n%s", err)
-	}
 }

--- a/test/integration/routes/testdata/routes.smoke.golden
+++ b/test/integration/routes/testdata/routes.smoke.golden
@@ -1,9 +1,0 @@
-==> deployment/smoke-test-gateway <==
-ROUTE                      SERVICE   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
-[DEFAULT]   smoke-test-gateway-svc         -     -             -             -             -
-
-==> deployment/smoke-test-terminus <==
-ROUTE                         SERVICE   SUCCESS   RPS   LATENCY_P50   LATENCY_P95   LATENCY_P99
-[DEFAULT]     smoke-test-terminus-svc         -     -             -             -             -
-theFunction   smoke-test-terminus-svc         -     -             -             -             -
-

--- a/test/integration/tracing/tracing_test.go
+++ b/test/integration/tracing/tracing_test.go
@@ -56,16 +56,6 @@ func TestTracing(t *testing.T) {
 		t.Skip("Skipping due to flakiness. See linkerd/linkerd2#7538")
 	}
 
-	// cleanup cluster before proceeding
-	namespaces := []string{"smoke-test", "smoke-test-manual", "smoke-test-ann", "opaque-ports-test"}
-	for _, ns := range namespaces {
-		prefixedNs := TestHelper.GetTestNamespace(ns)
-		if err := TestHelper.DeleteNamespaceIfExists(ctx, prefixedNs); err != nil {
-			testutil.AnnotatedFatalf(t, "error deleting namespace",
-				"error deleting namespace '%s': %s", prefixedNs, err)
-		}
-	}
-
 	// linkerd-jaeger extension
 	tracingNs := "linkerd-jaeger"
 	out, err := TestHelper.LinkerdRun("jaeger", "install")


### PR DESCRIPTION
Integration tests are expected to cleanup their components
once a test succeeds. This is missing in the `opaque_ports` test.
This PR fixes that, and also adds a cleaning function in the
`install_test`

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
