### PR TITLE
ci: Verify the devcontainer configuration in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,8 +50,9 @@ ARG YQ_VERSION=v4.2.0
 RUN scurl -vo $HOME/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
     && chmod +x $HOME/bin/yq
 
+ARG RUST_TOOLCHAIN=1.56.1
 RUN scurl -v https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain 1.56.1 -c rustfmt -c clippy -c rls
+    | sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN}" -c rustfmt -c clippy -c rls
 
 RUN mkdir /tmp/cargo-deny && cd /tmp/cargo-deny && \
     scurl -v https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.0/cargo-deny-0.11.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - && \

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,51 @@
+name: devcontainer
+
+# When a pull request is opened that changes the Devcontainer configuration,
+# ensure that the container continues to build properly.
+on:
+  pull_request:
+    paths:
+      - rust-toolchain
+      - .devcontainer/**
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: docker build . -f .devcontainer/Dockerfile
+
+  rust-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: |
+          versions=$(sed -nE 's|^FROM (.*/)?rust:([^ -]+)|\2|p' .devcontainer/Dockerfile)
+          ex=0
+          for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
+            echo "::error file=.devcontainer/Dockerfile::Devcontainer uses incorrect rust version(s): $mismatch"
+            ex=$((ex + 1))
+          done
+          exit $ex
+
+  devcontainer-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install jq
+      - run: |
+          image=$(sed -E '/^\s*\/\/.*/d' .devcontainer/devcontainer.json |jq -Mr .image)
+          if [ "$image" == "null" ]; then
+            echo "::error file=.devcontainer/devcontainer.json::Missing image"
+            exit 1
+          fi
+          if ! docker pull "$image" ; then
+            echo "::error file=.devcontainer/devcontainer.json::Unable to pull image: $image"
+            exit 1
+          fi

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: |
-          versions=$(sed -nE 's|^FROM (.*/)?rust:([^ -]+)|\2|p' .devcontainer/Dockerfile)
+          versions=$(sed -nE 's/^ARG RUST_TOOLCHAIN=([^ ]+)/\1/p' .devcontainer/Dockerfile)
           ex=0
           for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
             echo "::error file=.devcontainer/Dockerfile::Devcontainer uses incorrect rust version(s): $mismatch"
@@ -41,6 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y --no-install-recommends install jq
       - run: |
+          # Strip jsonc comments because `jq` doesn't support them.
           image=$(sed -E '/^\s*\/\/.*/d' .devcontainer/devcontainer.json |jq -Mr .image)
           if [ "$image" == "null" ]; then
             echo "::error file=.devcontainer/devcontainer.json::Missing image"

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,4 +1,4 @@
-name: devcontainer
+name: Devcontainer
 
 # When a pull request is opened that changes the Devcontainer configuration,
 # ensure that the container continues to build properly.

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - rust-toolchain
       - .devcontainer/**
+      - .github/workflows/devcontainer.yml
 
 permissions:
   contents: read

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -82,3 +82,28 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: cargo test --workspace --no-run
       - run: cargo test --workspace
+
+  rust-toolchain:
+    name: rust toolchain
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: |
+          versions=$(sed -nE 's|.*docker://(.*/)?rust:([^ #]+).*|\2|p' .github/workflows/policy_controller.yml)
+          ex=0
+          for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
+            echo "::error file=.github/workflows/policy_controller.yml::Workflow uses incorrect rust version(s): $mismatch"
+            ex=$((ex + 1))
+          done
+          exit $ex
+      - run: |
+          ex=0
+          for f in policy-controller/*.dockerfile ; do
+            versions=$(sed -nE 's|ARG RUST_IMAGE=(.*/)?rust:([^ #]+).*|\2|p' "$f")
+            for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
+              echo "::error file=\"$f\"::$f uses incorrect rust version(s): $mismatch"
+              ex=$((ex + 1))
+            done
+          done
+          exit $ex

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -90,15 +90,17 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: |
-          versions=$(sed -nE 's|.*docker://(.*/)?rust:([^ #]+).*|\2|p' .github/workflows/policy_controller.yml)
           ex=0
+
+          # Check this workflow against the version in rust-toolchain.
+          versions=$(sed -nE 's|.*docker://(.*/)?rust:([^ #]+).*|\2|p' .github/workflows/policy_controller.yml)
           for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
             echo "::error file=.github/workflows/policy_controller.yml::Workflow uses incorrect rust version(s): $mismatch"
             ex=$((ex + 1))
           done
-          exit $ex
-      - run: |
-          ex=0
+
+          # Check the policy-controller dockerfiles workflow against the version
+          # in rust-toolchain.
           for f in policy-controller/*.dockerfile ; do
             versions=$(sed -nE 's|ARG RUST_IMAGE=(.*/)?rust:([^ #]+).*|\2|p' "$f")
             for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
@@ -106,4 +108,5 @@ jobs:
               ex=$((ex + 1))
             done
           done
+
           exit $ex


### PR DESCRIPTION
This change adds a _devcontainer_ CI workflow that only runs when the
devcontainer config or rust-toolchain changes. It ensures that the
devcontainer uses the same Rust toolchain as the repo, that the
devcontainer dockerfiles builds successfully, and that the devcontainer
config references a real, published image.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
