### PR TITLE
Remove the `proxy.disableIdentity` config

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -118,7 +118,6 @@ spec:
 {{- $tree := deepCopy . }}
 {{ $_ := set $tree.Values.proxy "workloadKind" "deployment" -}}
 {{ $_ := set $tree.Values.proxy "component" "linkerd-destination" -}}
-{{ include "linkerd.proxy.validation" .Values.proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -94,7 +94,6 @@ spec:
 {{- $tree := deepCopy . }}
 {{ $_ := set $tree.Values.proxy "workloadKind" "deployment" -}}
 {{ $_ := set $tree.Values.proxy "component" "linkerd-identity" -}}
-{{ include "linkerd.proxy.validation" .Values.proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -5,7 +5,6 @@
 {{- $tree := deepCopy . }}
 {{ $_ := set $tree.Values.proxy "workloadKind" "deployment" -}}
 {{ $_ := set $tree.Values.proxy "component" "linkerd-proxy-injector" -}}
-{{ include "linkerd.proxy.validation" .Values.proxy -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/partials/templates/_metadata.tpl
+++ b/charts/partials/templates/_metadata.tpl
@@ -7,7 +7,6 @@ linkerd.io/created-by: {{ .Values.cliVersion | default (printf "linkerd/helm %s"
 {{- end -}}
 
 {{- define "partials.proxy.annotations" -}}
-linkerd.io/identity-mode: {{ternary "default" "disabled" (not .Values.proxy.disableIdentity)}}
 linkerd.io/proxy-version: {{.Values.proxy.image.version | default .Values.linkerdVersion}}
 {{- end -}}
 

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -87,10 +87,6 @@ env:
 - name: LINKERD2_PROXY_DESTINATION_CONTEXT
   value: |
     {"ns":"$(_pod_ns)", "nodeName":"$(_pod_nodeName)"}
-{{ if .Values.proxy.disableIdentity -}}
-- name: LINKERD2_PROXY_IDENTITY_DISABLED
-  value: disabled
-{{ else -}}
 - name: _pod_sa
   valueFrom:
     fieldRef:
@@ -128,7 +124,6 @@ be used in other contexts.
   value: linkerd-destination.{{.Release.Namespace}}.serviceaccount.identity.{{.Release.Namespace}}.{{$trustDomain}}
 - name: LINKERD2_PROXY_POLICY_SVC_NAME
   value: linkerd-destination.{{.Release.Namespace}}.serviceaccount.identity.{{.Release.Namespace}}.{{$trustDomain}}
-{{ end -}}
 {{ if .Values.proxy.accessLog -}}
 - name: LINKERD2_PROXY_ACCESS_LOG
   value: {{.Values.proxy.accessLog | quote}}
@@ -178,20 +173,16 @@ lifecycle:
         - {{.Values.proxy.waitBeforeExitSeconds | quote}}
 {{- end }}
 {{- end }}
-{{- if or (not .Values.proxy.disableIdentity) (.Values.proxy.saMountPath) }}
 volumeMounts:
-{{- if not .Values.proxy.disableIdentity }}
 - mountPath: /var/run/linkerd/identity/end-entity
   name: linkerd-identity-end-entity
 {{- if .Values.identity.serviceAccountTokenProjection }}
 - mountPath: /var/run/secrets/tokens
   name: linkerd-identity-token
 {{- end }}
-{{- end -}}
 {{- if .Values.proxy.saMountPath }}
 - mountPath: {{.Values.proxy.saMountPath.mountPath}}
   name: {{.Values.proxy.saMountPath.name}}
   readOnly: {{.Values.proxy.saMountPath.readOnly}}
-{{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/partials/templates/_validate.tpl
+++ b/charts/partials/templates/_validate.tpl
@@ -1,9 +1,3 @@
-{{- define "linkerd.proxy.validation" -}}
-{{- if .disableIdentity -}}
-{{- fail (printf "Can't disable identity mTLS for %s. Set '.Values.proxy.disableIdentity' to 'false'" .component) -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "linkerd.webhook.validation" -}}
 
 {{- if and (.injectCaFrom) (.injectCaFromSecret) -}}

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -76,7 +76,6 @@
   },
   {{- end }}
   {{- if .Values.proxy }}
-  {{- if not .Values.proxy.disableIdentity -}}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/volumes/-",
@@ -94,7 +93,6 @@
     "value":
       {{- include "partials.proxy.volumes.service-account-token" . | fromYaml | toPrettyJson | nindent 6 }}
   },
-  {{- end }}
   {{- end }}
   {
     "op": "add",

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -213,10 +213,6 @@ func generateAnnotationsDocs() []annotationDoc {
 			Description: "Tag to be used for the Linkerd proxy images",
 		},
 		{
-			Name:        k8s.ProxyDisableIdentityAnnotation,
-			Description: "Disables resources from participating in TLS identity",
-		},
-		{
 			Name:        k8s.ProxyEnableDebugAnnotation,
 			Description: "Inject a debug sidecar for data plane debugging",
 		},

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -446,10 +446,6 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 		overrideAnnotations[k8s.ProxyLogFormatAnnotation] = proxy.LogFormat
 	}
 
-	if proxy.DisableIdentity != baseProxy.DisableIdentity {
-		overrideAnnotations[k8s.ProxyDisableIdentityAnnotation] = strconv.FormatBool(proxy.DisableIdentity)
-	}
-
 	if proxy.RequireIdentityOnInboundPorts != baseProxy.RequireIdentityOnInboundPorts {
 		overrideAnnotations[k8s.ProxyRequireIdentityOnInboundPortsAnnotation] = proxy.RequireIdentityOnInboundPorts
 	}

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -664,7 +664,6 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 	values.Proxy.UID = 999
 	values.Proxy.LogLevel = "debug"
 	values.Proxy.LogFormat = "cool"
-	values.Proxy.DisableIdentity = true
 	values.Proxy.EnableExternalProfiles = true
 	values.Proxy.Resources.CPU.Request = "10m"
 	values.Proxy.Resources.CPU.Limit = "100m"
@@ -684,7 +683,6 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 		k8s.ProxyUIDAnnotation:                 "999",
 		k8s.ProxyLogLevelAnnotation:            "debug",
 		k8s.ProxyLogFormatAnnotation:           "cool",
-		k8s.ProxyDisableIdentityAnnotation:     "true",
 
 		k8s.ProxyEnableExternalProfilesAnnotation: "true",
 		k8s.ProxyCPURequestAnnotation:             "10m",

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -469,12 +469,6 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 
-		flag.NewBoolFlag(injectFlags, "disable-identity", defaults.Proxy.DisableIdentity,
-			"Disables resources from participating in TLS identity", func(values *l5dcharts.Values, value bool) error {
-				values.Proxy.DisableIdentity = value
-				return nil
-			}),
-
 		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.Proxy.RequireIdentityOnInboundPorts, ","),
 			"Inbound ports on which the proxy should require identity", func(values *l5dcharts.Values, value []string) error {
 				values.Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
@@ -572,10 +566,6 @@ func validateProxyValues(values *l5dcharts.Values) error {
 		if _, _, err := net.ParseCIDR(network); err != nil {
 			return fmt.Errorf("cannot parse destination get networks: %s", err)
 		}
-	}
-
-	if values.Proxy.DisableIdentity && len(values.Proxy.RequireIdentityOnInboundPorts) > 0 {
-		return errors.New("Identity must be enabled when  --require-identity-on-inbound-ports is specified")
 	}
 
 	if values.Proxy.Image.Version != "" && !alphaNumDashDot.MatchString(values.Proxy.Image.Version) {

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -469,6 +469,11 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 
+		flag.NewBoolFlag(injectFlags, "disable-identity", false,
+			"Disables resources from participating in TLS identity", func(values *l5dcharts.Values, value bool) error {
+				return errors.New("--disable-identity is no longer supported; identity is always required")
+			}),
+
 		flag.NewStringSliceFlag(injectFlags, "require-identity-on-inbound-ports", strings.Split(defaults.Proxy.RequireIdentityOnInboundPorts, ","),
 			"Inbound ports on which the proxy should require identity", func(values *l5dcharts.Values, value []string) error {
 				values.Proxy.RequireIdentityOnInboundPorts = strings.Join(value, ",")
@@ -487,6 +492,7 @@ func makeInjectFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 				return nil
 			}),
 	}
+	injectFlags.MarkHidden("disable-identity")
 
 	return flags, injectFlags
 }

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -10,7 +10,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
       labels:
         app: nginx

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -10,7 +10,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
       labels:
         app: redis
@@ -208,7 +207,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
       labels:
         app: nginx

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -10,7 +10,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
       labels:
         app: redis

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -14,7 +14,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
         prometheus.io/format: prometheus
         prometheus.io/path: /stats

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc
@@ -221,7 +220,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc
@@ -430,7 +428,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc
@@ -639,7 +636,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -13,7 +13,6 @@ spec:
       annotations:
         config.linkerd.io/access-log: apache
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: testinjectversion
       labels:
         app: nginx

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -20,7 +20,6 @@ spec:
         config.linkerd.io/skip-inbound-ports: 7777,8888
         config.linkerd.io/skip-outbound-ports: "9999"
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: override
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc
@@ -221,7 +220,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -13,7 +13,6 @@ spec:
       annotations:
         config.linkerd.io/enable-debug-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -13,7 +13,6 @@ spec:
       annotations:
         config.linkerd.io/opaque-ports: 3000,5000-6000,mysql
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -13,7 +13,6 @@ spec:
       annotations:
         config.linkerd.io/admin-port: "1234"
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -14,7 +14,6 @@ spec:
         config.linkerd.io/skip-inbound-ports: 22,8100-8102
         config.linkerd.io/skip-outbound-ports: "5432"
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -12,7 +12,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -14,7 +14,6 @@ items:
       metadata:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
-          linkerd.io/identity-mode: default
           linkerd.io/proxy-version: test-inject-proxy-version
         labels:
           app: web-svc
@@ -222,7 +221,6 @@ items:
       metadata:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
-          linkerd.io/identity-mode: default
           linkerd.io/proxy-version: test-inject-proxy-version
         labels:
           app: emoji-svc

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -14,7 +14,6 @@ items:
       metadata:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
-          linkerd.io/identity-mode: default
           linkerd.io/proxy-version: test-inject-proxy-version
         labels:
           app: web-svc
@@ -222,7 +221,6 @@ items:
       metadata:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
-          linkerd.io/identity-mode: default
           linkerd.io/proxy-version: test-inject-proxy-version
         labels:
           app: emoji-svc

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -3,7 +3,6 @@ kind: Pod
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    linkerd.io/identity-mode: default
     linkerd.io/proxy-version: test-inject-proxy-version
   labels:
     app: vote-bot

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -3,7 +3,6 @@ kind: Pod
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
-    linkerd.io/identity-mode: default
     linkerd.io/inject: ingress
     linkerd.io/proxy-version: test-inject-proxy-version
   labels:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -5,7 +5,6 @@ metadata:
     config.linkerd.io/skip-inbound-ports: 22,8100-8102
     config.linkerd.io/skip-outbound-ports: "5432"
     linkerd.io/created-by: linkerd/cli dev-undefined
-    linkerd.io/identity-mode: default
     linkerd.io/proxy-version: test-inject-proxy-version
   labels:
     app: vote-bot

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -7,7 +7,6 @@ metadata:
     config.linkerd.io/proxy-memory-limit: 150Mi
     config.linkerd.io/proxy-memory-request: 100Mi
     linkerd.io/created-by: linkerd/cli dev-undefined
-    linkerd.io/identity-mode: default
     linkerd.io/proxy-version: test-inject-proxy-version
   labels:
     app: vote-bot

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -13,7 +13,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         app: web-svc

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -8,7 +8,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: testinjectversion
       labels:
         app: get-test
@@ -219,7 +218,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: testinjectversion
       labels:
         app: get-test

--- a/cli/cmd/testdata/inject_tap_deployment.input.yml
+++ b/cli/cmd/testdata/inject_tap_deployment.input.yml
@@ -30,7 +30,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli git-a94122bf
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: git-a94122bf
       creationTimestamp: null
       labels:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -29,7 +29,6 @@ spec:
       annotations:
         config.linkerd.io/enable-debug-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-inject-proxy-version
       labels:
         linkerd.io/control-plane-component: tap

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1735,7 +1733,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2094,7 +2091,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: my.custom.registry/linkerd-io/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1725,7 +1723,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2074,7 +2071,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1237,7 +1237,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1449,7 +1448,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1839,7 +1837,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2237,7 +2234,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1237,7 +1237,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1449,7 +1448,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1839,7 +1837,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2237,7 +2234,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1141,7 +1141,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1325,7 +1324,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1665,7 +1663,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1973,7 +1970,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -476,7 +476,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -654,7 +653,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -997,7 +995,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1360,7 +1357,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -503,7 +503,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -709,7 +708,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1102,7 +1100,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1505,7 +1502,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -507,7 +507,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -713,7 +712,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo
@@ -1110,7 +1108,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo
@@ -1521,7 +1518,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         asda: fasda
         bingo: bongo

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -503,7 +503,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -709,7 +708,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1102,7 +1100,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1505,7 +1502,6 @@ spec:
       annotations:
         linkerd.io/helm-release-version: "0"
         linkerd.io/created-by: linkerd/helm linkerd-version
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: test-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1697,7 +1695,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2018,7 +2015,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1207,7 +1207,6 @@ data:
       await: false
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: ProxyImageName
@@ -1391,7 +1390,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: CliVersion
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: CliVersion
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2102,7 +2099,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: CliVersion
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: ProxyVersion
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1210,7 +1210,6 @@ data:
       await: true
       capabilities: null
       defaultInboundPolicy: ""
-      disableIdentity: false
       enableExternalProfiles: false
       image:
         name: cr.l5d.io/linkerd/proxy
@@ -1394,7 +1393,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -1734,7 +1732,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"
       labels:
@@ -2092,7 +2089,6 @@ spec:
     metadata:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/identity-mode: default
         linkerd.io/proxy-version: install-proxy-version
         config.linkerd.io/opaque-ports: "8443"
         config.linkerd.io/default-inbound-policy: "all-unauthenticated"

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -520,7 +520,6 @@ kind: Pod
 metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli some-version
-    linkerd.io/identity-mode: default
     linkerd.io/proxy-version: some-version
   labels:
     linkerd.io/control-plane-ns: linkerd

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -376,7 +376,6 @@ func createWeightedAddr(address watcher.Address, opaquePorts map[uint32]struct{}
 	// multiple meshes can participate in identity if they share trust roots.
 	if identityTrustDomain != "" &&
 		controllerNSLabel == controllerNS &&
-		address.Pod.Annotations[k8s.IdentityModeAnnotation] == k8s.IdentityModeDefault &&
 		!isSkippedInboundPort {
 
 		id := fmt.Sprintf("%s.%s.serviceaccount.identity.%s.%s", sa, ns, controllerNSLabel, identityTrustDomain)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -26,7 +26,6 @@ func Main(args []string) {
 	metricsAddr := cmd.String("metrics-addr", ":9996", "address to serve scrapable metrics on")
 	kubeConfigPath := cmd.String("kubeconfig", "", "path to kube config")
 	enableH2Upgrade := cmd.Bool("enable-h2-upgrade", true, "Enable transparently upgraded HTTP2 connections among pods in the service mesh")
-	disableIdentity := cmd.Bool("disable-identity", false, "Disable identity configuration")
 	controllerNamespace := cmd.String("controller-namespace", "linkerd", "namespace in which Linkerd is installed")
 	enableEndpointSlices := cmd.Bool("enable-endpoint-slices", true, "Enable the usage of EndpointSlice informers and resources")
 	trustDomain := cmd.String("identity-trust-domain", "", "configures the name suffix used for identities")
@@ -47,13 +46,9 @@ func Main(args []string) {
 		log.Fatalf("Failed to listen on %s: %s", *addr, err)
 	}
 
-	if *disableIdentity {
-		log.Info("Identity is disabled")
-	} else {
-		if *trustDomain == "" {
-			*trustDomain = "cluster.local"
-			log.Warnf(" expected trust domain through args (falling back to %s)", *trustDomain)
-		}
+	if *trustDomain == "" {
+		*trustDomain = "cluster.local"
+		log.Warnf(" expected trust domain through args (falling back to %s)", *trustDomain)
 	}
 
 	if *clusterDomain == "" {

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -1,11 +1,6 @@
 [
   {
     "op": "add",
-    "path": "/metadata/annotations/linkerd.io~1identity-mode",
-    "value": "disabled"
-  },
-  {
-    "op": "add",
     "path": "/metadata/annotations/linkerd.io~1proxy-version",
     "value": "dev-undefined"
   },
@@ -101,6 +96,35 @@
       "name": "linkerd-debug",
       "terminationMessagePolicy": "FallbackToLogsOnError"
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "linkerd-identity-end-entity",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value":
+      {
+        "name": "linkerd-identity-token",
+        "projected": {
+          "sources": [
+            {
+              "serviceAccountToken": {
+                "audience": "identity.l5d.io",
+                "expirationSeconds": 86400,
+                "path": "linkerd-identity-token"
+              }
+            }
+          ]
+        }
+      }
   },
   {
     "op": "add",
@@ -220,8 +244,44 @@
           "value": "{\"ns\":\"$(_pod_ns)\", \"nodeName\":\"$(_pod_nodeName)\"}\n"
         },
         {
-          "name": "LINKERD2_PROXY_IDENTITY_DISABLED",
-          "value": "disabled"
+          "name": "_pod_sa",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.serviceAccountName"
+            }
+          }
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_DIR",
+          "value": "/var/run/linkerd/identity/end-entity"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS",
+          "value": "IdentityTrustAnchorsPEM\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TOKEN_FILE",
+          "value": "/var/run/secrets/tokens/linkerd-identity-token"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_ADDR",
+          "value": "linkerd-identity-headless.linkerd.svc.cluster.local.:8080"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_LOCAL_NAME",
+          "value": "$(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_NAME",
+          "value": "linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
         }
       ],
       "image": "cr.l5d.io/linkerd/proxy:dev-undefined",
@@ -266,7 +326,17 @@
         "readOnlyRootFilesystem": true,
         "runAsUser": 2102
       },
-      "terminationMessagePolicy": "FallbackToLogsOnError"
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/var/run/linkerd/identity/end-entity",
+          "name": "linkerd-identity-end-entity"
+        },
+        {
+          "mountPath": "/var/run/secrets/tokens",
+          "name": "linkerd-identity-token"
+        }
+      ]
     }
   }
 ]

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -11,11 +11,6 @@
   },
   {
     "op": "add",
-    "path": "/metadata/annotations/linkerd.io~1identity-mode",
-    "value": "disabled"
-  },
-  {
-    "op": "add",
     "path": "/metadata/annotations/linkerd.io~1proxy-version",
     "value": "dev-undefined"
   },
@@ -101,6 +96,35 @@
         }
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "linkerd-identity-end-entity",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value":
+      {
+        "name": "linkerd-identity-token",
+        "projected": {
+          "sources": [
+            {
+              "serviceAccountToken": {
+                "audience": "identity.l5d.io",
+                "expirationSeconds": 86400,
+                "path": "linkerd-identity-token"
+              }
+            }
+          ]
+        }
+      }
   },
   {
     "op": "add",
@@ -220,8 +244,44 @@
           "value": "{\"ns\":\"$(_pod_ns)\", \"nodeName\":\"$(_pod_nodeName)\"}\n"
         },
         {
-          "name": "LINKERD2_PROXY_IDENTITY_DISABLED",
-          "value": "disabled"
+          "name": "_pod_sa",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.serviceAccountName"
+            }
+          }
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_DIR",
+          "value": "/var/run/linkerd/identity/end-entity"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS",
+          "value": "IdentityTrustAnchorsPEM\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TOKEN_FILE",
+          "value": "/var/run/secrets/tokens/linkerd-identity-token"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_ADDR",
+          "value": "linkerd-identity-headless.linkerd.svc.cluster.local.:8080"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_LOCAL_NAME",
+          "value": "$(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_NAME",
+          "value": "linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
         }
       ],
       "image": "cr.l5d.io/linkerd/proxy:dev-undefined",
@@ -274,7 +334,17 @@
         "readOnlyRootFilesystem": true,
         "runAsUser": 2102
       },
-      "terminationMessagePolicy": "FallbackToLogsOnError"
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/var/run/linkerd/identity/end-entity",
+          "name": "linkerd-identity-end-entity"
+        },
+        {
+          "mountPath": "/var/run/secrets/tokens",
+          "name": "linkerd-identity-token"
+        }
+      ]
     }
   }
 ]

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -1,11 +1,6 @@
 [
   {
     "op": "add",
-    "path": "/metadata/annotations/linkerd.io~1identity-mode",
-    "value": "disabled"
-  },
-  {
-    "op": "add",
     "path": "/metadata/annotations/linkerd.io~1proxy-version",
     "value": "dev-undefined"
   },
@@ -91,6 +86,35 @@
         }
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "linkerd-identity-end-entity",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value":
+      {
+        "name": "linkerd-identity-token",
+        "projected": {
+          "sources": [
+            {
+              "serviceAccountToken": {
+                "audience": "identity.l5d.io",
+                "expirationSeconds": 86400,
+                "path": "linkerd-identity-token"
+              }
+            }
+          ]
+        }
+      }
   },
   {
     "op": "add",
@@ -210,8 +234,44 @@
           "value": "{\"ns\":\"$(_pod_ns)\", \"nodeName\":\"$(_pod_nodeName)\"}\n"
         },
         {
-          "name": "LINKERD2_PROXY_IDENTITY_DISABLED",
-          "value": "disabled"
+          "name": "_pod_sa",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.serviceAccountName"
+            }
+          }
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_DIR",
+          "value": "/var/run/linkerd/identity/end-entity"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS",
+          "value": "IdentityTrustAnchorsPEM\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TOKEN_FILE",
+          "value": "/var/run/secrets/tokens/linkerd-identity-token"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_ADDR",
+          "value": "linkerd-identity-headless.linkerd.svc.cluster.local.:8080"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_LOCAL_NAME",
+          "value": "$(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_NAME",
+          "value": "linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
         }
       ],
       "image": "cr.l5d.io/linkerd/proxy:dev-undefined",
@@ -256,7 +316,17 @@
         "readOnlyRootFilesystem": true,
         "runAsUser": 2102
       },
-      "terminationMessagePolicy": "FallbackToLogsOnError"
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/var/run/linkerd/identity/end-entity",
+          "name": "linkerd-identity-end-entity"
+        },
+        {
+          "mountPath": "/var/run/secrets/tokens",
+          "name": "linkerd-identity-token"
+        }
+      ]
     }
   }
 ]

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -62,7 +62,7 @@ func confNsWithConfigAnnotations() *inject.ResourceConfig {
 }
 func TestGetPodPatch(t *testing.T) {
 
-	values.Proxy.DisableIdentity = true
+	values.IdentityTrustAnchorsPEM = "IdentityTrustAnchorsPEM"
 
 	factory := fake.NewFactory(filepath.Join("fake", "data"))
 	nsEnabled, err := factory.Namespace("namespace-inject-enabled.yaml")

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -92,7 +92,6 @@ type (
 		Capabilities *Capabilities `json:"capabilities"`
 		// This should match .Resources.CPU.Limit, but must be a whole number
 		Cores                         int64            `json:"cores,omitempty"`
-		DisableIdentity               bool             `json:"disableIdentity"`
 		EnableExternalProfiles        bool             `json:"enableExternalProfiles"`
 		Image                         *Image           `json:"image"`
 		LogLevel                      string           `json:"logLevel"`

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2226,7 +2226,6 @@ data:
     proxy:
       capabilities: null
       component: linkerd-controller
-      disableIdentity: false
       disableTap: false
       enableExternalProfiles: false
       image:
@@ -2382,7 +2381,6 @@ data:
       proxy:
         capabilities: null
         component: linkerd-controller
-        disableIdentity: false
         disableTap: false
         enableExternalProfiles: false
         image:

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -40,7 +40,6 @@ func TestGetOverriddenValues(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							k8s.ProxyDisableIdentityAnnotation:               "true",
 							k8s.ProxyImageAnnotation:                         "cr.l5d.io/linkerd/proxy",
 							k8s.ProxyImagePullPolicyAnnotation:               pullPolicy,
 							k8s.ProxyInitImageAnnotation:                     "cr.l5d.io/linkerd/proxy-init",
@@ -79,7 +78,6 @@ func TestGetOverriddenValues(t *testing.T) {
 				values, _ := l5dcharts.NewValues()
 
 				values.Proxy.Cores = 2
-				values.Proxy.DisableIdentity = true
 				values.Proxy.Image.Name = "cr.l5d.io/linkerd/proxy"
 				values.Proxy.Image.PullPolicy = pullPolicy
 				values.Proxy.Image.Version = proxyVersionOverride
@@ -136,7 +134,6 @@ func TestGetOverriddenValues(t *testing.T) {
 		},
 		{id: "use namespace overrides",
 			nsAnnotations: map[string]string{
-				k8s.ProxyDisableIdentityAnnotation:        "true",
 				k8s.ProxyImageAnnotation:                  "cr.l5d.io/linkerd/proxy",
 				k8s.ProxyImagePullPolicyAnnotation:        pullPolicy,
 				k8s.ProxyInitImageAnnotation:              "cr.l5d.io/linkerd/proxy-init",
@@ -172,7 +169,6 @@ func TestGetOverriddenValues(t *testing.T) {
 				values, _ := l5dcharts.NewValues()
 
 				values.Proxy.Cores = 2
-				values.Proxy.DisableIdentity = true
 				values.Proxy.Image.Name = "cr.l5d.io/linkerd/proxy"
 				values.Proxy.Image.PullPolicy = pullPolicy
 				values.Proxy.Image.Version = proxyVersionOverride

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -112,10 +112,6 @@ const (
 	// disable injection for a pod or namespace.
 	ProxyInjectDisabled = Disabled
 
-	// IdentityModeAnnotation controls how a pod participates
-	// in service identity.
-	IdentityModeAnnotation = Prefix + "/identity-mode"
-
 	/*
 	 * Proxy config annotations
 	 */
@@ -234,9 +230,6 @@ const (
 	// to operate as a gateway, routing requests that target the inbound router.
 	ProxyEnableGatewayAnnotation = ProxyConfigAnnotationsPrefix + "/enable-gateway"
 
-	// ProxyDisableIdentityAnnotation can be used to disable identity on the injected proxy.
-	ProxyDisableIdentityAnnotation = ProxyConfigAnnotationsPrefix + "/disable-identity"
-
 	// ProxyEnableDebugAnnotation is set to true if the debug container is
 	// injected.
 	ProxyEnableDebugAnnotation = ProxyConfigAnnotationsPrefix + "/enable-debug-sidecar"
@@ -260,14 +253,6 @@ const (
 	// ProxyAccessLogAnnotation configures whether HTTP access logging is
 	// enabled, and what access log format is used.
 	ProxyAccessLogAnnotation = ProxyConfigAnnotationsPrefix + "/access-log"
-
-	// IdentityModeDefault is assigned to IdentityModeAnnotation to
-	// use the control plane's default identity scheme.
-	IdentityModeDefault = "default"
-
-	// IdentityModeDisabled is assigned to IdentityModeAnnotation to
-	// disable the proxy from participating in automatic identity.
-	IdentityModeDisabled = Disabled
 
 	// AllUnauthenticated allows all unathenticated connections.
 	AllUnauthenticated = "all-unauthenticated"

--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -21,18 +21,12 @@ import (
 
 const (
 	envDir          = "LINKERD2_PROXY_IDENTITY_DIR"
-	envDisabled     = "LINKERD2_PROXY_IDENTITY_DISABLED"
 	envLocalName    = "LINKERD2_PROXY_IDENTITY_LOCAL_NAME"
 	envTrustAnchors = "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS"
 )
 
 func main() {
 	defer runProxy()
-
-	if os.Getenv(envDisabled) != "" {
-		log.Debug("Identity disabled.")
-		return
-	}
 
 	dir := os.Getenv(envDir)
 	keyPath, csrPath, err := checkEndEntityDir(dir)

--- a/test/integration/inject/inject_test.go
+++ b/test/integration/inject/inject_test.go
@@ -59,7 +59,6 @@ func TestInjectManualParams(t *testing.T) {
 	}
 
 	injectionValidator := testutil.InjectValidator{
-		DisableIdentity:        true,
 		Version:                "proxy-version",
 		Image:                  reg + "/proxy-image",
 		InitImage:              reg + "/init-image",
@@ -83,8 +82,6 @@ func TestInjectManualParams(t *testing.T) {
 	// TODO: test config.linkerd.io/proxy-version
 	cmd := append([]string{"inject",
 		"--manual",
-		"--linkerd-namespace=fake-ns",
-		"--ignore-cluster",
 	}, flags...)
 
 	cmd = append(cmd, "testdata/inject_test.yaml")

--- a/test/integration/inject/inject_test.go
+++ b/test/integration/inject/inject_test.go
@@ -59,6 +59,7 @@ func TestInjectManualParams(t *testing.T) {
 	}
 
 	injectionValidator := testutil.InjectValidator{
+		NoInitContainer:        TestHelper.CNI(),
 		Version:                "proxy-version",
 		Image:                  reg + "/proxy-image",
 		InitImage:              reg + "/init-image",

--- a/testutil/inject_validator.go
+++ b/testutil/inject_validator.go
@@ -18,7 +18,6 @@ const enabled = "true"
 // injected pods
 type InjectValidator struct {
 	NoInitContainer         bool
-	DisableIdentity         bool
 	AutoInject              bool
 	AdminPort               int
 	ControlPort             int
@@ -427,11 +426,6 @@ func (iv *InjectValidator) GetFlagsAndAnnotations() ([]string, map[string]string
 	if iv.ControlPort != 0 {
 		annotations[k8s.ProxyControlPortAnnotation] = strconv.Itoa(iv.ControlPort)
 		flags = append(flags, fmt.Sprintf("--control-port=%s", strconv.Itoa(iv.ControlPort)))
-	}
-
-	if iv.DisableIdentity {
-		annotations[k8s.IdentityModeDisabled] = enabled
-		flags = append(flags, "--disable-identity")
 	}
 
 	if iv.EnableDebug {


### PR DESCRIPTION
Fixes #7724

Also:
- Removed the `linkerd.io/identity-mode` annotation.
- Removed the `config.linkerd.io/disable-identity` annotation.
- Removed the `linkerd.proxy.validation` template partial, which only
  made sense when `proxy.disableIdentity` was `true`.
- TestInjectManualParams now requires to hit the cluster to retrieve the
  trust root.
