### PR TITLE
Introduce annotation to skip subnets

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -233,6 +233,7 @@ Kubernetes: `>=1.20.0-0`
 | proxyInit.resources.memory.limit | string | `"50Mi"` | Maximum amount of memory that the proxy-init container can use |
 | proxyInit.resources.memory.request | string | `"10Mi"` | Amount of memory that the proxy-init container requests |
 | proxyInit.runAsRoot | bool | `false` | Allow overriding the runAsNonRoot behaviour (<https://github.com/linkerd/linkerd2/issues/7308>) |
+| proxyInit.skipSubnets | string | `""` | Comma-separated list of subnets in valid CIDR format that should be skipped by the proxy |
 | proxyInit.xtMountPath.mountPath | string | `"/run"` |  |
 | proxyInit.xtMountPath.name | string | `"linkerd-proxy-init-xtables-lock"` |  |
 | proxyInjector.caBundle | string | `""` | Bundle of CA certificates for proxy injector. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `proxyInjector.crtPEM`. If `proxyInjector.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -167,6 +167,8 @@ proxyInit:
   # -- Default set of outbound ports to skip via iptables
   # - Galera (4567,4568)
   ignoreOutboundPorts: "4567,4568"
+  # -- Comma-separated list of subnets in valid CIDR format that should be skipped by the proxy
+  skipSubnets: ""
   # -- Log level for the proxy-init
   # @default -- info
   logLevel: ""

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -24,6 +24,10 @@ args:
 - --log-level
 - {{ .Values.proxyInit.logLevel }}
 {{- end }}
+{{- if .Values.proxyInit.skipSubnets }}
+- --subnets-to-ignore
+- {{ .Values.proxyInit.skipSubnets | quote }}
+{{- end }}
 image: {{.Values.proxyInit.image.name}}:{{.Values.proxyInit.image.version}}
 imagePullPolicy: {{.Values.proxyInit.image.pullPolicy | default .Values.imagePullPolicy}}
 name: linkerd-init

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -236,5 +236,9 @@ func generateAnnotationsDocs() []annotationDoc {
 			Name:        k8s.CloseWaitTimeoutAnnotation,
 			Description: "Sets nf_conntrack_tcp_timeout_close_wait. Accepts a duration string, e.g. `1m` or `3600s`",
 		},
+		{
+			Name:        k8s.ProxySkipSubnetsAnnotation,
+			Description: "Comma-separated list of subnets in valid CIDR format that should be skipped by the proxy",
+		},
 	}
 }

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1293,6 +1293,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1293,6 +1293,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1197,6 +1197,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -532,6 +532,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -559,6 +559,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -563,6 +563,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -559,6 +559,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1263,6 +1263,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1266,6 +1266,7 @@ data:
           request: 10Mi
       runAsRoot: false
       saMountPath: null
+      skipSubnets: ""
       xtMountPath:
         mountPath: /run
         name: linkerd-proxy-init-xtables-lock

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -118,6 +118,7 @@ type (
 		Capabilities         *Capabilities    `json:"capabilities"`
 		IgnoreInboundPorts   string           `json:"ignoreInboundPorts"`
 		IgnoreOutboundPorts  string           `json:"ignoreOutboundPorts"`
+		SkipSubnets          string           `json:"skipSubnets"`
 		LogLevel             string           `json:"logLevel"`
 		LogFormat            string           `json:"logFormat"`
 		Image                *Image           `json:"image"`

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -69,6 +69,7 @@ var (
 		k8s.ProxyInboundConnectTimeout,
 		k8s.ProxyAwait,
 		k8s.ProxyDefaultInboundPolicyAnnotation,
+		k8s.ProxySkipSubnetsAnnotation,
 	}
 	// ProxyAlphaConfigAnnotations is the list of all alpha configuration
 	// (config.alpha prefix) that can be applied to a pod or namespace.
@@ -1079,6 +1080,10 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 		} else {
 			values.Proxy.DefaultInboundPolicy = override
 		}
+	}
+
+	if override, ok := annotations[k8s.ProxySkipSubnetsAnnotation]; ok {
+		values.ProxyInit.SkipSubnets = override
 	}
 }
 

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -68,6 +68,7 @@ func TestGetOverriddenValues(t *testing.T) {
 							k8s.ProxyInboundConnectTimeout:                   "600ms",
 							k8s.ProxyOpaquePortsAnnotation:                   "4320-4325,3306",
 							k8s.ProxyAwait:                                   "enabled",
+							k8s.ProxySkipSubnetsAnnotation:                   "172.17.0.0/16",
 						},
 					},
 					Spec: corev1.PodSpec{},
@@ -109,6 +110,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.ProxyInit.Image.Version = version.ProxyInitVersion
 				values.ProxyInit.IgnoreInboundPorts = "4222,6222"
 				values.ProxyInit.IgnoreOutboundPorts = "8079,8080"
+				values.ProxyInit.SkipSubnets = "172.17.0.0/16"
 				values.Proxy.RequireIdentityOnInboundPorts = "8888,9999"
 				values.Proxy.OutboundConnectTimeout = "6000ms"
 				values.Proxy.InboundConnectTimeout = "600ms"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -164,6 +164,9 @@ const (
 	// ignoreOutboundPorts config.
 	ProxyIgnoreOutboundPortsAnnotation = ProxyConfigAnnotationsPrefix + "/skip-outbound-ports"
 
+	// ProxySkipSubnetsAnnotation can be used to override the skipSubnets config
+	ProxySkipSubnetsAnnotation = ProxyConfigAnnotationsPrefix + "/skip-subnets"
+
 	// ProxyInboundPortAnnotation can be used to override the inboundPort config.
 	ProxyInboundPortAnnotation = ProxyConfigAnnotationsPrefix + "/inbound-port"
 

--- a/testutil/inject_validator.go
+++ b/testutil/inject_validator.go
@@ -47,6 +47,7 @@ type InjectValidator struct {
 	OutboundConnectTimeout  string
 	InboundConnectTimeout   string
 	WaitBeforeExitSeconds   int
+	SkipSubnets             string
 }
 
 func (iv *InjectValidator) getContainer(pod *v1.PodSpec, name string, isInit bool) *v1.Container {
@@ -363,6 +364,12 @@ func (iv *InjectValidator) validateInitContainer(pod *v1.PodSpec) error {
 		}
 	}
 
+	if iv.SkipSubnets != "" {
+		if err := iv.validateArg(initContainer, "--skip-subnets", iv.SkipSubnets); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -549,6 +556,11 @@ func (iv *InjectValidator) GetFlagsAndAnnotations() ([]string, map[string]string
 		annotations[k8s.ProxyWaitBeforeExitSecondsAnnotation] = strconv.Itoa(iv.WaitBeforeExitSeconds)
 		flags = append(flags, fmt.Sprintf("--wait-before-exit-secondst=%s", strconv.Itoa(iv.WaitBeforeExitSeconds)))
 
+	}
+
+	if iv.SkipSubnets != "" {
+		annotations[k8s.ProxySkipSubnetsAnnotation] = iv.SkipSubnets
+		flags = append(flags, fmt.Sprintf("--skip-subnets=%s", iv.SkipSubnets))
 	}
 
 	return flags, annotations


### PR DESCRIPTION
The goal is to support configuring the
`--subnets-to-ignore` flag in proxy-init

Add a new annotation `config.linkerd.io/skip-subnets` which
takes a comma-separated list of valid CIDR.
The argument will get map to the `--subnets-to-ignore`
flag in the proxy-init initContainer.

This can be validated with the provided integration test. Or
apply the following manifest
```yaml
kind: Pod
apiVersion: v1
metadata:
  name: debug-linkerd-dind
  annotations:
    linkerd.io/inject: enabled
    kubectl.kubernetes.io/default-container: docker
    config.linkerd.io/skip-subnets: "172.17.0.0/16"
spec:
  containers:
    - name: docker
      image: docker:19.03.5-dind
      imagePullPolicy: IfNotPresent
      securityContext:
        privileged: true
        runAsUser: 0
        capabilities:
            add:
            - NET_ADMIN
      resources: {}
```
Check the following
- the `--subnets-to-ignore` flag is added to `proxy-init`
- run `docker run  --rm curlimages/curl:7.78.0 -L -vv http://curl.haxx.se` inside the contaienr and it should work
- run `iptables -t nat --list --line-numbers` the iptables, there should be a rule in the `PROXY_INIT_REDIRECT` "return" on the provided subnet, learn more from https://github.com/linkerd/linkerd2-proxy-init/pull/53

Fixes #6758

Signed-off-by: Michael Lin <mlzc@hey.com>
