### PR TITLE
Add changes for edge-22.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,45 @@
 # Changes
 
+## edge-22.6.1
+
+This edge release fixes an issue where Linkerd injected pods could not be
+evicted by Cluster Autoscaler. It also adds the `--crds` flag to `linkerd check`
+which validates that the Linkerd CRDs have been installed with the proper
+versions.
+
+The previously noisy "cluster networks can be verified" check has been replaced
+with one that now verifies each running Pod IP is contained within the current
+`clusterNetworks` configuration value.
+
+Additionally, linkerd-viz is no longer required for linkerd-multicluster's
+`gateways` command — allowing the `Gateways` API to marked as deprecated for
+2.12.
+
+Finally, several security issues have been patched in the Docker images now that
+the builds are pinned only to minor — rather than patch — versions.
+
+* Replaced manual IP address parsing with functions available in the Go standard
+  library (thanks @zhlsunshine!)
+* Removed linkerd-multicluster's `gateway` command dependency on the linkerd-viz
+  extension
+* Fixed issue where Linkerd injected pods were prevented from being evicted by
+  Cluster Autoscaler
+* Added the `dst_target_cluster` metric to linkerd-multicluster's service-mirror
+  controller probe traffic
+* Added the `--crds` flag to `linkerd check` which validates that the Linkerd
+  CRDs have been installed
+* Removed the Docker image's hardcoded patch versions so that builds pick up
+  patch releases without manual intervention
+* Replaced the "cluster networks can be verified check" check with a "cluster
+  networks contains all pods" check which ensures that all currently running Pod
+  IPs are contained by the current `clusterNetworks` configuration
+* Added IPv6 compatible IP address generation in certain control plane
+  components that were only generating IPv4 (thanks @zhlsunshine!)
+* Deprecated linkerd-viz's `Gateways` API which is no longer used by
+  linkerd-multicluster
+* Added the `promm` package for making programatic Prometheus assertions in
+  tests (thanks @krzysztofdrys!)
+
 ## edge-22.5.3
 
 This edge release fixes a few proxy issues, improves the upgrade process, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ the builds are pinned only to minor — rather than patch — versions.
   linkerd-multicluster
 * Added the `promm` package for making programatic Prometheus assertions in
   tests (thanks @krzysztofdrys!)
+* Added the `runAsUser` configuration to extensions to fix a PodSecurityPolicy
+  violation when CNI is enabled
 
 ## edge-22.5.3
 

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.4.2-edge
+version: 1.4.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.4.2-edge](https://img.shields.io/badge/Version-1.4.2--edge-informational?style=flat-square)
+![Version: 1.4.3-edge](https://img.shields.io/badge/Version-1.4.3--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.20.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.1.3-edge
+version: 30.1.4-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.1.3-edge](https://img.shields.io/badge/Version-30.1.3--edge-informational?style=flat-square)
+![Version: 30.1.4-edge](https://img.shields.io/badge/Version-30.1.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.3-edge
+version: 30.3.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.3-edge](https://img.shields.io/badge/Version-30.3.3--edge-informational?style=flat-square)
+![Version: 30.3.4-edge](https://img.shields.io/badge/Version-30.3.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.3-edge
+version: 30.1.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.1.3-edge](https://img.shields.io/badge/Version-30.1.3--edge-informational?style=flat-square)
+![Version: 30.1.4-edge](https://img.shields.io/badge/Version-30.1.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.20.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.3-edge
+version: 30.2.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.3-edge](https://img.shields.io/badge/Version-30.2.3--edge-informational?style=flat-square)
+![Version: 30.2.4-edge](https://img.shields.io/badge/Version-30.2.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release fixes an issue where Linkerd injected pods could not be
evicted by Cluster Autoscaler. It also adds the `--crds` flag to `linkerd check`
which validates that the Linkerd CRDs have been installed with the proper
versions.

The previously noisy "cluster networks can be verified" check has been replaced
with one that now verifies each running Pod IP is contained within the current
`clusterNetworks` configuration value.

Additionally, linkerd-viz is no longer required for linkerd-multicluster's
`gateways` command — allowing the `Gateways` API to marked as deprecated for
2.12.

Finally, several security issues have been patched in the Docker images now that
the builds are pinned only to minor — rather than patch — versions.

* Replaced manual IP address parsing with functions available in the Go standard
  library (thanks @zhlsunshine!)
* Removed linkerd-multicluster's `gateway` command dependency on the linkerd-viz
  extension
* Fixed issue where Linkerd injected pods were prevented from being evicted by
  Cluster Autoscaler
* Added the `dst_target_cluster` metric to linkerd-multicluster's service-mirror
  controller probe traffic
* Added the `--crds` flag to `linkerd check` which validates that the Linkerd
  CRDs have been installed
* Removed the Docker image's hardcoded patch versions so that builds pick up
  patch releases without manual intervention
* Replaced the "cluster networks can be verified check" check with a "cluster
  networks contains all pods" check which ensures that all currently running Pod
  IPs are contained by the current `clusterNetworks` configuration
* Added IPv6 compatible IP address generation in certain control plane
  components that were only generating IPv4 (thanks @zhlsunshine!)
* Deprecated linkerd-viz's `Gateways` API which is no longer used by
  linkerd-multicluster
* Added the `promm` package for making programatic Prometheus assertions in
  tests (thanks @krzysztofdrys!)

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
