### PR TITLE
injector: Include pod probe ports in inbound proxy configuration

### DIFF
--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -62,7 +62,7 @@ spec:
             fieldRef:
               fieldPath: status.podIPs
         - name: LINKERD2_PROXY_INBOUND_PORTS
-          value: 9090,9090
+          value: "9090"
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: svc.cluster.local.
         - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
@@ -273,7 +273,7 @@ spec:
             fieldRef:
               fieldPath: status.podIPs
         - name: LINKERD2_PROXY_INBOUND_PORTS
-          value: 9090,9090
+          value: "9090"
         - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
           value: svc.cluster.local.
         - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE

--- a/controller/proxy-injector/fake/data/pod-inject-empty.yaml
+++ b/controller/proxy-injector/fake/data/pod-inject-empty.yaml
@@ -14,3 +14,7 @@ spec:
     ports:
     - name: http
       containerPort: 80
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: 9090

--- a/controller/proxy-injector/fake/data/pod-inject-enabled.yaml
+++ b/controller/proxy-injector/fake/data/pod-inject-enabled.yaml
@@ -14,3 +14,7 @@ spec:
     ports:
     - name: http
       containerPort: 80
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: 9090

--- a/controller/proxy-injector/fake/data/pod-with-debug-disabled.yaml
+++ b/controller/proxy-injector/fake/data/pod-with-debug-disabled.yaml
@@ -15,3 +15,13 @@ spec:
     ports:
     - name: http
       containerPort: 80
+    - name: metrics
+      containerPort: 9090
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: metrics
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: metrics

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -220,7 +220,7 @@
         },
         {
           "name": "LINKERD2_PROXY_INBOUND_PORTS",
-          "value": "80"
+          "value": "80,9090"
         },
         {
           "name": "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -210,7 +210,7 @@
         },
         {
           "name": "LINKERD2_PROXY_INBOUND_PORTS",
-          "value": "80"
+          "value": "80,9090"
         },
         {
           "name": "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES",


### PR DESCRIPTION
The injector configures the proxy with a set of known inbound ports
which are used (by the proxy) to discover inbound server configuration.
The list of ports is derived from the pod's container ports; container
ports may be optional and thus not present. The proxy supports dynamic
discovery of additional ports at runtime but since they are lazy,
additional ports may be dropped or updated long after pod start-up.

To ensure HTTP probes are handled correctly, this change introduces new
functionality to configure the list of inbound ports for the proxy with
any ports targeted by healthcheck probes, as long as they are HTTP, and
even if they are not present in the containerPorts configuration.

This change also introduces additional liveness (or readiness) probes to
the current injector webhook test fixtures in order to assert that
injected pods will always have their healthcheck target ports included
in the proxy's configuration.

Closes #8638

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
