### PR TITLE
Fix and reenable helm-update integration test

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,8 +54,7 @@ jobs:
         - viz
         - default-policy-deny
         - external
-        # FIXME the helm tests are broken
-        #- helm-upgrade
+        - helm-upgrade
         - multicluster
         - uninstall
         - upgrade-edge

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -264,7 +264,7 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 func getExtensionCheckFlags(lf *pflag.FlagSet) []string {
 	extensionFlags := []string{
 		"api-addr", "context", "as", "as-group", "kubeconfig", "linkerd-namespace", "verbose",
-		"namespace", "proxy", "wait",
+		"namespace", "proxy", "wait", "expected-version", "cli-version-override",
 	}
 	cmdLineFlags := []string{}
 	for _, flag := range extensionFlags {

--- a/test/integration/install/testdata/check.golden
+++ b/test/integration/install/testdata/check.golden
@@ -52,31 +52,22 @@ linkerd-webhooks-and-apisvc-tls
 √ policy-validator webhook has valid cert
 √ policy-validator cert is valid for at least 60 days
 
-linkerd-identity-data-plane
----------------------------
-√ data plane proxies certificate match CA
-
 linkerd-version
 ---------------
 √ can determine the latest version
 √ cli is up-to-date
+
+control-plane-version
+---------------------
+√ can retrieve the control plane version
+√ control plane is up-to-date
+√ control plane and cli versions match
 
 linkerd-control-plane-proxy
 ---------------------------
 √ control plane proxies are healthy
 √ control plane proxies are up-to-date
 √ control plane proxies and cli versions match
-
-linkerd-data-plane
-------------------
-√ data plane namespace exists
-√ data plane proxies are ready
-√ data plane is up-to-date
-√ data plane and cli versions match
-√ data plane pod labels are configured correctly
-√ data plane service labels are configured correctly
-√ data plane service annotations are configured correctly
-√ opaque ports are properly annotated
 
 Linkerd extensions checks
 =========================
@@ -97,10 +88,5 @@ linkerd-viz
 √ prometheus is installed and configured correctly
 √ can initialize the client
 √ viz extension self-check
-
-linkerd-viz-data-plane
-----------------------
-√ data plane namespace exists
-√ data plane proxy metrics are present in Prometheus
 
 Status check results are √

--- a/test/integration/install/testdata/check.viz.golden
+++ b/test/integration/install/testdata/check.viz.golden
@@ -1,0 +1,18 @@
+linkerd-viz
+-----------
+√ linkerd-viz Namespace exists
+√ linkerd-viz ClusterRoles exist
+√ linkerd-viz ClusterRoleBindings exist
+√ tap API server has valid cert
+√ tap API server cert is valid for at least 60 days
+√ tap API service is running
+√ linkerd-viz pods are injected
+√ viz extension pods are running
+√ viz extension proxies are healthy
+√ viz extension proxies are up-to-date
+√ viz extension proxies and cli versions match
+√ prometheus is installed and configured correctly
+√ can initialize the client
+√ viz extension self-check
+
+Status check results are √

--- a/test/integration/install/testdata/check.viz.proxy.golden
+++ b/test/integration/install/testdata/check.viz.proxy.golden
@@ -1,3 +1,86 @@
+Linkerd core checks
+===================
+
+kubernetes-api
+--------------
+√ can initialize the client
+√ can query the Kubernetes API
+
+kubernetes-version
+------------------
+√ is running the minimum Kubernetes API version
+√ is running the minimum kubectl version
+
+linkerd-existence
+-----------------
+√ 'linkerd-config' config map exists
+√ heartbeat ServiceAccount exist
+√ control plane replica sets are ready
+√ no unschedulable pods
+√ control plane pods are ready
+√ cluster networks can be verified
+√ cluster networks contains all node podCIDRs
+
+linkerd-config
+--------------
+√ control plane Namespace exists
+√ control plane ClusterRoles exist
+√ control plane ClusterRoleBindings exist
+√ control plane ServiceAccounts exist
+√ control plane CustomResourceDefinitions exist
+√ control plane MutatingWebhookConfigurations exist
+√ control plane ValidatingWebhookConfigurations exist
+√ proxy-init container runs as root user if docker container runtime is used
+
+linkerd-identity
+----------------
+√ certificate config is valid
+√ trust anchors are using supported crypto algorithm
+√ trust anchors are within their validity period
+√ trust anchors are valid for at least 60 days
+√ issuer cert is using supported crypto algorithm
+√ issuer cert is within its validity period
+√ issuer cert is valid for at least 60 days
+√ issuer cert is issued by the trust anchor
+
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ proxy-injector webhook has valid cert
+√ proxy-injector cert is valid for at least 60 days
+√ sp-validator webhook has valid cert
+√ sp-validator cert is valid for at least 60 days
+√ policy-validator webhook has valid cert
+√ policy-validator cert is valid for at least 60 days
+
+linkerd-identity-data-plane
+---------------------------
+√ data plane proxies certificate match CA
+
+linkerd-version
+---------------
+√ can determine the latest version
+√ cli is up-to-date
+
+linkerd-control-plane-proxy
+---------------------------
+√ control plane proxies are healthy
+√ control plane proxies are up-to-date
+√ control plane proxies and cli versions match
+
+linkerd-data-plane
+------------------
+√ data plane namespace exists
+√ data plane proxies are ready
+√ data plane is up-to-date
+√ data plane and cli versions match
+√ data plane pod labels are configured correctly
+√ data plane service labels are configured correctly
+√ data plane service annotations are configured correctly
+√ opaque ports are properly annotated
+
+Linkerd extensions checks
+=========================
+
 linkerd-viz
 -----------
 √ linkerd-viz Namespace exists
@@ -9,9 +92,7 @@ linkerd-viz
 √ linkerd-viz pods are injected
 √ viz extension pods are running
 √ viz extension proxies are healthy
-‼ viz extension proxies are up-to-date
-    {{.ProxyVersionErr}}
-    see {{.HintURL}}l5d-viz-proxy-cp-version for hints
+√ viz extension proxies are up-to-date
 √ viz extension proxies and cli versions match
 √ prometheus is installed and configured correctly
 √ can initialize the client


### PR DESCRIPTION
- Updated some golden files to include output from the viz extension
- Included the `--expected-version` and `--cli-version-override` flags in `linkerd viz check` to facilitate tests