### PR TITLE
Fix bad Host in dashboard's reverse proxy

### DIFF
--- a/web/srv/reverse_proxy.go
+++ b/web/srv/reverse_proxy.go
@@ -15,7 +15,6 @@ type reverseProxy struct {
 
 func newReverseProxy(addr string, prefix string) *reverseProxy {
 	director := func(req *http.Request) {
-		req.Host = addr
 		req.URL.Host = addr
 		req.URL.Scheme = "http"
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, prefix)


### PR DESCRIPTION
Fixes #8067

We were overridding the Host header with the target cluster address
(e.g. `grafana.grafana:3000`) which is different from the host requested
by the browser (`localhost:50750`), and recent Grafana versions are
rejecting such requests in their CSRF implementation. So here we stop
overridding that, and the reverse proxy uses the right Host header
coming from the client.
