### PR TITLE
cli: Only bind ephemeral ports on localhost

### DIFF
--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -142,6 +142,10 @@ func newPortForward(
 
 	var err error
 	if localPort == 0 {
+		if host != "localhost" {
+			return nil, fmt.Errorf("local port must be specified when host is not localhost")
+		}
+
 		localPort, err = getEphemeralPort()
 		if err != nil {
 			return nil, err
@@ -247,7 +251,7 @@ func (pf *PortForward) AddressAndPort() string {
 // getEphemeralPort selects a port for the port-forwarding. It binds to a free
 // ephemeral port and returns the port number.
 func getEphemeralPort() (int, error) {
-	ln, err := net.Listen("tcp", ":0")
+	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Most of our port forwards are created against localhost, except for when
exposing the dashboard with a user-specified host. Our socket binding
(for ephemeral ports), however, binds against all interfaces.

This change modifies ephemeral port binding to only occur on the
loopback interface.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
