### PR TITLE
identity: Use SHA256 fingerprints in events

### DIFF
--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -2,7 +2,7 @@ package identity
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
@@ -241,7 +241,7 @@ func (svc *Service) Certify(ctx context.Context, req *pb.CertifyRequest) (*pb.Ce
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	hasher := md5.New()
+	hasher := sha256.New()
 	hasher.Write(crts[0])
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	identitySegments := strings.Split(tokIdentity, ".")


### PR DESCRIPTION
When the identity controller emits logs & events, these messages
include the MD5 of the issued certificate. MD5 is unreliable and should
not be used, especially in a security-sensitive context.

This change replaces the use of md5 with sha256.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
