### PR TITLE
Bump minimum kubernetes version to 1.21

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.20
+          - v1.21
           - v1.23
     name: Policy controller integration (k8s ${{ matrix.k8s }})
 

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -236,7 +236,7 @@ setup_min_cluster() {
 
   test_setup
   if [ -z "$skip_cluster_create" ]; then
-    "$bindir"/k3d cluster create "$@" --image +v1.20
+    "$bindir"/k3d cluster create "$@" --image +v1.21
     image_load "$name"
   fi
   check_cluster

--- a/bin/install-deps
+++ b/bin/install-deps
@@ -40,7 +40,6 @@ CGO_ENABLED=0 GOOS=linux GOARCH=$arch go install -mod=readonly \
     k8s.io/client-go/kubernetes/typed/autoscaling/v1 \
     k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1 \
     k8s.io/client-go/kubernetes/typed/batch/v1 \
-    k8s.io/client-go/kubernetes/typed/batch/v1beta1 \
     k8s.io/client-go/kubernetes/typed/certificates/v1beta1 \
     k8s.io/client-go/kubernetes/typed/core/v1 \
     k8s.io/client-go/kubernetes/typed/events/v1beta1 \

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 name: "linkerd-control-plane"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -11,7 +11,7 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -123,7 +123,7 @@ extensions:
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd-control-plane/README.md.gotmpl
+++ b/charts/linkerd-control-plane/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -3,7 +3,7 @@
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 name: "linkerd-crds"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -10,7 +10,7 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd-crds/README.md.gotmpl
+++ b/charts/linkerd-crds/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
   up your pod's network so  incoming and outgoing traffic is proxied through the
   data plane.
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
 version: 30.1.4-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -12,7 +12,7 @@ data plane.
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1351,7 +1351,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1331,7 +1331,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1477,7 +1477,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1477,7 +1477,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -1324,7 +1324,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1452,7 +1452,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1464,7 +1464,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1442,7 +1442,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1275,7 +1275,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1346,7 +1346,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1349,7 +1349,7 @@ spec:
 ###
 ### Heartbeat
 ###
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat

--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/addr"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/discovery/v1beta1"
+	v1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -89,14 +89,14 @@ var (
 	west1aAddress = watcher.Address{
 		IP:   "1.1.1.1",
 		Port: 1,
-		ForZones: []v1beta1.ForZone{
+		ForZones: []v1.ForZone{
 			{Name: "west-1a"},
 		},
 	}
 	west1bAddress = watcher.Address{
 		IP:   "1.1.1.1",
 		Port: 2,
-		ForZones: []v1beta1.ForZone{
+		ForZones: []v1.ForZone{
 			{Name: "west-1b"},
 		},
 	}

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	logging "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -10,7 +10,7 @@ import (
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	logging "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	dv1beta1 "k8s.io/api/discovery/v1beta1"
+	dv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -706,7 +706,7 @@ func TestEndpointsWatcherWithEndpointSlices(t *testing.T) {
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -733,7 +733,7 @@ spec:
   - port: 8989`,
 				`
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 172.17.0.12
@@ -834,7 +834,7 @@ status:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -860,7 +860,7 @@ spec:
   ports:
   - port: 8989`, `
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 172.17.0.23
@@ -925,7 +925,7 @@ status:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -963,7 +963,7 @@ spec:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -1010,7 +1010,7 @@ spec:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -1036,7 +1036,7 @@ spec:
   ports:
   - port: 8989`, `
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 172.17.0.12
@@ -1129,7 +1129,7 @@ status:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -1155,7 +1155,7 @@ spec:
   ports:
   - port: 8989`, `
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 172.17.0.12
@@ -1200,7 +1200,7 @@ status:
 			k8sConfigs: []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -1226,7 +1226,7 @@ spec:
   ports:
   - port: 9000`, `
 addressType: IPv6
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 0:0:0:0:0:0:0:1
@@ -1422,7 +1422,7 @@ func TestEndpointsWatcherDeletionWithEndpointSlices(t *testing.T) {
 	k8sConfigsWithES := []string{`
 kind: APIResourceList
 apiVersion: v1
-groupVersion: discovery.k8s.io/v1beta1
+groupVersion: discovery.k8s.io/v1
 resources:
   - name: endpointslices
     singularName: endpointslice
@@ -1448,7 +1448,7 @@ spec:
   ports:
   - port: 8989`, `
 addressType: IPv4
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 endpoints:
 - addresses:
   - 172.17.0.12
@@ -1595,7 +1595,7 @@ spec:
   ports:
   - port: 8989`,
 				`
-apiVersion: discovery.k8s.io/v1beta1
+apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
   name: name1-remote-xxxx
@@ -1820,18 +1820,18 @@ func endpoints(identity string) *corev1.Endpoints {
 	}
 }
 
-func createTestEndpointSlice() *dv1beta1.EndpointSlice {
-	return &dv1beta1.EndpointSlice{
+func createTestEndpointSlice() *dv1.EndpointSlice {
+	return &dv1.EndpointSlice{
 		AddressType: "IPv4",
-		ObjectMeta:  metav1.ObjectMeta{Name: "name1-del", Namespace: "ns", Labels: map[string]string{dv1beta1.LabelServiceName: "name1"}},
-		Endpoints: []dv1beta1.Endpoint{
+		ObjectMeta:  metav1.ObjectMeta{Name: "name1-del", Namespace: "ns", Labels: map[string]string{dv1.LabelServiceName: "name1"}},
+		Endpoints: []dv1.Endpoint{
 			{
 				Addresses:  []string{"172.17.0.12"},
-				Conditions: dv1beta1.EndpointConditions{Ready: func(b bool) *bool { return &b }(true)},
+				Conditions: dv1.EndpointConditions{Ready: func(b bool) *bool { return &b }(true)},
 				TargetRef:  &corev1.ObjectReference{Name: "name1-1", Namespace: "ns", Kind: "Pod"},
 			},
 		},
-		Ports: []dv1beta1.EndpointPort{
+		Ports: []dv1.EndpointPort{
 			{
 				Name: func(s string) *string { return &s }(""),
 				Port: func(i int32) *int32 { return &i }(8989),

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,9 +31,8 @@ import (
 	arinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
 	appv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
-	batchv1beta1informers "k8s.io/client-go/informers/batch/v1beta1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	discoveryinformers "k8s.io/client-go/informers/discovery/v1beta1"
+	discoveryinformers "k8s.io/client-go/informers/discovery/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
@@ -71,7 +69,7 @@ type API struct {
 	Client        kubernetes.Interface
 	DynamicClient dynamic.Interface
 
-	cj       batchv1beta1informers.CronJobInformer
+	cj       batchv1informers.CronJobInformer
 	cm       coreinformers.ConfigMapInformer
 	deploy   appv1informers.DeploymentInformer
 	ds       appv1informers.DaemonSetInformer
@@ -196,7 +194,7 @@ func NewAPI(
 	for _, resource := range resources {
 		switch resource {
 		case CJ:
-			api.cj = sharedInformers.Batch().V1beta1().CronJobs()
+			api.cj = sharedInformers.Batch().V1().CronJobs()
 			api.syncChecks = append(api.syncChecks, api.cj.Informer().HasSynced)
 			api.addInformerSizeGauge("cron_job", api.cj.Informer())
 		case CM:
@@ -216,7 +214,7 @@ func NewAPI(
 			api.syncChecks = append(api.syncChecks, api.endpoint.Informer().HasSynced)
 			api.addInformerSizeGauge("endpoint", api.endpoint.Informer())
 		case ES:
-			api.es = sharedInformers.Discovery().V1beta1().EndpointSlices()
+			api.es = sharedInformers.Discovery().V1().EndpointSlices()
 			api.syncChecks = append(api.syncChecks, api.es.Informer().HasSynced)
 			api.addInformerSizeGauge("endpoint_slice", api.es.Informer())
 		case Job:
@@ -441,7 +439,7 @@ func (api *API) Secret() coreinformers.SecretInformer {
 }
 
 // CJ provides access to a shared informer and lister for CronJobs.
-func (api *API) CJ() batchv1beta1informers.CronJobInformer {
+func (api *API) CJ() batchv1informers.CronJobInformer {
 	if api.cj == nil {
 		panic("CJ informer not configured")
 	}
@@ -580,7 +578,7 @@ func (api *API) GetPodsFor(obj runtime.Object, includeFailed bool) ([]*corev1.Po
 		namespace = typed.Name
 		selector = labels.Everything()
 
-	case *batchv1beta1.CronJob:
+	case *batchv1.CronJob:
 		namespace = typed.Namespace
 		selector = labels.Everything()
 		jobs, err := api.Job().Lister().Jobs(namespace).List(selector)
@@ -701,7 +699,7 @@ func GetNameAndNamespaceOf(obj runtime.Object) (string, string, error) {
 	case *corev1.Namespace:
 		return typed.Name, typed.Name, nil
 
-	case *batchv1beta1.CronJob:
+	case *batchv1.CronJob:
 		return typed.Name, typed.Namespace, nil
 
 	case *appsv1.DaemonSet:
@@ -954,16 +952,16 @@ func (api *API) getServices(namespace, name string) ([]runtime.Object, error) {
 
 func (api *API) getCronjobs(namespace, name string, labelSelector labels.Selector) ([]runtime.Object, error) {
 	var err error
-	var cronjobs []*batchv1beta1.CronJob
+	var cronjobs []*batchv1.CronJob
 
 	if namespace == "" {
 		cronjobs, err = api.CJ().Lister().List(labelSelector)
 	} else if name == "" {
 		cronjobs, err = api.CJ().Lister().CronJobs(namespace).List(labelSelector)
 	} else {
-		var cronjob *batchv1beta1.CronJob
+		var cronjob *batchv1.CronJob
 		cronjob, err = api.CJ().Lister().CronJobs(namespace).Get(name)
-		cronjobs = []*batchv1beta1.CronJob{cronjob}
+		cronjobs = []*batchv1.CronJob{cronjob}
 	}
 	if err != nil {
 		return nil, err

--- a/controller/k8s/api_test.go
+++ b/controller/k8s/api_test.go
@@ -200,14 +200,14 @@ metadata:
 				resType:   k8s.CronJob,
 				name:      "my-cronjob",
 				k8sResResults: []string{`
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: my-cronjob
   namespace: my-ns`,
 				},
 				k8sResMisc: []string{`
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: my-cronjob
@@ -499,7 +499,7 @@ status:
 			{
 				err: nil,
 				k8sResInput: `
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: emoji
@@ -527,7 +527,7 @@ metadata:
   namespace: emojivoto
   uid: job
   ownerReferences:
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     uid: cronjob
 spec:
   selector:
@@ -1066,7 +1066,7 @@ metadata:
   name: my-job
   namespace: my-ns
   ownerReferences:
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     kind: CronJob
     name: my-cronjob`,
 			},

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -11,7 +11,7 @@ OpenCensus and Jaeger.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -63,7 +63,7 @@ helm install linkerd-jaeger -n linkerd-jaeger --create-namespace linkerd/linkerd
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/linkerd-jaeger/README.md.gotmpl
+++ b/jaeger/charts/linkerd-jaeger/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/multicluster/charts/linkerd-multicluster-link/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   `cluster-credentials` secret and the Link CR, which are not found in this
   chart. Therefore this chart is not a replacement for that command, and
   shouldn't be used as-is unless you really know what you're doing ;-)
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd-multicluster-link"
 version: 0.1.1

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -15,7 +15,7 @@ shouldn't be used as-is unless you really know what you're doing ;-)
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -11,7 +11,7 @@ linking to remote clusters
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd-multicluster -n linkerd-multicluster --create-namespace lin
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster/README.md.gotmpl
+++ b/multicluster/charts/linkerd-multicluster/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -26,7 +26,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -492,7 +491,7 @@ func (conf *ResourceConfig) getFreshWorkloadObj() runtime.Object {
 	case k8s.Namespace:
 		return &corev1.Namespace{}
 	case k8s.CronJob:
-		return &batchv1beta1.CronJob{}
+		return &batchv1.CronJob{}
 	case k8s.Service:
 		return &corev1.Service{}
 	}
@@ -625,7 +624,7 @@ func (conf *ResourceConfig) parse(bytes []byte) error {
 			conf.workload.Meta.Annotations = map[string]string{}
 		}
 
-	case *batchv1beta1.CronJob:
+	case *batchv1.CronJob:
 		if err := yaml.Unmarshal(bytes, v); err != nil {
 			return err
 		}
@@ -811,7 +810,7 @@ func (conf *ResourceConfig) injectPodAnnotations(values *podPatch) {
 	// ObjectMetaAnnotations.Annotations is nil for new empty structs, but we always initialize
 	// it to an empty map in parse() above, so we follow suit here.
 	emptyMeta := &metav1.ObjectMeta{Annotations: map[string]string{}}
-	// Cronjobs in batch/v1beta1 might have an empty `spec.jobTemplate.spec.template.metadata`
+	// Cronjobs might have an empty `spec.jobTemplate.spec.template.metadata`
 	// field so we make sure to create it if needed, before attempting adding annotations
 	values.AddRootMetadata = reflect.DeepEqual(conf.pod.meta, emptyMeta)
 	values.AddRootAnnotations = len(conf.pod.meta.Annotations) == 0

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -27,7 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-var minAPIVersion = [3]int{1, 20, 0}
+var minAPIVersion = [3]int{1, 21, 0}
 
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
 // TODO: support ServiceProfile ClientSet. A prerequisite is moving the

--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	authV1 "k8s.io/api/authorization/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
@@ -149,7 +149,7 @@ func EndpointSliceAccess(ctx context.Context, k8sClient kubernetes.Interface) er
 }
 
 func checkEndpointSlicesExist(ctx context.Context, k8sClient kubernetes.Interface) error {
-	sliceList, err := k8sClient.DiscoveryV1beta1().EndpointSlices("").List(ctx, metav1.ListOptions{})
+	sliceList, err := k8sClient.DiscoveryV1().EndpointSlices("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -11,7 +11,7 @@ import (
 
 	spscheme "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/scheme"
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -95,7 +95,7 @@ func NewFakeClientSets(configs ...string) (
 		}
 	}
 
-	endpointslice, err := ToRuntimeObject(`apiVersion: discovery.k8s.io/v1beta1
+	endpointslice, err := ToRuntimeObject(`apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
   name: kubernetes

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -11,7 +11,7 @@ components for Linkerd.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -61,7 +61,7 @@ helm install linkerd-viz -n linkerd-viz --create-namespace linkerd/linkerd-viz
 
 ## Requirements
 
-Kubernetes: `>=1.20.0-0`
+Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/viz/charts/linkerd-viz/README.md.gotmpl
+++ b/viz/charts/linkerd-viz/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.20+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd


### PR DESCRIPTION
Fixes #8592

Increase the minimum supported kubernetes version from 1.20 to 1.21.  This allows us to drop support for batch/v1beta1/CronJob and discovery/v1beta1/EndpointSlices, instead using only v1 of those resources.  This fixes deprecation warnings about these warnings printed by the CLI.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
