### PR TITLE
Bump `linkerd-crd` version after `Server` change

### DIFF
--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -10,11 +10,11 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-crds"
 sources:
 - https://github.com/linkerd/linkerd2/
-dependencies: 
+dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.0.1-edge
+version: 1.0.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.0.1-edge](https://img.shields.io/badge/Version-1.0.1--edge-informational?style=flat-square)
+![Version: 1.0.2-edge](https://img.shields.io/badge/Version-1.0.2--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>


### PR DESCRIPTION
This is a backwards compatible bug fix so it just bumps the patch version.

This should have been included in `edge-22.2.4` but will just be included in `edge-22.3.1`.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
