### PR TITLE
CI: run RUSTSEC audit across repos

### DIFF
--- a/.github/workflows/rust_audit.yml
+++ b/.github/workflows/rust_audit.yml
@@ -10,9 +10,18 @@ permissions:
 
 jobs:
   audit:
+    strategy:
+      matrix:
+        repository:
+        - linkerd2
+        - linkerd2-proxy
+        - linkerd-await
     runs-on: ubuntu-latest
+    name: RUSTSEC audit (${{ matrix.repository }})
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        with:
+          repository: linkerd/${{ matrix.repository }}
       - uses: actions-rs/toolchain@88dc2356392166efad76775c878094f4e83ff746
         with:
           toolchain: stable


### PR DESCRIPTION
Fixes #7632

This updates the rustsec audit cron-job's strategy to
run the same check across Rust repos in the linkerd org
and still raise issues in the `linkerd2` repo.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
