### PR TITLE
viz: Update charts to use AuthorizationPolicy resources

### DIFF
--- a/viz/charts/linkerd-viz/templates/admin-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/admin-policy.yaml
@@ -29,23 +29,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   {{ include "partials.namespace" . }}
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/charts/linkerd-viz/templates/admin-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/admin-policy.yaml
@@ -15,8 +15,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   {{ include "partials.namespace" . }}
   name: admin
@@ -25,9 +25,27 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  {{ include "partials.namespace" . }}
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"

--- a/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
@@ -17,8 +17,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   {{ include "partials.namespace" . }}
   name: metrics-api
@@ -28,10 +28,28 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  {{ include "partials.namespace" . }}
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus

--- a/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
@@ -35,13 +35,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   {{ include "partials.namespace" . }}
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -51,5 +51,3 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus

--- a/viz/charts/linkerd-viz/templates/proxy-admin-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/proxy-admin-policy.yaml
@@ -15,8 +15,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   {{ include "partials.namespace" . }}
   name: proxy-admin
@@ -25,9 +25,27 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  {{ include "partials.namespace" . }}
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"

--- a/viz/charts/linkerd-viz/templates/proxy-admin-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/proxy-admin-policy.yaml
@@ -29,23 +29,7 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  {{ include "partials.namespace" . }}
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    {{ include "partials.annotations.created-by" . }}
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet

--- a/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
@@ -17,8 +17,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   {{ include "partials.namespace" . }}
   name: tap-injector
@@ -28,8 +28,28 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  {{ include "partials.namespace" . }}
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"

--- a/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
@@ -32,24 +32,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   {{ include "partials.namespace" . }}
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/charts/linkerd-viz/templates/tap-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-policy.yaml
@@ -32,24 +32,7 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  {{ include "partials.namespace" . }}
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    {{ include "partials.annotations.created-by" . }}
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server

--- a/viz/charts/linkerd-viz/templates/tap-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-policy.yaml
@@ -17,8 +17,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   {{ include "partials.namespace" . }}
   name: tap
@@ -28,8 +28,28 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  {{ include "partials.namespace" . }}
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -388,23 +388,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"
@@ -439,26 +439,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet
 ---
 ###
 ### Metrics API
@@ -584,13 +568,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   namespace: linkerd-viz
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -600,8 +584,6 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus
 ---
 ###
 ### Prometheus
@@ -982,27 +964,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server
 ---
 ###
 ### Tap Injector RBAC
@@ -1191,24 +1156,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -374,8 +374,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: admin
@@ -384,12 +384,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: Server
@@ -407,8 +425,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: proxy-admin
@@ -417,12 +435,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Metrics API
@@ -530,8 +566,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: metrics-api
@@ -541,13 +577,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus
 ---
 ###
 ### Prometheus
@@ -913,8 +967,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap
@@ -924,11 +978,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Tap Injector RBAC
@@ -1102,8 +1176,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap-injector
@@ -1113,11 +1187,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Web

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -388,23 +388,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"
@@ -439,26 +439,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet
 ---
 ###
 ### Metrics API
@@ -584,13 +568,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   namespace: linkerd-viz
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -600,8 +584,6 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus
 ---
 ###
 ### Prometheus
@@ -982,27 +964,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server
 ---
 ###
 ### Tap Injector RBAC
@@ -1191,24 +1156,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -374,8 +374,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: admin
@@ -384,12 +384,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: Server
@@ -407,8 +425,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: proxy-admin
@@ -417,12 +435,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Metrics API
@@ -530,8 +566,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: metrics-api
@@ -541,13 +577,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus
 ---
 ###
 ### Prometheus
@@ -913,8 +967,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap
@@ -924,11 +978,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Tap Injector RBAC
@@ -1102,8 +1176,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap-injector
@@ -1113,11 +1187,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -348,23 +348,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"
@@ -399,26 +399,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet
 ---
 ###
 ### Metrics API
@@ -544,13 +528,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   namespace: linkerd-viz
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -560,8 +544,6 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus
 ---
 ###
 ### Tap
@@ -701,27 +683,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server
 ---
 ###
 ### Tap Injector RBAC
@@ -910,24 +875,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -334,8 +334,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: admin
@@ -344,12 +344,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: Server
@@ -367,8 +385,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: proxy-admin
@@ -377,12 +395,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Metrics API
@@ -490,8 +526,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: metrics-api
@@ -501,13 +537,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus
 ---
 ###
 ### Tap
@@ -632,8 +686,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap
@@ -643,11 +697,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Tap Injector RBAC
@@ -821,8 +895,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap-injector
@@ -832,11 +906,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Web

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -388,23 +388,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"
@@ -439,26 +439,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet
 ---
 ###
 ### Metrics API
@@ -584,13 +568,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   namespace: linkerd-viz
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -600,8 +584,6 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus
 ---
 ###
 ### Prometheus
@@ -982,27 +964,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server
 ---
 ###
 ### Tap Injector RBAC
@@ -1191,24 +1156,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -374,8 +374,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: admin
@@ -384,12 +384,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: Server
@@ -407,8 +425,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: proxy-admin
@@ -417,12 +435,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Metrics API
@@ -530,8 +566,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: metrics-api
@@ -541,13 +577,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus
 ---
 ###
 ### Prometheus
@@ -913,8 +967,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap
@@ -924,11 +978,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Tap Injector RBAC
@@ -1102,8 +1176,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap-injector
@@ -1113,11 +1187,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -374,8 +374,8 @@ spec:
   port: admin-http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: admin
@@ -384,12 +384,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: admin
-  client:
-    # for kubelet probes and prometheus scraping
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: Server
@@ -407,8 +425,8 @@ spec:
   port: linkerd-admin
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: proxy-admin
@@ -417,12 +435,30 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: proxy-admin
-  client:
-    # for kubelet probes
-    unauthenticated: true
-
+  # Permits traffic from the kubelet. This could be restricted further and share
+  # a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: proxy-admin-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: proxy-admin-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Metrics API
@@ -530,8 +566,8 @@ spec:
   port: http
   proxyProtocol: HTTP/1
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: metrics-api
@@ -541,13 +577,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: metrics-api
-  client:
-    meshTLS:
-      serviceAccounts:
-      - name: web
-      - name: prometheus
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: MeshTLSAuthentication
+    name: metrics-api
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: metrics-api
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  identityRefs:
+  - kind: ServiceAccount
+    name: web
+  - kind: ServiceAccount
+    name: prometheus
 ---
 ###
 ### Prometheus
@@ -921,8 +975,8 @@ spec:
   port: apiserver
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap
@@ -932,11 +986,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-api
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-api-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-api-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Tap Injector RBAC
@@ -1110,8 +1184,8 @@ spec:
   port: tap-injector
   proxyProtocol: TLS
 ---
-apiVersion: policy.linkerd.io/v1beta1
-kind: ServerAuthorization
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
 metadata:
   namespace: linkerd-viz
   name: tap-injector
@@ -1121,11 +1195,31 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  server:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
     name: tap-injector-webhook
-  client:
-    # traffic coming from kube-api
-    unauthenticated: true
+  # Permits traffic from the kube API server. This could be restricted further
+  # and share a common network resource.
+  requiredAuthenticationRefs:
+  - group: policy.linkerd.io
+    kind: NetworkAuthentication
+    name: tap-injector-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: NetworkAuthentication
+metadata:
+  namespace: linkerd-viz
+  name: tap-injector-unauthenticated
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+  annotations:
+    linkerd.io/created-by: linkerd/helm dev-undefined
+spec:
+  networks:
+  - cidr: "0.0.0.0/0"
+  - cidr: "::/0"
 ---
 ###
 ### Web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -388,23 +388,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: admin-unauthenticated
+    name: kubelet
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: admin-unauthenticated
+  name: kubelet
   labels:
     linkerd.io/extension: viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs kubelet uses in
+  # a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"
@@ -439,26 +439,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: proxy-admin
-  # Permits traffic from the kubelet. This could be restricted further and share
-  # a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: proxy-admin-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: proxy-admin-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kubelet
 ---
 ###
 ### Metrics API
@@ -584,13 +568,13 @@ spec:
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: MeshTLSAuthentication
-    name: metrics-api
+    name: metrics-api-web
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
   namespace: linkerd-viz
-  name: metrics-api
+  name: metrics-api-web
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -600,8 +584,6 @@ spec:
   identityRefs:
   - kind: ServiceAccount
     name: web
-  - kind: ServiceAccount
-    name: prometheus
 ---
 ###
 ### Prometheus
@@ -990,27 +972,10 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-api
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-api-unauthenticated
----
-apiVersion: policy.linkerd.io/v1alpha1
-kind: NetworkAuthentication
-metadata:
-  namespace: linkerd-viz
-  name: tap-api-unauthenticated
-  labels:
-    linkerd.io/extension: viz
-    component: tap
-  annotations:
-    linkerd.io/created-by: linkerd/helm dev-undefined
-spec:
-  networks:
-  - cidr: "0.0.0.0/0"
-  - cidr: "::/0"
+    name: kube-api-server
 ---
 ###
 ### Tap Injector RBAC
@@ -1199,24 +1164,23 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: tap-injector-webhook
-  # Permits traffic from the kube API server. This could be restricted further
-  # and share a common network resource.
   requiredAuthenticationRefs:
   - group: policy.linkerd.io
     kind: NetworkAuthentication
-    name: tap-injector-unauthenticated
+    name: kube-api-server
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
   namespace: linkerd-viz
-  name: tap-injector-unauthenticated
+  name: kube-api-server
   labels:
     linkerd.io/extension: viz
-    component: tap-injector
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
+  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
   - cidr: "::/0"


### PR DESCRIPTION
`ServerAuthorization`s have been deprecated in favor of
`AuthorizationPolicy`. This change updates the `viz` extension to use
the new resource types.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
