### PR TITLE
Revert "repair endoints mirrors for headless services (#8066)"

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -945,21 +945,29 @@ func (rcsw *RemoteClusterServiceWatcher) repairEndpoints(ctx context.Context) er
 		// Endpoints point to auxiliary services instead of pointing to
 		// the gateway, so they're skipped.
 		if svc.Spec.ClusterIP == corev1.ClusterIPNone {
-			rcsw.log.Debugf("Skipped repairing endpoints for headless mirror %s/%s", svc.Namespace, svc.Name)
+			rcsw.log.Debugf("Skipped repairing endpoints for %s/%s", svc.Namespace, svc.Name)
+			continue
+		}
+		// And these auxiliary services have Endpoints that point to
+		// the gateway but aren't mirroring per se any Endpoints on the
+		// target cluster, so they're also skipped.
+		if _, found := svc.Labels[consts.MirroredHeadlessSvcNameLabel]; found {
+			rcsw.log.Debugf("Skipped repairing endpoints for %s/%s", svc.Namespace, svc.Name)
 			continue
 		}
 
 		endpoints, err := rcsw.localAPIClient.Endpoint().Lister().Endpoints(svc.Namespace).Get(svc.Name)
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
-				rcsw.log.Errorf("Failed to list local endpoints: %s", err)
+				rcsw.log.Errorf("failed to list local endpoints: %s", err)
 				continue
 			}
 			endpoints, err = rcsw.localAPIClient.Client.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
-				rcsw.log.Errorf("Failed to get local endpoints %s/%s: %s", svc.Namespace, svc.Name, err)
+				rcsw.log.Errorf("failed to get local endpoints %s/%s: %s", svc.Namespace, svc.Name, err)
 			}
 		}
+
 		updatedEndpoints := endpoints.DeepCopy()
 		updatedEndpoints.Subsets = []corev1.EndpointSubset{
 			{
@@ -968,23 +976,17 @@ func (rcsw *RemoteClusterServiceWatcher) repairEndpoints(ctx context.Context) er
 			},
 		}
 
-		// We want to skip this service empty check for auxiliary services --
-		// services which are not headless but do belong to a headless
-		// mirrored service. This is because they do not have a corresponding
-		// endpoint on the target cluster, only a pod. If we attempt to find
-		// endpoints for services like this, they'll always be set to empty.
-		if _, found := svc.Labels[consts.MirroredHeadlessSvcNameLabel]; !found {
-			targetService := svc.DeepCopy()
-			targetService.Name = rcsw.targetResourceName(svc.Name)
-			empty, err := rcsw.isEmptyService(targetService)
-			if err != nil {
-				rcsw.log.Errorf("Could not check service emptiness: %s", err)
-				continue
-			}
-			if empty {
-				rcsw.log.Warnf("Exported service %s/%s is empty", targetService.Namespace, targetService.Name)
-				updatedEndpoints.Subsets = []corev1.EndpointSubset{}
-			}
+		// If the Service's Endpoints has no Subsets, use an empty Subset locally as well
+		targetService := svc.DeepCopy()
+		targetService.Name = rcsw.targetResourceName(svc.Name)
+		empty, err := rcsw.isEmptyService(targetService)
+		if err != nil {
+			rcsw.log.Errorf("could not check service emptiness: %s", err)
+			continue
+		}
+		if empty {
+			rcsw.log.Warnf("exported service %s/%s is empty", targetService.Namespace, targetService.Name)
+			updatedEndpoints.Subsets = []corev1.EndpointSubset{}
 		}
 
 		if updatedEndpoints.Annotations == nil {

--- a/multicluster/service-mirror/cluster_watcher_headless.go
+++ b/multicluster/service-mirror/cluster_watcher_headless.go
@@ -301,14 +301,11 @@ func (rcsw *RemoteClusterServiceWatcher) createHeadlessMirrorEndpoints(ctx conte
 	}
 
 	rcsw.log.Infof("Creating a new headless mirror endpoints object for headless mirror %s/%s", headlessMirrorServiceName, exportedService.Namespace)
-	// The addresses for the headless mirror service point to the Cluster IPs
-	// of auxiliary services that are tied to gateway liveness. Therefore,
-	// these addresses should always be considered ready.
-	_, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(exportedService.Namespace).Create(ctx, headlessMirrorEndpoints, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(exportedService.Namespace).Create(ctx, headlessMirrorEndpoints, metav1.CreateOptions{}); err != nil {
 		if svcErr := rcsw.localAPIClient.Client.CoreV1().Services(exportedService.Namespace).Delete(ctx, headlessMirrorServiceName, metav1.DeleteOptions{}); svcErr != nil {
 			rcsw.log.Errorf("failed to delete Service %s after Endpoints creation failed: %s", headlessMirrorServiceName, svcErr)
 		}
+		// and retry
 		return RetryableError{[]error{err}}
 	}
 
@@ -380,14 +377,21 @@ func (rcsw *RemoteClusterServiceWatcher) createEndpointMirrorService(ctx context
 		}
 	}
 
+	// todo: The endpoints are created without checking for gateway liveness.
+	// We do this because if we do check — and the gateway is down — these endpoints are
+	// never repaired. This is because in repairEndpoints we skip local
+	// endpoints that are mirroring headless services since they may not have
+	// a matching endpoint on the remote cluster.
+	//
+	// Explained by cluster_watcher.go L943-L945.
 	rcsw.log.Infof("Creating a new endpoints object for endpoint mirror service %s", endpointMirrorInfo)
-	err = rcsw.createOrUpdateEndpoints(ctx, endpointMirrorEndpoints)
-	if err != nil {
+	if _, err := rcsw.localAPIClient.Client.CoreV1().Endpoints(endpointMirrorService.Namespace).Create(ctx, endpointMirrorEndpoints, metav1.CreateOptions{}); err != nil {
 		if svcErr := rcsw.localAPIClient.Client.CoreV1().Services(endpointMirrorService.Namespace).Delete(ctx, endpointMirrorName, metav1.DeleteOptions{}); svcErr != nil {
 			rcsw.log.Errorf("Failed to delete service %s after endpoints creation failed: %s", endpointMirrorName, svcErr)
 		}
 		return createdService, RetryableError{[]error{err}}
 	}
+
 	return createdService, nil
 }
 


### PR DESCRIPTION
This reverts commit be6b536924bd73c39f6b1f63c45a98473210f6e6.

c78b4259053bd03fec01ee0ff3a16a577d958c9c removed the
`createOrUpdateEndpoints` method. But this change, uses it, which breaks
CI.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
