### PR TITLE
Add support for MeshTLSAuthentication to target namespaces

### DIFF
--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -71,4 +71,11 @@ impl ClusterInfo {
             sa, ns, self.control_plane_ns, self.identity_domain
         )
     }
+
+    fn namespace_identity(&self, ns: &str) -> String {
+        format!(
+            "*.{}.serviceaccount.identity.{}.{}",
+            ns, self.control_plane_ns, self.identity_domain
+        )
+    }
 }

--- a/policy-controller/k8s/index/src/meshtls_authentication.rs
+++ b/policy-controller/k8s/index/src/meshtls_authentication.rs
@@ -2,7 +2,7 @@ use crate::ClusterInfo;
 use anyhow::Result;
 use linkerd_policy_controller_core::IdentityMatch;
 use linkerd_policy_controller_k8s_api::{
-    policy::MeshTLSAuthentication, ResourceExt, ServiceAccount, Namespace,
+    policy::MeshTLSAuthentication, Namespace, ResourceExt, ServiceAccount,
 };
 
 #[derive(Debug, PartialEq)]

--- a/policy-controller/k8s/index/src/meshtls_authentication.rs
+++ b/policy-controller/k8s/index/src/meshtls_authentication.rs
@@ -31,7 +31,7 @@ impl Spec {
                 Ok(IdentityMatch::Exact(id))
             } else if tgt.targets_kind::<Namespace>() {
                 let id = cluster.namespace_identity(tgt.name.as_str());
-                Ok(id.parse::<IdentityMatch>()?)
+                id.parse::<IdentityMatch>()
             } else {
                 anyhow::bail!("unsupported target type: {:?}", tgt.canonical_kind())
             }

--- a/policy-controller/k8s/index/src/meshtls_authentication.rs
+++ b/policy-controller/k8s/index/src/meshtls_authentication.rs
@@ -30,11 +30,8 @@ impl Spec {
                 let id = cluster.service_account_identity(ns, &tgt.name);
                 Ok(IdentityMatch::Exact(id))
             } else if tgt.targets_kind::<Namespace>() {
-                let identity_suffix = format!(
-                    "{}.serviceaccount.identity.{}.{}",
-                    tgt.name, cluster.control_plane_ns, cluster.identity_domain
-                );
-                Ok(IdentityMatch::Suffix(vec![identity_suffix]))
+                let id = cluster.namespace_identity(tgt.name.as_str());
+                Ok(id.parse::<IdentityMatch>()?)
             } else {
                 anyhow::bail!("unsupported target type: {:?}", tgt.canonical_kind())
             }

--- a/policy-controller/k8s/index/src/meshtls_authentication.rs
+++ b/policy-controller/k8s/index/src/meshtls_authentication.rs
@@ -31,7 +31,7 @@ impl Spec {
                 Ok(IdentityMatch::Exact(id))
             } else if tgt.targets_kind::<Namespace>() {
                 let id = cluster.namespace_identity(tgt.name.as_str());
-                id.parse::<IdentityMatch>()
+                Ok(id.parse::<IdentityMatch>()?)
             } else {
                 anyhow::bail!("unsupported target type: {:?}", tgt.canonical_kind())
             }

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -11,7 +11,7 @@ use futures::future;
 use hyper::{body::Buf, http, Body, Request, Response};
 use k8s_openapi::api::core::v1::ServiceAccount;
 use kube::{core::DynamicObject, Resource, ResourceExt};
-use linkerd_policy_controller_k8s_api::Namespace;
+use linkerd_policy_controller_k8s_api::{policy::NamespacedTargetRef, Namespace};
 use serde::de::DeserializeOwned;
 use std::task;
 use thiserror::Error;
@@ -234,20 +234,27 @@ impl Validate<AuthorizationPolicySpec> for Admission {
     }
 }
 
+fn validate_identity_ref(id: &NamespacedTargetRef) -> Result<()> {
+    if id.targets_kind::<ServiceAccount>() {
+        return Ok(());
+    }
+
+    if id.targets_kind::<Namespace>() {
+        if id.namespace.is_some() {
+            bail!("Namespace identity_ref is cluster-scoped and cannot have a namespace");
+        }
+        return Ok(());
+    }
+
+    bail!("invalid identity target kind: {}", id.canonical_kind());
+}
+
 #[async_trait::async_trait]
 impl Validate<MeshTLSAuthenticationSpec> for Admission {
     async fn validate(self, _ns: &str, _name: &str, spec: MeshTLSAuthenticationSpec) -> Result<()> {
         // The CRD validates identity strings, but does not validate identity references.
-
         for id in spec.identity_refs.iter().flatten() {
-            if id.targets_kind::<ServiceAccount>() {
-            } else if id.targets_kind::<Namespace>() {
-                if id.namespace.is_some() {
-                    bail!("Namespace identity_ref is cluster-scoped and cannot have a namespace");
-                }
-            } else {
-                bail!("invalid identity target kind: {}", id.canonical_kind());
-            }
+            validate_identity_ref(id)?;
         }
 
         Ok(())

--- a/policy-test/tests/admit_meshtls_authentication.rs
+++ b/policy-test/tests/admit_meshtls_authentication.rs
@@ -26,6 +26,27 @@ async fn accepts_valid_ref() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn accepts_ns_ref() {
+    admission::accepts(|ns| MeshTLSAuthentication {
+        metadata: api::ObjectMeta {
+            namespace: Some(ns),
+            name: Some("test".to_string()),
+            ..Default::default()
+        },
+        spec: MeshTLSAuthenticationSpec {
+            identity_refs: Some(vec![NamespacedTargetRef {
+                group: Some("core".to_string()),
+                kind: "Namespace".to_string(),
+                name: "default".to_string(),
+                namespace: None,
+            }]),
+            ..Default::default()
+        },
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn accepts_strings() {
     admission::accepts(|ns| MeshTLSAuthentication {
         metadata: api::ObjectMeta {

--- a/policy-test/tests/admit_meshtls_authentication.rs
+++ b/policy-test/tests/admit_meshtls_authentication.rs
@@ -35,10 +35,31 @@ async fn accepts_ns_ref() {
         },
         spec: MeshTLSAuthenticationSpec {
             identity_refs: Some(vec![NamespacedTargetRef {
-                group: Some("core".to_string()),
+                group: None,
                 kind: "Namespace".to_string(),
                 name: "default".to_string(),
                 namespace: None,
+            }]),
+            ..Default::default()
+        },
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_namespaced_namespace() {
+    admission::rejects(|ns| MeshTLSAuthentication {
+        metadata: api::ObjectMeta {
+            namespace: Some(ns),
+            name: Some("test".to_string()),
+            ..Default::default()
+        },
+        spec: MeshTLSAuthenticationSpec {
+            identity_refs: Some(vec![NamespacedTargetRef {
+                group: None,
+                kind: "Namespace".to_string(),
+                name: "default".to_string(),
+                namespace: Some("default".to_string()),
             }]),
             ..Default::default()
         },

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -39,11 +39,11 @@ async fn meshtls() {
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
-        assert_eq!(
-            injected_status, 0,
-            "injected curl must contact nginx"
+        assert_eq!(injected_status, 0, "injected curl must contact nginx");
+        assert_ne!(
+            uninjected_status, 0,
+            "uninjected curl must fail to contact nginx"
         );
-        assert_ne!(uninjected_status, 0, "uninjected curl must fail to contact nginx");
     })
     .await;
 }
@@ -84,11 +84,11 @@ async fn meshtls_namespace() {
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
-        assert_eq!(
-            injected_status, 0,
-            "injected curl must contact nginx"
+        assert_eq!(injected_status, 0, "injected curl must contact nginx");
+        assert_ne!(
+            uninjected_status, 0,
+            "uninjected curl must fail to contact nginx"
         );
-        assert_ne!(uninjected_status, 0, "uninjected curl must fail to contact nginx");
     })
     .await;
 }
@@ -405,7 +405,7 @@ fn ns_authenticated(ns: &str) -> k8s::policy::MeshTLSAuthentication {
             ..Default::default()
         },
         spec: k8s::policy::MeshTLSAuthenticationSpec {
-            identity_refs: Some(vec![NamespacedTargetRef{
+            identity_refs: Some(vec![NamespacedTargetRef {
                 group: Some("core".to_string()),
                 kind: "Namespace".to_string(),
                 name: ns.to_string(),

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -406,7 +406,7 @@ fn ns_authenticated(ns: &str) -> k8s::policy::MeshTLSAuthentication {
         },
         spec: k8s::policy::MeshTLSAuthenticationSpec {
             identity_refs: Some(vec![NamespacedTargetRef {
-                group: Some("core".to_string()),
+                group: None,
                 kind: "Namespace".to_string(),
                 name: ns.to_string(),
                 namespace: None,


### PR DESCRIPTION
Fixes #8298 

The `identity_refs` section of the `MeshTLSAuthentication` resource currently only supports ServiceAccount resources.  We add support for Namespace resources as well.  When a `MeshTLSAuthentication` has a Namespace identity_ref, this means that all ServiceAccounts in that Namespace are authenticated.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
