### PR TITLE
Update debian to bullseye

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM debian:buster-20210208-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     dnsutils \

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -39,7 +39,7 @@ COPY --from=fetch /build/proxy-version /usr/lib/linkerd/linkerd2-proxy-version.t
 COPY --from=fetch /build/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
 COPY --from=fetch /build/linkerd-await /usr/lib/linkerd/linkerd-await
 COPY --from=golang /out/proxy-identity /usr/lib/linkerd/linkerd2-proxy-identity
-COPY --from=debian:buster-20210208-slim /bin/sleep /bin/sleep
+COPY --from=debian:bullseye-slim /bin/sleep /bin/sleep
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}
 ENV LINKERD2_PROXY_LOG=warn,linkerd=info

--- a/cni-plugin/Dockerfile
+++ b/cni-plugin/Dockerfile
@@ -18,7 +18,7 @@ COPY cni-plugin cni-plugin
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /go/bin/linkerd-cni -v -mod=readonly ./cni-plugin/
 
-FROM debian:buster-20210208-slim
+FROM debian:bullseye-slim
 WORKDIR /linkerd
 RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \


### PR DESCRIPTION
Several container images use `debian:buster-20210208-slim`. `bullseye`
is now the default version (i.e., referenced by the `latest` tag).

This change updates container images that use debian to reference
`bullseye` instead of `buster`. The date tags have been dropped so that
we pick up the latest patch version on each Linkerd release.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
