### PR TITLE
ci: Don't short-circuit integration tests on failure

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,6 +52,7 @@ jobs:
         path: /home/runner/archives
 
   integration_tests:
+    needs: [docker_build]
     strategy:
       matrix:
         integration_test:
@@ -67,8 +68,12 @@ jobs:
         - uninstall
         - upgrade-edge
         - upgrade-stable
-    needs: [docker_build]
     name: Integration tests (${{ matrix.integration_test }})
+
+    # If a single test fails, allow other tests to run. This is mostly to
+    # account for the fact that CI is flakey and failed workflows may need to be
+    # rerun.
+    continue-on-error: true
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
When a single integration test fails, all other tests are skipped. Now
that we can selectively rerun failed builds, this behavior is no longer
desirable. This changes the behavior to allow all tests to succeed when
an error is encountered in another test.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
