### PR TITLE
Add `/gateway.json` endpoint to service mirror

### DIFF
--- a/multicluster/service-mirror/http_server.go
+++ b/multicluster/service-mirror/http_server.go
@@ -1,0 +1,93 @@
+package servicemirror
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/linkerd/linkerd2/controller/k8s"
+	pkgk8s "github.com/linkerd/linkerd2/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type gatewayStats struct {
+	Alive            bool   `json:"alive"`
+	Latency          string `json:"latency"`
+	NumberOfServices int    `json:"numberOfServices"`
+}
+
+// GatewayStatus is the status of a gateway.
+type GatewayStatus struct {
+	alive   bool
+	latency uint64
+}
+
+type handler struct {
+	k8sAPI        *k8s.API
+	clusterName   string
+	gatewayStatus GatewayStatus
+}
+
+// NewServer returns a new instance of the service mirror server.
+//
+// The service mirror server serves stats about its gateway via the
+// /gateway.json endpoint.
+func NewServer(addr string, k8sAPI *k8s.API, clusterNameUpdates chan string, gatewayUpdates chan GatewayStatus) *http.Server {
+	handler := &handler{
+		k8sAPI: k8sAPI,
+	}
+
+	go func() {
+		for {
+			select {
+			case name := <-clusterNameUpdates:
+				handler.clusterName = name
+			case status := <-gatewayUpdates:
+				handler.gatewayStatus = status
+			}
+		}
+	}()
+
+	return &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+}
+
+func (handler *handler) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	switch request.URL.Path {
+	case "/gateway.json":
+		handler.gateway(w)
+	default:
+		http.NotFound(w, request)
+	}
+}
+
+func (handler *handler) gateway(w http.ResponseWriter) {
+	// Multiple service mirrors can be mirroring services on a cluster, so we
+	// ensure through selector that we are only selecting mirror services from
+	// this service mirror's target cluster.
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		pkgk8s.MirroredResourceLabel, "true",
+		pkgk8s.RemoteClusterNameLabel, handler.clusterName,
+	)
+	services, err := handler.k8sAPI.Client.CoreV1().Services(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to get services: %s", err)
+		return
+	}
+	stats := gatewayStats{
+		Alive:            handler.gatewayStatus.alive,
+		Latency:          fmt.Sprintf("%dms", handler.gatewayStatus.latency),
+		NumberOfServices: len(services.Items),
+	}
+	out, err := json.MarshalIndent(stats, "", "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshalling JSON: %s\n", err)
+		return
+	}
+	w.Write([]byte(fmt.Sprintf("%s\n", out)))
+}


### PR DESCRIPTION
Part of #8376 

In order to separate linkerd-viz from linkerd-multicluster's `gateways` command, the service mirror should expose probe stats about its own gateway. These stats should mirror the stats currently obtained by the `gateways` command: liveness, number of services, and latency.

This exposes a new server for the service mirror component which serves a single `/gateway.json` endpoint. It returns — in JSON format — the current stats about its gateway. Updates are received from the service mirror's probe worker and drive the `Alive` and `Latency` values. `NumberOfServices` is fetched when a call to the endpoint is made and returns the number of services on the _local_ cluster that are mirrored from that specific target cluster.

### Testing

Set up two clusters such that one can link to the other (same network and credentials). You can just use the current edge for this as we only care about this version's controller for linkerd-multicluster.

```shell
$ bin/docker-build-controller
...
$ bin/image-load --k3d --cluster source-cluster
...
$ linkerd --context target-cluster multicluster link --cluster-name target-cluster --api-server-address https://172.29.0.3:6443 > link.yaml
```

In `link.yaml`, change the image `cr.l5d.io/linkerd/controller:edge-22.4.1` to `cr.l5d.io/linkerd/controller:{version-from-docker-build-controller}`

```shell
$ kubectl --context source-cluster apply -f link.yaml
```

We should now be able to run the current `gateways` command and see that the cluster is succesfully linked

```shell
$ linkerd multicluster gateways
CLUSTER  ALIVE    NUM_SVC  LATENCY_P50  LATENCY_P95  LATENCY_P99  
k3d-x    True           1          2ms          3ms          3ms
```

Now we'll test the service mirror's `/gateway.json` endpoint by installing a curl pod on the source cluster and hitting that endpoint.

```shell
$ kubectl port-forward -n linkerd-multicluster linkerd-service-mirror-... 8083:8083
...
$ curl http://localhost:8083/gateway.json
{
"alive": true,
"latency": "3ms",
"numberOfServices": 1
}
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
