### PR TITLE
split creating and updating mirror endpoints

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -438,7 +438,7 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUpdated(ctx context.
 	}
 	copiedEndpoints.Annotations[consts.RemoteGatewayIdentity] = rcsw.link.GatewayIdentity
 
-	err = rcsw.createOrUpdateEndpoints(ctx, copiedEndpoints)
+	err = rcsw.updateMirrorEndpoints(ctx, copiedEndpoints)
 	if err != nil {
 		return RetryableError{[]error{err}}
 	}
@@ -616,7 +616,7 @@ func (rcsw *RemoteClusterServiceWatcher) createGatewayEndpoints(ctx context.Cont
 	}
 
 	rcsw.log.Infof("Creating a new endpoints for %s", serviceInfo)
-	err = rcsw.createOrUpdateEndpoints(ctx, endpointsToCreate)
+	err = rcsw.createMirrorEndpoints(ctx, endpointsToCreate)
 	if err != nil {
 		if svcErr := rcsw.localAPIClient.Client.CoreV1().Services(exportedService.Namespace).Delete(ctx, localServiceName, metav1.DeleteOptions{}); svcErr != nil {
 			rcsw.log.Errorf("Failed to delete service %s after endpoints creation failed: %s", localServiceName, svcErr)
@@ -999,7 +999,7 @@ func (rcsw *RemoteClusterServiceWatcher) repairEndpoints(ctx context.Context) er
 			rcsw.log.Error(err)
 			continue
 		}
-		err = rcsw.createOrUpdateEndpoints(ctx, updatedEndpoints)
+		err = rcsw.updateMirrorEndpoints(ctx, updatedEndpoints)
 		if err != nil {
 			rcsw.log.Error(err)
 		}
@@ -1110,14 +1110,13 @@ func (rcsw *RemoteClusterServiceWatcher) handleCreateOrUpdateEndpoints(
 			},
 		}
 	}
-	return rcsw.createOrUpdateEndpoints(ctx, ep)
+	return rcsw.updateMirrorEndpoints(ctx, ep)
 }
 
-// createOrUpdateEndpoints will create or update endpoints based off gateway
-// liveness. If the gateway is not alive, then the addresses in each subset
-// will be set to not ready; these will moved back to ready once the gateway
-// is alive and an update is received.
-func (rcsw *RemoteClusterServiceWatcher) createOrUpdateEndpoints(ctx context.Context, endpoints *corev1.Endpoints) error {
+// createMirrorEndpoints will create endpoints based off gateway liveness. If
+// the gateway is not alive, then the addresses in each subset will be set to
+// not ready.
+func (rcsw *RemoteClusterServiceWatcher) createMirrorEndpoints(ctx context.Context, endpoints *corev1.Endpoints) error {
 	if !rcsw.gatewayAlive {
 		rcsw.log.Warnf("gateway for %s/%s does not have ready addresses; setting addresses to not ready", endpoints.Namespace, endpoints.Name)
 		for i := range endpoints.Subsets {
@@ -1125,18 +1124,29 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateEndpoints(ctx context.Con
 			endpoints.Subsets[i].Addresses = nil
 		}
 	}
-	_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpoints.Namespace).Get(ctx, endpoints.Name, metav1.GetOptions{})
+	_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpoints.Namespace).Create(ctx, endpoints, metav1.CreateOptions{})
 	if err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("Failed to get endpoints for %s/%s: %w", endpoints.Namespace, endpoints.Name, err)
-		}
-		_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpoints.Namespace).Create(ctx, endpoints, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("Failed to create endpoints for %s/%s: %w", endpoints.Namespace, endpoints.Name, err)
-		}
-		return nil
+		return fmt.Errorf("Failed to create mirror endpoints for %s/%s: %w", endpoints.Namespace, endpoints.Name, err)
 	}
-	_, err = rcsw.localAPIClient.Client.CoreV1().Endpoints(endpoints.Namespace).Update(ctx, endpoints, metav1.UpdateOptions{})
+	return nil
+}
+
+// updateMirrorEndpoints will update endpoints based off gateway liveness. If
+// the gateway is not alive, then the addresses in each subset will be set to
+// not ready. Future calls to updateMirrorEndpoints can set the addresses back
+// to ready if the gateway is alive.
+func (rcsw *RemoteClusterServiceWatcher) updateMirrorEndpoints(ctx context.Context, endpoints *corev1.Endpoints) error {
+	if !rcsw.gatewayAlive {
+		rcsw.log.Warnf("gateway for %s/%s does not have ready addresses; setting addresses to not ready", endpoints.Namespace, endpoints.Name)
+		for i := range endpoints.Subsets {
+			endpoints.Subsets[i].NotReadyAddresses = append(endpoints.Subsets[i].NotReadyAddresses, endpoints.Subsets[i].Addresses...)
+			endpoints.Subsets[i].Addresses = nil
+		}
+	}
+	_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpoints.Namespace).Update(ctx, endpoints, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed to update mirror endpoints for %s/%s: %w", endpoints.Namespace, endpoints.Name, err)
+	}
 	return err
 }
 

--- a/multicluster/service-mirror/cluster_watcher_headless.go
+++ b/multicluster/service-mirror/cluster_watcher_headless.go
@@ -169,7 +169,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateHeadlessEndpoints(ctx con
 
 	// Update endpoints
 	mirrorEndpoints.Subsets = newSubsets
-	err = rcsw.createOrUpdateEndpoints(ctx, mirrorEndpoints)
+	err = rcsw.updateMirrorEndpoints(ctx, mirrorEndpoints)
 	if err != nil {
 		return RetryableError{[]error{err}}
 	}


### PR DESCRIPTION
#8022 introduced `createOrUpdateEndpoints` which creates or updates mirror endpoints in multicluster installations. The reason that creating and updating endpoints was put behind a single function is so that we could consolidate the `gatewayAlive` check down to a single location. This is good because we know that we aren't missing any places in the service mirror code where we should be checking `gatewayAlive`.

This isn't ideal though for updating endpoints because it always involves an API `Endpoints(...).Get(...)` to satisfy the `Create` case. If `Get` fails, we know we have to create; if it does not fail we _ignore_ the returned endpoints and instead `Update` with the given endpoints. While this isn't a huge bottleneck, it does scale with the number of services that are being mirrored and is easy to skip.

We always know whether we want to update or create; we never are in a case of falling back to create endpoints. Therefore, we can split this function into separate `Create` and `Update` API calls and just make sure to have the same `gatewayAlive` check at the start of each.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
