### PR TITLE
multicluster: create unique PSP `RoleBinding` for links

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -25,10 +25,10 @@ Kubernetes: `>=1.20.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| enablePSP  | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
-| controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the Service mirror component (uses t  he Linkerd controller image) |
+| controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the Service mirror component (uses the Linkerd controller image) |
 | controllerImageVersion | string | `"linkerdVersionValue"` | Tag for the Service Mirror container Docker image |
 | enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
+| enablePSP | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | serviceMirrorRetryLimit | int | `3` | Number of times update from the remote cluster is allowed to be requeued (retried) |

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -25,7 +25,8 @@ Kubernetes: `>=1.20.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the Service mirror component (uses the Linkerd controller image) |
+| enablePSP  | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
+| controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the Service mirror component (uses t  he Linkerd controller image) |
 | controllerImageVersion | string | `"linkerdVersionValue"` | Tag for the Service Mirror container Docker image |
 | enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |

--- a/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
@@ -1,8 +1,9 @@
+{{if .Values.enablePSP -}}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: multicluster-link-psp
+  name: multicluster-link-psp-{{.Values.targetClusterName}}
   {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
@@ -15,3 +16,4 @@ subjects:
 - kind: ServiceAccount
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   namespace: {{.Release.Namespace}}
+{{ end -}}

--- a/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/psp.yaml
@@ -3,7 +3,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: multicluster-link-psp-{{.Values.targetClusterName}}
+  name: linkerd-multicluster-link-psp-{{.Values.targetClusterName}}
   {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -16,3 +16,9 @@ logLevel: info
 serviceMirrorRetryLimit: 3
 # -- User id under which the Service Mirror shall be ran
 serviceMirrorUID: 2103
+
+# -- Create RoleBindings to associate ServiceAccount of target cluster Service
+# Mirror to the control plane PSP resource. This requires that `enabledPSP` is
+# set to true on the extension and control plane install. Note PSP has been
+# deprecated since k8s v1.21
+enablePSP: false 

--- a/multicluster/charts/linkerd-multicluster/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/psp.yaml
@@ -17,7 +17,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: multicluster-psp
+  name: linkerd-multicluster-psp
   {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -252,7 +252,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: multicluster-psp
+  name: linkerd-multicluster-psp
   namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -214,7 +214,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: multicluster-psp
+  name: linkerd-multicluster-psp
   namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster


### PR DESCRIPTION
fixes https://github.com/linkerd/linkerd2/issues/7496

### Background

PSP resources are no longer created by default, since they were deprecated in k8s `v1.21`. In order to use it with linkerd, it has to be explicitly enabled in the control plane, and in the multicluster installation. The multicluster PSP role will make use of the policy created during the installation of the control plane.

When two clusters are linked, a `RoleBinding` will be created to link the multicluster PSP role and the ServiceAccount of the target cluster's service mirror component. As described in #7496, the resource name should include the target cluster suffix, otherwise this will be overwritten every time a new cluster is linked against the same source cluster.

### Solution

To fix this, I've done two things:

* Add the target cluster suffix to the PSP `RoleB`inding -- this will prevent the same resource from being overwritten -- each link with create its own binding. Below is the example output of all `RoleBindings` in the multicluster namespace after a source cluster (dev) is linked with two target clusters (east and west).

```
:; k get rolebindings -n linkerd-multicluster
NAME                                            ROLE                                                 AGE
multicluster-psp                                Role/psp                                             134m
linkerd-service-mirror-read-remote-creds-east   Role/linkerd-service-mirror-read-remote-creds-east   132m
linkerd-service-mirror-read-remote-creds-west   Role/linkerd-service-mirror-read-remote-creds-west   132m
multicluster-link-psp-east                      Role/psp                                             130m
multicluster-link-psp-west                      Role/psp                                             130m
```

* Add a new `enablePSP` flag to the link template. This isn't necessary for the fix, but I thought I'd add it in since it's unlikely we'd want to create a `RoleBinding` when linking, unless the extension itself was installed with the flag turned on. This is the easiest way I could think of to avoid creating unnecessary bindings.
 