### PR TITLE
ci: Test policy on the minimum k8s version (v1.20)

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -20,7 +20,7 @@ env:
   CARGO_ACTION_FMT_VERSION: v0.1.3
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  K3D_VERSION: v5.3.0
+  K3D_VERSION: v5.4.1
   PROTOC_NO_VENDOR: 1
   PROXY_INIT_VERSION: v1.5.3
   RUST_BACKTRACE: short
@@ -164,8 +164,14 @@ jobs:
           path: /home/runner/archives
 
   integration:
+    strategy:
+      matrix:
+        k8s:
+          - v1.20
+          - v1.23
+    name: Policy controller integration (k8s ${{ matrix.k8s }})
+
     needs: [docker_build]
-    name: Policy controller integration
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:
@@ -187,7 +193,7 @@ jobs:
 
       - run: bin/scurl -v https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
       - run: k3d --version
-      - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"
+      - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*" --image +${{ matrix.k8s }}
       - run: kubectl version
 
       # Build the tests before installing Linkerd and running the tests. This gives the cluster a

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -131,7 +131,7 @@ jobs:
 
           exit $ex
 
-  docker_build:
+  docker-build:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -163,6 +163,43 @@ jobs:
           name: image-archives
           path: /home/runner/archives
 
+  integration-build:
+    runs-on: ubuntu-20.04
+    name: Integration build
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Install rust
+        run: |
+          rm -rf $HOME/.cargo
+          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain $(cat rust-toolchain)
+          source $HOME/.cargo/env
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          bin/scurl -o /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
+          chmod 755 /usr/local/bin/cargo-action-fmt
+          bin/scurl -L https://get.nexte.st/latest/linux | tar xzf - -C /usr/local/bin
+          cargo version
+          cargo-action-fmt --version
+          cargo nextest --version
+
+      - run: mkdir target
+      - run: cargo fetch --locked
+      - run: cargo metadata --format-version 1 >target/metadata.json
+      - run: cargo nextest list --frozen --package=linkerd-policy-test --list-type=binaries-only --message-format=json >target/nextest.json
+      - name: Create tarball
+        run: |
+          mkdir -p /home/runner/archives
+          jq -r '.["rust-binaries"] | to_entries | .[].value | .["binary-path"]' target/nextest.json | sed -e "s,^$PWD/,," \
+            | xargs tar -czvf /home/runner/archives/nextest.tar.gz target/nextest.json target/metadata.json
+      - name: Upload artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        with:
+          name: image-archives
+          path: /home/runner/archives
+
+
   integration:
     strategy:
       matrix:
@@ -171,7 +208,7 @@ jobs:
           - v1.23
     name: Policy controller integration (k8s ${{ matrix.k8s }})
 
-    needs: [docker_build]
+    needs: [docker-build, integration-build]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     env:
@@ -188,26 +225,23 @@ jobs:
           echo "PATH=$PATH" >> $GITHUB_ENV
           bin/scurl -o /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
           chmod 755 /usr/local/bin/cargo-action-fmt
+          bin/scurl -L https://get.nexte.st/latest/linux | tar xzf - -C /usr/local/bin
           cargo version
           cargo-action-fmt --version
+          cargo nextest --version
 
       - run: bin/scurl -v https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh | bash
       - run: k3d --version
       - run: k3d cluster create --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*" --image +${{ matrix.k8s }}
       - run: kubectl version
 
-      # Build the tests before installing Linkerd and running the tests. This gives the cluster a
-      # chance to settle down before loading images, etc. It also ensures that the tests compile
-      # before doing extra work.
-      - run: cargo fetch --locked
-      - name: Build tests
-        run: cargo test -p linkerd-policy-test --frozen --no-run | cargo-action-fmt
-
       - name: Download image archives
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: image-archives
           path: image-archives
+      - name: Load test binaries
+        run: tar -xzvf image-archives/nextest.tar.gz
       - name: Load images
         run: |
           docker pull -q docker.io/bitnami/kubectl:latest &
@@ -247,5 +281,6 @@ jobs:
 
       # Run the tests. We disable parallelism to avoid spurious timeouts caused
       # by resource contention.
-      - name: Run cargo test
-        run: cargo test -p linkerd-policy-test --frozen -- --test-threads=1
+      - run: cargo nextest run --cargo-metadata=target/metadata.json --binaries-metadata=target/nextest.json --test-threads=1
+        env:
+          NEXTEST_EXPERIMENTAL_REUSE_BUILD: 1

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -23,7 +23,10 @@ impl Runner {
             namespace: ns.to_string(),
             client: client.clone(),
         };
-        runner.create_rbac().await;
+        tokio::time::timeout(tokio::time::Duration::from_secs(60), runner.create_rbac())
+            .await
+            .expect("must create RBAC within a minute");
+
         runner
     }
 
@@ -92,6 +95,7 @@ impl Runner {
             },
         )
         .await;
+        super::await_service_account(&self.client, &self.namespace, "curl").await;
 
         create(
             &self.client,

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -128,6 +128,12 @@ where
     )
     .await;
     tracing::trace!(?ns);
+    tokio::time::timeout(
+        tokio::time::Duration::from_secs(60),
+        await_service_account(&client, &ns.name(), "default"),
+    )
+    .await
+    .expect("Timed out waiting for a serviceaccount");
 
     tracing::trace!("Spawning");
     let test = test(client.clone(), ns.name());
@@ -160,6 +166,70 @@ where
         .expect("failed to delete Namespace");
     if let Err(err) = res {
         std::panic::resume_unwind(err.into_panic());
+    }
+}
+
+pub async fn await_service_account(client: &kube::Client, ns: &str, name: &str) {
+    use futures::StreamExt;
+    let secret_name = await_service_account_secret(client, ns, name).await;
+
+    tracing::trace!(name = %secret_name, "Waiting for secret");
+    tokio::pin! {
+        let secrets = kube::runtime::watcher(
+            kube::Api::<k8s::api::core::v1::Secret>::namespaced(client.clone(), ns),
+            kube::api::ListParams::default().fields(&format!("metadata.name={}", secret_name)),
+        );
+    }
+    loop {
+        match secrets
+            .next()
+            .await
+            .expect("secret watch must not end")
+            .expect("secret watch must not fail")
+        {
+            kube::runtime::watcher::Event::Restarted(secrets) if !secrets.is_empty() => break,
+            kube::runtime::watcher::Event::Applied(_) => break,
+            _ => {}
+        }
+    }
+}
+
+async fn await_service_account_secret(client: &kube::Client, ns: &str, name: &str) -> String {
+    use futures::StreamExt;
+
+    tracing::trace!(%name, "Waiting for serviceaccount");
+    tokio::pin! {
+        let sas = kube::runtime::watcher(
+            kube::Api::<k8s::ServiceAccount>::namespaced(client.clone(), ns),
+            kube::api::ListParams::default().fields(&format!("metadata.name={}", name)),
+        );
+    }
+    loop {
+        let ev = sas
+            .next()
+            .await
+            .expect("serviceaccounts watch must not end")
+            .expect("serviceaccounts watch must not fail");
+        tracing::info!(?ev);
+        match ev {
+            kube::runtime::watcher::Event::Restarted(sas) => {
+                if let Some(sa) = sas.get(0) {
+                    if let Some(sec) = sa.secrets.iter().flatten().next() {
+                        if let Some(name) = sec.name.as_ref() {
+                            return name.clone();
+                        }
+                    }
+                }
+            }
+            kube::runtime::watcher::Event::Applied(sa) => {
+                if let Some(sec) = sa.secrets.iter().flatten().next() {
+                    if let Some(name) = sec.name.as_ref() {
+                        return name.clone();
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 }
 


### PR DESCRIPTION
The policy tests only run on the most recent Kubernetes version. This
change updates the policy test workflow to use a matrix to run these
tests on the minimum-supported kubernetes version.

In order for the tests to pass on k8s v1.20, we need to block resource
creation on service account availability. Otherwise, pods may fail due
to the serviceaccount not being available.

The policy test runner is changed to `nextest` so that we can build the
tests once and share the artifacts in all instances of the cluster tests.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
