### PR TITLE
Add enableHA flag for use with autoscalers that don't support podAntiAffinity

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -149,6 +149,7 @@ Kubernetes: `>=1.20.0-0`
 | disableHeartBeat | bool | `false` | Set to true to not start the heartbeat cronjob |
 | enableEndpointSlices | bool | `true` | enables the use of EndpointSlice informers for the destination service; enableEndpointSlices should be set to true only if EndpointSlice K8s feature gate is on |
 | enableH2Upgrade | bool | `true` | Allow proxies to perform transparent HTTP/2 upgrading |
+| enableHA | bool | `false` | Enables HA PDB and RollingUpdate configuration without podAntiAffinity |
 | enablePSP | bool | `false` | Add a PSP resource and bind it to the control plane ServiceAccounts. Note PSP has been deprecated since k8s v1.21 |
 | enablePprof | bool | `false` | enables the use of pprof endpoints on control plane component's admin servers |
 | identity.externalCA | bool | `false` | If the linkerd-identity-trust-roots ConfigMap has already been created |

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -96,7 +96,7 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
-{{- if .Values.enablePodAntiAffinity }}
+{{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
@@ -138,7 +138,7 @@ spec:
       linkerd.io/control-plane-component: destination
       linkerd.io/control-plane-ns: {{.Release.Namespace}}
       {{- include "partials.proxy.labels" $tree.Values.proxy | nindent 6}}
-  {{- if .Values.enablePodAntiAffinity }}
+  {{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
   strategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -72,7 +72,7 @@ spec:
   - name: grpc
     port: 8080
     targetPort: 8080
-{{- if .Values.enablePodAntiAffinity }}
+{{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
@@ -114,7 +114,7 @@ spec:
       linkerd.io/control-plane-component: identity
       linkerd.io/control-plane-ns: {{.Release.Namespace}}
       {{- include "partials.proxy.labels" $tree.Values.proxy | nindent 6}}
-  {{- if .Values.enablePodAntiAffinity }}
+  {{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
   strategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -23,7 +23,7 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: proxy-injector
-  {{- if .Values.enablePodAntiAffinity }}
+  {{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
   strategy:
     rollingUpdate:
       maxUnavailable: 1
@@ -151,7 +151,7 @@ spec:
   - name: proxy-injector
     port: 443
     targetPort: proxy-injector
-{{- if .Values.enablePodAntiAffinity }}
+{{- if or (.Values.enablePodAntiAffinity) (.Values.enableHA) }}
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -27,6 +27,10 @@ linkerdVersion: linkerdVersionValue
 # enableEndpointSlices should be set to true only if EndpointSlice K8s feature
 # gate is on
 enableEndpointSlices: true
+
+# -- enables the PDB and RollingUpdates for HA without adding
+# podAntiAffinity to pods
+enableHA: false
 # -- enables the use of pprof endpoints on control plane component's admin
 # servers
 enablePprof: false


### PR DESCRIPTION
Some autoscalers, namely Karpenter, don't allow podAntiAffinity and that flag is currently overloaded with other HA requirements. This adds another flag enableHA that can be used in place of podAntiAffinity to only add PDB and RollingUpdate configuration.
    
Diffing the helm template debug . --values values.yaml --values values.ha.yaml output shows only podAntiAffinity is removed. There are no changes if podAntiAffinity: true.
    
Fixes #8062 

Signed-off-by: Evan Hines <evan@firebolt.io>
