### PR TITLE
refactor: Split CRD and control-plane installation

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -261,7 +261,7 @@ func renderInstallManifest(ctx context.Context) (*charts.Values, string, error) 
 	}
 
 	var b strings.Builder
-	err = install(ctx, k8sAPI, &b, values, []flag.Flag{}, false, valuespkg.Options{})
+	err = installControlPlane(ctx, k8sAPI, &b, values, []flag.Flag{}, valuespkg.Options{})
 	if err != nil {
 		return values, "", err
 	}

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -249,7 +249,10 @@ func isRunAsRoot(values map[string]interface{}) bool {
 	return false
 }
 
-func bufferChart(files []*loader.BufferedFile, values *l5dcharts.Values, valuesOverrides map[string]interface{}) (*bytes.Buffer, chartutil.Values, error) {
+// renderChartToBuffer takes a slice of loaded template files and configuration values and renders
+// them into a buffer. The coalesced values are also returned so that they may be rendered via
+// `renderOverrides` if appropriate.
+func renderChartToBuffer(files []*loader.BufferedFile, values *l5dcharts.Values, valuesOverrides map[string]interface{}) (*bytes.Buffer, chartutil.Values, error) {
 	// Load the partials in addition to the main chart.
 	var partials []*loader.BufferedFile
 	for _, template := range charts.L5dPartials {
@@ -311,7 +314,7 @@ func renderCRDs(w io.Writer, values *l5dcharts.Values, valuesOverrides map[strin
 		return err
 	}
 
-	buf, _, err := bufferChart(files, values, valuesOverrides)
+	buf, _, err := renderChartToBuffer(files, values, valuesOverrides)
 	if err != nil {
 		return err
 	}
@@ -331,7 +334,7 @@ func renderControlPlane(w io.Writer, values *l5dcharts.Values, valuesOverrides m
 		return err
 	}
 
-	buf, vals, err := bufferChart(files, values, valuesOverrides)
+	buf, vals, err := renderChartToBuffer(files, values, valuesOverrides)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -236,7 +236,7 @@ func TestRender(t *testing.T) {
 				t.Fatalf("Failed to get values overrides: %v", err)
 			}
 			var buf bytes.Buffer
-			if err := render(&buf, tc.values, false, valuesOverrides); err != nil {
+			if err := renderControlPlane(&buf, tc.values, valuesOverrides); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			testDataDiffer.DiffTestdata(t, tc.goldenFileName, buf.String())
@@ -252,7 +252,7 @@ func TestIgnoreCluster(t *testing.T) {
 	addFakeTLSSecrets(defaultValues)
 
 	var buf bytes.Buffer
-	if err := install(context.Background(), nil, &buf, defaultValues, nil, false, values.Options{}); err != nil {
+	if err := installControlPlane(context.Background(), nil, &buf, defaultValues, nil, values.Options{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -265,7 +265,7 @@ func TestRenderCRDs(t *testing.T) {
 	addFakeTLSSecrets(defaultValues)
 
 	var buf bytes.Buffer
-	if err := render(&buf, defaultValues, true, map[string]interface{}{}); err != nil {
+	if err := renderCRDs(&buf, defaultValues, map[string]interface{}{}); err != nil {
 		t.Fatalf("Failed to render templates: %v", err)
 	}
 	testDataDiffer.DiffTestdata(t, "install_crds.golden", buf.String())

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -227,10 +227,16 @@ the 'linkerd repair' command to repair the Linkerd config`)
 	// rendering to a buffer and printing full contents of buffer after
 	// render is complete, to ensure that okStatus prints separately
 	var buf bytes.Buffer
-	if err = render(&buf, values, crds, valuesOverrides); err != nil {
-		upgradeErrorf("Could not render upgrade configuration: %s", err)
+	if crds {
+		if err = renderCRDs(&buf, values, valuesOverrides); err != nil {
+			upgradeErrorf("Could not render upgrade configuration: %s", err)
+		}
+		return buf, nil
 	}
 
+	if err = renderControlPlane(&buf, values, valuesOverrides); err != nil {
+		upgradeErrorf("Could not render upgrade configuration: %s", err)
+	}
 	return buf, nil
 }
 

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -566,7 +566,7 @@ func pathMatch(path []string, template []string) bool {
 
 func renderInstall(t *testing.T, values *linkerd2.Values) bytes.Buffer {
 	var installBuf bytes.Buffer
-	if err := render(&installBuf, values, false, nil); err != nil {
+	if err := renderControlPlane(&installBuf, values, nil); err != nil {
 		t.Fatalf("could not render install manifests: %s", err)
 	}
 	return installBuf


### PR DESCRIPTION
We currently have singular `install` and `render` functions, each of
which takes a `crds` bool that completely alters the behavior of the
function. This change splits this behavior into distinct functions so
we have `installCRDs`/`renderCRDs` and `installControlPlane`/
`renderControlPlane`. At the very least, this improves clarity from the
callers perspective at the cost of duplicating some of the rendering
boilerplate.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
