### PR TITLE
Fix the if condition in namespace-metadata Job

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -35,7 +35,7 @@ spec:
           ns=$(curl -kfv -H "Authorization: Bearer $token" \
             "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
 
-          if echo "$ns" | grep -vq 'labels'; then
+          if ! echo "$ns" | grep -q 'labels'; then
             ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
           fi
 

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -35,7 +35,7 @@ spec:
           ns=$(curl -kfv -H "Authorization: Bearer $token" \
             "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
 
-          if echo "$ns" | grep -vq 'labels'; then
+          if ! echo "$ns" | grep -q 'labels'; then
             ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
           fi
 

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -36,10 +36,10 @@ spec:
           ns=$(curl -kfv -H "Authorization: Bearer $token" \
             "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
 
-          if echo "$ns" | grep -vq 'labels'; then
+          if ! echo "$ns" | grep -q 'labels'; then
             ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
           fi
-          if echo "$ns" | grep -vq 'annotations'; then
+          if ! echo "$ns" | grep -q 'annotations'; then
             ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {}},"
           fi
 


### PR DESCRIPTION
This fixes the if condition in the namespace-metadata Job which is part of the linkerd-viz chart.

I found this while using ArgoCD to sync both the linkerd2 chart and linkerd-viz chart (versions 21.12.x). The namespace-metadata Job overwrites the namespace labels and annotions of the namespace object from the linkerd2 chart, which prevents the linkerd2 application from getting in sync.

Tested by manually making the changes to the chart and verifying the namespace exists with expected values.

Signed-off-by: Naveen Nalam <nnalam@gmail.com>

@alpeb 