### PR TITLE
Add retries to starting server watch in test

### DIFF
--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -330,9 +330,12 @@ async fn retry_watch_server(
     // policy.
     let mut policy_api = grpc::PolicyClient::port_forwarded(client).await;
     loop {
-        if let Ok(rx) = policy_api.watch_port(ns, pod_name, 4191).await {
-            return rx;
+        match policy_api.watch_port(ns, pod_name, 4191).await {
+            Ok(rx) => return rx,
+            Err(error) => {
+                tracing::error!(?error);
+                time::sleep(Duration::from_secs(1)).await;
+            }
         }
-        time::sleep(Duration::from_secs(1)).await;
     }
 }

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -333,7 +333,7 @@ async fn retry_watch_server(
         match policy_api.watch_port(ns, pod_name, 4191).await {
             Ok(rx) => return rx,
             Err(error) => {
-                tracing::error!(?error);
+                tracing::error!(?error, ns, pod_name, "failed to watch policy for port 4191");
                 time::sleep(Duration::from_secs(1)).await;
             }
         }

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -328,7 +328,7 @@ async fn retry_watch_server(
     // Port-forward to the control plane and start watching the pod's admin
     // server's policy and ensure that the first update uses the default
     // policy.
-    let mut policy_api = grpc::PolicyClient::port_forwarded(&client).await;
+    let mut policy_api = grpc::PolicyClient::port_forwarded(client).await;
     loop {
         if let Ok(rx) = policy_api.watch_port(ns, pod_name, 4191).await {
             return rx;

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::prelude::*;
 use kube::ResourceExt;
 use linkerd_policy_controller_core::{Ipv4Net, Ipv6Net};
@@ -19,14 +21,7 @@ async fn server_with_server_authorization() {
         let pod = create_ready_pod(&client, mk_pause(&ns, "pause")).await;
         tracing::trace!(?pod);
 
-        // Port-forward to the control plane and start watching the pod's admin
-        // server's policy and ensure that the first update uses the default
-        // policy.
-        let mut policy_api = grpc::PolicyClient::port_forwarded(&client).await;
-        let mut rx = policy_api
-            .watch_port(&ns, &pod.name(), 4191)
-            .await
-            .expect("failed to establish watch");
+        let mut rx = retry_watch_server(&client, &ns, &pod.name()).await;
         let config = rx
             .next()
             .await
@@ -160,14 +155,7 @@ async fn server_with_authorization_policy() {
         let pod = create_ready_pod(&client, mk_pause(&ns, "pause")).await;
         tracing::trace!(?pod);
 
-        // Port-forward to the control plane and start watching the pod's admin
-        // server's policy and ensure that the first update uses the default
-        // policy.
-        let mut policy_api = grpc::PolicyClient::port_forwarded(&client).await;
-        let mut rx = policy_api
-            .watch_port(&ns, &pod.name(), 4191)
-            .await
-            .expect("failed to establish watch");
+        let mut rx = retry_watch_server(&client, &ns, &pod.name()).await;
         let config = rx
             .next()
             .await
@@ -329,5 +317,22 @@ fn mk_admin_server(ns: &str, name: &str) -> k8s::policy::Server {
             port: k8s::policy::server::Port::Number(4191),
             proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
         },
+    }
+}
+
+async fn retry_watch_server(
+    client: &kube::Client,
+    ns: &str,
+    pod_name: &str,
+) -> tonic::Streaming<grpc::inbound::Server> {
+    // Port-forward to the control plane and start watching the pod's admin
+    // server's policy and ensure that the first update uses the default
+    // policy.
+    let mut policy_api = grpc::PolicyClient::port_forwarded(&client).await;
+    loop {
+        if let Ok(rx) = policy_api.watch_port(ns, pod_name, 4191).await {
+            return rx;
+        }
+        time::sleep(Duration::from_secs(1)).await;
     }
 }


### PR DESCRIPTION
We're sometimes hitting flakiness in the server_with_authorization_policy test: https://github.com/linkerd/linkerd2/runs/6887386256?check_suite_focus=true

My guess is that there's a race condition where we create a ready pod but try to start a watch on that pod's port before the policy control notices that the pod exists.

We add some retry logic to keep attempting to start the watch until it succeeds.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
