### PR TITLE
Fix redundant error handling

### DIFF
--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -87,7 +87,6 @@ func jaegerCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
 				}
 
 				return healthcheck.CheckPodsRunning(pods, jaegerNamespace)
-
 			}))
 
 	checkers = append(checkers,

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1506,12 +1506,7 @@ func (hc *HealthChecker) CheckProxyHealth(ctx context.Context, controlPlaneNames
 	}
 
 	// Check proxy certificates
-	err = checkPodsProxiesCertificate(ctx, *hc.kubeAPI, namespace, controlPlaneNamespace)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return checkPodsProxiesCertificate(ctx, *hc.kubeAPI, namespace, controlPlaneNamespace)
 }
 
 // CheckCertAndAnchorsExpiringSoon checks if the given cert and anchors expire soon, and returns an

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -293,21 +293,17 @@ func requestTapByResourceFromAPI(ctx context.Context, w io.Writer, k8sAPI *k8s.K
 }
 
 func writeTapEventsToBuffer(w io.Writer, tapByteStream *bufio.Reader, req *tapPb.TapByResourceRequest, options *tapOptions) error {
-	var err error
 	switch options.output {
 	case "":
-		err = renderTapEvents(tapByteStream, w, renderTapEvent, "")
+		return renderTapEvents(tapByteStream, w, renderTapEvent, "")
 	case wideOutput:
 		resource := req.GetTarget().GetResource().GetType()
-		err = renderTapEvents(tapByteStream, w, renderTapEvent, resource)
+		return renderTapEvents(tapByteStream, w, renderTapEvent, resource)
 	case jsonOutput:
-		err = renderTapEvents(tapByteStream, w, renderTapEventJSON, "")
+		return renderTapEvents(tapByteStream, w, renderTapEventJSON, "")
+	default:
+		return fmt.Errorf("unknown output format: %q", options.output)
 	}
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func renderTapEvents(tapByteStream *bufio.Reader, w io.Writer, render renderTapEventFunc, resource string) error {

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -240,12 +240,7 @@ func (hc *HealthChecker) VizCategory() *healthcheck.Category {
 					return err
 				}
 
-				err = healthcheck.CheckForPods(pods, []string{"prometheus"})
-				if err != nil {
-					return err
-				}
-
-				return nil
+				return healthcheck.CheckForPods(pods, []string{"prometheus"})
 			}),
 		*healthcheck.NewChecker("can initialize the client").
 			WithHintAnchor("l5d-viz-existence-client").


### PR DESCRIPTION
Various methods check if an error is `nil` before returning it, however
continuing down the code path returns a `nil`. This can be reduced to
just returning the error whether it is `nil` or not.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
