### PR TITLE
Remove external- tests for new viz and external suites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,11 +158,9 @@ jobs:
         - cluster-domain
         - cni-calico-deep
         - deep
+        - viz
         - default-policy-deny
-        - external-issuer
-        - external-prometheus-deep
-        - external-resources
-        - helm-deep
+        - external
         # Skipping Helm upgrade test given chart in 2.11 is backwards-incompatible
         #- helm-upgrade
         - uninstall


### PR DESCRIPTION
#7721 introduced the `viz` and `external` test suites, but the updates to the release workflow were missed. This removes the old test names and uses the new ones.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
