### PR TITLE
policy: Add an integration test to exercise the gRPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,10 +99,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -179,6 +194,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +256,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -405,6 +449,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -738,6 +792,7 @@ dependencies = [
  "openssl",
  "pem",
  "pin-project",
+ "rand",
  "rustls",
  "rustls-pemfile 0.3.0",
  "secrecy",
@@ -747,6 +802,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
+ "tokio-tungstenite",
  "tokio-util 0.7.0",
  "tower",
  "tower-http",
@@ -943,15 +999,20 @@ name = "linkerd-policy-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
+ "hyper",
+ "ipnet",
  "k8s-openapi",
  "kube",
  "linkerd-policy-controller-k8s-api",
+ "linkerd2-proxy-api",
  "rand",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
  "tokio-test",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1635,6 +1696,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1917,18 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2073,6 +2157,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2225,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "valuable"

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -7,13 +7,18 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-kube = { version = "0.70", default-features = false, features = ["client", "native-tls"] }
+hyper = { version = "0.14", features = ["client", "http2"] }
+kube = { version = "0.70", default-features = false, features = ["client", "native-tls", "ws"] }
+futures = { version = "0.3", default-features = false }
+ipnet = "2"
 k8s-openapi = { version = "0.14", features = ["v1_20"] }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
+linkerd2-proxy-api = { version = "0.3", features = ["inbound", "client"] }
 rand = "0.8"
 serde = "1"
 serde_json = "1"
 schemars = "0.8"
+tonic = { version = "0.6" }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod admission;
 
-use linkerd_policy_controller_k8s_api::{self as api};
+use linkerd_policy_controller_k8s_api as api;
 use rand::Rng;
 use tracing::Instrument;
 
@@ -17,11 +17,7 @@ where
 
     let namespace = {
         // TODO(ver) include the test name in this string?
-        let rng = &mut rand::thread_rng();
-        let sfx = (0..6)
-            .map(|_| rng.sample(LowercaseAlphanumeric) as char)
-            .collect::<String>();
-        format!("linkerd-policy-test-{}", sfx)
+        format!("linkerd-policy-test-{}", random_suffix(6))
     };
 
     tracing::debug!("initializing client");
@@ -58,6 +54,13 @@ where
     if let Err(err) = res {
         std::panic::resume_unwind(err.into_panic());
     }
+}
+
+pub fn random_suffix(len: usize) -> String {
+    let rng = &mut rand::thread_rng();
+    (0..len)
+        .map(|_| rng.sample(LowercaseAlphanumeric) as char)
+        .collect()
 }
 
 fn init_tracing() -> tracing::subscriber::DefaultGuard {

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -1,0 +1,305 @@
+use futures::prelude::*;
+use kube::{
+    runtime::wait::{await_condition, conditions},
+    ResourceExt,
+};
+use linkerd2_proxy_api::{
+    self as grpc, inbound::inbound_server_policies_client::InboundServerPoliciesClient,
+};
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::with_temp_ns;
+use tokio::{io, time};
+
+#[tokio::test(flavor = "current_thread")]
+async fn watch_updates() {
+    with_temp_ns(|client, ns| async move {
+        // Create a pod that does nothing. It's injected with a proxy, so we can attach resources to
+        let pod_api = kube::Api::<k8s::Pod>::namespaced(client.clone(), &ns);
+        let pod = pod_api
+            .create(&kube::api::PostParams::default(), &mk_pause(&ns, "pause"))
+            .await
+            .expect("pod must apply");
+        time::timeout(
+            time::Duration::from_secs(60),
+            await_condition(pod_api, &pod.name(), conditions::is_pod_running()),
+        )
+        .await
+        .expect("pod failed to become running")
+        .expect("pod failed to become running");
+        tracing::trace!(?pod);
+
+        // Start a watch
+        let mut policy_api = policy_client(&client).await;
+        let mut rx = policy_api
+            .watch_port(tonic::Request::new(grpc::inbound::PortSpec {
+                port: 4191,
+                workload: format!("{}:{}", ns, pod.name()),
+            }))
+            .await
+            .expect("failed to establish watch")
+            .into_inner();
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must return an initial config")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_eq!(
+            config.protocol,
+            Some(grpc::inbound::ProxyProtocol {
+                kind: Some(grpc::inbound::proxy_protocol::Kind::Detect(
+                    grpc::inbound::proxy_protocol::Detect {
+                        timeout: Some(time::Duration::from_secs(10).into()),
+                    }
+                )),
+            }),
+        );
+        assert_eq!(
+            config.authorizations,
+            vec![grpc::inbound::Authz {
+                labels: Some((
+                    "name".to_string(),
+                    "default:all-unauthenticated".to_string()
+                ))
+                .into_iter()
+                .collect(),
+                authentication: Some(grpc::inbound::Authn {
+                    permit: Some(grpc::inbound::authn::Permit::Unauthenticated(
+                        grpc::inbound::authn::PermitUnauthenticated {}
+                    )),
+                }),
+                networks: vec![
+                    grpc::inbound::Network {
+                        net: Some(grpc::net::IpNetwork::from(ipnet::IpNet::from(
+                            ipnet::Ipv4Net::default()
+                        ))),
+                        except: vec![],
+                    },
+                    grpc::inbound::Network {
+                        net: Some(grpc::net::IpNetwork::from(ipnet::IpNet::from(
+                            ipnet::Ipv6Net::default()
+                        ))),
+                        except: vec![],
+                    }
+                ]
+            }]
+        );
+        assert_eq!(
+            config.labels,
+            Some((
+                "name".to_string(),
+                "default:all-unauthenticated".to_string()
+            ))
+            .into_iter()
+            .collect()
+        );
+
+        // Create a server that selects the pod's proxy admin server.
+        let server = kube::Api::<k8s::policy::Server>::namespaced(client.clone(), &ns)
+            .create(
+                &kube::api::PostParams::default(),
+                &mk_admin_server(&ns, "linkerd-admin"),
+            )
+            .await
+            .expect("server must apply");
+        tracing::trace!(?server);
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must return an initial config")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_eq!(
+            config.protocol,
+            Some(grpc::inbound::ProxyProtocol {
+                kind: Some(grpc::inbound::proxy_protocol::Kind::Http1(
+                    grpc::inbound::proxy_protocol::Http1::default()
+                )),
+            }),
+        );
+        assert_eq!(config.authorizations, vec![]);
+        assert_eq!(
+            config.labels,
+            Some(("name".to_string(), "linkerd-admin".to_string()))
+                .into_iter()
+                .collect()
+        );
+
+        // Create a server that selects the pod's proxy admin server.
+        let server_authz =
+            kube::Api::<k8s::policy::ServerAuthorization>::namespaced(client.clone(), &ns)
+                .create(
+                    &kube::api::PostParams::default(),
+                    &k8s::policy::ServerAuthorization {
+                        metadata: kube::api::ObjectMeta {
+                            namespace: Some(ns.clone()),
+                            name: Some("all-admin".to_string()),
+                            ..Default::default()
+                        },
+                        spec: k8s::policy::ServerAuthorizationSpec {
+                            server: k8s::policy::server_authorization::Server {
+                                name: Some("linkerd-admin".to_string()),
+                                selector: None,
+                            },
+                            client: k8s::policy::server_authorization::Client {
+                                unauthenticated: true,
+                                ..k8s::policy::server_authorization::Client::default()
+                            },
+                        },
+                    },
+                )
+                .await
+                .expect("serverauthorization must apply");
+        tracing::trace!(?server_authz);
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must return an initial config")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_eq!(
+            config.protocol,
+            Some(grpc::inbound::ProxyProtocol {
+                kind: Some(grpc::inbound::proxy_protocol::Kind::Http1(
+                    grpc::inbound::proxy_protocol::Http1::default()
+                )),
+            }),
+        );
+        assert_eq!(
+            config.authorizations.first().unwrap().labels,
+            Some(("name".to_string(), "all-admin".to_string()))
+                .into_iter()
+                .collect()
+        );
+        assert_eq!(
+            *config
+                .authorizations
+                .first()
+                .unwrap()
+                .authentication
+                .as_ref()
+                .unwrap(),
+            grpc::inbound::Authn {
+                permit: Some(grpc::inbound::authn::Permit::Unauthenticated(
+                    grpc::inbound::authn::PermitUnauthenticated {}
+                )),
+            }
+        );
+
+        assert_eq!(
+            config.labels,
+            Some(("name".to_string(), "linkerd-admin".to_string()))
+                .into_iter()
+                .collect()
+        );
+    })
+    .await;
+}
+
+struct GrpcClient {
+    tx: hyper::client::conn::SendRequest<tonic::body::BoxBody>,
+}
+
+async fn policy_client(client: &kube::Client) -> InboundServerPoliciesClient<GrpcClient> {
+    let io = connect_to_api(client).await;
+    let (tx, conn) = hyper::client::conn::Builder::new()
+        .http2_only(true)
+        .handshake(io)
+        .await
+        .expect("http connection failed");
+    tokio::spawn(conn);
+    InboundServerPoliciesClient::new(GrpcClient { tx })
+}
+
+async fn connect_to_api(client: &kube::Client) -> impl io::AsyncRead + io::AsyncWrite + Unpin {
+    let pod = get_policy_controller_pod(client).await;
+    let mut pf = kube::Api::<k8s::Pod>::namespaced(client.clone(), "linkerd")
+        .portforward(&pod, &[8090])
+        .await
+        .expect("portforward failed");
+    pf.ports()[0].stream().expect("must have a stream")
+}
+
+async fn get_policy_controller_pod(client: &kube::Client) -> String {
+    kube::Api::<k8s::Pod>::namespaced(client.clone(), "linkerd")
+        .list(
+            &kube::api::ListParams::default()
+                .labels("linkerd.io/control-plane-component=destination"),
+        )
+        .await
+        .expect("must list controllers")
+        .items
+        .pop()
+        .expect("must have a pod")
+        .name()
+}
+
+fn mk_pause(ns: &str, name: &str) -> k8s::Pod {
+    k8s::Pod {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            annotations: Some(
+                Some(("linkerd.io/inject".to_string(), "enabled".to_string()))
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        },
+        spec: Some(k8s::PodSpec {
+            containers: vec![k8s::api::core::v1::Container {
+                name: "pause".to_string(),
+                image: Some("gcr.io/google_containers/pause:3.2".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+        ..k8s::Pod::default()
+    }
+}
+
+fn mk_admin_server(ns: &str, name: &str) -> k8s::policy::Server {
+    k8s::policy::Server {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: k8s::policy::ServerSpec {
+            pod_selector: k8s::labels::Selector::default(),
+            port: k8s::policy::server::Port::Number(4191),
+            proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+        },
+    }
+}
+
+impl hyper::service::Service<hyper::Request<tonic::body::BoxBody>> for GrpcClient {
+    type Response = hyper::Response<hyper::Body>;
+    type Error = hyper::Error;
+    type Future = hyper::client::conn::ResponseFuture;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.tx.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: hyper::Request<tonic::body::BoxBody>) -> Self::Future {
+        let (mut parts, body) = req.into_parts();
+
+        let mut uri = parts.uri.into_parts();
+        uri.scheme = Some(hyper::http::uri::Scheme::HTTP);
+        uri.authority = Some(
+            "linkerd-destination.linkerd.svc.cluster.local:8090"
+                .parse()
+                .unwrap(),
+        );
+        parts.uri = hyper::Uri::from_parts(uri).unwrap();
+
+        self.tx.call(hyper::Request::from_parts(parts, body))
+    }
+}


### PR DESCRIPTION
This change adds a simple policy integration test that exercises an
installed Linkerd control plane to verify that the gRPC API responds to
resource changes in the control plane.

This test works by establishing a port-forward to the gRPC server,
creating resources, and verifying that an API watch updates as expected.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
