### PR TITLE
Changes for edge-22.5.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## edge-22.5.3
+
+This edge release fixes a few proxy issues, improves the upgrade process, and
+introduces proto retries to Service Profiles. Also included are updates to the
+bash scripts to ensure that they follow best practices.
+
+* Polished the shell scripts (thanks @joakimr-axis)
+* Introduced retries to Service Profiles by adding an isRetryable function to
+  the proto definition (thanks @mahlunar)
+* Fixed proxy responses to CONNECT requests by removing the content-length
+  and/or transfer-encoding headers from the response
+* Fixed DNS lookups in the proxy to consistently use A records when SRV records
+  cannot be resolved
+* Added dynamic policy discovery to the proxy by evaluating traffic on ports
+  not included in the LINKERD2_PROXY_INBOUND_PORTS environment variable
+* Added logic to require that the linkerd CRDs are installed when running
+  the `linkerd upgrade` command
+
 ## edge-22.5.2
 
 This edge release ships a few changes to the chart values, a fix for

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,9 @@ introduces proto retries to Service Profiles. Also included are updates to the
 bash scripts to ensure that they follow best practices.
 
 * Polished the shell scripts (thanks @joakimr-axis)
-* Introduced retries to Service Profiles by adding an isRetryable function to
-  the proto definition (thanks @mahlunar)
+* Introduced retries to Service Profiles based on the idempotency option of the
+  method by adding an isRetryable function to the proto definition
+ (thanks @mahlunar)
 * Fixed proxy responses to CONNECT requests by removing the content-length
   and/or transfer-encoding headers from the response
 * Fixed DNS lookups in the proxy to consistently use A records when SRV records

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.4.1-edge
+version: 1.4.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.4.1-edge](https://img.shields.io/badge/Version-1.4.1--edge-informational?style=flat-square)
+![Version: 1.4.2-edge](https://img.shields.io/badge/Version-1.4.2--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.20.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.1.2-edge
+version: 30.1.3-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.1.2-edge](https://img.shields.io/badge/Version-30.1.2--edge-informational?style=flat-square)
+![Version: 30.1.3-edge](https://img.shields.io/badge/Version-30.1.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.2-edge
+version: 30.3.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.2-edge](https://img.shields.io/badge/Version-30.3.2--edge-informational?style=flat-square)
+![Version: 30.3.3-edge](https://img.shields.io/badge/Version-30.3.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.2-edge
+version: 30.1.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.1.2-edge](https://img.shields.io/badge/Version-30.1.2--edge-informational?style=flat-square)
+![Version: 30.1.3-edge](https://img.shields.io/badge/Version-30.1.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.2-edge
+version: 30.2.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.2-edge](https://img.shields.io/badge/Version-30.2.2--edge-informational?style=flat-square)
+![Version: 30.2.3-edge](https://img.shields.io/badge/Version-30.2.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release fixes a few proxy issues, improves the upgrade process, and
introduces proto retries to Service Profiles. Also included are updates to the
bash scripts to ensure that they follow best practices.

* Polished the shell scripts (thanks @joakimr-axis)
* Introduced retries to Service Profiles by adding an isRetryable function to
  the proto definition (thanks @mahlunar)
* Fixed proxy responses to CONNECT requests by removing the content-length
  and/or transfer-encoding headers from the response
* Fixed DNS lookups in the proxy to consistently use A records when SRV records
  cannot be resolved
* Added dynamic policy discovery to the proxy by evaluating traffic on ports
  not included in the LINKERD2_PROXY_INBOUND_PORTS environment variable
* Added logic to require that the linkerd CRDs are installed when running
  the `linkerd upgrade` command

Signed-off-by: Charles Pretzer <charles@buoyant.io>

