### PR TITLE
Fix race in destination unit test

### DIFF
--- a/controller/api/destination/watcher/profile_watcher_test.go
+++ b/controller/api/destination/watcher/profile_watcher_test.go
@@ -94,6 +94,8 @@ func TestProfileWatcherUpdates(t *testing.T) {
 
 			actualProfiles := make([]*sp.ServiceProfileSpec, 0)
 
+			listener.mu.RLock()
+			defer listener.mu.RUnlock()
 			for _, profile := range listener.Profiles {
 				if profile == nil {
 					actualProfiles = append(actualProfiles, nil)

--- a/controller/api/destination/watcher/test_util.go
+++ b/controller/api/destination/watcher/test_util.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"encoding/json"
 	"reflect"
+	"sync"
 	"testing"
 
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
@@ -32,6 +33,7 @@ func (dpl *DeletingProfileListener) Update(profile *sp.ServiceProfile) {
 // in a slice.  Useful for unit tests.
 type BufferingProfileListener struct {
 	Profiles []*sp.ServiceProfile
+	mu       sync.RWMutex
 }
 
 // NewBufferingProfileListener creates a new BufferingProfileListener.
@@ -43,6 +45,8 @@ func NewBufferingProfileListener() *BufferingProfileListener {
 
 // Update stores the update in the internal buffer.
 func (bpl *BufferingProfileListener) Update(profile *sp.ServiceProfile) {
+	bpl.mu.Lock()
+	defer bpl.mu.Unlock()
 	bpl.Profiles = append(bpl.Profiles, profile)
 }
 


### PR DESCRIPTION
Fixes report
https://github.com/linkerd/linkerd2/runs/5518386921?check_suite_focus=true

by guarding `BufferingProfileListener` with a mutex.
