### PR TITLE
cli: consistent flag to ignore cluster on install

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -198,25 +198,25 @@ The installation can be configured by using the --set, --values, --set-string an
 A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/charts/linkerd2/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !skipChecks {
-				// check if global resources exist to determine if the `install config`
-				// stage succeeded
-				if err := errAfterRunningChecks(values.CNIEnabled); err == nil {
-					if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
-						fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
-					} else {
-						fmt.Fprintf(os.Stderr, errMsgGlobalResourcesMissing, controlPlaneNamespace)
-					}
-					os.Exit(1)
-				}
-			}
 			if !ignoreCluster {
+				if !skipChecks {
+					// check if global resources exist to determine if the `install config`
+					// stage succeeded
+					if err := errAfterRunningChecks(values.CNIEnabled); err == nil {
+						if healthcheck.IsCategoryError(err, healthcheck.KubernetesAPIChecks) {
+							fmt.Fprintf(os.Stderr, errMsgCannotInitializeClient, err)
+						} else {
+							fmt.Fprintf(os.Stderr, errMsgGlobalResourcesMissing, controlPlaneNamespace)
+						}
+						os.Exit(1)
+					}
+				}
+
 				// Ensure there is not already an existing Linkerd installation.
 				if err := errIfLinkerdConfigConfigMapExists(cmd.Context()); err != nil {
 					fmt.Fprintf(os.Stderr, errMsgLinkerdConfigResourceConflict, controlPlaneNamespace, err.Error())
 					os.Exit(1)
 				}
-
 			}
 
 			return install(cmd.Context(), os.Stdout, values, flags, controlPlaneStage, options)

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -39,6 +39,7 @@ var (
 func newCmdInstall() *cobra.Command {
 	var registry string
 	var skipChecks bool
+	var ignoreCluster bool
 	var wait time.Duration
 	var options values.Options
 
@@ -56,7 +57,7 @@ The installation can be configured by using the --set, --values, --set-string an
 A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/jaeger/charts/linkerd-jaeger/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !skipChecks {
+			if !skipChecks && !ignoreCluster {
 				// Wait for the core control-plane to be up and running
 				api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
 					ControlPlaneNamespace: controlPlaneNamespace,
@@ -76,6 +77,8 @@ A full list of configurable values can be found at https://www.github.com/linker
 	cmd.Flags().StringVar(&registry, "registry", "cr.l5d.io/linkerd",
 		fmt.Sprintf("Docker registry to pull jaeger-webhook image from ($%s)", flags.EnvOverrideDockerRegistry))
 	cmd.Flags().BoolVar(&skipChecks, "skip-checks", false, `Skip checks for linkerd core control-plane existence`)
+	cmd.Flags().BoolVar(&ignoreCluster, "ignore-cluster", false,
+		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)")
 	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for core control-plane components to be available")
 
 	flags.AddValueOptionsFlags(cmd.Flags(), &options)

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -29,8 +29,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var ignoreCluster bool
-
 type (
 	multiclusterInstallOptions struct {
 		gateway                 multicluster.Gateway
@@ -43,6 +41,7 @@ func newMulticlusterInstallCommand() *cobra.Command {
 	var ha bool
 	var wait time.Duration
 	var valuesOptions valuespkg.Options
+	var ignoreCluster bool
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err)
@@ -72,7 +71,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 					RetryDeadline:         time.Now().Add(wait),
 				})
 			}
-			return install(cmd.Context(), stdout, options, valuesOptions, ha)
+			return install(cmd.Context(), stdout, options, valuesOptions, ha, ignoreCluster)
 		},
 	}
 
@@ -102,8 +101,8 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	return cmd
 }
 
-func install(ctx context.Context, w io.Writer, options *multiclusterInstallOptions, valuesOptions valuespkg.Options, ha bool) error {
-	values, err := buildMulticlusterInstallValues(ctx, options)
+func install(ctx context.Context, w io.Writer, options *multiclusterInstallOptions, valuesOptions valuespkg.Options, ha, ignoreCluster bool) error {
+	values, err := buildMulticlusterInstallValues(ctx, options, ignoreCluster)
 	if err != nil {
 		return err
 	}
@@ -217,7 +216,7 @@ func newMulticlusterInstallOptionsWithDefault() (*multiclusterInstallOptions, er
 	}, nil
 }
 
-func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInstallOptions) (*multicluster.Values, error) {
+func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInstallOptions, ignoreCluster bool) (*multicluster.Values, error) {
 	defaults, err := multicluster.NewInstallValues()
 	if err != nil {
 		return nil, err

--- a/viz/cmd/install.go
+++ b/viz/cmd/install.go
@@ -49,6 +49,7 @@ var (
 
 func newCmdInstall() *cobra.Command {
 	var skipChecks bool
+	var ignoreCluster bool
 	var ha bool
 	var wait time.Duration
 	var options values.Options
@@ -60,12 +61,12 @@ func newCmdInstall() *cobra.Command {
 		Long:  `Output Kubernetes resources to install linkerd-viz extension.`,
 		Example: `  # Default install.
   linkerd viz install | kubectl apply -f -
- 
+
 The installation can be configured by using the --set, --values, --set-string and --set-file flags.
 A full list of configurable values can be found at https://www.github.com/linkerd/linkerd2/tree/main/viz/charts/linkerd-viz/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !skipChecks {
+			if !skipChecks && !ignoreCluster {
 				// Wait for the core control-plane to be up and running
 				api.CheckPublicAPIClientOrRetryOrExit(healthcheck.Options{
 					ControlPlaneNamespace: controlPlaneNamespace,
@@ -83,6 +84,8 @@ A full list of configurable values can be found at https://www.github.com/linker
 	}
 
 	cmd.Flags().BoolVar(&skipChecks, "skip-checks", false, `Skip checks for linkerd core control-plane existence`)
+	cmd.Flags().BoolVar(&ignoreCluster, "ignore-cluster", false,
+		"Ignore the current Kubernetes cluster when checking for existing cluster configuration (default false)")
 	cmd.Flags().BoolVar(&ha, "ha", false, `Install Viz Extension in High Availability mode.`)
 	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for core control-plane components to be available")
 


### PR DESCRIPTION
Add consistent option to ignore the cluster (and existing intallation)
on install.

Fixes https://github.com/linkerd/linkerd2/issues/7330

Signed-off-by: Krzysztof Dryś <krzysztofdrys@gmail.com>
