### PR TITLE
Fix flakiness in opaque ports integration test

### DIFF
--- a/test/integration/deep/opaqueports/testdata/opaque_ports_client.yaml
+++ b/test/integration/deep/opaqueports/testdata/opaque_ports_client.yaml
@@ -1,5 +1,5 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: slow-cooker-opaque-service
 spec:
@@ -21,8 +21,8 @@ spec:
         - containerPort: 9999
       restartPolicy: OnFailure
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: slow-cooker-opaque-pod
 spec:
@@ -44,8 +44,8 @@ spec:
         - containerPort: 9999
       restartPolicy: OnFailure
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: slow-cooker-opaque-unmeshed-svc
 spec:

--- a/test/integration/deep/opaqueports/testdata/opaque_ports_client.yaml
+++ b/test/integration/deep/opaqueports/testdata/opaque_ports_client.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: slow-cooker-opaque-service
 spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque-service
   template:
     metadata:
       annotations:
@@ -19,13 +22,15 @@ spec:
         - http://{{ .ServiceCookerOpaqueServiceTargetHost}}:8080
         ports:
         - containerPort: 9999
-      restartPolicy: OnFailure
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: slow-cooker-opaque-pod
 spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque-pod
   template:
     metadata:
       annotations:
@@ -42,13 +47,15 @@ spec:
         - http://{{ .ServiceCookerOpaquePodTargetHost}}:8080
         ports:
         - containerPort: 9999
-      restartPolicy: OnFailure
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: slow-cooker-opaque-unmeshed-svc
 spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque-unmeshed-svc
   template:
     metadata:
       annotations:
@@ -65,4 +72,3 @@ spec:
         - http://{{ .ServiceCookerOpaqueUnmeshedSVCTargetHost}}:8080
         ports:
         - containerPort: 9999
-      restartPolicy: OnFailure


### PR DESCRIPTION
The opaque ports integration test launches some slowcooker pods and then immediately queries them for metrics without waiting for them to fully start up.  This leads to flakiness as those pods may not be ready right away.

We change the slowcooker Job resources into Deployment resources and use the WaitRollout machinery to wait for these pods to become ready before querying them.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
