### PR TITLE
Use correct rustls feature name

### DIFF
--- a/policy-controller/arm64.dockerfile
+++ b/policy-controller/arm64.dockerfile
@@ -13,7 +13,7 @@ COPY Cargo.toml Cargo.lock policy-controller/ /build/
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.56.1,source=/usr/local/cargo,target=/usr/local/cargo \
     cargo build --locked --release --target=aarch64-unknown-linux-gnu \
-        --package=linkerd-policy-controller --no-default-features --features="rustls" && \
+        --package=linkerd-policy-controller --no-default-features --features="rustls-tls" && \
     mv target/aarch64-unknown-linux-gnu/release/linkerd-policy-controller /tmp/
 
 FROM --platform=linux/arm64 $RUNTIME_IMAGE


### PR DESCRIPTION
#7698 changed the `rustls` feature name to `rustls-tls` but it was not updated in the ARM build.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
