### PR TITLE
devcontainer: Pull rust installation from docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,34 @@ RUN for p in \
     golang.org/x/tools/gopls@latest \
     ; do go install "$p" ; done
 
+FROM docker.io/golang:${GO_VERSION}-bullseye as cargo-deny
+ARG CARGO_DENY_VERSION=0.11.1
+COPY bin/scurl /usr/local/bin/scurl
+RUN scurl "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar zvxf - --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
+
+FROM docker.io/golang:${GO_VERSION}-bullseye as yq
+ARG YQ_VERSION=v4.2.0
+COPY bin/scurl /usr/local/bin/scurl
+RUN scurl -vo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    && chmod +x /usr/local/bin/yq
+
+FROM docker.io/golang:${GO_VERSION}-bullseye as kubectl
+COPY bin/scurl /usr/local/bin/scurl
+RUN scurl -vo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(scurl https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod 755 /usr/local/bin/kubectl
+
+FROM docker.io/golang:${GO_VERSION}-bullseye as k3d
+COPY bin/scurl /usr/local/bin/scurl
+RUN scurl -v https://raw.githubusercontent.com/rancher/k3d/main/install.sh \
+    | USE_SUDO=false K3D_INSTALL_DIR=/usr/local/bin bash
+
 FROM docker.io/rust:${RUST_TOOLCHAIN}-bullseye as rust
 RUN rustup component add rustfmt clippy rls
+
+##
+## Main container configuration
+##
 
 FROM docker.io/golang:${GO_VERSION}-bullseye
 
@@ -63,23 +89,14 @@ ENV HOME=/home/$USER
 RUN mkdir -p $HOME/bin
 ENV PATH=$HOME/bin:$PATH
 
-RUN scurl -vo $HOME/bin/kubectl "https://dl.k8s.io/release/$(scurl https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-    && chmod 755 $HOME/bin/kubectl
-RUN scurl -v https://raw.githubusercontent.com/rancher/k3d/main/install.sh \
-    | USE_SUDO=false K3D_INSTALL_DIR=$HOME/bin bash
-
-ARG YQ_VERSION=v4.2.0
-RUN scurl -vo $HOME/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
-    && chmod +x $HOME/bin/yq
-
-ARG CARGO_DENY_VERSION=0.11.1
-RUN curl --proto '=https' --tlsv1.3 -vsSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-    | tar zvxf - --strip-components=1 -C $HOME/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
-
 RUN scurl -v https://run.linkerd.io/install-edge | sh \
     && ln -s $(readlink ~/.linkerd2/bin/linkerd) ~/bin/linkerd
 
 COPY --from=go /go /go
+COPY --from=cargo-deny /usr/local/bin/cargo-deny /user/local/bin/cargo-deny
+COPY --from=k3d /usr/local/bin/k3d /user/local/bin/k3d
+COPY --from=kubectl /usr/local/bin/kubectl /user/local/bin/kubectl
+COPY --from=yq /usr/local/bin/yq /user/local/bin/yq
 
 COPY --from=rust /usr/local/cargo /usr/local/cargo
 COPY --from=rust /usr/local/rustup /usr/local/rustup

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ RUN for p in \
 FROM docker.io/rust:${RUST_TOOLCHAIN}-bullseye as rust
 RUN rustup component add rustfmt clippy rls
 
-FROM docker.io/golang:1.17-bullseye
+FROM docker.io/golang:${GO_VERSION}-bullseye
 
 # Note: we do *not* delete the apt cache so subsequent steps (like docker,
 # dotfiles) need not pull the cache again. This comes at the cost of a fatter

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
-FROM docker.io/golang:1.17-bullseye as go
+ARG GO_VERSION=1.17
+ARG RUST_TOOLCHAIN=1.56.1
+
+FROM docker.io/golang:${GO_VERSION}-bullseye as go
 RUN for p in \
     github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
     github.com/ramya-rao-a/go-outline@latest \
@@ -10,6 +13,9 @@ RUN for p in \
     github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
     golang.org/x/tools/gopls@latest \
     ; do go install "$p" ; done
+
+FROM docker.io/rust:${RUST_TOOLCHAIN}-bullseye as rust
+RUN rustup component add rustfmt clippy rls
 
 FROM docker.io/golang:1.17-bullseye
 
@@ -51,8 +57,6 @@ RUN scurl -v https://raw.githubusercontent.com/microsoft/vscode-dev-containers/m
 RUN (echo "LC_ALL=en_US.UTF-8" \
     && echo "LANGUAGE=en_US.UTF-8") >/etc/default/locale
 
-COPY --from=go /go /go
-
 USER $USER
 ENV USER=$USER
 ENV HOME=/home/$USER
@@ -68,10 +72,6 @@ ARG YQ_VERSION=v4.2.0
 RUN scurl -vo $HOME/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
     && chmod +x $HOME/bin/yq
 
-ARG RUST_TOOLCHAIN=1.56.1
-RUN scurl -v https://sh.rustup.rs \
-    | sh -s -- -y --default-toolchain "${RUST_TOOLCHAIN}" -c rustfmt -c clippy -c rls
-
 RUN mkdir /tmp/cargo-deny && cd /tmp/cargo-deny && \
     scurl -v https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.0/cargo-deny-0.11.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - && \
     mv cargo-deny-0.11.0-x86_64-unknown-linux-musl/cargo-deny $HOME/bin && \
@@ -79,6 +79,14 @@ RUN mkdir /tmp/cargo-deny && cd /tmp/cargo-deny && \
 
 RUN scurl -v https://run.linkerd.io/install-edge | sh \
     && ln -s $(readlink ~/.linkerd2/bin/linkerd) ~/bin/linkerd
+
+COPY --from=go /go /go
+
+COPY --from=rust /usr/local/cargo /usr/local/cargo
+COPY --from=rust /usr/local/rustup /usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:$PATH
 
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,10 +72,9 @@ ARG YQ_VERSION=v4.2.0
 RUN scurl -vo $HOME/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
     && chmod +x $HOME/bin/yq
 
-RUN mkdir /tmp/cargo-deny && cd /tmp/cargo-deny && \
-    scurl -v https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.0/cargo-deny-0.11.0-x86_64-unknown-linux-musl.tar.gz | tar zxf - && \
-    mv cargo-deny-0.11.0-x86_64-unknown-linux-musl/cargo-deny $HOME/bin && \
-    cd .. && rm -rf /tmp/cargo-deny
+ARG CARGO_DENY_VERSION=0.11.1
+RUN curl --proto '=https' --tlsv1.3 -vsSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar zvxf - --strip-components=1 -C $HOME/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
 
 RUN scurl -v https://run.linkerd.io/install-edge | sh \
     && ln -s $(readlink ~/.linkerd2/bin/linkerd) ~/bin/linkerd


### PR DESCRIPTION
We currently install rustup manually and then install a rust toolchain;
but this is slow and serial.

This change moves rust environment provisioning into a separate build
stage that fetches a rust environment in parallel with other build
steps. The rust environment is copied over towards the end of the build.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
