### PR TITLE
ci: Bump actions/cache from 3.0.2 to 3.0.3

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -31,7 +31,7 @@ runs:
       echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
       echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
   - name: Cache docker layers
-    uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+    uses: actions/cache@30f413bfed0a2bc738fdfd409e5a9e96b24545fd
     with:
       path: ${{ env.DOCKER_BUILDKIT_CACHE }}
       key: ${{ runner.os }}-buildx-${{ inputs.component }}-${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
         echo "TAG=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_ENV
         echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
     - name: Cache docker layers
-      uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+      uses: actions/cache@30f413bfed0a2bc738fdfd409e5a9e96b24545fd
       with:
         path: ${{ env.DOCKER_BUILDKIT_CACHE }}
         key: policy-controller-${{ matrix.arch }}-${{ env.TAG }}


### PR DESCRIPTION
This change supersedes the PR submitted by dependabot to update
actions/cache from 3.0.2 to 3.0.3. The dependency bump PR does not
change the version for the docker-build action that we use to build
images for our control plane components.

This change updates all references to actions/cache to use 3.0.3 (both
the release workflow, and the action).

Signed-off-by: Matei David <matei@buoyant.io>

Change notes are in the superseded PR (https://github.com/linkerd/linkerd2/pull/8594)

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
