### PR TITLE
Add nodeAffinity support to assign linkerd pods to a group of nodes.

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -165,7 +165,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "destination" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.destinationProxyResources) }}
       {{- $r := merge .Values.destinationProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -164,10 +164,8 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "destination" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "destination" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.destinationProxyResources) }}
       {{- $r := merge .Values.destinationProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -165,7 +165,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "destination" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       {{- if not (empty .Values.destinationProxyResources) }}
       {{- $r := merge .Values.destinationProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -138,7 +138,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "identity" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - identity

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -138,7 +138,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "identity" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       - args:
         - identity

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -137,10 +137,8 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "identity" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "identity" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - identity

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -50,10 +50,8 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "proxy-injector" "label" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "proxy-injector" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.proxyInjectorProxyResources) }}
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "proxy-injector" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.proxyInjectorProxyResources) }}
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "proxy-injector" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       {{- if not (empty .Values.proxyInjectorProxyResources) }}
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.proxy.resources }}

--- a/charts/linkerd-control-plane/values-ha.yaml
+++ b/charts/linkerd-control-plane/values-ha.yaml
@@ -4,7 +4,7 @@
 
 enablePodAntiAffinity: true
 
-nodeAffinity: null
+# nodeAffinity: 
 
 # proxy configuration
 proxy:

--- a/charts/linkerd-control-plane/values-ha.yaml
+++ b/charts/linkerd-control-plane/values-ha.yaml
@@ -4,6 +4,8 @@
 
 enablePodAntiAffinity: true
 
+nodeAffinity: null
+
 # proxy configuration
 proxy:
   resources:

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -455,3 +455,8 @@ nodeSelector:
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 # for more information
 #tolerations:
+
+# -|- NodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+# for more information
+#nodeAffinity:

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -195,6 +195,10 @@ spec:
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
+      {{- if .Values.nodeAffinity }}
+      affinity:
+      {{- include "linkerd.node-affinity" . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       serviceAccountName: linkerd-cni
       {{- if .Values.priorityClassName }}

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -197,7 +197,7 @@ spec:
         kubernetes.io/os: linux
       {{- if .Values.nodeAffinity }}
       affinity:
-      {{- include "linkerd.node-affinity" . | nindent 8 -}}
+      {{- include "linkerd.node-affinity" . | nindent 8 }}
       {{- end }}
       hostNetwork: true
       serviceAccountName: linkerd-cni

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -197,7 +197,7 @@ spec:
         kubernetes.io/os: linux
       {{- if .Values.nodeAffinity }}
       affinity:
-      {{- include "linkerd.node-affinity" . | nindent 8 }}
+      {{- include "linkerd.node-affinity" . | nindent 8 -}}
       {{- end }}
       hostNetwork: true
       serviceAccountName: linkerd-cni

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -41,6 +41,11 @@ privileged: false
 # for more information
 #tolerations:
 
+# -|- NodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+# for more information
+#nodeAffinity:
+
 #
 ## For Private docker registries, authentication is needed.
 # If the control plane service images are pulled from a

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -27,7 +27,7 @@ nodeAffinity:
 
 {{ define "linkerd.affinity" -}}
 {{- if or .Values.enablePodAntiAffinity .Values.nodeAffinity -}}
-affinity: 
+affinity:
 {{- end }}
 {{- if .Values.enablePodAntiAffinity -}}
 {{- include "linkerd.pod-affinity" . | nindent 2 }}

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -1,22 +1,44 @@
 {{ define "linkerd.pod-affinity" -}}
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-    - podAffinityTerm:
-        labelSelector:
-          matchExpressions:
-          - key: {{ default "linkerd.io/control-plane-component" .label }}
-            operator: In
-            values:
-            - {{ .component }}
-        topologyKey: failure-domain.beta.kubernetes.io/zone
-      weight: 100
-    requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
+{{- if not .Values.enablePodAntiAffinity -}}
+podAntiAffinity: {}
+{{- else -}}
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+  - podAffinityTerm:
+      labelSelector:
         matchExpressions:
         - key: {{ default "linkerd.io/control-plane-component" .label }}
           operator: In
           values:
           - {{ .component }}
-      topologyKey: kubernetes.io/hostname
+      topologyKey: failure-domain.beta.kubernetes.io/zone
+    weight: 100
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: {{ default "linkerd.io/control-plane-component" .label }}
+        operator: In
+        values:
+        - {{ .component }}
+    topologyKey: kubernetes.io/hostname
+{{- end }}
+{{- end }}
+
+{{ define "linkerd.node-affinity" -}}
+{{- if not .Values.nodeAffinityOverride -}}
+nodeAffinity: {}
+{{- else -}}
+nodeAffinity:
+{{- toYaml .Values.nodeAffinityOverride | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{ define "linkerd.affinity" -}}
+{{- if not .Values.enablePodAntiAffinity -}}
+affinity: {}
+{{- else -}}
+affinity:
+{{- include "linkerd.pod-affinity" . | nindent 2 }}
+{{- include "linkerd.node-affinity" . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -1,7 +1,4 @@
 {{ define "linkerd.pod-affinity" -}}
-{{- if not .Values.enablePodAntiAffinity -}}
-podAntiAffinity: null
-{{- else -}}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:
@@ -22,23 +19,20 @@ podAntiAffinity:
         - {{ .component }}
     topologyKey: kubernetes.io/hostname
 {{- end }}
-{{- end }}
 
 {{ define "linkerd.node-affinity" -}}
-{{- if not .Values.nodeAffinity -}}
-nodeAffinity: null
-{{- else -}}
 nodeAffinity:
 {{- toYaml .Values.nodeAffinity | trim | nindent 2 }}
 {{- end }}
-{{- end }}
 
 {{ define "linkerd.affinity" -}}
-{{- if not .Values.enablePodAntiAffinity -}}
-affinity: null
-{{- else -}}
-affinity:
+{{- if or .Values.enablePodAntiAffinity .Values.nodeAffinity -}}
+affinity: 
+{{- end }}
+{{- if .Values.enablePodAntiAffinity -}}
 {{- include "linkerd.pod-affinity" . | nindent 2 }}
+{{- end }}
+{{- if .Values.nodeAffinity -}}
 {{- include "linkerd.node-affinity" . | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -1,6 +1,6 @@
 {{ define "linkerd.pod-affinity" -}}
 {{- if not .Values.enablePodAntiAffinity -}}
-podAntiAffinity: {}
+podAntiAffinity: null
 {{- else -}}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
@@ -25,17 +25,17 @@ podAntiAffinity:
 {{- end }}
 
 {{ define "linkerd.node-affinity" -}}
-{{- if not .Values.nodeAffinityOverride -}}
-nodeAffinity: {}
+{{- if not .Values.nodeAffinity -}}
+nodeAffinity: null
 {{- else -}}
 nodeAffinity:
-{{- toYaml .Values.nodeAffinityOverride | trim | nindent 2 }}
+{{- toYaml .Values.nodeAffinity | trim | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{ define "linkerd.affinity" -}}
 {{- if not .Values.enablePodAntiAffinity -}}
-affinity: {}
+affinity: null
 {{- else -}}
 affinity:
 {{- include "linkerd.pod-affinity" . | nindent 2 }}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1759,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2121,6 +2124,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1758,6 +1759,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2122,6 +2124,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1759,7 +1758,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2124,7 +2122,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1747,6 +1749,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2101,6 +2104,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1748,6 +1749,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2102,6 +2104,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1749,7 +1748,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2104,7 +2102,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1192,6 +1192,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: null
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1491,7 +1491,8 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - args:
         - identity
         - -log-level=info
@@ -1880,7 +1881,8 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -2282,7 +2284,8 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1491,8 +1491,7 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - args:
         - identity
         - -log-level=info
@@ -1881,8 +1880,7 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -2284,8 +2282,7 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1192,6 +1192,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: null
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1491,7 +1491,8 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - args:
         - identity
         - -log-level=info
@@ -1880,7 +1881,8 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -2282,7 +2284,8 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1491,8 +1491,7 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - args:
         - identity
         - -log-level=info
@@ -1881,8 +1880,7 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -2284,8 +2282,7 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1348,6 +1348,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1688,6 +1689,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2001,6 +2003,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1096,6 +1096,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1347,6 +1348,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1687,6 +1689,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2000,6 +2003,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1348,7 +1348,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1689,7 +1688,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2003,7 +2001,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -677,7 +677,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1021,7 +1020,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -1390,7 +1388,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -431,6 +431,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: linkerd-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -676,6 +677,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1019,6 +1021,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -1387,6 +1390,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -677,6 +677,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1020,6 +1021,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -1388,6 +1390,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -751,8 +751,7 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - args:
         - identity
         - -log-level=info
@@ -1144,8 +1143,7 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1552,8 +1550,7 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -751,7 +751,8 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - args:
         - identity
         - -log-level=info
@@ -1143,7 +1144,8 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1550,7 +1552,8 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -458,6 +458,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: null
     linkerdVersion: linkerd-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -759,8 +759,7 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - args:
         - identity
         - -log-level=info
@@ -1156,8 +1155,7 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1572,8 +1570,7 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -759,7 +759,8 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - args:
         - identity
         - -log-level=info
@@ -1155,7 +1156,8 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1570,7 +1572,8 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -458,6 +458,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: null
     linkerdVersion: linkerd-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -453,6 +453,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: null
     linkerdVersion: linkerd-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -741,8 +741,7 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - args:
         - identity
         - -log-level=info
@@ -1134,8 +1133,7 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1542,8 +1540,7 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -741,7 +741,8 @@ spec:
                 operator: In
                 values:
                 - identity
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - args:
         - identity
         - -log-level=info
@@ -1133,7 +1134,8 @@ spec:
                 operator: In
                 values:
                 - destination
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:
@@ -1540,7 +1542,8 @@ spec:
                 operator: In
                 values:
                 - proxy-injector
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
       - env:
         - name: _pod_name
           valueFrom:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1720,6 +1721,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2046,6 +2048,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1721,7 +1720,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2048,7 +2046,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1719,6 +1721,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2045,6 +2048,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1162,6 +1162,7 @@ data:
     imagePullPolicy: ImagePullPolicy
     imagePullSecrets: null
     linkerdVersion: ""
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1413,6 +1414,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2129,6 +2132,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1414,7 +1414,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2132,7 +2130,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1414,6 +1414,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2130,6 +2132,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1417,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1757,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2120,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1417,7 +1417,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - identity
@@ -1758,7 +1757,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name
@@ -2122,7 +2120,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1165,6 +1165,7 @@ data:
     imagePullPolicy: IfNotPresent
     imagePullSecrets: []
     linkerdVersion: install-control-plane-version
+    nodeAffinity: null
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations: {}
@@ -1416,6 +1417,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1756,6 +1758,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -2119,6 +2122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -86,7 +86,6 @@ Kubernetes: `>=1.20.0-0`
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
-| nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |
 | remoteMirrorServiceAccount | bool | `true` | If the remote mirror service account should be installed |
 | remoteMirrorServiceAccountName | string | `"linkerd-service-mirror-remote-access-default"` | The name of the service account used to allow remote clusters to mirror local services |

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -86,6 +86,7 @@ Kubernetes: `>=1.20.0-0`
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
+| nodeAffinity | string | `nil` |  |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |
 | remoteMirrorServiceAccount | bool | `true` | If the remote mirror service account should be installed |
 | remoteMirrorServiceAccountName | string | `"linkerd-service-mirror-remote-access-default"` | The name of the service account used to allow remote clusters to mirror local services |

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -86,7 +86,7 @@ Kubernetes: `>=1.20.0-0`
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
-| nodeAffinity | string | `nil` |  |
+| nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |
 | remoteMirrorServiceAccount | bool | `true` | If the remote mirror service account should be installed |
 | remoteMirrorServiceAccountName | string | `"linkerd-service-mirror-remote-access-default"` | The name of the service account used to allow remote clusters to mirror local services |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -34,10 +34,10 @@ spec:
       labels:
         app: {{.Values.gateway.name}}
     spec:
-      {{- if .Values.enablePodAntiAffinity -}}
       {{- $local := dict "label" "app" "component" .Values.gateway.name -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" .Values.gateway.name -}}
+      {{- $_ := set $tree "label" "app" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       {{- $_ := set $tree "component" .Values.gateway.name -}}
       {{- $_ := set $tree "label" "app" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       {{- $_ := set $tree "component" .Values.gateway.name -}}
       {{- $_ := set $tree "label" "app" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -1,5 +1,6 @@
 {{if .Values.gateway.enabled -}}
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,7 +35,6 @@ spec:
       labels:
         app: {{.Values.gateway.name}}
     spec:
-      {{- $local := dict "label" "app" "component" .Values.gateway.name -}}
       {{- $_ := set $tree "component" .Values.gateway.name -}}
       {{- $_ := set $tree "label" "app" -}}
       {{- include "linkerd.affinity" $tree | nindent 6 }}

--- a/multicluster/charts/linkerd-multicluster/values-ha.yaml
+++ b/multicluster/charts/linkerd-multicluster/values-ha.yaml
@@ -3,4 +3,4 @@ gateway:
 
 enablePodAntiAffinity: true
 
-nodeAffinity: null
+# nodeAffinity:

--- a/multicluster/charts/linkerd-multicluster/values-ha.yaml
+++ b/multicluster/charts/linkerd-multicluster/values-ha.yaml
@@ -2,3 +2,5 @@ gateway:
   replicas: 3
 
 enablePodAntiAffinity: true
+
+nodeAffinity: null

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -54,4 +54,4 @@ enablePodAntiAffinity: false
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
-nodeAffinity: null
+# nodeAffinity:

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -51,7 +51,7 @@ enablePSP: false
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
-# -|- NodeAffinity section, See the
+# -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
 nodeAffinity: null

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -50,3 +50,8 @@ enablePSP: false
 # across hosts and zones for High Availability.
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
+
+# -|- NodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+# for more information
+nodeAffinity: null

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -34,6 +34,7 @@ spec:
       labels:
         app: linkerd-gateway
     spec:
+      
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -34,7 +34,6 @@ spec:
       labels:
         app: linkerd-gateway
     spec:
-      
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -56,7 +56,8 @@ spec:
                 operator: In
                 values:
                 - linkerd-gateway
-            topologyKey: kubernetes.io/hostnamecontainers:
+            topologyKey: kubernetes.io/hostname
+      containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
       serviceAccountName: linkerd-gateway

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -56,8 +56,7 @@ spec:
                 operator: In
                 values:
                 - linkerd-gateway
-            topologyKey: kubernetes.io/hostname
-      containers:
+            topologyKey: kubernetes.io/hostnamecontainers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
       serviceAccountName: linkerd-gateway

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -34,6 +34,7 @@ spec:
       labels:
         app: linkerd-gateway
     spec:
+      
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -34,7 +34,6 @@ spec:
       labels:
         app: linkerd-gateway
     spec:
-      
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -31,7 +31,7 @@ type (
 		ControllerUID                int64               `json:"controllerUID"`
 		EnableH2Upgrade              bool                `json:"enableH2Upgrade"`
 		EnablePodAntiAffinity        bool                `json:"enablePodAntiAffinity"`
-	    NodeAffinity                 map[string]string   `json:"nodeAffinity"`
+		NodeAffinity                 map[string]string   `json:"nodeAffinity"`
 		WebhookFailurePolicy         string              `json:"webhookFailurePolicy"`
 		DisableHeartBeat             bool                `json:"disableHeartBeat"`
 		HeartbeatSchedule            string              `json:"heartbeatSchedule"`

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -31,6 +31,7 @@ type (
 		ControllerUID                int64               `json:"controllerUID"`
 		EnableH2Upgrade              bool                `json:"enableH2Upgrade"`
 		EnablePodAntiAffinity        bool                `json:"enablePodAntiAffinity"`
+	    NodeAffinity                 interface{}         `json:"nodeAffinity"`
 		WebhookFailurePolicy         string              `json:"webhookFailurePolicy"`
 		DisableHeartBeat             bool                `json:"disableHeartBeat"`
 		HeartbeatSchedule            string              `json:"heartbeatSchedule"`

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -31,7 +31,7 @@ type (
 		ControllerUID                int64               `json:"controllerUID"`
 		EnableH2Upgrade              bool                `json:"enableH2Upgrade"`
 		EnablePodAntiAffinity        bool                `json:"enablePodAntiAffinity"`
-	    NodeAffinity                 interface{}         `json:"nodeAffinity"`
+	    NodeAffinity                 map[string]string   `json:"nodeAffinity"`
 		WebhookFailurePolicy         string              `json:"webhookFailurePolicy"`
 		DisableHeartBeat             bool                `json:"disableHeartBeat"`
 		HeartbeatSchedule            string              `json:"heartbeatSchedule"`

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2227,6 +2227,7 @@ data:
     disableHeartBeat: false
     enableH2Upgrade: true
     enablePodAntiAffinity: false
+    nodeAffinity: null
     cliVersion: CliVersion
     clusterDomain: cluster.local
     clusterNetworks: ClusterNetworks

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -121,7 +121,7 @@ Kubernetes: `>=1.20.0-0`
 | metricsAPI.resources.memory.limit | string | `nil` | Maximum amount of memory that metrics-api container can use |
 | metricsAPI.resources.memory.request | string | `nil` | Amount of memory that the metrics-api container requests |
 | metricsAPI.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
-| nodeAffinity | string | `nil` |  |
+| nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.alertRelabelConfigs | string | `nil` | Alert relabeling is applied to alerts before they are sent to the Alertmanager. |
 | prometheus.alertmanagers | string | `nil` | Alertmanager instances the Prometheus server sends alerts to configured via the static_configs parameter. |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -94,7 +94,7 @@ Kubernetes: `>=1.20.0-0`
 | defaultLogLevel | string | `"info"` | Log level for all the viz components |
 | defaultRegistry | string | `"cr.l5d.io/linkerd"` | Docker registry for all viz components |
 | defaultUID | int | `2103` | UID for all the viz components |
-| enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
+| enablePSP | bool | `false` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information nodeAffinity: -- Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
 | grafana.externalUrl | string | `nil` | url of a Grafana instance hosted off-cluster. Cannot be set if grafana.url is set. The reverse proxy will not be used for this URL. |
 | grafana.uidPrefix | string | `nil` | prefix for Grafana dashboard UID's, used when grafana.externalUrl is set. |
@@ -121,7 +121,6 @@ Kubernetes: `>=1.20.0-0`
 | metricsAPI.resources.memory.limit | string | `nil` | Maximum amount of memory that metrics-api container can use |
 | metricsAPI.resources.memory.request | string | `nil` | Amount of memory that the metrics-api container requests |
 | metricsAPI.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
-| nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.alertRelabelConfigs | string | `nil` | Alert relabeling is applied to alerts before they are sent to the Alertmanager. |
 | prometheus.alertmanagers | string | `nil` | Alertmanager instances the Prometheus server sends alerts to configured via the static_configs parameter. |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -121,6 +121,7 @@ Kubernetes: `>=1.20.0-0`
 | metricsAPI.resources.memory.limit | string | `nil` | Maximum amount of memory that metrics-api container can use |
 | metricsAPI.resources.memory.request | string | `nil` | Amount of memory that the metrics-api container requests |
 | metricsAPI.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| nodeAffinity | string | `nil` |  |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | prometheus.alertRelabelConfigs | string | `nil` | Alert relabeling is applied to alerts before they are sent to the Alertmanager. |
 | prometheus.alertmanagers | string | `nil` | Alertmanager instances the Prometheus server sends alerts to configured via the static_configs parameter. |

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -65,10 +65,9 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.metricsAPI) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.metricsAPI) | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "metrics-api" "label" "component" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "metrics-api" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       - args:
         - -controller-namespace={{.Values.linkerdNamespace}}

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -23,6 +23,7 @@ spec:
     port: 8085
     targetPort: 8085
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -23,6 +23,7 @@ spec:
     port: 443
     targetPort: tap-injector
 ---
+{{- $tree := deepCopy . }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -71,7 +71,7 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "tap-injector" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - injector

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -71,7 +71,7 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "tap-injector" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       - args:
         - injector

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -68,10 +68,9 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "tap-injector" "label" "component" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "tap-injector" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - injector

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -80,7 +80,7 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "tap" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - api

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -77,10 +77,9 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
-      {{- if .Values.enablePodAntiAffinity -}}
-      {{- $local := dict "component" "tap" "label" "component" -}}
-      {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-      {{- end }}
+      {{- $_ := set $tree "component" "tap" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - api

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -27,6 +27,7 @@ spec:
     port: 443
     targetPort: apiserver
 ---
+{{- $tree := deepCopy . }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -80,7 +80,7 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "tap" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 -}}
       containers:
       - args:
         - api

--- a/viz/charts/linkerd-viz/values-ha.yaml
+++ b/viz/charts/linkerd-viz/values-ha.yaml
@@ -4,7 +4,7 @@
 
 enablePodAntiAffinity: true
 
-nodeAffinity: null
+# nodeAffinity:
 
 resources: &ha_resources
   cpu: &ha_resources_cpu

--- a/viz/charts/linkerd-viz/values-ha.yaml
+++ b/viz/charts/linkerd-viz/values-ha.yaml
@@ -4,6 +4,8 @@
 
 enablePodAntiAffinity: true
 
+nodeAffinity: null
+
 resources: &ha_resources
   cpu: &ha_resources_cpu
     limit: ""

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -49,7 +49,7 @@ enablePodAntiAffinity: false
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
-nodeAffinity: null
+# nodeAffinity:
 
 # -- Create Roles and RoleBindings to associate this extension's
 # ServiceAccounts to the control plane PSP resource. This requires that

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -46,7 +46,7 @@ tolerations: &default_tolerations
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
-# -|- NodeAffinity section, See the
+# -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
 nodeAffinity: null

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -46,6 +46,11 @@ tolerations: &default_tolerations
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
+# -|- NodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+# for more information
+nodeAffinity: null
+
 # -- Create Roles and RoleBindings to associate this extension's
 # ServiceAccounts to the control plane PSP resource. This requires that
 # `enabledPSP` is set to true on the control plane install. Note PSP has been

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -854,7 +854,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - api
@@ -1047,7 +1046,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -854,6 +854,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - api
@@ -1046,6 +1047,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -854,7 +854,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - api
@@ -1047,7 +1046,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -854,6 +854,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - api
@@ -1046,6 +1047,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -573,6 +573,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - api
@@ -765,6 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -573,7 +573,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - api
@@ -766,7 +765,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -854,7 +854,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - api
@@ -1047,7 +1046,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -854,6 +854,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - api
@@ -1046,6 +1047,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -862,6 +862,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - api
@@ -1054,6 +1055,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - injector

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -862,7 +862,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - api
@@ -1055,7 +1054,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
       containers:
       - args:
         - injector


### PR DESCRIPTION
Subject
Add nodeAffinity support to assign linkerd pods to a group of nodes.

Problem
Spread linkerd pods among different node pools. Described deeply in this [Slack](https://linkerd.slack.com/archives/C89RTCWJF/p1647855153313799) thread.

Solution
Introduce `nodeAffinity` helm value that will be rendered in specification of linkerd pods. The value was introduced in a smiliar way as `tolerations`

Validation
Not sure how to add a test. What would you expect to be added? A golang test?

Fixes [8136](https://github.com/linkerd/linkerd2/issues/8136)

Signed-off-by: Michal Romanowski <michal.rom089@gmail.com>
