### PR TITLE
Fix PSP when `proxyInit.runAsRoot` is true

### DIFF
--- a/charts/linkerd-control-plane/templates/psp.yaml
+++ b/charts/linkerd-control-plane/templates/psp.yaml
@@ -10,7 +10,11 @@ metadata:
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
 spec:
+  {{- if or .Values.proxyInit.closeWaitTimeoutSecs .Values.proxyInit.runAsRoot }}
+  allowPrivilegeEscalation: true
+  {{- else }}
   allowPrivilegeEscalation: false
+  {{- end }}
   readOnlyRootFilesystem: true
   {{- if empty .Values.cniEnabled }}
   allowedCapabilities:


### PR DESCRIPTION
When installing with `--set enablePSP=true` and `--set
proxyInit.runAsRoot=true` the pods failed to start with the following
error:

```
$ k -n linkerd describe rs linkerd-destination-55c88bf5cd
Events:
  Type     Reason        Age                From                   Message
  ----     ------        ----               ----                   -------
  Warning  FailedCreate  3s (x13 over 23s)  replicaset-controller  Error creating: pods "linkerd-destination-55c88bf5cd-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.initContainers[0].securityContext.allowPrivilegeEscalation: Invalid value: true: Allowing privilege escalation for containers is not allowed]
```

This change aligns the `allowPrivilegeEscalation` entry in the PSP with
how it's used in the linkerd-init (see
`./charts/partials/templates/_proxy-init.tpl`

(found while testing FML with PSP!)
