### PR TITLE
Allow integration tests to run in parallel

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -381,7 +381,7 @@ run_test(){
 
   printf 'Test script: [%s] Params: [%s]\n' "${filename##*/}" "$*"
   # Exit on failure here
-  GO111MODULE=on go test -p 1 -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --default-allow-policy="$default_allow_policy" --k8s-context="$context" --integration-tests "$@" || exit 1
+  GO111MODULE=on go test -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --default-allow-policy="$default_allow_policy" --k8s-context="$context" --integration-tests "$@" || exit 1
 }
 
 # Returns the latest version for the release channel

--- a/test/integration/deep/egress/egress_test.go
+++ b/test/integration/deep/egress/egress_test.go
@@ -17,6 +17,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/deep/endpoints/endpoints_test.go
+++ b/test/integration/deep/endpoints/endpoints_test.go
@@ -23,6 +23,9 @@ type testCase struct {
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/deep/localhost/localhost_test.go
+++ b/test/integration/deep/localhost/localhost_test.go
@@ -15,6 +15,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/deep/opaqueports/opaque_ports_test.go
+++ b/test/integration/deep/opaqueports/opaque_ports_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+
 	"regexp"
 	"testing"
 	"time"
@@ -37,6 +38,9 @@ var (
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/deep/serviceaccounts/serviceaccounts_test.go
+++ b/test/integration/deep/serviceaccounts/serviceaccounts_test.go
@@ -1,6 +1,7 @@
 package serviceaccounts
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -13,6 +14,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/deep/skipports/skip_ports_test.go
+++ b/test/integration/deep/skipports/skip_ports_test.go
@@ -23,6 +23,9 @@ var (
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/external/externalissuer/external_issuer_test.go
+++ b/test/integration/external/externalissuer/external_issuer_test.go
@@ -21,6 +21,10 @@ const (
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	// External issuer test relies on viz so block until viz is ready.
+	if err := TestHelper.WaitUntilDeployReady(testutil.ExternalVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/external/externalresources/rabbitmq_test.go
+++ b/test/integration/external/externalresources/rabbitmq_test.go
@@ -14,6 +14,11 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	// External resources test only relies on control plane, so block until its
+	// pods are ready
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/external/stat/stat_test.go
+++ b/test/integration/external/stat/stat_test.go
@@ -20,6 +20,10 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	// External stat relies on viz so block until viz is ready.
+	if err := TestHelper.WaitUntilDeployReady(testutil.ExternalVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/install/inject/inject_test.go
+++ b/test/integration/install/inject/inject_test.go
@@ -33,6 +33,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/install/smoke/install_smoke_test.go
+++ b/test/integration/install/smoke/install_smoke_test.go
@@ -25,8 +25,8 @@ var (
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
-	if TestHelper.CNI() {
-		os.Exit(0)
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasStable); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
 	}
 	os.Exit(m.Run())
 }

--- a/test/integration/viz/edges/edges_test.go
+++ b/test/integration/viz/edges/edges_test.go
@@ -19,6 +19,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/policy/policy_test.go
+++ b/test/integration/viz/policy/policy_test.go
@@ -16,6 +16,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/routes/routes_test.go
+++ b/test/integration/viz/routes/routes_test.go
@@ -17,6 +17,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/serviceprofiles/serviceprofiles_test.go
+++ b/test/integration/viz/serviceprofiles/serviceprofiles_test.go
@@ -28,6 +28,9 @@ type testCase struct {
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/stat/stat_test.go
+++ b/test/integration/viz/stat/stat_test.go
@@ -20,6 +20,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/tap/tap_test.go
+++ b/test/integration/viz/tap/tap_test.go
@@ -2,6 +2,7 @@ package tap
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -17,6 +18,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/tracing/tracing_test.go
+++ b/test/integration/viz/tracing/tracing_test.go
@@ -37,6 +37,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/test/integration/viz/trafficsplit/trafficsplit_test.go
+++ b/test/integration/viz/trafficsplit/trafficsplit_test.go
@@ -15,6 +15,9 @@ var TestHelper *testutil.TestHelper
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
+	if err := TestHelper.WaitUntilDeployReady(testutil.LinkerdVizDeployReplicas); err != nil {
+		panic(fmt.Sprintf("error running test: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -75,8 +75,9 @@ var LinkerdDeployReplicasEdge = map[string]DeploySpec{
 	"linkerd-proxy-injector": {"linkerd", 1},
 }
 
-// LinkerdDeployReplicasStable is a map containing the number of replicas for each Deployment and the main
-// container name. Override whenever edge deviates from stable.
+// LinkerdDeployReplicasStable is a map containing the number of replicas for
+// each Deployment and the main container name. Override whenever edge deviates
+// from stable.
 var LinkerdDeployReplicasStable = LinkerdDeployReplicasEdge
 
 // LinkerdVizDeployReplicas is a map containing the number of replicas for
@@ -90,10 +91,20 @@ var LinkerdVizDeployReplicas = map[string]DeploySpec{
 	"web":          {"linkerd-viz", 1},
 }
 
-// MulticlusterDeployReplicas is a map containing the number of replicas for each Deployment and the main
-// container name for multicluster components
+// MulticlusterDeployReplicas is a map containing the number of replicas for
+// each Deployment and the main container name for multicluster components
 var MulticlusterDeployReplicas = map[string]DeploySpec{
 	"linkerd-gateway": {"linkerd-multicluster", 1},
+}
+
+// ExternalVizDeployReplicas has an external prometheus instance that's in a
+// separate namespace
+var ExternalVizDeployReplicas = map[string]DeploySpec{
+	"prometheus":   {"external-prometheus", 1},
+	"metrics-api":  {"linkerd-viz", 1},
+	"tap":          {"linkerd-viz", 1},
+	"tap-injector": {"linkerd-viz", 1},
+	"web":          {"linkerd-viz", 1},
 }
 
 // NewGenericTestHelper returns a new *TestHelper from the options provided as function parameters.


### PR DESCRIPTION
Go's test runner (`go test`) can be non-deterministic with the order in
which it runs the tests. This is due to the way package paths are
handled in Go, and due to its parallelism; tests in Go seem to be always
run in parallel, but the specifics here differ depending on the
available CPU.

Normally, we'd expect our tests to be run in a
predictable order, starting with `1_install_test`. To force this
behaviour, we rely on a `-p 1` argument that forces the runner to run
all tests sequentially. If we remove this, tests are prone to being run
in parallel and they will start executing before the control plane is in
a ready state.

We can take advantage of parallelism here to get better timing on our
tests, however, we need to block the start of each test until the
control plane (or extension) pods are ready. In each `TestMain`, we
block until the pods are ready.

Signed-off-by: Matei David <matei@buoyant.io>

---

### Additional notes

1. I think for the implementation of blocking until the pods are ready, there are two approaches: checking the pods through the k8s client (which I ultimately went with), or [waiting for the rollout status](https://github.com/linkerd/linkerd2/blob/d73f298683bd8330ec995e1587b13f57c79b411f/testutil/kubernetes_helper.go#L323). The latter seems like the Kubernetes way of doing things, however, we need to wrap it in a retry, otherwise we are prone to a race condition whereby if a test runs before `install_test` it will not find the rollout for the deployment and will fail the entire run. The current solution seemed simpler and easier to understand to me than wrapping `WaitRollout` in a retry.

2. To panic, or not to panic. It conviniently sets the exit code for us, simpler to copy&pasta, and no additional imports (ish, we still need to bring `fmt` into scope). The output is a bit ugly though, we can switch it to log records if that'd be easier on the eye.

```
panic: error running test: <error>

goroutine 1 [running]:
github.com/linkerd/linkerd2/test/integration/deep/endpoints.TestMain(0xc0000001a0)
        /home/matei/workspace/linkerd2/test/integration/deep/endpoints/endpoints_test.go:27 +0xbf
main.main()
        _testmain.go:47 +0x165
FAIL    github.com/linkerd/linkerd2/test/integration/deep/endpoints     0.048s

```

3. Multicluster is not covered by this change, we still run it using our test runner script. The tests are run in sequential order.

4. I "benchmarked" a few runs for the `deep suite` locally:

```
________________________________________________________
Executed in   88.57 secs    fish           external
   usr time   26.03 secs  468.00 micros   26.03 secs
   sys time    4.09 secs   44.00 micros    4.09 secs


^^ using current CheckPods approach


________________________________________________________
Executed in   92.25 secs    fish           external
   usr time   27.09 secs    0.00 millis   27.09 secs
   sys time    5.57 secs    2.56 millis    5.57 secs

^^ using WaitRollout


Executed in  123.50 secs    fish           external
   usr time   13.43 secs    1.14 millis   13.43 secs
   sys time    1.78 secs    0.15 millis    1.78 secs

^^ using -p 1

if my math is right, around 30% decrease in time (from 123.50s to 88.57s)
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
