### PR TITLE
Allow for empty inbound ports env var

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -61,10 +61,8 @@ env:
   valueFrom:
     fieldRef:
       fieldPath: status.podIPs
-{{ if .Values.proxy.podInboundPorts -}}
 - name: LINKERD2_PROXY_INBOUND_PORTS
   value: {{ .Values.proxy.podInboundPorts | quote }}
-{{ end -}}
 {{ if .Values.proxy.isGateway -}}
 - name: LINKERD2_PROXY_INBOUND_GATEWAY_SUFFIXES
   value: {{printf "svc.%s." .Values.clusterDomain}}

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -57,6 +57,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIPs
+    - name: LINKERD2_PROXY_INBOUND_PORTS
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: svc.cluster.local.
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -58,6 +58,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIPs
+    - name: LINKERD2_PROXY_INBOUND_PORTS
     - name: LINKERD2_PROXY_INGRESS_MODE
       value: "true"
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -59,6 +59,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIPs
+    - name: LINKERD2_PROXY_INBOUND_PORTS
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: svc.cluster.local.
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -61,6 +61,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIPs
+    - name: LINKERD2_PROXY_INBOUND_PORTS
     - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
       value: svc.cluster.local.
     - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE


### PR DESCRIPTION
Depends on a proxy release with linkerd/linkerd2-proxy#1478.

Closes #7816.

With this change, the `LINKERD2_PROXY_INBOUND_PORTS` is always rendered in install/inject output. This means that if a workload does not expose any ports, then the env var is rendered as the empty string.

Coupled with linkerd/linkerd2-proxy#1478, no error is printed upon proxy startup.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
