### PR TITLE
github: Clarify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,22 @@
 name: "🐛 Bug Report"
-description: "If something isn't working as expected 🤔."
+description: If you've found a reproducible bug
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
+        Thanks for taking the time to file a bug report!
 
-        Please search to see if an issue already exists for the bug you encountered.
+        We're most likely to fix bugs that are easy to reproduce, so please try
+        to provide enough information for us to understand how to reproduce the
+        issue. Example Kubernetes manifests are encouraged!
 
   - type: textarea
     attributes:
       label: What is the issue?
-      description: A clear and concise description of what Linkerd is doing and what you would expect.
+      description: |
+        A clear and concise description of what Linkerd is doing and what you
+        would expect.
     validations:
       required: true
 
@@ -25,7 +29,9 @@ body:
   - type: textarea
     attributes:
       label: Logs, error output, etc
-      description: If the output is long, please create a [gist](https://gist.github.com/) and paste the link here.
+      description: |
+        If the output is long, please create a [gist](https://gist.github.com/)
+        and paste the link here.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
 - name: 🙋🏾 Question
   url: https://github.com/linkerd/linkerd2/discussions/new
-  about: Use this link to submit your ❓ to GitHub Discussions.
+  about: If you need help debugging something or have a general question about Linkerd

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: 💡 Feature Request"
-description: I have a suggestion (and may want to implement it 🙂)!
+description: If you have a suggestion for how to improve Linkerd
 labels: ["enhancement"]
 body:
   - type: markdown


### PR DESCRIPTION
We frequently get bug reports that are basically support requests and
not actual bug descriptions. This change tries to direct those requests
into a Discussion.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
