### PR TITLE
Clarify that `multicluster link` is one direction

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -61,7 +61,12 @@ func newLinkCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "link",
 		Short: "Outputs resources that allow another cluster to mirror services from this one",
-		Args:  cobra.NoArgs,
+		Long: `Outputs resources that allow another cluster to mirror services from this one.
+
+Note that the Link resource applies only in one direction. In order for two
+clusters to mirror each other, a Link resource will have to be generated for
+each cluster and applied to the other.`,
+		Args: cobra.NoArgs,
 		Example: `  # To link the west cluster to east
   linkerd --context=east multicluster link --cluster-name east | kubectl --context=west apply -f -
 


### PR DESCRIPTION
linkerd/website#1304

This explicitly states in `multicluster link` docs that the Link is one direction and should avoid any confusion about linking two clusters together so that they _both_ mirror each other.

The CLI docs are generated based off these descriptions and if there is a a `Long` field than that is used.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
