### PR TITLE
edge-22.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,6 @@ from the HA values and are now configurable for the control plane. On the proxy
 side, non-HTTP traffic will now be forwarded on the outbound side within the
 cluster when the proxy runs in ingress mode.
 
-a multicluster fix for headless services, 
-This release updates "ingress-mode" proxies to be able to forward
-non-HTTP traffic within the cluster. Protocol detection is always
-attempted for outbound connections, however, when in ingress mode.
-
 * Updated `ingress-mode` proxies to forward non-HTTP traffic within the cluster
   (protocol detection will always be attempted for outbound connections)
 * Added a new proxy metric `process_uptime_seconds_total` to keep track of the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Changes
 
+## edge-22.5.2
+
+This edge release ships a few changes to the chart values, a fix for
+multicluster headless services, and notable proxy features. HA functionality,
+such as PDBs, deployment strategies, and pod anti-affinity, have been split
+from the HA values and are now configurable for the control plane. On the proxy
+side, non-HTTP traffic will now be forwarded on the outbound side within the
+cluster when the proxy runs in ingress mode.
+
+a multicluster fix for headless services, 
+This release updates "ingress-mode" proxies to be able to forward
+non-HTTP traffic within the cluster. Protocol detection is always
+attempted for outbound connections, however, when in ingress mode.
+
+* Updated `ingress-mode` proxies to forward non-HTTP traffic within the cluster
+  (protocol detection will always be attempted for outbound connections)
+* Added a new proxy metric `process_uptime_seconds_total` to keep track of the
+  number of seconds since the proxy started
+* Fixed an issue with multicluster headless service mirroring, where exported
+  endpoints would be mirrored with a delay, or when changes to the export label
+  would be ignored
+* Split HA functionality, such as PodDisruptionBudgets, into multiple
+  configurable values (thanks @evan-hines-firebolt for the initial work)
+
 ## edge-22.5.1
 
 This edge release adds more flexibility to the MeshTLSAuthentication and

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.3.1-edge
+version: 1.4.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.3.1-edge](https://img.shields.io/badge/Version-1.3.1--edge-informational?style=flat-square)
+![Version: 1.4.1-edge](https://img.shields.io/badge/Version-1.4.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.20.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.1.1-edge
+version: 30.1.2-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.1.1-edge](https://img.shields.io/badge/Version-30.1.1--edge-informational?style=flat-square)
+![Version: 30.1.2-edge](https://img.shields.io/badge/Version-30.1.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.1-edge
+version: 30.3.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.1-edge](https://img.shields.io/badge/Version-30.3.1--edge-informational?style=flat-square)
+![Version: 30.3.2-edge](https://img.shields.io/badge/Version-30.3.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.1-edge
+version: 30.1.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.1.1-edge](https://img.shields.io/badge/Version-30.1.1--edge-informational?style=flat-square)
+![Version: 30.1.2-edge](https://img.shields.io/badge/Version-30.1.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.1-edge
+version: 30.2.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.1-edge](https://img.shields.io/badge/Version-30.2.1--edge-informational?style=flat-square)
+![Version: 30.2.2-edge](https://img.shields.io/badge/Version-30.2.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release ships a few changes to the chart values, a fix for
multicluster headless services, and notable proxy features. HA functionality,
such as PDBs, deployment strategies, and pod anti-affinity, have been split
from the HA values and are now configurable for the control plane. On the proxy
side, non-HTTP traffic will now be forwarded on the outbound side within the
cluster when the proxy runs in ingress mode.

a multicluster fix for headless services,
This release updates "ingress-mode" proxies to be able to forward
non-HTTP traffic within the cluster. Protocol detection is always
attempted for outbound connections, however, when in ingress mode.

* Updated `ingress-mode` proxies to forward non-HTTP traffic within the cluster
  (protocol detection will always be attempted for outbound connections)
* Added a new proxy metric `process_uptime_seconds_total` to keep track of the
  number of seconds since the proxy started
* Fixed an issue with multicluster headless service mirroring, where exported
  endpoints would be mirrored with a delay, or when changes to the export label
  would be ignored
* Split HA functionality, such as PodDisruptionBudgets, into multiple
  configurable values (thanks @evan-hines-firebolt for the initial work)

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
