### PR TITLE
dev: Configure the Go linting tool

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,7 @@ RUN for p in \
     github.com/go-delve/delve/cmd/dlv@latest \
     github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
     golang.org/x/tools/gopls@latest \
+    honnef.co/go/tools/cmd/staticcheck@latest \
     ; do go install "$p" ; done
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as cargo-deny

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 ARG GO_VERSION=1.17
 ARG RUST_TOOLCHAIN=1.56.1
+ARG GOLANGCI_LINT=1.44.0
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as go
 RUN for p in \
@@ -10,7 +11,7 @@ RUN for p in \
     github.com/josharian/impl@latest \
     github.com/haya14busa/goplay/cmd/goplay@latest \
     github.com/go-delve/delve/cmd/dlv@latest \
-    github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
+    github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT} \
     golang.org/x/tools/gopls@latest \
     ; do go install "$p" ; done
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 ARG GO_VERSION=1.17
 ARG RUST_TOOLCHAIN=1.56.1
-ARG GOLANGCI_LINT=1.44.0
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as go
+ARG GOLANGCI_LINT_VERSION=v1.44.0
 RUN for p in \
     github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
     github.com/ramya-rao-a/go-outline@latest \
@@ -11,7 +11,7 @@ RUN for p in \
     github.com/josharian/impl@latest \
     github.com/haya14busa/goplay/cmd/goplay@latest \
     github.com/go-delve/delve/cmd/dlv@latest \
-    github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT} \
+    github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION#v} \
     golang.org/x/tools/gopls@latest \
     ; do go install "$p" ; done
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,6 @@ RUN for p in \
     github.com/go-delve/delve/cmd/dlv@latest \
     github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
     golang.org/x/tools/gopls@latest \
-    honnef.co/go/tools/cmd/staticcheck@latest \
     ; do go install "$p" ; done
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as cargo-deny

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,8 @@
     "remoteUser": "code",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
-    ]
+    ],
+    "settings": {
+        "go.lintTool": "golangci-lint"
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,9 @@
         "vadimcn.vscode-lldb",
         "zxh404.vscode-proto3"
     ],
+    "settings": {
+        "go.lintTool": "golangci-lint"
+    },
     "runArgs": [
         "--init",
         // Use the host network so we can access k3d, etc.
@@ -26,8 +29,5 @@
     "remoteUser": "code",
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
-    ],
-    "settings": {
-        "go.lintTool": "golangci-lint"
-    }
+    ]
 }

--- a/bin/lint
+++ b/bin/lint
@@ -6,7 +6,7 @@ cd "$(pwd -P)"
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
-devcontainerdir=$( cd "$bindir"/../.devcontainer && pwd )
+devcontainerdir=$( cd "$rootdir"/.devcontainer && pwd )
 targetbin=$rootdir/target/bin
 
 cd "$rootdir"
@@ -19,13 +19,16 @@ elif [ "$(uname -o)" = Msys ]; then
   exe=.exe
 fi
 
-lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT=([^ ]+)/\1/p' "$devcontainerdir"/Dockerfile)
+lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT_VERSION=(v[^ ]+)/\1/p' "$devcontainerdir"/Dockerfile | head -n 1)
+if [ -z "$lintversion" ]; then
+  echo "GOLANGCI_LINT_VERSION is not set in .devcontainer/Dockerfile" >&2
+  exit 1
+fi
 lintbin=$targetbin/.golangci-lint-"$lintversion"$exe
-exit 0
 
 if [ ! -f "$lintbin" ]; then
   mkdir -p "$targetbin"
-  "$bindir"/scurl https://raw.githubusercontent.com/golangci/golangci-lint/v"$lintversion"/install.sh | sh -s -- -b . v"$lintversion"
+  "$bindir"/scurl https://raw.githubusercontent.com/golangci/golangci-lint/"$lintversion"/install.sh | sh -s -- -b . "$lintversion"
   mv ./golangci-lint$exe "$lintbin"
 fi
 

--- a/bin/lint
+++ b/bin/lint
@@ -19,8 +19,9 @@ elif [ "$(uname -o)" = Msys ]; then
   exe=.exe
 fi
 
-lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT=([^ ]+)/\1/p' .devcontainer/Dockerfile)
+lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT=([^ ]+)/\1/p' "$devcontainerdir"/Dockerfile)
 lintbin=$targetbin/.golangci-lint-$lintversion$exe
+exit 0
 
 if [ ! -f "$lintbin" ]; then
   mkdir -p "$targetbin"

--- a/bin/lint
+++ b/bin/lint
@@ -20,12 +20,12 @@ elif [ "$(uname -o)" = Msys ]; then
 fi
 
 lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT=([^ ]+)/\1/p' "$devcontainerdir"/Dockerfile)
-lintbin=$targetbin/.golangci-lint-$lintversion$exe
+lintbin=$targetbin/.golangci-lint-"$lintversion"$exe
 exit 0
 
 if [ ! -f "$lintbin" ]; then
   mkdir -p "$targetbin"
-  "$bindir"/scurl https://raw.githubusercontent.com/golangci/golangci-lint/v$lintversion/install.sh | sh -s -- -b . v$lintversion
+  "$bindir"/scurl https://raw.githubusercontent.com/golangci/golangci-lint/v"$lintversion"/install.sh | sh -s -- -b . v"$lintversion"
   mv ./golangci-lint$exe "$lintbin"
 fi
 

--- a/bin/lint
+++ b/bin/lint
@@ -2,12 +2,11 @@
 
 set -eu
 
-lintversion=1.43.0
-
 cd "$(pwd -P)"
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
+devcontainerdir=$( cd "$bindir"/../.devcontainer && pwd )
 targetbin=$rootdir/target/bin
 
 cd "$rootdir"
@@ -20,6 +19,7 @@ elif [ "$(uname -o)" = Msys ]; then
   exe=.exe
 fi
 
+lintversion=$(sed -nE 's/^ARG GOLANGCI_LINT=([^ ]+)/\1/p' .devcontainer/Dockerfile)
 lintbin=$targetbin/.golangci-lint-$lintversion$exe
 
 if [ ! -f "$lintbin" ]; then


### PR DESCRIPTION
When opening in a devcontainer, it is initially missing the `staticcheck` analysis tool.

Installation is from the [docs](https://staticcheck.io/docs/getting-started/#installation).

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>