### PR TITLE
Issue individual warnings for nodes missing podCIDRs

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -748,7 +748,7 @@ func (hc *HealthChecker) allCategories() []*Category {
 						}
 						var warningNodes []string
 						for _, node := range nodes {
-							if node.Spec.PodCIDR != "" {
+							if node.Spec.PodCIDR == "" {
 								warningNodes = append(warningNodes, node.Name)
 							}
 						}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1857,10 +1857,13 @@ func (hc *HealthChecker) checkClusterNetworks(ctx context.Context) error {
 		}
 	}
 	var badPodCIDRS []string
+	var nodesSkipped []string
+	var errStrings []string
 	var podCIDRExists bool
 	for _, node := range nodes {
 		podCIDR := node.Spec.PodCIDR
 		if podCIDR == "" {
+			nodesSkipped = append(nodesSkipped, node.Name)
 			continue
 		}
 		podCIDRExists = true
@@ -1873,14 +1876,25 @@ func (hc *HealthChecker) checkClusterNetworks(ctx context.Context) error {
 			badPodCIDRS = append(badPodCIDRS, podCIDR)
 		}
 	}
+	// If none of the nodes exposed a podCIDR then we cannot verify the clusterNetworks.
 	if !podCIDRExists {
 		// DigitalOcean for example, doesn't expose spec.podCIDR (#6398)
 		return &SkipError{Reason: podCIDRUnavailableSkipReason}
 	}
+	// If there is at least one node that does not expose a podCIDR, issue a
+	// warning that clusterNetworks could not be completely verified.
+	if len(nodesSkipped) != 0 {
+		for _, node := range nodesSkipped {
+			errStrings = append(errStrings, fmt.Sprintf("node %s does not expose podCIDRs so clusterNetworks could not be verified", node))
+		}
+	}
 	if len(badPodCIDRS) > 0 {
 		sort.Strings(badPodCIDRS)
-		return fmt.Errorf("node has podCIDR(s) %v which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=\"%s\"",
-			badPodCIDRS, strings.Join(badPodCIDRS, "\\,"))
+		s := fmt.Sprintf("node has podCIDR(s) %v which are not contained in the Linkerd clusterNetworks.\n\tTry installing linkerd via --set clusterNetworks=\"%s\"", badPodCIDRS, strings.Join(badPodCIDRS, "\\,"))
+		errStrings = append(errStrings, s)
+	}
+	if len(errStrings) > 0 {
+		return fmt.Errorf(strings.Join(errStrings, "\n    "))
 	}
 	return nil
 }

--- a/test/integration/install/testdata/check.proxy.golden
+++ b/test/integration/install/testdata/check.proxy.golden
@@ -18,6 +18,7 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ control plane pods are ready
+√ cluster networks can be verified
 √ cluster networks contains all node podCIDRs
 
 linkerd-config


### PR DESCRIPTION
Closes #7760

This introduces a new warning check that ensures we can verify the cluster networks. This check is separate from the existing `cluster networks contains all node podCIDRs` because unlike this existing check which results in an error, this new check is just a warning.

When a node is missing the field

```
$ linkerd check -o short
Linkerd core checks
===================

linkerd-existence
-----------------
‼ cluster networks can be verified
    the following nodes do not expose a podCIDR:
        k3d-k3s-default-agent-0
        k3d-k3s-default-server-0
        k3d-k3s-default-agent-1
    see https://linkerd.io/2/checks/#l5d-cluster-networks-verified for hints
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
