### PR TITLE
Replace time.After with time.NewTimer to avoid memory leaks

### DIFF
--- a/cli/cmd/metrics_diagnostics_util.go
+++ b/cli/cmd/metrics_diagnostics_util.go
@@ -132,7 +132,6 @@ func getMetrics(
 	defer timeout.Stop()
 wait:
 	for {
-		timeout.Reset(waitingTime)
 		select {
 		case result := <-resultChan:
 			results = append(results, result)

--- a/cli/cmd/metrics_diagnostics_util.go
+++ b/cli/cmd/metrics_diagnostics_util.go
@@ -128,12 +128,15 @@ func getMetrics(
 		}(pod)
 	}
 
+	timeout := time.NewTimer(waitingTime)
+	defer timeout.Stop()
 wait:
 	for {
+		timeout.Reset(waitingTime)
 		select {
 		case result := <-resultChan:
 			results = append(results, result)
-		case <-time.After(waitingTime):
+		case <-timeout.C:
 			break wait // timed out
 		}
 		if atomic.LoadInt32(&activeRoutines) == 0 {

--- a/testutil/stream.go
+++ b/testutil/stream.go
@@ -27,7 +27,8 @@ func (s *Stream) Stop() {
 func (s *Stream) ReadUntil(lineCount int, timeout time.Duration) ([]string, error) {
 	output := make([]string, 0)
 	lines := make(chan string)
-	timeoutAfter := time.After(timeout)
+	timeoutAfter := time.NewTimer(timeout)
+	defer timeoutAfter.Stop()
 	scanner := bufio.NewScanner(s.out)
 	stopSignal := false
 
@@ -44,7 +45,7 @@ func (s *Stream) ReadUntil(lineCount int, timeout time.Duration) ([]string, erro
 
 	for {
 		select {
-		case <-timeoutAfter:
+		case <-timeoutAfter.C:
 			stopSignal = true
 			return output, fmt.Errorf("cmd [%s] Timed out trying to read %d lines", strings.Join(s.cmd.Args, " "), lineCount)
 		case line := <-lines:

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -603,14 +603,16 @@ func (h *TestHelper) RetryFor(timeout time.Duration, fn func() error) error {
 		return nil
 	}
 
-	timeoutAfter := time.After(timeout)
-	retryAfter := time.Tick(time.Second)
+	timeoutAfter := time.NewTimer(timeout)
+	defer timeoutAfter.Stop()
+	retryAfter := time.NewTicker(time.Second)
+	defer retryAfter.Stop()
 
 	for {
 		select {
-		case <-timeoutAfter:
+		case <-timeoutAfter.C:
 			return err
-		case <-retryAfter:
+		case <-retryAfter.C:
 			err = fn()
 			if err == nil {
 				return nil


### PR DESCRIPTION
The timer created by calling `time.After` is not cleaned up until the timer fires.  Repeated calls to `time.After` in a loop create multiple timers which can accumulate if the loop runs faster than the timeout.

We replace `time.After` with `time.NewTimer` and explicitly call `Stop` when we are finished to clean up the timer.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
