### PR TITLE
Upgrade jaeger and ot-collector

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -78,7 +78,7 @@ Kubernetes: `>=1.20.0-0`
 | collector.enabled | bool | `true` | Set to false to exclude collector installation |
 | collector.image.name | string | `"otel/opentelemetry-collector"` |  |
 | collector.image.pullPolicy | string | `"Always"` |  |
-| collector.image.version | string | `"0.27.0"` |  |
+| collector.image.version | string | `"0.43.0"` |  |
 | collector.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | collector.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the collector container can use |
 | collector.resources.cpu.request | string | `nil` | Amount of CPU units that the collector container requests |
@@ -92,7 +92,7 @@ Kubernetes: `>=1.20.0-0`
 | jaeger.enabled | bool | `true` | Set to false to exclude all-in-one Jaeger installation |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
-| jaeger.image.version | string | `"1.19.2"` |  |
+| jaeger.image.version | float | `1.31` |  |
 | jaeger.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | jaeger.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the jaeger container can use |
 | jaeger.resources.cpu.request | string | `nil` | Amount of CPU units that the jaeger container requests |

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -24,7 +24,7 @@ collector:
   enabled: true
   image:
     name: otel/opentelemetry-collector
-    version: 0.27.0
+    version: 0.43.0
     pullPolicy: Always
 
   resources:
@@ -77,7 +77,8 @@ collector:
     exporters:
       jaeger:
         endpoint: jaeger.${POD_NAMESPACE}:14250
-        insecure: true
+        tls:
+          insecure: true
     service:
       extensions: [health_check]
       pipelines:
@@ -91,7 +92,7 @@ jaeger:
   enabled: true
   image:
     name: jaegertracing/all-in-one
-    version: 1.19.2
+    version: 1.31
     pullPolicy: Always
 
   # -- CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory)

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -305,7 +305,7 @@ spec:
       containers:
       - args:
         - --query.base-path=/jaeger
-        image: jaegertracing/all-in-one:1.19.2
+        image: jaegertracing/all-in-one:1.31
         imagePullPolicy: Always
         name: jaeger
         ports:

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -292,7 +292,8 @@ data:
     exporters:
       jaeger:
         endpoint: jaeger.${POD_NAMESPACE}:14250
-        insecure: true
+        tls:
+          insecure: true
     service:
       extensions: [health_check]
       pipelines:
@@ -378,7 +379,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: otel/opentelemetry-collector:0.27.0
+        image: otel/opentelemetry-collector:0.43.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -465,7 +466,7 @@ spec:
       containers:
       - args:
         - --query.base-path=/jaeger
-        image: jaegertracing/all-in-one:1.19.2
+        image: jaegertracing/all-in-one:1.31
         imagePullPolicy: Always
         name: jaeger
         ports:

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -283,7 +283,8 @@ data:
     exporters:
       jaeger:
         endpoint: jaeger.${POD_NAMESPACE}:14250
-        insecure: true
+        tls:
+          insecure: true
     service:
       extensions: [health_check]
       pipelines:
@@ -369,7 +370,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: otel/opentelemetry-collector:0.27.0
+        image: otel/opentelemetry-collector:0.43.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/test/integration/viz/tracing/testdata/check.jaeger.golden
+++ b/test/integration/viz/tracing/testdata/check.jaeger.golden
@@ -1,10 +1,8 @@
 linkerd-jaeger
 --------------
 √ linkerd-jaeger extension Namespace exists
-√ collector and jaeger service account exists
-√ collector config map exists
 √ jaeger extension pods are injected
-√ jaeger extension pods are running
+√ jaeger injector pods are running
 √ jaeger extension proxies are healthy
 ‼ jaeger extension proxies are up-to-date
     {{.ProxyVersionErr}}

--- a/test/integration/viz/tracing/tracing_test.go
+++ b/test/integration/viz/tracing/tracing_test.go
@@ -46,9 +46,6 @@ func TestMain(m *testing.M) {
 
 func TestTracing(t *testing.T) {
 	ctx := context.Background()
-	if os.Getenv("RUN_ARM_TEST") != "" {
-		t.Skip("Skipped. Jaeger & Open Census images does not support ARM yet")
-	}
 
 	// Require an environment variable to be set for this test to be run.
 	if os.Getenv("RUN_FLAKEY_TEST") == "" {


### PR DESCRIPTION
Fixes #7793

Their latest images are multi-arch, so now the jaeger extension supports ARM as well.

The Collector config required a minimal change.

Also updated the tracing integration test golden file to account for #7750.