### PR TITLE
Update `linkerd2-proxy-api` to v0.5.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,7 +8,6 @@
 bin
 !bin/fetch-proxy
 !bin/install-deps
-!bin/protoc
 !bin/scurl
 !bin/web
 **/Dockerfile*

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -21,10 +21,10 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   K3D_VERSION: v5.3.0
+  PROTOC_NO_VENDOR: 1
   PROXY_INIT_VERSION: v1.5.3
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
-  PROTOC_NO_VENDOR: 1
 
 
 jobs:
@@ -67,7 +67,7 @@ jobs:
           chmod 755 /usr/local/bin/cargo-action-fmt
       - run: cargo fetch --locked
       - name: Run cargo clippy
-        run: PROTOC=$PWD/bin/protoc cargo clippy --frozen --all --no-deps --message-format=json | cargo-action-fmt
+        run: cargo clippy --frozen --all --no-deps --message-format=json | cargo-action-fmt
 
   check:
     timeout-minutes: 20
@@ -82,7 +82,6 @@ jobs:
       - run: cargo fetch --locked
       # Check each crate independently to ensure its Cargo.toml is sufficient.
       - run: |
-          export PROTOC=$PWD/bin/protoc
           for toml in $(find . -mindepth 2 -name Cargo.toml | sort -r)
           do
             d=$(dirname "$toml")
@@ -100,9 +99,9 @@ jobs:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - run: cargo fetch --locked
       - name: Build tests
-        run: PROTOC=$PWD/bin/protoc cargo test --workspace --exclude=linkerd-policy-test --frozen --no-run
+        run: cargo test --workspace --exclude=linkerd-policy-test --frozen --no-run
       - name: Run cargo test
-        run: PROTOC=$PWD/bin/protoc cargo test --workspace --exclude=linkerd-policy-test --frozen
+        run: cargo test --workspace --exclude=linkerd-policy-test --frozen
 
   rust-toolchain:
     name: rust toolchain
@@ -196,7 +195,7 @@ jobs:
       # before doing extra work.
       - run: cargo fetch --locked
       - name: Build tests
-        run: PROTOC=$PWD/bin/protoc cargo test -p linkerd-policy-test --frozen --no-run | cargo-action-fmt
+        run: cargo test -p linkerd-policy-test --frozen --no-run | cargo-action-fmt
 
       - name: Download image archives
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
@@ -243,4 +242,4 @@ jobs:
       # Run the tests. We disable parallelism to avoid spurious timeouts caused
       # by resource contention.
       - name: Run cargo test
-        run: PROTOC=$PWD/bin/protoc cargo test -p linkerd-policy-test --frozen -- --test-threads=1
+        run: cargo test -p linkerd-policy-test --frozen -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,49 +67,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "mime",
-]
-
-[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,15 +166,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -361,12 +309,6 @@ checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -990,6 +932,7 @@ dependencies = [
  "async-trait",
  "drain",
  "futures",
+ "hyper",
  "linkerd-policy-controller-core",
  "linkerd2-proxy-api",
  "maplit",
@@ -1060,16 +1003,15 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fcbfd8f3f305638c81aa5e42f289db74cb71cec785be6a7fb55bf68791187"
+checksum = "12c93aba8dbdc8f465de51ef08c5e1938790ea0ae7390d66b3f4d2d36c297d0b"
 dependencies = [
  "ipnet",
  "prost",
  "prost-types",
  "thiserror",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1113,22 +1055,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "matchit"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -1152,12 +1082,6 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -1311,16 +1235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "petgraph"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,16 +1279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "prettyplease"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,28 +1319,6 @@ checksum = "1bd5316aa8f5c82add416dfbc25116b84b748a21153f512917e8143640a71bbd"
 dependencies = [
  "bytes",
  "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328f9f29b82409216decb172d81e936415d21245befa79cd34c3f29d87d1c50b"
-dependencies = [
- "bytes",
- "cfg-if",
- "cmake",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
- "regex",
- "tempfile",
- "which",
 ]
 
 [[package]]
@@ -1840,12 +1722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,41 +1921,21 @@ checksum = "30fb54bf1e446f44d870d260d99957e7d11fb9d0a0f5bd1a662ad1411cc103f9"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
  "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
- "hyper",
- "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
  "prost-derive",
- "tokio",
  "tokio-stream",
  "tokio-util 0.7.0",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2090,11 +1946,8 @@ checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
  "tokio-util 0.7.0",
  "tower-layer",
@@ -2117,7 +1970,6 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2167,16 +2019,6 @@ checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2418,17 +2260,6 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "which"
-version = "4.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
-dependencies = [
- "either",
- "lazy_static",
- "libc",
 ]
 
 [[package]]

--- a/policy-controller/amd64.dockerfile
+++ b/policy-controller/amd64.dockerfile
@@ -6,9 +6,6 @@ FROM $RUST_IMAGE as build
 ARG TARGETARCH
 WORKDIR /build
 COPY bin/scurl bin/scurl
-COPY bin/protoc bin/protoc
-ENV PROTOC_NO_VENDOR=1
-ENV PROTOC=/build/bin/protoc
 COPY Cargo.toml Cargo.lock .
 COPY policy-controller policy-controller
 RUN cargo new policy-test --lib

--- a/policy-controller/arm.dockerfile
+++ b/policy-controller/arm.dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
 WORKDIR /build
 COPY bin/scurl bin/scurl
-COPY bin/protoc bin/protoc
-ENV PROTOC_NO_VENDOR=1
-ENV PROTOC=/build/bin/protoc
 COPY Cargo.toml Cargo.lock .
 COPY policy-controller policy-controller
 RUN cargo new policy-test --lib

--- a/policy-controller/arm64.dockerfile
+++ b/policy-controller/arm64.dockerfile
@@ -9,9 +9,6 @@ RUN apt-get update && \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 WORKDIR /build
 COPY bin/scurl bin/scurl
-COPY bin/protoc bin/protoc
-ENV PROTOC_NO_VENDOR=1
-ENV PROTOC=/build/bin/protoc
 COPY Cargo.toml Cargo.lock .
 COPY policy-controller policy-controller
 RUN cargo new policy-test --lib

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -9,10 +9,11 @@ publish = false
 async-stream = "0.3"
 async-trait = "0.1"
 drain = "0.1"
+hyper = { version = "0.14", features = ["http2", "server", "tcp"] }
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.4", features = ["inbound", "server"] }
+linkerd2-proxy-api = { version = "0.5", features = ["inbound"] }
 linkerd-policy-controller-core = { path = "../core" }
 maplit = "1"
 tokio = { version = "1", features = ["macros"] }
-tonic = { version = "0.7", default-features = false, features = ["transport"] }
+tonic = { version = "0.7", default-features = false }
 tracing = "0.1"

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -8,22 +8,30 @@ publish = false
 [dependencies]
 anyhow = "1"
 hyper = { version = "0.14", features = ["client", "http2"] }
-kube = { version = "0.70", default-features = false, features = ["client", "native-tls", "ws"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-openapi = { version = "0.14", features = ["v1_20"] }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
-linkerd2-proxy-api = { version = "0.4", features = ["inbound", "client"] }
+linkerd2-proxy-api = { version = "0.5", features = ["inbound"] }
 maplit = "1"
 rand = "0.8"
 serde = "1"
 serde_json = "1"
 schemars = "0.8"
-tonic = { version = "0.7" }
+tonic = { version = "0.7", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dependencies.kube]
+version = "0.70"
+default-features = false
+features = [
+    "client",
+    "native-tls",
+    "ws",
+]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/policy-test/README.md
+++ b/policy-test/README.md
@@ -26,7 +26,7 @@ with:
 :; bin/docker-build-policy-controller &; \
     bin/docker-build-controller &; \
     bin/docker-build-proxy &; \
-    wait && wait && wait && \
+    wait && \
     bin/image-load --k3d policy-controller controller proxy && \
     rm -rf target/cli && \
     bin/linkerd install --set 'policyController.logLevel=info\,linkerd=trace\,kubert=trace' \


### PR DESCRIPTION
3f2061d updated the repo to use `linkerd2-proxy-api` v0.4.0 with `tonic`
v0.7.0; but this change does not work properly with ARM builds, as there
no `protoc` binary available on this platform. Now that
`linkerd2-proxy-api` includes statically-generated protobuf bindings,
the policy controller no longer needs protoc at build-time.

This change also removes the use of the `tonic/transport` feature, since
it has some annoying dependency implications. Instead we build a simple
`hyper` server as tonic would.