### PR TITLE
Fix the upgrade-edge test

### DIFF
--- a/test/integration/upgrade-edge/upgrade_edge_test.go
+++ b/test/integration/upgrade-edge/upgrade_edge_test.go
@@ -73,14 +73,15 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 	// Nest all pre-upgrade tests here so they can install and check resources
 	// using the latest edge CLI
 	t.Run(fmt.Sprintf("installing Linkerd %s control plane", linkerdBaseEdgeVersion), func(t *testing.T) {
-		args := []string{
-			"install",
-			"--controller-log-level", "debug",
-			"--set", "proxyInit.ignoreInboundPorts=1234\\,5678",
+		if _, err := TestHelper.CmdRun(cliPath, "install", "--crds"); err != nil {
+			testutil.AnnotatedFatalf(t, "'linkerd install' command failed", "'linkerd install --crds' command failed:\n%v", err)
 		}
 
-		// Pipe cmd & args to `linkerd`
-		out, err := TestHelper.CmdRun(cliPath, args...)
+		out, err := TestHelper.CmdRun(cliPath,
+			"install",
+			"--controller-log-level=debug",
+			"--set=proxyInit.ignoreInboundPorts=1234\\,5678",
+		)
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'linkerd install' command failed", "'linkerd install' command failed:\n%v", err)
 		}
@@ -97,13 +98,7 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 	// TestInstallViz will install the viz extension to be used by the rest of the
 	// tests in the viz suite
 	t.Run(fmt.Sprintf("installing Linkerd %s viz extension", linkerdBaseEdgeVersion), func(t *testing.T) {
-		args := []string{
-			"viz",
-			"install",
-			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()),
-		}
-
-		out, err := TestHelper.CmdRun(cliPath, args...)
+		out, err := TestHelper.CmdRun(cliPath, "viz", "install", "--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()))
 		if err != nil {
 			testutil.AnnotatedFatal(t, "'linkerd viz install' command failed", err)
 		}

--- a/test/integration/upgrade-edge/upgrade_edge_test.go
+++ b/test/integration/upgrade-edge/upgrade_edge_test.go
@@ -74,7 +74,16 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 	// using the latest edge CLI
 	t.Run(fmt.Sprintf("installing Linkerd %s control plane", linkerdBaseEdgeVersion), func(t *testing.T) {
 		if _, err := TestHelper.CmdRun(cliPath, "install", "--crds"); err != nil {
-			testutil.AnnotatedFatalf(t, "'linkerd install' command failed", "'linkerd install --crds' command failed:\n%v", err)
+			testutil.AnnotatedFatalf(t, "'linkerd install --crds' command failed", "'linkerd install --crds' command failed:\n%v", err)
+		}
+
+		if _, err := TestHelper.Kubectl("", "wait", "--for", "condition=established", "--timeout=60s", "crd",
+			"authorizationpolicies.policy.linkerd.io",
+			"meshtlsauthentications.policy.linkerd.io",
+			"networkauthentications.policy.linkerd.io",
+			"servers.policy.linkerd.io",
+			"serverauthorizations.policy.linkerd.io"); err != nil {
+			testutil.AnnotatedFatalf(t, "'kubectl wait crd' command failed", "'kubectl wait crd' command failed:\n%v", err)
 		}
 
 		out, err := TestHelper.CmdRun(cliPath,

--- a/test/integration/upgrade-edge/upgrade_edge_test.go
+++ b/test/integration/upgrade-edge/upgrade_edge_test.go
@@ -84,12 +84,15 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 				"'kubectl apply' command failed\n%s", out)
 		}
 
-		if _, err := TestHelper.Kubectl("", "wait", "--for", "condition=established", "--timeout=60s", "crd",
+		waitArgs := []string{
+			"wait", "--for", "condition=established", "--timeout=60s", "crd",
 			"authorizationpolicies.policy.linkerd.io",
 			"meshtlsauthentications.policy.linkerd.io",
 			"networkauthentications.policy.linkerd.io",
 			"servers.policy.linkerd.io",
-			"serverauthorizations.policy.linkerd.io"); err != nil {
+			"serverauthorizations.policy.linkerd.io",
+		}
+		if _, err := TestHelper.Kubectl("", waitArgs...); err != nil {
 			testutil.AnnotatedFatalf(t, "'kubectl wait crd' command failed", "'kubectl wait crd' command failed:\n%v", err)
 		}
 

--- a/test/integration/upgrade-edge/upgrade_edge_test.go
+++ b/test/integration/upgrade-edge/upgrade_edge_test.go
@@ -73,8 +73,15 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 	// Nest all pre-upgrade tests here so they can install and check resources
 	// using the latest edge CLI
 	t.Run(fmt.Sprintf("installing Linkerd %s control plane", linkerdBaseEdgeVersion), func(t *testing.T) {
-		if _, err := TestHelper.CmdRun(cliPath, "install", "--crds"); err != nil {
+		out, err := TestHelper.CmdRun(cliPath, "install", "--crds")
+		if err != nil {
 			testutil.AnnotatedFatalf(t, "'linkerd install --crds' command failed", "'linkerd install --crds' command failed:\n%v", err)
+		}
+
+		out, err = TestHelper.KubectlApply(out, "")
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
+				"'kubectl apply' command failed\n%s", out)
 		}
 
 		if _, err := TestHelper.Kubectl("", "wait", "--for", "condition=established", "--timeout=60s", "crd",
@@ -86,7 +93,7 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 			testutil.AnnotatedFatalf(t, "'kubectl wait crd' command failed", "'kubectl wait crd' command failed:\n%v", err)
 		}
 
-		out, err := TestHelper.CmdRun(cliPath,
+		out, err = TestHelper.CmdRun(cliPath,
 			"install",
 			"--controller-log-level=debug",
 			"--set=proxyInit.ignoreInboundPorts=1234\\,5678",


### PR DESCRIPTION
Now that the latest edge release requires `install --crds`, the
upgrade-edge test needs to run this before installing the control plane.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
