### PR TITLE
Linkerd init container should be run first

### DIFF
--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -62,7 +62,7 @@
   },
   {
     "op": "add",
-    "path": "{{$prefix}}/spec/initContainers/-",
+    "path": "{{$prefix}}/spec/initContainers/0",
     "value":
       {{- include "partials.proxy-init" . | fromYaml | toPrettyJson | nindent 6 }}
   },

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -178,17 +178,6 @@ spec:
           name: contour-config
       initContainers:
       - args:
-        - bootstrap
-        - /config/contour.yaml
-        command:
-        - contour
-        image: gcr.io/heptio-images/contour:master
-        imagePullPolicy: Always
-        name: envoy-initconfig
-        volumeMounts:
-        - mountPath: /config
-          name: contour-config
-      - args:
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -222,6 +211,17 @@ spec:
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      - args:
+        - bootstrap
+        - /config/contour.yaml
+        command:
+        - contour
+        image: gcr.io/heptio-images/contour:master
+        imagePullPolicy: Always
+        name: envoy-initconfig
+        volumeMounts:
+        - mountPath: /config
+          name: contour-config
       volumes:
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -39,7 +39,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/spec/initContainers/0",
     "value": {
       "args": [
         "--incoming-proxy-port",

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -49,7 +49,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/spec/initContainers/0",
     "value": {
       "args": [
         "--incoming-proxy-port",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -39,7 +39,7 @@
   },
   {
     "op": "add",
-    "path": "/spec/initContainers/-",
+    "path": "/spec/initContainers/0",
     "value": {
       "args": [
         "--incoming-proxy-port",

--- a/test/integration/install/inject/inject_test.go
+++ b/test/integration/install/inject/inject_test.go
@@ -486,7 +486,7 @@ func TestInjectAutoPod(t *testing.T) {
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "failed to get pods", "failed to get pods for namespace %s: %s", ns, err)
 		}
-		if len(opaquePods) != 1 {
+		if len(initContainerPods) != 1 {
 			testutil.Fatalf(t, "wrong number of pods returned for namespace %s: %d", ns, len(initContainerPods))
 		}
 

--- a/test/integration/install/inject/testdata/pods.yaml
+++ b/test/integration/install/inject/testdata/pods.yaml
@@ -27,3 +27,24 @@ spec:
     args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
     ports:
     - containerPort: 9090
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: init-container-pod-test-terminus
+  labels:
+    app: init-container-pod-test-terminus
+spec:
+  initContainers:
+    - name: test-init
+      image: alpine
+      command:
+        - sh
+        - -c
+        - sleep 1
+  containers:
+    - name: bb-terminus
+      image: buoyantio/bb:v0.0.6
+      args: ["terminus", "--grpc-server-port", "9090", "--response-text", "BANANA"]
+      ports:
+        - containerPort: 9090


### PR DESCRIPTION
When there are multiple init containers, linkerd init container should
go first.

Fixes #7999

Signed-off-by: Krzysztof Dryś <krzysztofdrys@gmail.com>