### PR TITLE
Change erroneous 'minutes' to 'seconds' in web util fn

### DIFF
--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -65,7 +65,7 @@ const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
   const l5dExtensionsPath = '/api/extensions';
 
   const validMetricsWindows = {
-    '10s': '10 minutes',
+    '10s': '10 seconds',
     '1m': '1 minute',
     '10m': '10 minutes',
     '1h': '1 hour',


### PR DESCRIPTION
The metrics api helper in our web component contains a set of valid time
windows for the collection and display of metrics. Although this is
potentially not actively used in the dashboard itself, the library
contains an erroneous measure whereby 10s are expressed as minutes.

This is a quick fix to change the seconds field to the appropriate
scale.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
