### PR TITLE
Fix bug in filtering logic

### DIFF
--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -157,6 +157,20 @@ func TestEndpointTranslatorForRemoteGateways(t *testing.T) {
 		}
 	})
 
+	t.Run("Recovers after emptying address et", func(t *testing.T) {
+		mockGetServer, translator := makeEndpointTranslator(t)
+
+		translator.Add(mkAddressSetForServices(remoteGateway1))
+		translator.Remove(mkAddressSetForServices(remoteGateway1))
+		translator.Add(mkAddressSetForServices(remoteGateway1))
+
+		expectedNumUpdates := 3
+		actualNumUpdates := len(mockGetServer.updatesReceived)
+		if actualNumUpdates != expectedNumUpdates {
+			t.Fatalf("Expecting [%d] updates, got [%d]. Updates: %v", expectedNumUpdates, actualNumUpdates, mockGetServer.updatesReceived)
+		}
+	})
+
 	t.Run("Sends TlsIdentity when enabled", func(t *testing.T) {
 		expectedTLSIdentity := &pb.TlsIdentity_DnsLikeIdentity{
 			Name: "some-identity",


### PR DESCRIPTION
Fixes #8143 

The endpoint translator has a bug with how it calculates diffs to determine which updates to send to clients of the destination controller.  This can result in an `Add` not being sent when the endpoint set is emptied and then has an endpoint is added.

When the endpoint translator receives a `Remove` call which removals all of it's addresses, the resultant call to `filterAddresses` falls through to the final case on line 155 because there are no addresses without zone hints (trivially: there are no addresses at all) and because there are no addresses with match zone hints (again, trivially).  In this case, we return the `availableEndpoints` set and set it as the filteredSnapshot.  Notably, this map is passed by reference and is not copied.  This means that the `availableEndpoints` and the `filteredSnapshot` now both refer to the same (empty) map.

When the endpoint translator later receives an `Add` call with a new address, it first adds this address into `availableEndpoints`.  However, since `availableEndpoints` and `filteredSnapshot` refer to the same map, this has the effect of adding it to `filteredSnapshot` as well.  We then compute a diff of `availableEndpoints` against `filteredSnapshot` to determine what updates need to be sent to the client.  We see no diff between these sets and send no update to the client.

This is fixed by always returning a new map from `filterAddresses` in all cases and never a reference to `availableEndpoints`.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
