### PR TITLE
change podCIDR check to use pod ips

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1891,6 +1891,9 @@ func (hc *HealthChecker) checkClusterNetworksContainAllPods(ctx context.Context)
 		if pod.Spec.HostNetwork {
 			continue
 		}
+		if len(pod.Status.PodIP) == 0 {
+			continue
+		}
 		if !clusterNetworksContainPod(clusterIPNets, pod) {
 			return fmt.Errorf("the Linkerd clusterNetworks [%q] do not include pod %s/%s (%s)", hc.linkerdConfig.ClusterNetworks, pod.Namespace, pod.Name, pod.Status.PodIP)
 		}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1888,8 +1888,11 @@ func (hc *HealthChecker) checkClusterNetworksContainAllPods(ctx context.Context)
 		return err
 	}
 	for _, pod := range pods.Items {
+		if pod.Spec.HostNetwork {
+			continue
+		}
 		if !clusterNetworksContainPod(clusterIPNets, pod) {
-			return fmt.Errorf("the Linkerd clusterNetworks do not include pod %s/%s", pod.Namespace, pod.Name)
+			return fmt.Errorf("the Linkerd clusterNetworks [%q] do not include pod %s/%s (%s)", hc.linkerdConfig.ClusterNetworks, pod.Namespace, pod.Name, pod.Status.PodIP)
 		}
 	}
 	return nil

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -696,27 +696,6 @@ func (hc *HealthChecker) allCategories() []*Category {
 					},
 				},
 				{
-					description: "cluster networks can be verified",
-					hintAnchor:  "l5d-cluster-networks-verified",
-					warning:     true,
-					check: func(ctx context.Context) error {
-						nodes, err := hc.kubeAPI.GetNodes(ctx)
-						if err != nil {
-							return err
-						}
-						var warningNodes []string
-						for _, node := range nodes {
-							if node.Spec.PodCIDR == "" {
-								warningNodes = append(warningNodes, node.Name)
-							}
-						}
-						if len(warningNodes) > 0 {
-							return fmt.Errorf("the following nodes do not expose a podCIDR:\n\t%s", strings.Join(warningNodes, "\n\t"))
-						}
-						return nil
-					},
-				},
-				{
 					description: "cluster networks contains all node podCIDRs",
 					hintAnchor:  "l5d-cluster-networks-cidr",
 					check: func(ctx context.Context) error {

--- a/test/integration/install/smoke/testdata/check.proxy.golden
+++ b/test/integration/install/smoke/testdata/check.proxy.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/install/testdata/check.cni.proxy.golden
+++ b/test/integration/install/testdata/check.cni.proxy.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/install/testdata/check.multicluster.proxy.golden
+++ b/test/integration/install/testdata/check.multicluster.proxy.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/install/testdata/check.proxy.golden
+++ b/test/integration/install/testdata/check.proxy.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/install/testdata/check.proxy.golden
+++ b/test/integration/install/testdata/check.proxy.golden
@@ -18,7 +18,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ control plane pods are ready
-√ cluster networks can be verified
 √ cluster networks contains all node podCIDRs
 
 linkerd-config

--- a/test/integration/upgrade-edge/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-edge/testdata/check.upgrade.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/upgrade-edge/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-edge/testdata/check.upgrade.golden
@@ -18,7 +18,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ control plane pods are ready
-√ cluster networks can be verified
 √ cluster networks contains all node podCIDRs
 
 linkerd-config

--- a/test/integration/upgrade-stable/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-stable/testdata/check.upgrade.golden
@@ -19,6 +19,7 @@ linkerd-existence
 √ no unschedulable pods
 √ control plane pods are ready
 √ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
 
 linkerd-config
 --------------

--- a/test/integration/upgrade-stable/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-stable/testdata/check.upgrade.golden
@@ -18,7 +18,6 @@ linkerd-existence
 √ control plane replica sets are ready
 √ no unschedulable pods
 √ control plane pods are ready
-√ cluster networks can be verified
 √ cluster networks contains all node podCIDRs
 
 linkerd-config


### PR DESCRIPTION
Fixes #8555

We remove the "cluster networks can be verified" which checks that the podCIDR field exists on nodes and replace it with a "cluster networks contains all pods" check.  This looks at all the pods in the cluster an verifies that each pod's IP is contained in the cluster networks.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
