### PR TITLE
policy_controller.yml matrix wasn't used

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
     - uses: EmbarkStudios/cargo-deny-action@2a55392931cddc0ae1d7397515fd0951d39ebaf2
       with:
-        command: check bans licenses sources
+        command: check ${{ matrix.checks }}
 
   clippy:
     timeout-minutes: 5


### PR DESCRIPTION
The audit job had a matrix that included an `advisories` entry that wasn't used.
