### PR TITLE
ci: Use cli-bin docker image in policy tests

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -131,6 +131,7 @@ jobs:
     strategy:
       matrix:
         component:
+          - cli-bin
           - controller
           - policy-controller
           - proxy
@@ -162,6 +163,8 @@ jobs:
     name: Policy controller integration
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    env:
+      LINKERD_DOCKER_REGISTRY: ghcr.io/linkerd
     steps:
       - name: Checkout code
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
@@ -211,17 +214,17 @@ jobs:
             echo retrying...
           done
 
-      # Build the CLI and install Linkerd.
-      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab
-        with:
-          go-version: '1.17'
-      - name: Build the Linkerd CLI
-        run: bin/linkerd version --short --client
-      - run: bin/linkerd check --pre --wait=1m
-      - run: bin/linkerd install | kubectl apply -f -
-        env:
-          LINKERD_DOCKER_REGISTRY: ghcr.io/linkerd
-      - run: bin/linkerd check --wait=1m
+      # Install the Linkerd CLI from a docker image
+      - name: Install the Linkerd CLI
+        run: |
+          tag="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+          docker load <image-archives/cli-bin.tar
+          container_id=$(docker create "ghcr.io/linkerd/cli-bin:$tag")
+          docker cp "$container_id":/out/linkerd-linux-amd64 /usr/local/bin/linkerd
+          docker rm "$container_id"
+      - run: linkerd check --pre --wait=1m
+      - run: linkerd install | kubectl apply -f -
+      - run: linkerd check --wait=1m
 
       # Run the tests.
       - run: cargo test -p linkerd-policy-test --frozen


### PR DESCRIPTION
The policy test currently builds the CLI from source, but this can be
pretty slow and doesn't leverage cacheing. This change updates the
policy integration workflow to build the CLI via docker, which permits
cacheing and parallelization.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
