### PR TITLE
release: Don't use a dedicated account to push images

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -13,12 +13,6 @@ inputs:
     description: Whether to push the built images to the registry
     required: false
     default: ''
-  docker-ghcr-username:
-    description: GH username under which to push images
-    required: false
-  docker-ghcr-pat:
-    description: GH PAT for docker-ghcr-username
-    required: false
   component:
     description: Image to build
     required: true
@@ -40,17 +34,19 @@ runs:
     uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
   - name: Set up Docker Buildx
     uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+  - if: inputs.docker-push
+    uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ github.token }}
   - name: Build docker images
     env:
       DOCKER_REGISTRY: ${{ inputs.docker-registry }}
       DOCKER_TARGET: ${{ inputs.docker-target }}
       DOCKER_PUSH: ${{ inputs.docker-push }}
     shell: bash
-    run: |
-      if [[ -n "$DOCKER_PUSH" ]];then
-        echo "${{ inputs.docker-ghcr-pat }}" | docker login ghcr.io -u "${{ inputs.docker-ghcr-username }}" --password-stdin
-      fi
-      bin/docker-build-${{ inputs.component }}
+    run: bin/docker-build-${{ inputs.component }}
   - name: Prune docker layers cache
     # changes generate new images while the existing ones don't get removed
     # so we manually do that to avoid bloating the cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         - web
     name: Docker build (${{ matrix.component }})
     timeout-minutes: 30
+    permissions:
+      package: write
     steps:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -39,8 +41,6 @@ jobs:
         docker-registry: ${{ env.DOCKER_REGISTRY }}
         docker-target: multi-arch
         docker-push: 1
-        docker-ghcr-username: ${{ secrets.DOCKER_GHCR_USERNAME }}
-        docker-ghcr-pat: ${{ secrets.DOCKER_GHCR_PAT }}
         component: ${{ matrix.component }}
     - name: Create artifact with CLI
       # windows_static_cli_tests below needs this because it can't create linux containers
@@ -65,6 +65,8 @@ jobs:
 
   policy_controller_build:
     runs-on: ubuntu-20.04
+    permisisons:
+      package: write
     timeout-minutes: 30
     strategy:
       matrix:
@@ -76,6 +78,11 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: |
@@ -90,7 +97,6 @@ jobs:
         restore-keys: policy-controller-
     - name: Build ${{ matrix.arch }}
       run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
         docker buildx build --push . \
           -f ./policy-controller/${{ matrix.arch }}.dockerfile \
           -t $DOCKER_REGISTRY/policy-controller:$TAG-${{ matrix.arch }} \
@@ -107,6 +113,8 @@ jobs:
     timeout-minutes: 30
     needs: [policy_controller_build]
     name: Policy controller manifest
+    permissions:
+      package: write
     steps:
     - name: Checkout code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -127,9 +135,13 @@ jobs:
             $DOCKER_REGISTRY/policy-controller:${TAG}-arm64 --os=linux --arch=arm64
         docker manifest annotate $DOCKER_REGISTRY/policy-controller:$TAG \
             $DOCKER_REGISTRY/policy-controller:${TAG}-arm --os=linux --arch=arm
+    - uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Push multiarch manifest
       run: |
-        echo "${{ secrets.DOCKER_GHCR_PAT }}" | docker login ghcr.io -u "${{ secrets.DOCKER_GHCR_USERNAME }}" --password-stdin
         docker manifest push $DOCKER_REGISTRY/policy-controller:$TAG
 
   windows_static_cli_tests:


### PR DESCRIPTION
We currently push images using a dedicated GitHub login/token. This is
unnecessary if we give the workflow sufficient permissions to push
packages.

This change updates the release workflow to use `docker/login-action` to
log into GHCR with the action's local secret so that pushes no longer
rely on a dedicated bot account.

---

This may impact this week's edge release, as it's not easy to test this outside of a real release.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
