### PR TITLE
dev: Configure locales

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,8 +10,8 @@ RUN apt install -y \
     cmake \
     jq \
     libssl-dev \
-    locales \
     lldb \
+    locales \
     lsb-release \
     npm \
     sudo \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,12 +10,15 @@ RUN apt install -y \
     cmake \
     jq \
     libssl-dev \
+    locales \
     lldb \
     lsb-release \
     npm \
     sudo \
     time
 RUN npm install markdownlint-cli@0.23.1 --global
+
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
 ARG USER=code
 ARG USER_UID=1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v5",
-    //"dockerFile": "./Dockerfile",
+    "image": "ghcr.io/linkerd/dev:v6",
+    // "dockerFile": "./Dockerfile",
+    // "context": "..",
     "extensions": [
         "DavidAnson.vscode-markdownlint",
         "golang.go",


### PR DESCRIPTION
The default devcontainer image doesn't configure locales so many tools
(less, zsh, etc), do not properly render unicode characters.

This change updates the devcontainer image with locales configured and
`en_US.UTF-8` enabled by default. This default can be overridden in
per-user configurations.
