### PR TITLE
Remove namespace entry in linkerd-control-plane values.yaml

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -163,7 +163,6 @@ Kubernetes: `>=1.20.0-0`
 | imagePullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
 | linkerdVersion | string | `"linkerdVersionValue"` | control plane version. See Proxy section for proxy version |
-| namespace | string | `"linkerd"` | Control plane namespace |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | podAnnotations | object | `{}` | Additional annotations to add to all pods |
 | podLabels | object | `{}` | Additional labels to add to all pods |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -23,8 +23,6 @@ controlPlaneTracing: false
 controlPlaneTracingNamespace: linkerd-jaeger
 # -- control plane version. See Proxy section for proxy version
 linkerdVersion: linkerdVersionValue
-# -- Control plane namespace
-namespace: linkerd
 # -- enables the use of EndpointSlice informers for the destination service;
 # enableEndpointSlices should be set to true only if EndpointSlice K8s feature
 # gate is on


### PR DESCRIPTION
Followup to #6635, where we missed removing the no longer used `namespace` entry.