### PR TITLE
edge-22.4.1 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,40 @@
 # Changes
 
+## edge-22.4.1
+
+In order to support having custom resources in the default Linkerd installation,
+the CLI install flow is now always a 2-step process where `linkerd install
+--crds` must be run first to install CRDs only and then `linkerd install` is run
+to install everything else. This more closely aligns the CLI install flow with
+the Helm install flow where the CRDs are a separate chart. This also applies to
+`linkerd upgrade`. Also, the `config` and `control-plane` sub-commands have been
+removed from both `linkerd install` and `linkerd upgrade`.
+
+On the proxy side, this release fixes an issue where proxies would not honor the
+cluster's opaqueness settings for non-pod/service addresses. This could cause
+protocol detection to be peformed, for instance, when using off-cluster
+databases.
+
+This release also disables the use of regexes in Linkerd log filters (i.e., as
+set by `LINKERD2_PROXY_LOG`). Malformed log directives could, in theory, cause a
+proxy to stop responding.
+
+The `helm.sh/chart` label in some of the CRDs had its formatting fixed, which
+avoids issues when installing/upgrading through external tools that make use of
+it, such as recent versions of Flux.
+
+* Added `--crds` flag to install/upgrade and remove config/control-plane stages
+* Allowed the `AuthorizationPolicy` CRD to have an empty
+  `requiredAuthenticationRefs` entry that allows all traffic
+* Introduced `nodeAffinity` config in all the charts for enhanced control on the
+  pods scheduling (thanks @michalrom089!)
+* Introduced `resources`, `nodeSelector` and `tolerations` configs in the
+  `linkerd-multicluster-link` chart for enhanced control on the service mirror
+  deployment (thanks @utay!)
+* Fixed formatting of the `helm.sh/chart` label in CRDs
+* Updated container base images from buster to bullseye
+* Added support for spaces in the `config.linkerd.io/opaque-ports` annotation
+
 ## edge-22.3.5
 
 This edge release introduces new policy CRDs that allow for more generalized

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.2.0-edge
+version: 1.3.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.2.0-edge](https://img.shields.io/badge/Version-1.2.0--edge-informational?style=flat-square)
+![Version: 1.3.0-edge](https://img.shields.io/badge/Version-1.3.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.1.0-edge
+version: 1.1.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.1.0-edge](https://img.shields.io/badge/Version-1.1.0--edge-informational?style=flat-square)
+![Version: 1.1.1-edge](https://img.shields.io/badge/Version-1.1.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.20.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.0.12-edge
+version: 30.1.0-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.0.12-edge](https://img.shields.io/badge/Version-30.0.12--edge-informational?style=flat-square)
+![Version: 30.1.0-edge](https://img.shields.io/badge/Version-30.1.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -105,7 +105,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -191,7 +191,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -244,7 +244,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -390,7 +390,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -659,7 +659,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.1.0-edge
+    helm.sh/chart: linkerd-crds-1.1.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.8-edge
+version: 30.3.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.2.8-edge](https://img.shields.io/badge/Version-30.2.8--edge-informational?style=flat-square)
+![Version: 30.3.0-edge](https://img.shields.io/badge/Version-30.3.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.0.11-edge
+version: 30.1.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.0.11-edge](https://img.shields.io/badge/Version-30.0.11--edge-informational?style=flat-square)
+![Version: 30.1.0-edge](https://img.shields.io/badge/Version-30.1.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.0-edge
+version: 30.2.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.1.0-edge](https://img.shields.io/badge/Version-30.1.0--edge-informational?style=flat-square)
+![Version: 30.2.0-edge](https://img.shields.io/badge/Version-30.2.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-22.4.1

In order to support having custom resources in the default Linkerd installation,
the CLI install flow is now always a 2-step process where `linkerd install
--crds` must be run first to install CRDs only and then `linkerd install` is run
to install everything else. This more closely aligns the CLI install flow with
the Helm install flow where the CRDs are a separate chart. This also applies to
`linkerd upgrade`. Also, the `config` and `control-plane` sub-commands have been
removed from both `linkerd install` and `linkerd upgrade`.

On the proxy side, this release fixes an issue where proxies would not honor the
cluster's opaqueness settings for non-pod/service addresses. This could cause
protocol detection to be peformed, for instance, when using off-cluster
databases.

This release also disables the use of regexes in Linkerd log filters (i.e., as
set by `LINKERD2_PROXY_LOG`). Malformed log directives could, in theory, cause a
proxy to stop responding.

The `helm.sh/chart` label in some of the CRDs had its formatting fixed, which
avoids issues when installing/upgrading through external tools that make use of
it, such as recent versions of Flux.

* Added `--crds` flag to install/upgrade and remove config/control-plane stages
* Allowed the `AuthorizationPolicy` CRD to have an empty
  `requiredAuthenticationRefs` entry that allows all traffic
* Introduced `nodeAffinity` config in all the charts for enhanced control on the
  pods scheduling (thanks @michalrom089!)
* Introduced `resources`, `nodeSelector` and `tolerations` configs in the
  `linkerd-multicluster-link` chart for enhanced control on the service mirror
  deployment (thanks @utay!)
* Fixed formatting of the `helm.sh/chart` label in CRDs
* Updated container base images from buster to bullseye
* Added support for spaces in the `config.linkerd.io/opaque-ports` annotation
