### PR TITLE
fix: don't remove gateway addresses from headless mirror endpoints

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -526,6 +526,11 @@ func (rcsw *RemoteClusterServiceWatcher) handleLocalNamespaceAdded(ns *corev1.Na
 // - svc's Endpoint has Subsets, but none have addresses (only notReadyAddresses,
 // when the pod is not ready yet)
 func (rcsw *RemoteClusterServiceWatcher) isEmptyService(svc *corev1.Service) (bool, error) {
+	if _, found := svc.Labels[consts.MirroredHeadlessSvcNameLabel]; found {
+		// Service is a mirrored headless service, remote will not have a service or endpoints with
+		// this name
+		return false, nil
+	}
 	ep, err := rcsw.remoteAPIClient.Endpoint().Lister().Endpoints(svc.Namespace).Get(svc.Name)
 	if err != nil {
 		if kerrors.IsNotFound(err) {


### PR DESCRIPTION
# Problem

The endpoints associated with headless endpoint services lose their subsets approximately 30 seconds after being created.

# Details

Suppose I have a headless service named `svc` with a statefulset pod named `nginx-0` under it, exported from a cluster named `east`, meshed with a cluster `west`.

Cluster `west` meshed will create:
* A headless endpoint service named `nginx-0-east` with a cluster IP and endpoints pointing to the gateway address(es) of east. The service will be created with at least the label `mirror.linkerd.io/headless-mirror-svc-name: svc-east`
* A mirror service named `svc-east`, and endpoints for that service pointing to the cluster IP of the headless endpoint service.

However, when the cluster watcher processes the message `RepairEndpoints`, it will call the function `rcsw.isEmptyService(targetService)` for the headless endpoint service `nginx-0-east`. It will then attempt to resolve that service to its mirrored counterpart, "nginx-0" (obtained by trimming `-east` off the end).

But `nginx-0` is not a service in the remote cluster, and `isEmptyService` returns true.

# Solution

If the service has the label `mirror.linkerd.io/headless-mirror-svc-name` set, we do not consider it empty.

# Alternative solutions:

* Filter headless endpoint services out of the slice iterated over, perhaps in `getMirrorServices`
* ???
