### PR TITLE
ci: Relax policy controller timeouts

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -48,7 +48,7 @@ jobs:
         command: check ${{ matrix.checks }}
 
   clippy:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.56.1
@@ -59,7 +59,7 @@ jobs:
           bin/scurl -o /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
           chmod 755 /usr/local/bin/cargo-action-fmt
       - run: cargo fetch
-      - run: cargo clippy --frozen --all --message-format=json | cargo-action-fmt
+      - run: cargo clippy --frozen --all --no-deps --message-format=json | cargo-action-fmt
 
   check:
     timeout-minutes: 20
@@ -89,8 +89,9 @@ jobs:
       image: docker://rust:1.56.1
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - run: cargo test --workspace --no-run
-      - run: cargo test --workspace
+      - run: cargo fetch
+      - run: cargo test --workspace --frozen --no-run
+      - run: cargo test --workspace --frozen
 
   rust-toolchain:
     name: rust toolchain


### PR DESCRIPTION
* Run `cargo fetch` in its own step  to separate pull times from build
  times;
* Update the clippy timeout to 10 minutes (because pull times can be slow);
* Run `clippy` with `--no-deps`

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
