### PR TITLE
multicluster: Fix metadata prefix matching

### DIFF
--- a/multicluster/service-mirror/events_formatting.go
+++ b/multicluster/service-mirror/events_formatting.go
@@ -21,7 +21,7 @@ func formatMetadata(meta map[string]string) string {
 	var metadata []string
 
 	for k, v := range meta {
-		if strings.Contains(k, consts.Prefix) || strings.Contains(k, consts.ProxyConfigAnnotationsPrefix) {
+		if strings.HasPrefix(k, consts.Prefix) || strings.HasPrefix(k, consts.ProxyConfigAnnotationsPrefix) {
 			metadata = append(metadata, fmt.Sprintf("%s=%s", k, v))
 		}
 	}


### PR DESCRIPTION
When formatting event metadata, the method `formatMetadata` checks if a
given string in the metadata map contains a given prefix. However it
does this using `strings.Contains` rather than `strings.HasPrefix`,
which will return true if the given prefix string is located anywhere in
the target string to search.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
