### PR TITLE
Add --crds flag to linkerd check

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -202,17 +202,20 @@ func configureAndRunChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, o
 	}
 	success, warning := healthcheck.RunChecks(wout, werr, hc, options.output)
 
-	extensionSuccess, extensionWarning, err := runExtensionChecks(cmd, wout, werr, options)
-	if err != nil {
-		fmt.Fprintf(werr, "Failed to run extensions checks: %s\n", err)
-		os.Exit(1)
+	if !options.preInstallOnly && !options.crdsOnly {
+		extensionSuccess, extensionWarning, err := runExtensionChecks(cmd, wout, werr, options)
+		if err != nil {
+			fmt.Fprintf(werr, "Failed to run extensions checks: %s\n", err)
+			os.Exit(1)
+		}
+
+		success = success && extensionSuccess
+		warning = warning || extensionWarning
 	}
 
-	totalSuccess := success && extensionSuccess
-	totalWarning := warning || extensionWarning
-	healthcheck.PrintChecksResult(wout, options.output, totalSuccess, totalWarning)
+	healthcheck.PrintChecksResult(wout, options.output, success, warning)
 
-	if !totalSuccess {
+	if !success {
 		os.Exit(1)
 	}
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -54,7 +54,7 @@ func (options *checkOptions) nonConfigFlagSet() *pflag.FlagSet {
 	flags.BoolVar(&options.cniEnabled, "linkerd-cni-enabled", options.cniEnabled, "When running pre-installation checks (--pre), assume the linkerd-cni plugin is already installed, and a NET_ADMIN check is not needed")
 	flags.StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
 	flags.BoolVar(&options.preInstallOnly, "pre", options.preInstallOnly, "Only run pre-installation checks, to determine if the control plane can be installed")
-	flags.BoolVar(&options.crdsOnly, "crds", options.crdsOnly, "Only run checks, to determine if the Linkerd CRDs have been installed")
+	flags.BoolVar(&options.crdsOnly, "crds", options.crdsOnly, "Only run checks which determine if the Linkerd CRDs have been installed")
 	flags.BoolVar(&options.dataPlaneOnly, "proxy", options.dataPlaneOnly, "Only run data-plane checks, to determine if the data plane is healthy")
 
 	return flags

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -642,7 +642,7 @@ func (hc *HealthChecker) allCategories() []*Category {
 					fatal:         true,
 					retryDeadline: hc.RetryDeadline,
 					check: func(ctx context.Context) error {
-						return CheckCustomResourceDefinitions(ctx, hc.kubeAPI, true)
+						return CheckCustomResourceDefinitions(ctx, hc.kubeAPI, hc.CRDManifest)
 					},
 				},
 			},

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -64,6 +64,11 @@ const (
 	// checks must be added first.
 	LinkerdPreInstallChecks CategoryID = "pre-kubernetes-setup"
 
+	// LinkerdCRDChecks adds checks to validate that the control plane CRDs
+	// exist. These checks can be run after installing the control plane CRDs
+	// but before installing the control plane itself.
+	LinkerdCRDChecks CategoryID = "linkerd-crd"
+
 	// LinkerdConfigChecks enabled by `linkerd check config`
 
 	// LinkerdConfigChecks adds a series of checks to validate that the Linkerd
@@ -620,6 +625,21 @@ func (hc *HealthChecker) allCategories() []*Category {
 					warning:     true,
 					check: func(ctx context.Context) error {
 						return hc.checkClockSkew(ctx)
+					},
+				},
+			},
+			false,
+		),
+		NewCategory(
+			LinkerdCRDChecks,
+			[]Checker{
+				{
+					description:   "control plane CustomResourceDefinitions exist",
+					hintAnchor:    "l5d-existence-crd",
+					fatal:         true,
+					retryDeadline: hc.RetryDeadline,
+					check: func(ctx context.Context) error {
+						return CheckCustomResourceDefinitions(ctx, hc.kubeAPI, true)
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #8372

Add a `--crds` flag to `linkerd check`.  This flag causes `linkerd check` to validate that the Linkerd  CRDs have been installed, and will wait until the check succeeds.  This way, `linkerd check --crds` can be used after `linkerd install --crds` and before `linkerd install` to ensure the CRDs have been installed successfully and to avoid race conditions where `linkerd install` could potentially attempt to create custom resources for which the CRD does not yet exist.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
