### PR TITLE
Add sidecar container support and extra ports for linkerd-viz dashboard helm chart

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -89,6 +89,8 @@ Kubernetes: `>=1.20.0-0`
 | dashboard.resources.memory.limit | string | `nil` | Maximum amount of memory that web container can use |
 | dashboard.resources.memory.request | string | `nil` | Amount of memory that the web container requests |
 | dashboard.restrictPrivileges | bool | `false` | Restrict the Linkerd Dashboard's default privileges to disallow Tap and Check |
+| dashboard.service.extraPorts | string | `nil` | An extra Ports section specifies a list of ports to add to the web service e.g. port to sidecar container |
+| dashboard.sidecarContainers | string | `nil` | A sidecarContainers section specifies a list of secondary containers to run in the web pod e.g. oauth2 container for autentication |
 | defaultImagePullPolicy | string | `"IfNotPresent"` | Docker imagePullPolicy for all viz components |
 | defaultLogFormat | string | `"plain"` | Log format (`plain` or `json`) for all the viz components. |
 | defaultLogLevel | string | `"info"` | Log level for all the viz components |

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -20,6 +20,9 @@ spec:
     linkerd.io/extension: viz
     component: web
   ports:
+  {{- if .Values.dashboard.service.extraPorts -}}
+  {{- toYaml .Values.dashboard.service.extraPorts | trim | nindent 2 }}
+  {{- end}}
   - name: http
     port: 8084
     targetPort: 8084
@@ -70,6 +73,9 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       containers:
+      {{- if .Values.dashboard.sidecarContainers -}}
+      {{- toYaml .Values.dashboard.sidecarContainers | trim | nindent 6 }}
+      {{- end}}
       - args:
         - -linkerd-metrics-api-addr=metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:8085
         - -cluster-domain={{.Values.clusterDomain}}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -343,6 +343,41 @@ dashboard:
     # into the dashboard component
     # resources:
 
+  # -- An extra Ports section specifies a list of ports to add 
+  # to the web service e.g. port to sidecar container
+  service:
+    extraPorts:
+      # Ex:
+      # - name: extraPort
+      #   port: 4180
+      #   targetPort: 4180
+
+
+  # -- A sidecarContainers section specifies a list of secondary containers to run
+  # in the web pod e.g. oauth2 container for autentication
+  sidecarContainers:
+  # Ex:
+  # - name: oauth2-proxy
+  #   image: quay.io/oauth2-proxy/oauth2-proxy:latest
+  #   args:
+  #     - "-upstream=http://127.0.0.1:8084/"
+  #     - "-provider=github"
+  #     - "-cookie-secure=true"
+  #     - "-cookie-expire=168h0m"
+  #     - "-cookie-refresh=60m"
+  #     - "-cookie-secret=SECRET COOKIE"
+  #     - "-cookie-domain=DOMAIN"
+  #     - "-http-address=0.0.0.0:4180"
+  #     - "-redirect-url=REDIRECT URL"
+  #     - "-github-org=fromAtoB"
+  #     - "-email-domain=*"
+  #     - "-client-id=github oauth ID"
+  #     - "-client-secret=github oauth secret"
+  #   ports:
+  #   - containerPort: 4180
+
+
+
 grafana:
   # -- url of an in-cluster Grafana instance with reverse proxy configured, used by the
   # Linkerd viz web dashboard to provide direct links to specific Grafana


### PR DESCRIPTION
**Subject**
Add sidecar container support for linkerd-viz(dashboard) helm chart

**Problem**
We want to use the oauth2 authentication method but we don't have an ingress controller installed in our clusters. Because of that, we want to use it as a sidecar.

**Solution**
This PR adds a sidecarContainers: [] key to the linkerd-viz dashboard value section, each list element is a pod container definition, This PR also adds a service value section to the dashboard section with extraPort: [] key, each list element is a service port definition