### PR TITLE
Sign container images during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
         docker-ghcr-username: ${{ secrets.DOCKER_GHCR_USERNAME }}
         docker-ghcr-pat: ${{ secrets.DOCKER_GHCR_PAT }}
         component: ${{ matrix.component }}
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@main
+    - name: Sign the images with Cosign
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: cosign sign $DOCKER_REGISTRY/${{ matrix.component }}:$TAG
     - name: Create artifact with CLI
       # windows_static_cli_tests below needs this because it can't create linux containers
       # inside windows
@@ -96,6 +102,12 @@ jobs:
           -t $DOCKER_REGISTRY/policy-controller:$TAG-${{ matrix.arch }} \
           --cache-from type=local,src=${DOCKER_BUILDKIT_CACHE} \
           --cache-to type=local,dest=${DOCKER_BUILDKIT_CACHE},mode=max
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@main
+    - name: Sign the image with Cosign
+      env:
+        COSIGN_EXPERIMENTAL: 1
+      run: cosign sign $DOCKER_REGISTRY/policy-controller:$TAG-${{ matrix.arch }}
     - name: Prune docker layers cache
       # changes generate new images while the existing ones don't get removed
       # so we manually do that to avoid bloating the cache


### PR DESCRIPTION
We add a step to the release process to sign the docker containers with [Cosign](https://github.com/sigstore/cosign).

We use the "keyless" signing method as described here: https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures which is the same method used by Kubernetes: https://kubernetes.io/docs/tasks/administer-cluster/verify-signed-images/

Note: While I have tested signing containers with this method manually, it's unclear how to test these github action changes outside of the release process.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
