### PR TITLE
policy: Support empty `requiredAuthenticationRefs`

### DIFF
--- a/policy-controller/k8s/api/src/policy/authorization_policy.rs
+++ b/policy-controller/k8s/api/src/policy/authorization_policy.rs
@@ -1,13 +1,7 @@
 use super::{LocalTargetRef, NamespacedTargetRef};
 
 #[derive(
-    Clone,
-    Debug,
-    Default,
-    kube::CustomResource,
-    serde::Deserialize,
-    serde::Serialize,
-    schemars::JsonSchema,
+    Clone, Debug, kube::CustomResource, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
 )]
 #[kube(
     group = "policy.linkerd.io",

--- a/policy-controller/k8s/api/src/policy/target_ref.rs
+++ b/policy-controller/k8s/api/src/policy/target_ref.rs
@@ -1,24 +1,18 @@
-#[derive(
-    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct ClusterTargetRef {
     pub group: Option<String>,
     pub kind: String,
     pub name: String,
 }
 
-#[derive(
-    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct LocalTargetRef {
     pub group: Option<String>,
     pub kind: String,
     pub name: String,
 }
 
-#[derive(
-    Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct NamespacedTargetRef {
     pub group: Option<String>,
     pub kind: String,
@@ -242,9 +236,9 @@ mod tests {
     #[test]
     fn cluster_targets_namespace() {
         let t = ClusterTargetRef {
+            group: None,
             kind: "Namespace".to_string(),
             name: "appns".to_string(),
-            ..Default::default()
         };
         assert!(t.targets_kind::<Namespace>());
         assert!(t.targets(&Namespace {
@@ -260,10 +254,10 @@ mod tests {
     fn namespaced_targets_service_account() {
         for tgt in &[
             NamespacedTargetRef {
+                group: None,
                 kind: "ServiceAccount".to_string(),
                 name: "default".to_string(),
                 namespace: Some("appns".to_string()),
-                ..Default::default()
             },
             NamespacedTargetRef {
                 group: Some("core".to_string()),
@@ -278,9 +272,10 @@ mod tests {
                 namespace: Some("APPNS".to_string()),
             },
             NamespacedTargetRef {
+                group: None,
                 kind: "ServiceAccount".to_string(),
                 name: "default".to_string(),
-                ..Default::default()
+                namespace: None,
             },
         ] {
             assert!(tgt.targets_kind::<ServiceAccount>());
@@ -317,9 +312,10 @@ mod tests {
         }
 
         let tgt = NamespacedTargetRef {
+            group: None,
             kind: "ServiceAccount".to_string(),
             name: "default".to_string(),
-            ..Default::default()
+            namespace: None,
         };
         assert!(
             {

--- a/policy-controller/k8s/index/src/tests/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/tests/authorization_policy.rs
@@ -49,7 +49,7 @@ fn links_authorization_policy_with_mtls_name() {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: "NetworkAuthentication".to_string(),
                 name: "net-foo".to_string(),
-                ..Default::default()
+                namespace: None,
             },
             NamespacedTargetRef {
                 group: Some("policy.linkerd.io".to_string()),

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -229,10 +229,6 @@ impl Validate<AuthorizationPolicySpec> for Admission {
             bail!("unsupported authentication kind(s): {}", kinds.join(", "));
         }
 
-        if mtls_authns_count + net_authns_count == 0 {
-            bail!("at least one authentication reference must be set");
-        }
-
         Ok(())
     }
 }

--- a/policy-test/tests/admit_meshtls_authentication.rs
+++ b/policy-test/tests/admit_meshtls_authentication.rs
@@ -14,9 +14,10 @@ async fn accepts_valid_ref() {
         },
         spec: MeshTLSAuthenticationSpec {
             identity_refs: Some(vec![NamespacedTargetRef {
+                group: None,
                 kind: "ServiceAccount".to_string(),
                 name: "default".to_string(),
-                ..Default::default()
+                namespace: None,
             }]),
             ..Default::default()
         },
@@ -64,9 +65,10 @@ async fn rejects_both_refs_and_strings() {
         spec: MeshTLSAuthenticationSpec {
             identities: Some(vec!["example.id".to_string()]),
             identity_refs: Some(vec![NamespacedTargetRef {
+                group: None,
                 kind: "ServiceAccount".to_string(),
                 name: "default".to_string(),
-                ..Default::default()
+                namespace: None,
             }]),
         },
     })


### PR DESCRIPTION
Currently, the policy admission controller requires that the
`AuthorizationPolicy` resources include a non-empty
`requiredAuthenticationRefs` field. This means that all authorization
policies require at least a `NetworkAuthentication` to permit traffic.
For example:

```yaml
---
apiVersion: policy.linkerd.io/v1alpha1
kind: AuthorizationPolicy
metadata:
  name: ingress-all-nets
spec:
  targetRef:
    group: policy.linkerd.io
    kind: Server
    name: ingress-http
  requiredAuthenticationRefs:
  - group: policy.linkerd.io
    kind: NetworkAuthentication
    name: all-nets
---
apiVersion: policy.linkerd.io/v1alpha1
kind: NetworkAuthentication
metadata:
  name: all-nets
spec:
  networks:
  - cidr: 0.0.0.0/0
  - cidr: ::/0
```

This is needlessly verbose and can more simply be expressed as:

```yaml
---
apiVersion: policy.linkerd.io/v1alpha1
kind: AuthorizationPolicy
metadata:
  name: ingress
spec:
  targetRef:
    group: policy.linkerd.io
    kind: Server
    name: ingress-http
  requiredAuthenticationRefs: []
```

That is: there are explicitly no required authentications for this
policy.

This change updates the admission controller to permit such a policy.
Note that the `requiredAuthenticationRefs` field is still required so
that it's harder for simple misconfigurations to result in allowing
traffic.

This change also removes `Default` implementation for resources where do
they not make sense because there are required fields.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
