### PR TITLE
destination: Use net.JoinHostPort to format names

### DIFF
--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -3,7 +3,7 @@ package destination
 import (
 	"errors"
 	"fmt"
-	"strings"
+	"net"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -113,11 +113,9 @@ func toDstOverrides(dsts []*sp.WeightedDst, port uint32) []*pb.WeightedDst {
 	pbDsts := []*pb.WeightedDst{}
 	for _, dst := range dsts {
 		authority := dst.Authority
-		// Authority should be a FQDN with port
-		// Use the port from GetProfile is absent in authority
-		hostPort := strings.Split(authority, ":")
-		if len(hostPort) == 1 {
-			authority = fmt.Sprintf("%s:%d", authority, port)
+		// If the authority does not parse as a host:port, add the port provided by `GetProfile`.
+		if _, _, err := net.SplitHostPort(authority); err != nil {
+			authority = net.JoinHostPort(authority, fmt.Sprintf("%d", port))
 		}
 
 		pbDst := &pb.WeightedDst{

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -468,7 +468,7 @@ func (s *server) getEndpointByHostname(k8sAPI *k8s.API, hostname string, svcID w
 // port.
 func getPodByIP(k8sAPI *k8s.API, podIP string, port uint32, log *logging.Entry) (*corev1.Pod, error) {
 	// First we check if the address maps to a pod in the host network.
-	addr := fmt.Sprintf("%s:%d", podIP, port)
+	addr := net.JoinHostPort(podIP, fmt.Sprintf("%d", port))
 	hostIPPods, err := getIndexedPods(k8sAPI, watcher.HostIPIndex, addr)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"sync"
@@ -750,7 +751,7 @@ func (pp *portPublisher) endpointSliceToAddresses(es *discovery.EndpointSlice) A
 			for _, IPAddr := range endpoint.Addresses {
 				var authorityOverride string
 				if fqName, ok := es.Annotations[consts.RemoteServiceFqName]; ok {
-					authorityOverride = fmt.Sprintf("%s:%d", fqName, pp.srcPort)
+					authorityOverride = net.JoinHostPort(fqName, fmt.Sprintf("%d", pp.srcPort))
 				}
 
 				identity := es.Annotations[consts.RemoteGatewayIdentity]

--- a/controller/api/destination/watcher/k8s.go
+++ b/controller/api/destination/watcher/k8s.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -93,7 +94,7 @@ func InitializeIndexers(k8sAPI *k8s.API) error {
 				for _, c := range pod.Spec.Containers {
 					for _, p := range c.Ports {
 						if p.HostPort != 0 {
-							addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, p.HostPort)
+							addr := net.JoinHostPort(pod.Status.HostIP, fmt.Sprintf("%d", p.HostPort))
 							hostIPPods = append(hostIPPods, addr)
 						}
 					}


### PR DESCRIPTION
We use `fmt.Sprintf` to format URIs in several places we could be using
`net.JoinHostPort`. `net.JoinHostPort` ensures that IPv6 addresses are
properly escaped in URIs.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
