### PR TITLE
dev: Make CARGO_HOME and RUSTUP_HOME writeable

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,13 +86,8 @@ RUN (echo "LC_ALL=en_US.UTF-8" \
 USER $USER
 ENV USER=$USER
 ENV HOME=/home/$USER
-RUN mkdir -p $HOME/bin
-ENV PATH=$HOME/bin:$PATH
 
-RUN scurl -v https://run.linkerd.io/install-edge | sh \
-    && ln -s $(readlink ~/.linkerd2/bin/linkerd) ~/bin/linkerd
-
-COPY --from=go /go /go
+COPY --from=go /go/bin /go/bin
 COPY --from=cargo-deny /usr/local/bin/cargo-deny /user/local/bin/cargo-deny
 COPY --from=k3d /usr/local/bin/k3d /user/local/bin/k3d
 COPY --from=kubectl /usr/local/bin/kubectl /user/local/bin/kubectl
@@ -102,7 +97,11 @@ COPY --from=rust /usr/local/cargo /usr/local/cargo
 COPY --from=rust /usr/local/rustup /usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
+RUN sudo chmod 777 $CARGO_HOME $RUSTUP_HOME
 ENV PATH=/usr/local/cargo/bin:$PATH
+
+RUN scurl -v https://run.linkerd.io/install-edge | sh
+ENV PATH=$HOME/.linkerd2/bin:$PATH
 
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
When `CARGO_HOME` and `RUSTUP_HOME` are not writeable, cargo commands
fail. This updates the devcontainer to match the rust container image.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
