### PR TITLE
Fix injector not emitting skip events properly

### DIFF
--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -150,7 +150,10 @@ func Inject(linkerdNamespace string) webhook.Handler {
 			return nil, err
 		}
 
-		var admissionResp *admissionv1beta1.AdmissionResponse
+		admissionResp := &admissionv1beta1.AdmissionResponse{
+			UID:     request.UID,
+			Allowed: true,
+		}
 		if len(patchJSON) != 0 {
 			// If resource needs to be patched with annotations (e.g opaque
 			// ports), then admit the request with the relevant patch
@@ -170,10 +173,6 @@ func Inject(linkerdNamespace string) webhook.Handler {
 			// entirely skipped and admit without any mutations
 			log.Infof("skipped %s: %s", report.ResName(), readableReasons)
 			proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", strings.Join(reasons, ","), report.InjectAnnotationAt, configLabels)).Inc()
-			admissionResp = &admissionv1beta1.AdmissionResponse{
-				UID:     request.UID,
-				Allowed: true,
-			}
 		}
 
 		return admissionResp, nil

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -133,14 +133,14 @@ func Inject(linkerdNamespace string) webhook.Handler {
 
 		// Resource could not be injected with the sidecar, format the reason
 		// for injection being skipped to emit an event
-		var readableReasons string
+		readableReasons := make([]string, 0, len(reasons))
 		for _, reason := range reasons {
-			readableReasons = readableReasons + ", " + inject.Reasons[reason]
+			readableReasons = append(readableReasons, inject.Reasons[reason])
 		}
-		// removing the initial comma, space
-		readableReasons = readableReasons[2:]
+		readableMsg := strings.Join(readableReasons, ", ")
+
 		if parent != nil {
-			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", readableReasons)
+			recorder.Eventf(*parent, v1.EventTypeNormal, eventTypeSkipped, "Linkerd sidecar proxy injection skipped: %s", readableMsg)
 		}
 
 		// Create a patch which adds the opaque ports annotation if the workload
@@ -150,32 +150,37 @@ func Inject(linkerdNamespace string) webhook.Handler {
 			return nil, err
 		}
 
-		admissionResp := &admissionv1beta1.AdmissionResponse{
-			UID:     request.UID,
-			Allowed: true,
-		}
+		// If resource needs to be patched with annotations (e.g opaque
+		// ports), then admit the request with the relevant patch
 		if len(patchJSON) != 0 {
-			// If resource needs to be patched with annotations (e.g opaque
-			// ports), then admit the request with the relevant patch
 			log.Infof("annotation patch generated for: %s", report.ResName())
 			log.Debugf("annotation patch: %s", patchJSON)
 			proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "false", "", report.InjectAnnotationAt, configLabels)).Inc()
 			patchType := admissionv1beta1.PatchTypeJSONPatch
-			admissionResp = &admissionv1beta1.AdmissionResponse{
+			return &admissionv1beta1.AdmissionResponse{
 				UID:       request.UID,
 				Allowed:   true,
 				PatchType: &patchType,
 				Patch:     patchJSON,
-			}
-		} else if resourceConfig.IsPod() {
-			// Otherwise, if the resource is a pod, and no annotation patch has
-			// been generated, record in the metrics (and log) that it has been
-			// entirely skipped and admit without any mutations
-			log.Infof("skipped %s: %s", report.ResName(), readableReasons)
-			proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", strings.Join(reasons, ","), report.InjectAnnotationAt, configLabels)).Inc()
+			}, nil
 		}
 
-		return admissionResp, nil
+		// If the resource is a pod, and no annotation patch has
+		// been generated, record in the metrics (and log) that it has been
+		// entirely skipped and admit without any mutations
+		if resourceConfig.IsPod() {
+			log.Infof("skipped %s: %s", report.ResName(), readableMsg)
+			proxyInjectionAdmissionResponses.With(admissionResponseLabels(ownerKind, request.Namespace, "true", strings.Join(reasons, ","), report.InjectAnnotationAt, configLabels)).Inc()
+			return &admissionv1beta1.AdmissionResponse{
+				UID:     request.UID,
+				Allowed: true,
+			}, nil
+		}
+
+		return &admissionv1beta1.AdmissionResponse{
+			UID:     request.UID,
+			Allowed: true,
+		}, nil
 	}
 }
 


### PR DESCRIPTION
A resource that cannot be injected -- for a variety of reasons, such as
using the host network, or not mounting a SA token when token projection
is disabled -- may still have an annotation patch if the resource's
endpoints have ports marked as opaque.

When an annotation patch is generated but an injection patch is not, the
injector will not emit an event and consider the resource as "injected",
when in fact it does not have the sidecar. This can make it hard to
investigate issues where resources that are supposed to be injected are
not because the failure is not obvious.

This change refactors and simplifies the logic by emitting an event
whenever a resource is not injected, regardless of whether an annotation
patch is generated for it. This should provide better visibility in case
of failures. Furthermore, the change refactors the code to avoid too
many early returns and make it easier to trace the codepath through the
function. The initial assumption that an annotation patch should not
increment injection skipped admission response has been left intact; in
other words, an annotation patch will not count in the metrics as a
skip, but an event with the skip reason is still emitted.

Fixes #8634

Signed-off-by: Matei David <matei@buoyant.io>

### Validation
---

To validate, I used the same steps I had for the repro in #8634. I deployed `bitnami/mariadb` in the cluster; I installed in a test cluster using `stable-2.11.1` that _does not include projected tokens_. Since `mariadb`'s SA does not automount, the pod is never injected. We receive an annotation patch for its opaque ports but not further information why injection failed:

```yaml
# Autoomount is false hence why injection is skipped
apiVersion: v1
automountServiceAccountToken: false
kind: ServiceAccount
metadata:
  annotations:
    meta.helm.sh/release-name: my-release
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2022-06-09T12:08:14Z"
  labels:
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: mariadb
    helm.sh/chart: mariadb-11.0.12
  name: my-release-mariadb
  namespace: default
  resourceVersion: "1237318"
  uid: 92269811-7170-4dab-a792-4f8cce55675c
secrets:
- name: my-release-mariadb-token-q4pb7
```

```
# injector logs
time="2022-06-09T12:08:15Z" level=info msg="received pod/my-release-mariadb-0"
time="2022-06-09T12:08:15Z" level=info msg="annotation patch generated for: pod/my-release-mariadb-0"

# pod state, not injected
my-release-mariadb-0               1/1     Running                 0          48m   10.42.0.65   k3d-demo-server-0   <none>           <none>

# No events
48m         Normal    Created                 pod/my-release-mariadb-0                          Created container mariadb
48m         Normal    Started                 pod/my-release-mariadb-0                          Started container mariadb
```

After fix, I had to change the spec for the deployment to use `hostNetwork=true` to have injection be skipped. In current edge versions we use projected tokens so `automountServiceAccountToken` does not have to explicitly set to true.

```
# injector logs are same as before, we generate the patch and skip injection
time="2022-06-09T12:50:53Z" level=info msg="received pod/my-release-mariadb-0"
time="2022-06-09T12:50:53Z" level=info msg="annotation patch generated for: pod/my-release-mariadb-0"

# pod is not injected
my-release-mariadb-0   1/1     Running   0          8m9s

# we now get an event though
8m26s       Normal    InjectionSkipped          statefulset/my-release-mariadb                    Linkerd sidecar proxy injection skipped: , hostNetwork is enabled
8m26s       Normal    SuccessfulCreate          statefulset/my-release-mariadb                    create Pod my-release-mariadb-0 in StatefulSet my-release-mar
```

Quick note, output in the event is messed because I tried to change how we process the string to use `strings.TrimPrefix` instead of returning a slice when creating readable messages. I reverted the change back to how it was since it didn't seem to do what I expected it to do.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
