### PR TITLE
policy: Run only a single integration test at once.

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -233,5 +233,6 @@ jobs:
       - run: linkerd install | kubectl apply -f -
       - run: linkerd check --wait=1m
 
-      # Run the tests.
-      - run: cargo test -p linkerd-policy-test --frozen
+      # Run the tests. We disable parallelism to avoid spurious timeouts caused
+      # by resource contention.
+      - run: cargo test -p linkerd-policy-test --frozen --jobs=1

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -235,4 +235,4 @@ jobs:
 
       # Run the tests. We disable parallelism to avoid spurious timeouts caused
       # by resource contention.
-      - run: cargo test -p linkerd-policy-test --frozen --jobs=1
+      - run: cargo test -p linkerd-policy-test --frozen -- --test-threads=1

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -237,7 +237,7 @@ impl Running {
         tracing::debug!(pod = %self.name, %code, "Curl exited");
 
         if let Err(error) = api
-            .delete(&self.name, &kube::api::DeleteParams::background())
+            .delete(&self.name, &kube::api::DeleteParams::foreground())
             .await
         {
             tracing::trace!(%error, name = %self.name, "Failed to delete pod");

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -1,5 +1,4 @@
 use super::{create, LinkerdInject};
-use kube::ResourceExt;
 use linkerd_policy_controller_k8s_api::{self as k8s};
 use maplit::{btreemap, convert_args};
 use tokio::time;
@@ -208,7 +207,6 @@ impl Running {
                 .iter()
                 .find(|c| c.name == "curl")?;
             let code = c.state.as_ref()?.terminated.as_ref()?.exit_code;
-            tracing::debug!(ns = %pod.namespace().unwrap(), pod = %pod.name(), %code, "Curl exited");
             Some(code)
         }
 
@@ -226,7 +224,8 @@ impl Running {
         };
 
         let curl_pod = api.get(&self.name).await.expect("pod must exist");
-        let ex = get_exit_code(&curl_pod).expect("curl pod must have an exit code");
+        let code = get_exit_code(&curl_pod).expect("curl pod must have an exit code");
+        tracing::debug!(pod = %self.name, %code, "Curl exited");
 
         if let Err(error) = api
             .delete(&self.name, &kube::api::DeleteParams::background())
@@ -235,6 +234,6 @@ impl Running {
             tracing::trace!(%error, name = %self.name, "Failed to delete pod");
         }
 
-        ex
+        code
     }
 }

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -221,13 +221,6 @@ impl Running {
             Ok(Ok(())) => {}
             Ok(Err(error)) => panic!("Failed to wait for exit code: {}: {}", self.name, error),
             Err(_timeout) => {
-                let pods = api
-                    .list(&Default::default())
-                    .await
-                    .expect("Failed to get pod status");
-                for p in pods.items.iter() {
-                    tracing::debug!(name = %self.name, status = ?p.status);
-                }
                 panic!("Timeout waiting for exit code: {}", self.name);
             }
         };

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -141,9 +141,10 @@ where
         for p in pods.items {
             let pod = p.name();
             if let Some(status) = p.status {
-                tracing::trace!(ns = ?ns.name(), %pod, reason = ?status.reason, message = ?status.message);
+                let _span = tracing::info_span!("pod", ns = %ns.name(), name = %pod).entered();
+                tracing::trace!(reason = ?status.reason, message = ?status.message);
                 for c in status.container_statuses.into_iter().flatten() {
-                    tracing::trace!(ns = ?ns.name(), %pod, container = %c.name, ready = %c.ready, state = ?c.state);
+                    tracing::trace!(container = %c.name, ready = %c.ready, state = ?c.state);
                 }
             }
         }

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -138,7 +138,7 @@ where
             .list(&Default::default())
             .await
             .expect("Failed to get pod status");
-        for p in pods.items.into_iter() {
+        for p in pods.items {
             let pod = p.name();
             if let Some(status) = p.status {
                 tracing::trace!(ns = ?ns.name(), %pod, reason = ?status.reason, message = ?status.message);

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -163,7 +163,7 @@ fn init_tracing() -> tracing::subscriber::DefaultGuard {
             .with_test_writer()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "e2e=trace,api=trace,linkerd=trace,info".parse().unwrap()),
+                    .unwrap_or_else(|_| "trace,hyper=info,kube=info,h2=info".parse().unwrap()),
             )
             .finish(),
     )


### PR DESCRIPTION
We sometimes see test timeouts where a process's exit code can't be
obtained within 2 minutes(!). This change reduces policy-test
concurrency to 1 to try to avoid resource contention in CI.

This change also fixes duplicate curl exit code logs; and it changes the
default test log level to default to `trace` except for known noisy
dependencies.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
