### PR TITLE
Set `runAsUser` in extensions

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -74,6 +74,7 @@ Kubernetes: `>=1.20.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterDomain | string | `"cluster.local"` | Kubernetes DNS Domain name to use |
+| collector.UID | string | `nil` | UID for the collector resource |
 | collector.config | string | see `value.yaml` for actual configuration | OpenTelemetry Collector config, See the [Configuration docs](https://opentelemetry.io/docs/collector/configuration/) for more information |
 | collector.enabled | bool | `true` | Set to false to exclude collector installation |
 | collector.image.name | string | `"otel/opentelemetry-collector"` |  |
@@ -87,8 +88,10 @@ Kubernetes: `>=1.20.0-0`
 | collector.resources.memory.limit | string | `nil` | Maximum amount of memory that collector container can use |
 | collector.resources.memory.request | string | `nil` | Amount of memory that the collector container requests |
 | collector.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| defaultUID | int | `2103` | Default UID for all the jaeger components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
+| jaeger.UID | string | `nil` | UID for the jaeger resource |
 | jaeger.args | list | `["--query.base-path=/jaeger"]` | CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory) |
 | jaeger.enabled | bool | `true` | Set to false to exclude all-in-one Jaeger installation |
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
@@ -106,6 +109,7 @@ Kubernetes: `>=1.20.0-0`
 | linkerdVersion | string | `"linkerdVersionValue"` |  |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | tolerations | string | `nil` | Default tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| webhook.UID | string | `nil` | UID for the webhook resource |
 | webhook.caBundle | string | `""` | Bundle of CA certificates for webhook. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `webhook.crtPEM`. If `webhook.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |
 | webhook.collectorSvcAccount | string | `"collector"` | service account associated with the collector instance |
 | webhook.collectorSvcAddr | string | `"collector.linkerd-jaeger:55678"` | collector service address for the proxies to send trace data. Points by default to the the linkerd-jaeger collector |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -59,6 +59,8 @@ spec:
           httpGet:
             path: /ready
             port: 9995
+        securityContext:
+          runAsUser: {{.Values.webhook.UID | default .Values.defaultUID}}
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls

--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -27,6 +27,8 @@ spec:
       - name: namespace-metadata
         image: curlimages/curl:7.78.0
         command: ["/bin/sh"]
+        securityContext:
+          runAsUser: {{.Values.defaultUID}}
         args:
         - -c
         - |

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -116,6 +116,8 @@ spec:
         {{- if .Values.collector.resources -}}
         {{- include "partials.resources" .Values.collector.resources | nindent 8 }}
         {{- end }}
+        securityContext:
+          runAsUser: {{.Values.collector.UID | default .Values.defaultUID}}
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val
@@ -204,6 +206,8 @@ spec:
         {{- if .Values.jaeger.resources -}}
         {{- include "partials.resources" .Values.jaeger.resources | nindent 8 }}
         {{- end }}
+        securityContext:
+          runAsUser: {{.Values.jaeger.UID | default .Values.defaultUID}}
       dnsPolicy: ClusterFirst
       serviceAccountName: jaeger
 {{ end -}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -22,6 +22,9 @@ tolerations: &default_tolerations
 # deprecated since k8s v1.21
 enablePSP: false
 
+# -- Default UID for all the jaeger components
+defaultUID: 2103
+
 # -- Kubernetes DNS Domain name to use
 clusterDomain: cluster.local
 collector:
@@ -56,6 +59,9 @@ collector:
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
   tolerations: *default_tolerations
+
+  # -- UID for the collector resource
+  UID:
 
   # -- OpenTelemetry Collector config, See the
   # [Configuration docs](https://opentelemetry.io/docs/collector/configuration/)
@@ -128,6 +134,9 @@ jaeger:
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
   tolerations: *default_tolerations
+
+  # -- UID for the jaeger resource
+  UID:
 
 linkerdVersion: &linkerd_version linkerdVersionValue
 
@@ -208,3 +217,6 @@ webhook:
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
   tolerations: *default_tolerations
+
+  # -- UID for the webhook resource
+  UID:

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -97,6 +97,8 @@ spec:
           httpGet:
             path: /ready
             port: 9995
+        securityContext:
+          runAsUser: 2103
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls
@@ -319,6 +321,8 @@ spec:
         - containerPort: 16686
           name: ui
         resources:
+        securityContext:
+          runAsUser: 2103
       dnsPolicy: ClusterFirst
       serviceAccountName: jaeger
 ---

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -97,6 +97,8 @@ spec:
           httpGet:
             path: /ready
             port: 9995
+        securityContext:
+          runAsUser: 2103
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls
@@ -400,6 +402,8 @@ spec:
             path: /
             port: 13133
         resources:
+        securityContext:
+          runAsUser: 2103
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val
@@ -480,6 +484,8 @@ spec:
         - containerPort: 16686
           name: ui
         resources:
+        securityContext:
+          runAsUser: 2103
       dnsPolicy: ClusterFirst
       serviceAccountName: jaeger
 ---

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -97,6 +97,8 @@ spec:
           httpGet:
             path: /ready
             port: 9995
+        securityContext:
+          runAsUser: 2103
         volumeMounts:
         - mountPath: /var/run/linkerd/tls
           name: tls
@@ -391,6 +393,8 @@ spec:
             path: /
             port: 13133
         resources:
+        securityContext:
+          runAsUser: 2103
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -73,6 +73,7 @@ Kubernetes: `>=1.20.0-0`
 |-----|------|---------|-------------|
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
+| gateway.UID | int | `2103` | User id under which the gateway shall be ran |
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -41,6 +41,8 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
+          securityContext:
+            runAsUser: {{.Values.gateway.UID}}
       serviceAccountName: {{.Values.gateway.name}}
 {{- if .Values.enablePodAntiAffinity }}
 ---

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -27,6 +27,8 @@ spec:
       - name: namespace-metadata
         image: curlimages/curl:7.78.0
         command: ["/bin/sh"]
+        securityContext:
+          runAsUser: {{.Values.gateway.UID}}
         args:
         - -c
         - |

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -26,6 +26,9 @@ gateway:
   # -- Set loadBalancerIP on gateway service
   loadBalancerIP: ""
 
+  # -- User id under which the gateway shall be ran
+  UID: 2103
+
 # -- Control plane version
 linkerdVersion: linkerdVersionValue
 # -- The port on which the proxy accepts outbound traffic

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -38,6 +38,8 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
+          securityContext:
+            runAsUser: 2103
       serviceAccountName: linkerd-gateway
 ---
 apiVersion: v1

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -60,6 +60,8 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
+          securityContext:
+            runAsUser: 2103
       serviceAccountName: linkerd-gateway
 ---
 kind: PodDisruptionBudget

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -38,6 +38,8 @@ spec:
       containers:
         - name: pause
           image: gcr.io/google_containers/pause:3.2
+          securityContext:
+            runAsUser: 2103
       serviceAccountName: linkerd-gateway
 ---
 apiVersion: v1

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -28,6 +28,8 @@ spec:
         image: curlimages/curl:7.78.0
         imagePullPolicy: {{.Values.defaultImagePullPolicy}}
         command: ["/bin/sh"]
+        securityContext:
+          runAsUser: {{.Values.defaultUID}}
         args:
         - -c
         - |


### PR DESCRIPTION
Fixes #8606

This adds a configurable `SecurityContext.runAsUser` section to the multicluster
gateway, the tracing deployments, and the `namespace-metadata` jobs in
all the extensions.