### PR TITLE
Fix HA race when installing through Helm

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -242,7 +242,8 @@ Kubernetes: `>=1.20.0-0`
 | proxyInjector.injectCaFrom | string | `""` | Inject the CA bundle from a cert-manager Certificate. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-certificate-resource) for more information. |
 | proxyInjector.injectCaFromSecret | string | `""` | Inject the CA bundle from a Secret. If set, the `cert-manager.io/inject-ca-from-secret` annotation will be added to the webhook. The Secret must have the CA Bundle stored in the `ca.crt` key and have the `cert-manager.io/allow-direct-injection` annotation set to `true`. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-secret-resource) for more information. |
 | proxyInjector.keyPEM | string | `""` | Certificate key for the proxy injector. If not provided and not using an external secret then Helm will generate one. |
-| proxyInjector.namespaceSelector | object | `{"matchExpressions":[{"key":"config.linkerd.io/admission-webhooks","operator":"NotIn","values":["disabled"]}]}` | Namespace selector used by admission webhook. If not set defaults to all namespaces without the annotation config.linkerd.io/admission-webhooks=disabled |
+| proxyInjector.namespaceSelector | object | `{"matchExpressions":[{"key":"config.linkerd.io/admission-webhooks","operator":"NotIn","values":["disabled"]},{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system","cert-manager"]}]}` | Namespace selector used by admission webhook. |
+| proxyInjector.objectSelector | object | `{"matchExpressions":[{"key":"linkerd.io/control-plane-component","operator":"DoesNotExist"},{"key":"linkerd.io/cni-resource","operator":"DoesNotExist"}]}` | Object selector used by admission webhook. |
 | webhookFailurePolicy | string | `"Ignore"` | Failure policy for the proxy injector |
 
 ----------------------------------------------

--- a/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
@@ -93,6 +93,8 @@ webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:
     {{- toYaml .Values.proxyInjector.namespaceSelector | trim | nindent 4 }}
+  objectSelector:
+    {{- toYaml .Values.proxyInjector.objectSelector | trim | nindent 4 }}
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -294,15 +294,26 @@ proxyInjector:
   # `proxyInjector.injectCaFrom` or `proxyInjector.injectCaFromSecret` (see below).
   externalSecret: false
 
-  # -- Namespace selector used by admission webhook. If not set defaults to all
-  # namespaces without the annotation
-  # config.linkerd.io/admission-webhooks=disabled
+  # -- Namespace selector used by admission webhook.
   namespaceSelector:
     matchExpressions:
     - key: config.linkerd.io/admission-webhooks
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+
+  # -- Object selector used by admission webhook.
+  objectSelector:
+    matchExpressions:
+    - key: linkerd.io/control-plane-component
+      operator: DoesNotExist
+    - key: linkerd.io/cni-resource
+      operator: DoesNotExist
 
   # -- Certificate for the proxy injector. If not provided and not using an external secret
   # then Helm will generate one.

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -22,8 +22,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: {{.Release.Namespace}}
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -187,6 +185,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         {{ include "partials.annotations.created-by" . }}
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       {{- if .Values.tolerations }}
       {{- include "linkerd.tolerations" . | nindent 6 }}

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -2,8 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -102,6 +100,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -2,8 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -102,6 +100,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -2,8 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -102,6 +100,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -2,8 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -102,6 +100,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -2,8 +2,6 @@ kind: Namespace
 apiVersion: v1
 metadata:
   name: linkerd-cni
-  annotations:
-    linkerd.io/inject: disabled
   labels:
     linkerd.io/cni-resource: "true"
     config.linkerd.io/admission-webhooks: disabled
@@ -103,6 +101,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -94,6 +94,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -94,6 +94,8 @@ spec:
         k8s-app: linkerd-cni
       annotations:
         linkerd.io/created-by: test-version
+        linkerd.io/cni-resource: "true"
+        linkerd.io/inject: disabled
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1311,6 +1318,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources:
       cpu:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1311,6 +1318,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources:
       cpu:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -994,6 +994,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1215,6 +1222,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -349,6 +349,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -550,6 +557,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tap:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -349,6 +349,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -577,6 +584,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources:
       cpu:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -349,6 +349,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -581,6 +588,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources:
       cpu:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -349,6 +349,8 @@ webhooks:
       operator: In
       values:
       - enabled
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1060,6 +1060,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1281,6 +1288,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1063,6 +1063,13 @@ webhooks:
       operator: NotIn
       values:
       - disabled
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - cert-manager
+  objectSelector:
+    null
   clientConfig:
     service:
       name: linkerd-proxy-injector
@@ -1284,6 +1291,11 @@ data:
           operator: NotIn
           values:
           - disabled
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - cert-manager
     proxyInjectorProxyResources: null
     proxyInjectorResources: null
     tolerations: null

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -5,7 +5,7 @@ metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
     linkerd.io/extension: multicluster
-    linkerd.io/control-plane-component: service-mirror
+    component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
 - apiGroups: [""]
@@ -21,7 +21,7 @@ metadata:
   name: linkerd-service-mirror-access-local-resources-{{.Values.targetClusterName}}
   labels:
     linkerd.io/extension: multicluster
-    linkerd.io/control-plane-component: service-mirror
+    component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -39,7 +39,7 @@ metadata:
   {{ include "partials.namespace" . }}
   labels:
       linkerd.io/extension: multicluster
-      linkerd.io/control-plane-component: service-mirror
+      component: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 rules:
   - apiGroups: [""]
@@ -57,7 +57,7 @@ metadata:
   {{ include "partials.namespace" . }}
   labels:
       linkerd.io/extension: multicluster
-      linkerd.io/control-plane-component: service-mirror
+      component: service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -75,7 +75,7 @@ metadata:
   {{ include "partials.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
-    linkerd.io/control-plane-component: service-mirror
+    component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
 ---
 apiVersion: apps/v1
@@ -83,7 +83,7 @@ kind: Deployment
 metadata:
   labels:
     linkerd.io/extension: multicluster
-    linkerd.io/control-plane-component: service-mirror
+    component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   {{ include "partials.namespace" . }}
@@ -91,14 +91,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
   template:
     metadata:
       annotations:
         linkerd.io/inject: enabled
       labels:
-        linkerd.io/control-plane-component: linkerd-service-mirror
+        component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
     spec:
       containers:

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     app: {{.Values.gateway.name}}
     linkerd.io/extension: multicluster
   name: {{.Values.gateway.name}}
@@ -72,7 +72,7 @@ metadata:
     mirror.linkerd.io/probe-period: "{{.Values.gateway.probe.seconds}}"
     mirror.linkerd.io/probe-path: {{.Values.gateway.probe.path}}
     mirror.linkerd.io/multicluster-gateway: "true"
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     {{ include "partials.annotations.created-by" . }}
     {{- with .Values.gateway.serviceAnnotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:

--- a/multicluster/charts/linkerd-multicluster/templates/proxy-admin-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/proxy-admin-policy.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---

--- a/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
@@ -5,11 +5,11 @@ metadata:
   {{ include "partials.namespace" . }}
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: admin-http
   proxyProtocol: HTTP/1
 ---
@@ -19,7 +19,7 @@ metadata:
   {{ include "partials.namespace" . }}
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   server:
     name: service-mirror

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: linkerdVersionValue
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     app: linkerd-gateway
     linkerd.io/extension: multicluster
   name: linkerd-gateway
@@ -51,7 +51,7 @@ metadata:
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
     mirror.linkerd.io/multicluster-gateway: "true"
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
 spec:
   ports:
@@ -115,7 +115,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
@@ -336,11 +336,11 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: admin-http
   proxyProtocol: HTTP/1
 ---
@@ -350,7 +350,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   server:
     name: service-mirror

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: linkerdVersionValue
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     app: linkerd-gateway
     linkerd.io/extension: multicluster
   name: linkerd-gateway
@@ -89,7 +89,7 @@ metadata:
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
     mirror.linkerd.io/multicluster-gateway: "true"
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
 spec:
   ports:
@@ -153,7 +153,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
@@ -405,11 +405,11 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: admin-http
   proxyProtocol: HTTP/1
 ---
@@ -419,7 +419,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   server:
     name: service-mirror

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: linkerdVersionValue
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     app: linkerd-gateway
     linkerd.io/extension: multicluster
   name: linkerd-gateway
@@ -51,7 +51,7 @@ metadata:
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
     mirror.linkerd.io/multicluster-gateway: "true"
-    linkerd.io/control-plane-component: gateway
+    component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
 spec:
   ports:
@@ -115,7 +115,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
@@ -367,11 +367,11 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   podSelector:
     matchLabels:
-      linkerd.io/control-plane-component: linkerd-service-mirror
+      component: linkerd-service-mirror
   port: admin-http
   proxyProtocol: HTTP/1
 ---
@@ -381,7 +381,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
-    linkerd.io/control-plane-component: linkerd-service-mirror
+    component: linkerd-service-mirror
 spec:
   server:
     name: service-mirror

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -17,15 +17,22 @@ func TestNewValues(t *testing.T) {
 
 	testVersion := "linkerd-dev"
 
-	namespaceSelector := &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      "config.linkerd.io/admission-webhooks",
-				Operator: "NotIn",
-				Values:   []string{"disabled"},
-			},
+	matchExpressionsSimple := []metav1.LabelSelectorRequirement{
+		{
+			Key:      "config.linkerd.io/admission-webhooks",
+			Operator: "NotIn",
+			Values:   []string{"disabled"},
 		},
 	}
+	matchExpressionsInjector := append(matchExpressionsSimple, metav1.LabelSelectorRequirement{
+		Key:      "kubernetes.io/metadata.name",
+		Operator: "NotIn",
+		Values:   []string{"kube-system", "cert-manager"},
+	},
+	)
+
+	namespaceSelectorSimple := &metav1.LabelSelector{MatchExpressions: matchExpressionsSimple}
+	namespaceSelectorInjector := &metav1.LabelSelector{MatchExpressions: matchExpressionsInjector}
 
 	expected := &Values{
 		ControllerImage:              "cr.l5d.io/linkerd/controller",
@@ -143,9 +150,9 @@ func TestNewValues(t *testing.T) {
 			},
 		},
 
-		ProxyInjector:    &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelector},
-		ProfileValidator: &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelector},
-		PolicyValidator:  &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelector},
+		ProxyInjector:    &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelectorInjector},
+		ProfileValidator: &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelectorSimple},
+		PolicyValidator:  &Webhook{TLS: &TLS{}, NamespaceSelector: namespaceSelectorSimple},
 	}
 
 	// pin the versions to ensure consistent test result.

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -77,7 +77,7 @@ data:
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -625,7 +625,7 @@ data:
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -625,7 +625,7 @@ data:
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -625,7 +625,7 @@ data:
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -625,7 +625,7 @@ data:
       - role: pod
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
+        - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
         regex: linkerd-service-mirror;admin-http$


### PR DESCRIPTION
Fixes #7699

The problem didn't affect 2.11, only latest edges since the Helm charts
got split into `linkerd-crds` and `linkerd-control-plane` and we stopped
creating the linkerd namespace.

With the surrendering of the creation of the namespace, we can no longer
guarantee the existence of the `config.linkerd.io/admission-webhooks`
label, so this PR creates an `objectSelector` for the injector that
filters-out control-plane components, based on the existence of the
`linkerd.io/control-plane-component` label.

Given we still want the multicluster components to be injected, we had
to be rename its `linkerd.io/control-plane-component` label to
`component`, following the same convention used by the other extensions.
The corresponding Prometheus rule for scraping the service mirrors was
updated accordingly.

A similar filter was added for the linkerd-cni DaemonSet.

Also, now that the `kubernetes.io/metadata.name` is prevalent, we're
also using it to filter out the kube-system and cert-manager namespaces.
The former namespace was already mentioned in the docs; the latter is
also included to avoid having races with cert-manager-cainjector which
can be used to provision the injector's cert.