### PR TITLE
Add changes for edge-22.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Changes
 
+## edge-22.2.1
+
+This edge release removed the `disableIdentity` configuration now that the proxy
+no longer supports running without identity.
+
+* Added a `privileged` configuration to linkerd-cni which is required by some
+  environments
+* Fixed an issue where the TLS credentials used by the policy validator were not
+  updated when the credentials were rotated
+* Removed the `disableIdentity` configurations now that the proxy no longer
+  supports running without identity
+* Fixed an issue where `linkerd jaeger check` would needlessly fail for BYO
+  Jaeger or collector installations
+* Fixed a Helm HA installation race condition introduced by the stoppage of
+  namespace creation
+
 ## edge-22.1.5
 
 This edge release adds support for per-request Access Logging for HTTP inbound

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -12,11 +12,11 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-control-plane"
 sources:
 - https://github.com/linkerd/linkerd2/
-dependencies: 
+dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.1.3-edge
+version: 1.1.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.1.3-edge](https://img.shields.io/badge/Version-1.1.3--edge-informational?style=flat-square)
+![Version: 1.1.4-edge](https://img.shields.io/badge/Version-1.1.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.20.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.0.3-edge
+version: 30.0.4-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.0.3-edge](https://img.shields.io/badge/Version-30.0.3--edge-informational?style=flat-square)
+![Version: 30.0.4-edge](https://img.shields.io/badge/Version-30.0.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: CliVersion
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: CliVersion
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: CliVersion
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -152,7 +152,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -441,7 +441,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-control-plane-1.1.3-edge
+    helm.sh/chart: linkerd-control-plane-1.1.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io


### PR DESCRIPTION
## edge-22.2.1

This edge release removed the `disableIdentity` configuration now that the proxy
no longer supports running without identity.

* Added a `privileged` configuration to linkerd-cni which is required by some
  environments
* Fixed an issue where the TLS credentials used by the policy validator were not
  updated when the credentials were rotated
* Removed the `disableIdentity` configurations now that the proxy no longer
  supports running without identity
* Fixed an issue where `linkerd jaeger check` would needlessly fail for BYO
  Jaeger or collector installations
* Fixed a Helm HA installation race condition introduced by the stoppage of
  namespace creation

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
