### PR TITLE
policy: Set a `group` label

### DIFF
--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -203,10 +203,12 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
 
     let labels = match &srv.reference {
         ServerRef::Default(name) => convert_args!(hashmap!(
+            "group" => "",
             "kind" => "default",
             "name" => name,
         )),
         ServerRef::Server(name) => convert_args!(hashmap!(
+            "group" => "policy.linkerd.io",
             "kind" => "server",
             "name" => name,
         )),
@@ -249,14 +251,17 @@ fn to_authz(
 
     let labels = match reference {
         AuthorizationRef::Default(name) => convert_args!(hashmap!(
+            "group" => "",
             "kind" => "default",
             "name" => name,
         )),
         AuthorizationRef::ServerAuthorization(name) => convert_args!(hashmap!(
+            "group" => "policy.linkerd.io",
             "kind" => "serverauthorization",
             "name" => name,
         )),
         AuthorizationRef::AuthorizationPolicy(name) => convert_args!(hashmap!(
+            "group" => "policy.linkerd.io",
             "kind" => "authorizationpolicy",
             "name" => name,
         )),

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -15,6 +15,7 @@ macro_rules! assert_is_default_all_unauthenticated {
         assert_eq!(
             $config.labels,
             vec![
+                ("group".to_string(), "".to_string()),
                 ("kind".to_string(), "default".to_string()),
                 ("name".to_string(), "all-unauthenticated".to_string()),
             ]

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -56,7 +56,11 @@ async fn server_with_server_authorization() {
         assert_eq!(config.authorizations, vec![]);
         assert_eq!(
             config.labels,
-            convert_args!(hashmap!("kind" => "server", "name" => "linkerd-admin")),
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => "linkerd-admin"
+            )),
         );
 
         // Create a server authorizaation that refers to the `linkerd-admin`
@@ -100,6 +104,7 @@ async fn server_with_server_authorization() {
         assert_eq!(
             config.authorizations.first().unwrap().labels,
             convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
                 "kind" => "serverauthorization",
                 "name" => "all-admin",
             )),
@@ -120,7 +125,11 @@ async fn server_with_server_authorization() {
         );
         assert_eq!(
             config.labels,
-            convert_args!(hashmap!("kind" => "server", "name" => server.name()))
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => server.name()
+            ))
         );
 
         // Delete the `Server` and ensure that the update reverts to the
@@ -188,7 +197,11 @@ async fn server_with_authorization_policy() {
         assert_eq!(config.authorizations, vec![]);
         assert_eq!(
             config.labels,
-            convert_args!(hashmap!("kind" => "server", "name" => server.name()))
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => server.name()
+            ))
         );
 
         let all_nets = create(
@@ -251,6 +264,7 @@ async fn server_with_authorization_policy() {
         assert_eq!(
             config.authorizations.first().unwrap().labels,
             convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
                 "kind" => "authorizationpolicy",
                 "name" => authz_policy.name(),
             ))
@@ -271,7 +285,11 @@ async fn server_with_authorization_policy() {
         );
         assert_eq!(
             config.labels,
-            convert_args!(hashmap!("kind" => "server", "name" => server.name()))
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => server.name()
+            ))
         );
     })
     .await;


### PR DESCRIPTION
For the sake of completeness, we should set a `group` label in addition
to `kind`. This makes it possible to differentiate & discover resource
types handled by the proxy.

The `group` value is empty when a response does not refer to an actual
resource--usually when the `kind` is _default_.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
