### PR TITLE
Use cached data to validate policy admissions

### DIFF
--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -5,38 +5,9 @@ pub mod labels;
 pub mod policy;
 
 pub use self::{labels::Labels, watcher::Event};
-use futures::prelude::*;
 pub use k8s_openapi::api::{
     self,
     core::v1::{Namespace, Node, NodeSpec, Pod, PodSpec, PodStatus},
 };
 pub use kube::api::{ObjectMeta, ResourceExt};
 use kube::runtime::watcher;
-use parking_lot::Mutex;
-use std::sync::Arc;
-
-pub type EventResult<T> = watcher::Result<watcher::Event<T>>;
-
-/// Processes an `E`-typed event stream of `T`-typed resources.
-///
-/// The `F`-typed processor is called for each event with exclusive mutable accecss to an `S`-typed
-/// store.
-///
-/// The `H`-typed initialization handle is dropped after the first event is processed to signal to
-/// the application that the index has been updated.
-///
-/// It is assumed that the event stream is infinite. If an error is encountered, the stream is
-/// immediately polled again; and if this attempt to read from the stream fails, a backoff is
-/// employed before attempting to read from the stream again.
-pub async fn index<T, E, H, S, F>(events: E, store: Arc<Mutex<S>>, process: F)
-where
-    E: Stream<Item = watcher::Event<T>>,
-    F: Fn(&mut S, watcher::Event<T>),
-{
-    tokio::pin!(events);
-    while let Some(ev) = events.next().await {
-        process(&mut *store.lock(), ev);
-    }
-
-    tracing::warn!("k8s event stream terminated");
-}

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -5,9 +5,38 @@ pub mod labels;
 pub mod policy;
 
 pub use self::{labels::Labels, watcher::Event};
+use futures::prelude::*;
 pub use k8s_openapi::api::{
     self,
     core::v1::{Namespace, Node, NodeSpec, Pod, PodSpec, PodStatus},
 };
 pub use kube::api::{ObjectMeta, ResourceExt};
 use kube::runtime::watcher;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+pub type EventResult<T> = watcher::Result<watcher::Event<T>>;
+
+/// Processes an `E`-typed event stream of `T`-typed resources.
+///
+/// The `F`-typed processor is called for each event with exclusive mutable accecss to an `S`-typed
+/// store.
+///
+/// The `H`-typed initialization handle is dropped after the first event is processed to signal to
+/// the application that the index has been updated.
+///
+/// It is assumed that the event stream is infinite. If an error is encountered, the stream is
+/// immediately polled again; and if this attempt to read from the stream fails, a backoff is
+/// employed before attempting to read from the stream again.
+pub async fn index<T, E, H, S, F>(events: E, store: Arc<Mutex<S>>, process: F)
+where
+    E: Stream<Item = watcher::Event<T>>,
+    F: Fn(&mut S, watcher::Event<T>),
+{
+    tokio::pin!(events);
+    while let Some(ev) = events.next().await {
+        process(&mut *store.lock(), ev);
+    }
+
+    tracing::warn!("k8s event stream terminated");
+}

--- a/policy-controller/k8s/index/src/authz.rs
+++ b/policy-controller/k8s/index/src/authz.rs
@@ -14,7 +14,7 @@ use tracing::{debug, instrument, trace, warn};
 
 /// Indexes `ServerAuthorization` resources within a namespace.
 #[derive(Debug, Default)]
-pub(crate) struct AuthzIndex {
+pub struct AuthzIndex {
     index: HashMap<String, Authz>,
 }
 

--- a/policy-controller/k8s/index/src/namespace.rs
+++ b/policy-controller/k8s/index/src/namespace.rs
@@ -10,7 +10,7 @@ pub(crate) struct NamespaceIndex {
 }
 
 #[derive(Debug)]
-pub(crate) struct Namespace {
+pub struct Namespace {
     /// Holds the global default-allow policy, which may be overridden per-workload.
     pub default_policy: DefaultPolicy,
 

--- a/policy-controller/k8s/index/src/pod.rs
+++ b/policy-controller/k8s/index/src/pod.rs
@@ -11,7 +11,7 @@ use tracing::{debug, instrument, trace, warn};
 
 /// Indexes pod state (within a namespace).
 #[derive(Debug, Default)]
-pub(crate) struct PodIndex {
+pub struct PodIndex {
     index: HashMap<String, Pod>,
 }
 


### PR DESCRIPTION
Currently, the policy-controller's admission server issues a request to
Kubernetes every admission review request. This is unnecessary, since
we already maintain a cache of the relevant data structure in the
process.

This change updates the admission server to hold a reference to the
process's `Index` data structure. Each time an admission request is
received, the admission server accesses the index to lookup servers that
already exist in the cluster.

Note that it's possible that the index may not be 100% up to date, as
event delivery can be delayed. I think it's okay to make the tradeoff
that the admission controller is best-effort in favor of reducing
resource usage.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
