### PR TITLE
Fix panic in install --ignore-cluster

### DIFF
--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -244,7 +244,7 @@ func TestRender(t *testing.T) {
 	}
 }
 
-func TestIgnoreClutster(t *testing.T) {
+func TestIgnoreCluster(t *testing.T) {
 	defaultValues, err := testInstallOptions()
 	if err != nil {
 		t.Fatal(err)

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -244,6 +244,19 @@ func TestRender(t *testing.T) {
 	}
 }
 
+func TestIgnoreClutster(t *testing.T) {
+	defaultValues, err := testInstallOptions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	addFakeTLSSecrets(defaultValues)
+
+	var buf bytes.Buffer
+	if err := install(context.Background(), nil, &buf, defaultValues, nil, false, values.Options{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRenderCRDs(t *testing.T) {
 	defaultValues, err := testInstallOptions()
 	if err != nil {


### PR DESCRIPTION
Fixes #8364 

When `linkerd install` is called with the `--ignore-cluster`, we pass `nil` for the `k8sAPI`.  This causes a panic when using this client for validation.  We add a conditional so that we skip this validation when the `k8sAPI` is `nil`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
