### PR TITLE
policy-controller: Replace structopt with clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,13 +116,29 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "textwrap",
- "unicode-width",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -482,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +860,7 @@ name = "linkerd-policy-controller"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "drain",
  "futures",
  "hyper",
@@ -848,7 +871,6 @@ dependencies = [
  "linkerd-policy-controller-k8s-api",
  "linkerd-policy-controller-k8s-index",
  "serde_json",
- "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1118,6 +1140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",
@@ -1701,30 +1732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,12 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -2111,12 +2115,6 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,7 @@ name = "ring"
 version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [bans]
@@ -47,7 +47,11 @@ skip-tree = [
     # Waiting on a release that updates itoa to v1.
     { name = "http" },
 ]
-skip = []
+skip = [
+    # Waiting on a prost-build release that includes
+    # https://github.com/tokio-rs/prost/pull/583
+    { name = "heck", version = "0.3" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -12,6 +12,7 @@ rustls = ["kube/rustls-tls"]
 
 [dependencies]
 anyhow = "1"
+clap = { version = "3", default-features = false, features = ["derive", "env", "std"] }
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
@@ -21,10 +22,22 @@ linkerd-policy-controller-grpc = { path = "./grpc" }
 linkerd-policy-controller-k8s-index = { path = "./k8s/index" }
 linkerd-policy-controller-k8s-api = { path = "./k8s/api" }
 serde_json = "1"
-structopt = { version = "0.3", default-features = false }
-tokio = { version = "1", features = ["macros", "parking_lot", "rt", "rt-multi-thread", "signal", "sync"] }
+tokio = { version = "1", features = [
+    "macros",
+    "parking_lot",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json", "smallvec", "tracing-log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+    "env-filter",
+    "fmt",
+    "json",
+    "smallvec",
+    "tracing-log",
+] }
 warp = { version = "0.3", default-features = false, features = ["tls"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -2,12 +2,12 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{bail, Context, Error, Result};
+use clap::Parser;
 use futures::{future, prelude::*};
 use linkerd_policy_controller::k8s::DefaultPolicy;
 use linkerd_policy_controller::{admin, admission};
 use linkerd_policy_controller_core::IpNet;
 use std::net::SocketAddr;
-use structopt::StructOpt;
 use tokio::{sync::watch, time};
 use tracing::{debug, info, info_span, instrument, Instrument};
 use tracing_subscriber::{fmt::format, prelude::*, EnvFilter};
@@ -16,10 +16,10 @@ use tracing_subscriber::{fmt::format, prelude::*, EnvFilter};
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "policy", about = "A policy resource prototype")]
+#[derive(Debug, Parser)]
+#[clap(name = "policy", about = "A policy resource prototype")]
 struct Args {
-    #[structopt(
+    #[clap(
         parse(try_from_str),
         long,
         default_value = "linkerd=info,warn",
@@ -27,34 +27,34 @@ struct Args {
     )]
     log_level: EnvFilter,
 
-    #[structopt(long, default_value = "plain")]
+    #[clap(long, default_value = "plain")]
     log_format: LogFormat,
 
-    #[structopt(long, default_value = "0.0.0.0:8080")]
+    #[clap(long, default_value = "0.0.0.0:8080")]
     admin_addr: SocketAddr,
 
-    #[structopt(long, default_value = "0.0.0.0:8090")]
+    #[clap(long, default_value = "0.0.0.0:8090")]
     grpc_addr: SocketAddr,
 
-    #[structopt(long)]
+    #[clap(long)]
     admission_addr: Option<SocketAddr>,
 
     /// Network CIDRs of pod IPs.
     ///
     /// The default includes all private networks.
-    #[structopt(
+    #[clap(
         long,
         default_value = "10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16"
     )]
     cluster_networks: IpNets,
 
-    #[structopt(long, default_value = "cluster.local")]
+    #[clap(long, default_value = "cluster.local")]
     identity_domain: String,
 
-    #[structopt(long, default_value = "all-unauthenticated")]
+    #[clap(long, default_value = "all-unauthenticated")]
     default_policy: DefaultPolicy,
 
-    #[structopt(long, default_value = "linkerd")]
+    #[clap(long, default_value = "linkerd")]
     control_plane_namespace: String,
 }
 
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
         log_level,
         log_format,
         control_plane_namespace,
-    } = Args::from_args();
+    } = Args::parse();
 
     log_init(log_level, log_format)?;
 


### PR DESCRIPTION
The new version of `clap` replaces the need for the `structopt`
dependency.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
