### PR TITLE
repair endoints mirrors for headless services

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -945,14 +945,41 @@ func (rcsw *RemoteClusterServiceWatcher) repairEndpoints(ctx context.Context) er
 		// Endpoints point to auxiliary services instead of pointing to
 		// the gateway, so they're skipped.
 		if svc.Spec.ClusterIP == corev1.ClusterIPNone {
-			rcsw.log.Debugf("Skipped repairing endpoints for %s/%s", svc.Namespace, svc.Name)
+			rcsw.log.Debugf("Skipped repairing endpoints for headless mirror %s/%s", svc.Namespace, svc.Name)
 			continue
 		}
-		// And these auxiliary services have Endpoints that point to
-		// the gateway but aren't mirroring per se any Endpoints on the
-		// target cluster, so they're also skipped.
+
+		// These endpoints belong to the auxiliary services pointed to by
+		// headless mirror services. They point the gateway addresses and
+		// their readiness is tied to the gateway liveness. We should attempt
+		// to repair these addresses in case there has been a change in
+		// gateway liveness.
 		if _, found := svc.Labels[consts.MirroredHeadlessSvcNameLabel]; found {
-			rcsw.log.Debugf("Skipped repairing endpoints for %s/%s", svc.Namespace, svc.Name)
+			endpoints, err := rcsw.localAPIClient.Endpoint().Lister().Endpoints(svc.Namespace).Get(svc.Name)
+			if err != nil {
+				// The endpoints do not yet exist for the auxiliary service so
+				// there is nothing to repair.
+				rcsw.log.Debugf("Skipped repairing mirror endpoints for headless mirror %s/%s", svc.Namespace, svc.Name)
+				continue
+			}
+
+			// Each of these subset's addresses should point to the gateway
+			// and default to ready. The call to createOrUpdateEndpoints
+			// ensures that if the gateway is not alive, these addresses are
+			// transitioned back to not ready.
+			gatewayAddresses, err := rcsw.resolveGatewayAddress()
+			if err != nil {
+				rcsw.log.Errorf("Failed to resolve gateway addresses: %s", err)
+				continue
+			}
+			for i := range endpoints.Subsets {
+				endpoints.Subsets[i].Addresses = gatewayAddresses
+				endpoints.Subsets[i].NotReadyAddresses = nil
+			}
+			err = rcsw.createOrUpdateEndpoints(ctx, endpoints)
+			if err != nil {
+				return RetryableError{[]error{err}}
+			}
 			continue
 		}
 

--- a/multicluster/service-mirror/cluster_watcher_headless.go
+++ b/multicluster/service-mirror/cluster_watcher_headless.go
@@ -301,11 +301,14 @@ func (rcsw *RemoteClusterServiceWatcher) createHeadlessMirrorEndpoints(ctx conte
 	}
 
 	rcsw.log.Infof("Creating a new headless mirror endpoints object for headless mirror %s/%s", headlessMirrorServiceName, exportedService.Namespace)
-	if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(exportedService.Namespace).Create(ctx, headlessMirrorEndpoints, metav1.CreateOptions{}); err != nil {
+	// The addresses for the headless mirror service point to the Cluster IPs
+	// of auxiliary services that are tied to gateway liveness. Therefore,
+	// these addresses should always be considered ready.
+	_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(exportedService.Namespace).Create(ctx, headlessMirrorEndpoints, metav1.CreateOptions{})
+	if err != nil {
 		if svcErr := rcsw.localAPIClient.Client.CoreV1().Services(exportedService.Namespace).Delete(ctx, headlessMirrorServiceName, metav1.DeleteOptions{}); svcErr != nil {
 			rcsw.log.Errorf("failed to delete Service %s after Endpoints creation failed: %s", headlessMirrorServiceName, svcErr)
 		}
-		// and retry
 		return RetryableError{[]error{err}}
 	}
 
@@ -377,21 +380,14 @@ func (rcsw *RemoteClusterServiceWatcher) createEndpointMirrorService(ctx context
 		}
 	}
 
-	// todo: The endpoints are created without checking for gateway liveness.
-	// We do this because if we do check — and the gateway is down — these endpoints are
-	// never repaired. This is because in repairEndpoints we skip local
-	// endpoints that are mirroring headless services since they may not have
-	// a matching endpoint on the remote cluster.
-	//
-	// Explained by cluster_watcher.go L943-L945.
 	rcsw.log.Infof("Creating a new endpoints object for endpoint mirror service %s", endpointMirrorInfo)
-	if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpointMirrorService.Namespace).Create(ctx, endpointMirrorEndpoints, metav1.CreateOptions{}); err != nil {
+	err = rcsw.createOrUpdateEndpoints(ctx, endpointMirrorEndpoints)
+	if err != nil {
 		if svcErr := rcsw.localAPIClient.Client.CoreV1().Services(endpointMirrorService.Namespace).Delete(ctx, endpointMirrorName, metav1.DeleteOptions{}); svcErr != nil {
 			rcsw.log.Errorf("Failed to delete service %s after endpoints creation failed: %s", endpointMirrorName, svcErr)
 		}
 		return createdService, RetryableError{[]error{err}}
 	}
-
 	return createdService, nil
 }
 


### PR DESCRIPTION
#8022 fixed an issue where if the gateway for a target cluster was down, the endpoints of mirror services still indicated their addresses (the gateway in this case) were ready. This was not fixed for _headless_ mirror services and a comment was left explaining the issue [here](https://github.com/linkerd/linkerd2/blob/9829f486a0cdb49b329156259943e33436102ecc/multicluster/service-mirror/cluster_watcher_headless.go#L380-L386).

This fixes that last issue and ties gateway liveness to the endpoints for headless mirror services now as well. This involved changes to the two sets of endpoints created for each headless mirror service.

1. The first set of endpoints point to auxiliary services that actually target the gateway addresses. Therefore, these addresses should always be ready and we skip the `gatewayAlive` check—going through just an API `Create`.
2. The second set of endpoints belong to these auxiliary services and target the gateway addresses. These are the endpoints that are created through `createOrUpdateEndpoints` — ensuring that `gatewayAlive` is checked — and are the endpoints that we care about repairing. `repairEndpoints` now attempts to repair the endpoints that belong to these auxiliary services by defaulting their addresses to ready which is then checked by `createOrUpdateEndpoints`.

### Testing

No tests were added because we're already properly testing this. If we just replace the `Endpoints(...).Update(...)` with `createOrUpdateEndpoints`, integration tests start failing because we never attempt to repair the endpoints created as not ready.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
