### PR TITLE
Fix panic when injector encounters unsupported owner kind

### DIFF
--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -479,6 +479,35 @@ func (api *API) GetObjects(namespace, restype, name string, label labels.Selecto
 	}
 }
 
+// KindSupported returns true if there is an informer configured for the
+// specified resource type.
+func (api *API) KindSupported(restype string) bool {
+	switch restype {
+	case k8s.Namespace:
+		return api.ns != nil
+	case k8s.CronJob:
+		return api.cj != nil
+	case k8s.DaemonSet:
+		return api.ds != nil
+	case k8s.Deployment:
+		return api.deploy != nil
+	case k8s.Job:
+		return api.job != nil
+	case k8s.Pod:
+		return api.pod != nil
+	case k8s.ReplicationController:
+		return api.rc != nil
+	case k8s.ReplicaSet:
+		return api.rs != nil
+	case k8s.Service:
+		return api.svc != nil
+	case k8s.StatefulSet:
+		return api.ss != nil
+	default:
+		return false
+	}
+}
+
 // GetOwnerKindAndName returns the pod owner's kind and name, using owner
 // references from the Kubernetes API. The kind is represented as the Kubernetes
 // singular resource type (e.g. deployment, daemonset, job, etc.).

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -73,15 +73,17 @@ func Inject(linkerdNamespace string) webhook.Handler {
 		var parent *runtime.Object
 		var ownerKind string
 		if ownerRef := resourceConfig.GetOwnerRef(); ownerRef != nil {
-			objs, err := api.GetObjects(request.Namespace, ownerRef.Kind, ownerRef.Name, labels.Everything())
-			if err != nil {
-				log.Warnf("couldn't retrieve parent object %s-%s-%s; error: %s", request.Namespace, ownerRef.Kind, ownerRef.Name, err)
-			} else if len(objs) == 0 {
-				log.Warnf("couldn't retrieve parent object %s-%s-%s", request.Namespace, ownerRef.Kind, ownerRef.Name)
-			} else {
-				parent = &objs[0]
+			if api.KindSupported(ownerRef.Kind) {
+				objs, err := api.GetObjects(request.Namespace, ownerRef.Kind, ownerRef.Name, labels.Everything())
+				if err != nil {
+					log.Warnf("couldn't retrieve parent object %s-%s-%s; error: %s", request.Namespace, ownerRef.Kind, ownerRef.Name, err)
+				} else if len(objs) == 0 {
+					log.Warnf("couldn't retrieve parent object %s-%s-%s", request.Namespace, ownerRef.Kind, ownerRef.Name)
+				} else {
+					parent = &objs[0]
+				}
+				ownerKind = strings.ToLower(ownerRef.Kind)
 			}
-			ownerKind = strings.ToLower(ownerRef.Kind)
 		}
 
 		configLabels := configToPrometheusLabels(resourceConfig)


### PR DESCRIPTION
Fixes #8624

When the proxy-injector encounters a resource with an owner ref, it calls `api.GetObjects` to fetch the owner.  If the owner is a kind which is not supported by the proxy-injector, we will panic.

We add a condition so that we only attempt to fetch the owner resource if it is a kind we support.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
