### PR TITLE
Fix multicluster check

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -679,7 +679,7 @@ func joinErrors(errs []error, tabDepth int) error {
 }
 
 func serviceMirrorComponentsSelector(targetCluster string) string {
-	return fmt.Sprintf("%s=%s,%s=%s",
-		k8s.ControllerComponentLabel, linkerdServiceMirrorComponentName,
+	return fmt.Sprintf("component=%s,%s=%s",
+		linkerdServiceMirrorComponentName,
 		k8s.RemoteClusterNameLabel, targetCluster)
 }


### PR DESCRIPTION
Fixes #7824

In #7718 we renamed the multicluster resource labels from
`linkerd.io/control-plane-component` to just `component`, but the
`linkerd mc check` code wasn't updated accordingly.

This should be followed up by an upgdate of the multicluster integration
tests with a `linkerd mc check` output verification on the source
cluster.