### PR TITLE
identity: Document use of `InsecureSkipVerify`

### DIFF
--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -197,6 +197,10 @@ func getCertResponse(url string, pod corev1.Pod) ([]*x509.Certificate, error) {
 	}
 	connURL := strings.Trim(url, "http://")
 	conn, err := tls.Dial("tcp", connURL, &tls.Config{
+		// We want to connect directly to a proxy port to dump its certificate. We don't necessarily
+		// want to verify the server's certificate, since this is purely for diagnostics and may be
+		// used when a proxy's issuer doesn't match the control plane's trust root.
+		//nolint:gosec
 		InsecureSkipVerify: true,
 		ServerName:         serverName,
 	})


### PR DESCRIPTION
The CLI's diagnostic command that dumps a proxy's certificate
information does not (and should not) verify the proxy's certificate.

This change documents why verification is disabled.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
