### PR TITLE
Allow `Server` CRD to have empty `PodSelector`

### DIFF
--- a/charts/linkerd-crds/templates/policy/server.yaml
+++ b/charts/linkerd-crds/templates/policy/server.yaml
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/charts/linkerd-crds/templates/policy/server.yaml
+++ b/charts/linkerd-crds/templates/policy/server.yaml
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -96,10 +96,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -96,7 +96,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -96,10 +96,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -96,7 +96,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -94,7 +94,10 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace. Selects all if empty.
+                    Selects pods in the same namespace.
+
+                    The result of matchLabels and matchExpressions are ANDed.
+                    Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -94,10 +94,7 @@ spec:
                 podSelector:
                   type: object
                   description: >-
-                    Selects pods in the same namespace.
-                  oneOf:
-                    - required: [matchExpressions]
-                    - required: [matchLabels]
+                    Selects pods in the same namespace. Selects all if empty.
                   properties:
                     matchLabels:
                       type: object

--- a/controller/gen/apis/server/v1beta1/types.go
+++ b/controller/gen/apis/server/v1beta1/types.go
@@ -29,7 +29,7 @@ type Server struct {
 
 // ServerSpec specifies a Server resource.
 type ServerSpec struct {
-	PodSelector   *metav1.LabelSelector `json:"podSelector,omitempty"`
+	PodSelector   *metav1.LabelSelector `json:"podSelector"`
 	Port          intstr.IntOrString    `json:"port,omitempty"`
 	ProxyProtocol string                `json:"proxyProtocol,omitempty"`
 }


### PR DESCRIPTION
Fixes #7904

Allow the `Server` CRD to have the `PodSelector` entry be an empty object, by removing the `omitempty` tag from its go type definition and the `oneof` section in the CRD. No update to the CRD version is required, as this is BC change -- The CRD overriding was tested fine.

Also added some unit tests to confirm podSelector conditions are ANDed, and some minor refactorings in the `Selector` constructors.