### PR TITLE
Introduce proto retries to Service Profiles

### DIFF
--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -54,19 +54,13 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain 
 					path = fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)
 				}
 
-				rpc, ok := visitee.(*proto.RPC)
-				isRetryable := false
-				if ok {
-					isRetryable = isMethodRetryable(rpc)
-				}
-
 				route := &sp.RouteSpec{
 					Name: typed.Name,
 					Condition: &sp.RequestMatch{
 						Method:    http.MethodPost,
 						PathRegex: regexp.QuoteMeta(path),
 					},
-					IsRetryable: isRetryable,
+					IsRetryable: isMethodRetryable(typed),
 				}
 				routes = append(routes, route)
 			}

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -89,7 +89,8 @@ func isMethodRetryable(rpc *proto.RPC) bool {
 			continue
 		}
 
-		if !strings.Contains(option.Name, "idempotency_level") {
+		// method options can be wrapped in parentheses so we trim them away
+		if strings.Trim(option.Name, "()") != "idempotency_level" {
 			// Not an idempotency option
 			continue
 		}

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/emicklei/proto"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
@@ -52,12 +53,20 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain 
 				default:
 					path = fmt.Sprintf("/%s.%s/%s", pkg, service.Name, typed.Name)
 				}
+
+				rpc, ok := visitee.(*proto.RPC)
+				isRetryable := false
+				if ok {
+					isRetryable = isMethodRetryable(rpc)
+				}
+
 				route := &sp.RouteSpec{
 					Name: typed.Name,
 					Condition: &sp.RequestMatch{
 						Method:    http.MethodPost,
 						PathRegex: regexp.QuoteMeta(path),
 					},
+					IsRetryable: isRetryable,
 				}
 				routes = append(routes, route)
 			}
@@ -76,4 +85,24 @@ func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain 
 			Routes: routes,
 		},
 	}, nil
+}
+
+func isMethodRetryable(rpc *proto.RPC) bool {
+	for _, e := range rpc.Elements {
+		option, ok := e.(*proto.Option)
+		if !ok {
+			// Not an option
+			continue
+		}
+
+		if !strings.Contains(option.Name, "idempotency_level") {
+			// Not an idempotency option
+			continue
+		}
+
+		return option.Constant.Source == "IDEMPOTENT" ||
+			option.Constant.Source == "NO_SIDE_EFFECTS"
+	}
+
+	return false
 }

--- a/pkg/profiles/proto_test.go
+++ b/pkg/profiles/proto_test.go
@@ -10,54 +10,215 @@ import (
 )
 
 func TestProtoToServiceProfile(t *testing.T) {
-	namespace := "myns"
-	name := "mysvc"
-	clusterDomain := "mycluster.local"
+	var (
+		namespace     = "myns"
+		name          = "mysvc"
+		clusterDomain = "mycluster.local"
+	)
 
-	protobuf := `syntax = "proto3";
+	t.Run("rpc", func(t *testing.T) {
+		protobuf := `syntax = "proto3";
+	
+	package emojivoto.v1;
+	
+	message VoteRequest {
+	}
+	
+	message VotingResult {
+		string Shortcode = 1;
+		int32 Votes = 2;
+	}
+	
+	service VotingService {
+		rpc VotePoop (VoteRequest) returns (VoteResponse);
+	}`
 
-package emojivoto.v1;
+		parser := proto.NewParser(strings.NewReader(protobuf))
 
-message VoteRequest {
-}
-
-message VotingResult {
-    string Shortcode = 1;
-    int32 Votes = 2;
-}
-
-service VotingService {
-	rpc VotePoop (VoteRequest) returns (VoteResponse);
-}`
-
-	parser := proto.NewParser(strings.NewReader(protobuf))
-
-	expectedServiceProfile := sp.ServiceProfile{
-		TypeMeta: ServiceProfileMeta,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "." + namespace + ".svc." + clusterDomain,
-			Namespace: namespace,
-		},
-		Spec: sp.ServiceProfileSpec{
-			Routes: []*sp.RouteSpec{
-				{
-					Name: "VotePoop",
-					Condition: &sp.RequestMatch{
-						PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,
-						Method:    "POST",
+		expectedServiceProfile := sp.ServiceProfile{
+			TypeMeta: ServiceProfileMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "." + namespace + ".svc." + clusterDomain,
+				Namespace: namespace,
+			},
+			Spec: sp.ServiceProfileSpec{
+				Routes: []*sp.RouteSpec{
+					{
+						Name: "VotePoop",
+						Condition: &sp.RequestMatch{
+							PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,
+							Method:    "POST",
+						},
+						IsRetryable: false,
 					},
 				},
 			},
-		},
-	}
+		}
 
-	actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
-	if err != nil {
-		t.Fatalf("Failed to create ServiceProfile: %v", err)
-	}
+		actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
+		if err != nil {
+			t.Fatalf("Failed to create ServiceProfile: %v", err)
+		}
 
-	err = ServiceProfileYamlEquals(*actualServiceProfile, expectedServiceProfile)
-	if err != nil {
-		t.Fatalf("ServiceProfiles are not equal: %v", err)
+		err = ServiceProfileYamlEquals(*actualServiceProfile, expectedServiceProfile)
+		if err != nil {
+			t.Fatalf("ServiceProfiles are not equal: %v", err)
+		}
+	})
+
+	t.Run("rpc unknown idempotency level", func(t *testing.T) {
+		protobuf := `syntax = "proto3";
+	
+	package emojivoto.v1;
+	
+	message VoteRequest {
 	}
+	
+	message VotingResult {
+		string Shortcode = 1;
+		int32 Votes = 2;
+	}
+	
+	service VotingService {
+		rpc VotePoop (VoteRequest) returns (VoteResponse){
+			option idempotency_level = "UNKNOWN";
+		};
+	}`
+
+		parser := proto.NewParser(strings.NewReader(protobuf))
+
+		expectedServiceProfile := sp.ServiceProfile{
+			TypeMeta: ServiceProfileMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "." + namespace + ".svc." + clusterDomain,
+				Namespace: namespace,
+			},
+			Spec: sp.ServiceProfileSpec{
+				Routes: []*sp.RouteSpec{
+					{
+						Name: "VotePoop",
+						Condition: &sp.RequestMatch{
+							PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,
+							Method:    "POST",
+						},
+						IsRetryable: false,
+					},
+				},
+			},
+		}
+
+		actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
+		if err != nil {
+			t.Fatalf("Failed to create ServiceProfile: %v", err)
+		}
+
+		err = ServiceProfileYamlEquals(*actualServiceProfile, expectedServiceProfile)
+		if err != nil {
+			t.Fatalf("ServiceProfiles are not equal: %v", err)
+		}
+	})
+
+	t.Run("rpc idempotent", func(t *testing.T) {
+		protobuf := `syntax = "proto3";
+	
+	package emojivoto.v1;
+	
+	message VoteRequest {
+	}
+	
+	message VotingResult {
+		string Shortcode = 1;
+		int32 Votes = 2;
+	}
+	
+	service VotingService {
+		rpc VotePoop (VoteRequest) returns (VoteResponse){
+			option idempotency_level = "IDEMPOTENT";
+		};
+	}`
+
+		parser := proto.NewParser(strings.NewReader(protobuf))
+
+		expectedServiceProfile := sp.ServiceProfile{
+			TypeMeta: ServiceProfileMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "." + namespace + ".svc." + clusterDomain,
+				Namespace: namespace,
+			},
+			Spec: sp.ServiceProfileSpec{
+				Routes: []*sp.RouteSpec{
+					{
+						Name: "VotePoop",
+						Condition: &sp.RequestMatch{
+							PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,
+							Method:    "POST",
+						},
+						IsRetryable: true,
+					},
+				},
+			},
+		}
+
+		actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
+		if err != nil {
+			t.Fatalf("Failed to create ServiceProfile: %v", err)
+		}
+
+		err = ServiceProfileYamlEquals(*actualServiceProfile, expectedServiceProfile)
+		if err != nil {
+			t.Fatalf("ServiceProfiles are not equal: %v", err)
+		}
+	})
+
+	t.Run("rpc no side effects", func(t *testing.T) {
+		protobuf := `syntax = "proto3";
+	
+	package emojivoto.v1;
+	
+	message VoteRequest {
+	}
+	
+	message VotingResult {
+		string Shortcode = 1;
+		int32 Votes = 2;
+	}
+	
+	service VotingService {
+		rpc VotePoop (VoteRequest) returns (VoteResponse){
+			option (idempotency_level) = "NO_SIDE_EFFECTS";
+		};
+	}`
+
+		parser := proto.NewParser(strings.NewReader(protobuf))
+
+		expectedServiceProfile := sp.ServiceProfile{
+			TypeMeta: ServiceProfileMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name + "." + namespace + ".svc." + clusterDomain,
+				Namespace: namespace,
+			},
+			Spec: sp.ServiceProfileSpec{
+				Routes: []*sp.RouteSpec{
+					{
+						Name: "VotePoop",
+						Condition: &sp.RequestMatch{
+							PathRegex: `/emojivoto\.v1\.VotingService/VotePoop`,
+							Method:    "POST",
+						},
+						IsRetryable: true,
+					},
+				},
+			},
+		}
+
+		actualServiceProfile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
+		if err != nil {
+			t.Fatalf("Failed to create ServiceProfile: %v", err)
+		}
+
+		err = ServiceProfileYamlEquals(*actualServiceProfile, expectedServiceProfile)
+		if err != nil {
+			t.Fatalf("ServiceProfiles are not equal: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Currently, proto Service Profiles are generated without setting the
IsRetryable field which limits the resiliency you get out of the box
as requests are never retried unless you manually update it.

This change sets the IsRetryable field to true if
idempotency_level is either IDEMPOTENT or NO_SIDE_EFFECTS.

The new functionality is tested by extending the existing unit tests.

Fixes: #8472

Signed-off-by: Martin Anker Have <mah@lunar.app>