### PR TITLE
Use prommatch everywhere

### DIFF
--- a/test/integration/deep/localhost/localhost_test.go
+++ b/test/integration/deep/localhost/localhost_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
+	"github.com/linkerd/linkerd2/testutil/prommatch"
 )
 
 var TestHelper *testutil.TestHelper
@@ -19,6 +20,42 @@ func TestMain(m *testing.M) {
 	TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasEdge)
 	os.Exit(m.Run())
 }
+
+var (
+	nginxPodRE  = regexp.MustCompile(`nginx.*`)
+	nginxLabels = prommatch.Labels{
+		"direction":             prommatch.Equals("outbound"),
+		"authority":             prommatch.Equals("nginx.linkerd-localhost-test.svc.cluster.local:8080"),
+		"dst_deployment":        prommatch.Equals("nginx"),
+		"dst_namespace":         prommatch.Equals("linkerd-localhost-test"),
+		"dst_pod":               prommatch.Like(nginxPodRE),
+		"dst_pod_template_hash": prommatch.Any(),
+		"dst_service":           prommatch.Equals("nginx"),
+		"dst_serviceaccount":    prommatch.Equals("default"),
+	}
+	requestsToNGINXMatcher = prommatch.NewMatcher("request_total",
+		nginxLabels,
+		prommatch.HasPositiveValue(),
+	)
+	failedResponsesFromNGINXMatcher = prommatch.NewMatcher("response_total",
+		nginxLabels,
+		prommatch.Labels{
+			"classification": prommatch.Equals("failure"),
+		},
+		prommatch.HasPositiveValue(),
+	)
+	successResponsesMatcher = prommatch.NewMatcher("response_total",
+		prommatch.Labels{
+			"direction":      prommatch.Equals("outbound"),
+			"classification": prommatch.Equals("success"),
+		},
+		prommatch.HasPositiveValue(),
+	)
+	tcpOpenMatcher = prommatch.NewMatcher("tcp_open_connections",
+		nginxLabels,
+		prommatch.HasValueOf(0),
+	)
+)
 
 // TestLocalhostServer creates an nginx deployment which listens on localhost
 // and a slow-cooker which attempts to send traffic to the nginx.  Since
@@ -67,27 +104,14 @@ func TestLocalhostServer(t *testing.T) {
 					"unexpected diagnostics error: %s\n%s", err, out)
 			}
 
-			rpsRE := regexp.MustCompile(
-				`request_total\{direction="outbound",authority="nginx\.linkerd-localhost-test\.svc\.cluster\.local:8080",.*,dst_deployment="nginx",dst_namespace="linkerd-localhost-test",dst_pod="nginx.*",dst_pod_template_hash=".*",dst_service="nginx",dst_serviceaccount="default"\} [1-9]\d*`,
-			)
-			if !rpsRE.MatchString(metrics) {
-				return fmt.Errorf("expected non-zero RPS from slowcooker to nginx\nexpected: %s, got: %s", rpsRE, metrics)
-			}
+			m := prommatch.Suite{}.
+				MustContain("requests from slowcooker to nginx", requestsToNGINXMatcher).
+				MustContain("failed responses returned to slowcooker from nginx", failedResponsesFromNGINXMatcher).
+				MustNotContain("success responses returned to slowcooker from nginx", successResponsesMatcher).
+				MustContain("zero open tcp connections to nginx", tcpOpenMatcher)
 
-			// Requests sent to a port which is only bound to localhost should
-			// fail.
-			successRE := regexp.MustCompile(
-				`response_total\{direction="outbound",authority="nginx\.linkerd-localhost-test\.svc\.cluster\.local:8080",.*,classification="success"\} [1-9]\d*`,
-			)
-			if successRE.MatchString(metrics) {
-				return fmt.Errorf("expected zero success-rate from slowcooker to nginx\nexpected: %s, got: %s", successRE, metrics)
-			}
-
-			tcpConnRE := regexp.MustCompile(
-				`tcp_open_connections\{direction="outbound",peer="dst",authority="nginx\.linkerd-localhost-test\.svc\.cluster\.local:8080",.*\} 0`,
-			)
-			if !tcpConnRE.MatchString(metrics) {
-				return fmt.Errorf("expected no tcp connections from slowcooker to nginx\nexpected: %s, got: %s", tcpConnRE, metrics)
+			if err := m.CheckString(metrics); err != nil {
+				return fmt.Errorf("metrics check failed: %w", err)
 			}
 
 			return nil

--- a/test/integration/deep/opaqueports/assertions.go
+++ b/test/integration/deep/opaqueports/assertions.go
@@ -8,8 +8,6 @@ import (
 )
 
 var (
-	addrRE      = regexp.MustCompile(`[0-9\.]+:[0-9]+`)
-	ipRE        = regexp.MustCompile(`[0-9\.]+`)
 	authorityRE = regexp.MustCompile(`[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+`)
 )
 
@@ -41,13 +39,12 @@ func hasNoOutboundHTTPRequest(metrics, ns string) error {
 func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
 	m := prommatch.NewMatcher("request_total", prommatch.Labels{
 		"direction":          prommatch.Equals("outbound"),
-		"target_addr":        prommatch.Like(addrRE),
-		"target_ip":          prommatch.Like(ipRE),
 		"tls":                prommatch.Equals("true"),
 		"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
 		"dst_namespace":      prommatch.Equals(ns),
 		"dst_serviceaccount": prommatch.Equals("default"),
 	},
+		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
@@ -72,13 +69,12 @@ func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
 func hasOutboundHTTPRequestNoTLS(metrics, ns string) error {
 	m := prommatch.NewMatcher("request_total", prommatch.Labels{
 		"direction":          prommatch.Equals("outbound"),
-		"target_addr":        prommatch.Like(addrRE),
-		"target_ip":          prommatch.Like(ipRE),
 		"tls":                prommatch.Equals("no_identity"),
 		"no_tls_reason":      prommatch.Equals("not_provided_by_service_discovery"),
 		"dst_namespace":      prommatch.Equals(ns),
 		"dst_serviceaccount": prommatch.Equals("default"),
 	},
+		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
@@ -105,15 +101,14 @@ func hasInboundTCPTrafficWithTLS(metrics, ns string) error {
 	m := prommatch.NewMatcher(
 		"tcp_open_total",
 		prommatch.Labels{
-			"direction":   prommatch.Equals("inbound"),
-			"peer":        prommatch.Equals("src"),
-			"tls":         prommatch.Equals("true"),
-			"client_id":   prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
-			"srv_kind":    prommatch.Equals("default"),
-			"srv_name":    prommatch.Equals("all-unauthenticated"),
-			"target_addr": prommatch.Like(addrRE),
-			"target_ip":   prommatch.Like(ipRE),
+			"direction": prommatch.Equals("inbound"),
+			"peer":      prommatch.Equals("src"),
+			"tls":       prommatch.Equals("true"),
+			"client_id": prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"srv_kind":  prommatch.Equals("default"),
+			"srv_name":  prommatch.Equals("all-unauthenticated"),
 		},
+		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue(),
 	)
 	ok, err := m.HasMatchInString(metrics)
@@ -189,12 +184,12 @@ func hasOutboundTCPWithNoTLSAndNoAuthority(metrics, ns string) error {
 // }
 func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
 	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction":   prommatch.Equals("outbound"),
-		"peer":        prommatch.Equals("dst"),
-		"tls":         prommatch.Equals("true"),
-		"target_addr": prommatch.Like(addrRE),
-		"authority":   prommatch.Like(authorityRE),
+		"direction": prommatch.Equals("outbound"),
+		"peer":      prommatch.Equals("dst"),
+		"tls":       prommatch.Equals("true"),
+		"authority": prommatch.Like(authorityRE),
 	},
+		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
@@ -216,12 +211,12 @@ func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
 // }
 func hasOutboundTCPWithTLSAndNoAuthority(metrics, ns string) error {
 	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction":   prommatch.Equals("outbound"),
-		"peer":        prommatch.Equals("dst"),
-		"tls":         prommatch.Equals("true"),
-		"target_addr": prommatch.Like(addrRE),
-		"authority":   prommatch.Absent(),
+		"direction": prommatch.Equals("outbound"),
+		"peer":      prommatch.Equals("dst"),
+		"tls":       prommatch.Equals("true"),
+		"authority": prommatch.Absent(),
 	},
+		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {

--- a/test/integration/deep/opaqueports/assertions.go
+++ b/test/integration/deep/opaqueports/assertions.go
@@ -14,9 +14,10 @@ var (
 // hasNoOutboundHTTPRequest returns error if there is any
 // series matching request_total{direction="outbound"}
 func hasNoOutboundHTTPRequest(metrics, ns string) error {
-	m := prommatch.NewMatcher("request_total", prommatch.Labels{
-		"direction": prommatch.Equals("outbound"),
-	})
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+		})
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
 		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
@@ -37,13 +38,14 @@ func hasNoOutboundHTTPRequest(metrics, ns string) error {
 //   dst_serviceaccount="default"
 // }
 func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
-	m := prommatch.NewMatcher("request_total", prommatch.Labels{
-		"direction":          prommatch.Equals("outbound"),
-		"tls":                prommatch.Equals("true"),
-		"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
-		"dst_namespace":      prommatch.Equals(ns),
-		"dst_serviceaccount": prommatch.Equals("default"),
-	},
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("true"),
+			"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
 		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
@@ -67,13 +69,14 @@ func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
 //   dst_serviceaccount="default"
 // }
 func hasOutboundHTTPRequestNoTLS(metrics, ns string) error {
-	m := prommatch.NewMatcher("request_total", prommatch.Labels{
-		"direction":          prommatch.Equals("outbound"),
-		"tls":                prommatch.Equals("no_identity"),
-		"no_tls_reason":      prommatch.Equals("not_provided_by_service_discovery"),
-		"dst_namespace":      prommatch.Equals(ns),
-		"dst_serviceaccount": prommatch.Equals("default"),
-	},
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("no_identity"),
+			"no_tls_reason":      prommatch.Equals("not_provided_by_service_discovery"),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
 		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
@@ -130,13 +133,14 @@ func hasInboundTCPTrafficWithTLS(metrics, ns string) error {
 //   authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
 // }
 func hasOutboundTCPWithAuthorityAndNoTLS(metrics, ns string) error {
-	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction":     prommatch.Equals("outbound"),
-		"peer":          prommatch.Equals("dst"),
-		"tls":           prommatch.Equals("no_identity"),
-		"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
-		"authority":     prommatch.Like(authorityRE),
-	},
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Like(authorityRE),
+		},
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
@@ -157,13 +161,14 @@ func hasOutboundTCPWithAuthorityAndNoTLS(metrics, ns string) error {
 //   authority=""
 // }
 func hasOutboundTCPWithNoTLSAndNoAuthority(metrics, ns string) error {
-	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction":     prommatch.Equals("outbound"),
-		"peer":          prommatch.Equals("dst"),
-		"tls":           prommatch.Equals("no_identity"),
-		"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
-		"authority":     prommatch.Absent(),
-	})
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Absent(),
+		})
 	ok, err := m.HasMatchInString(metrics)
 	if err != nil {
 		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
@@ -183,12 +188,13 @@ func hasOutboundTCPWithNoTLSAndNoAuthority(metrics, ns string) error {
 //   authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
 // }
 func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
-	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction": prommatch.Equals("outbound"),
-		"peer":      prommatch.Equals("dst"),
-		"tls":       prommatch.Equals("true"),
-		"authority": prommatch.Like(authorityRE),
-	},
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Like(authorityRE),
+		},
 		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)
@@ -210,12 +216,13 @@ func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
 //   authority=""
 // }
 func hasOutboundTCPWithTLSAndNoAuthority(metrics, ns string) error {
-	m := prommatch.NewMatcher("tcp_open_total", prommatch.Labels{
-		"direction": prommatch.Equals("outbound"),
-		"peer":      prommatch.Equals("dst"),
-		"tls":       prommatch.Equals("true"),
-		"authority": prommatch.Absent(),
-	},
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Absent(),
+		},
 		prommatch.TargetAddrLabels(),
 		prommatch.HasPositiveValue())
 	ok, err := m.HasMatchInString(metrics)

--- a/test/integration/deep/skipports/skip_ports_test.go
+++ b/test/integration/deep/skipports/skip_ports_test.go
@@ -4,22 +4,35 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 	"testing"
 	"time"
 
 	"github.com/linkerd/linkerd2/testutil"
+	"github.com/linkerd/linkerd2/testutil/prommatch"
 )
 
 var TestHelper *testutil.TestHelper
 
 var (
-	skipPortsNs               = "skip-ports-test"
-	booksappDeployments       = []string{"books", "traffic", "authors", "webapp"}
-	httpResponseTotalMetricRE = regexp.MustCompile(
-		`route_response_total\{direction="outbound",dst="books\.skip-ports-test\.svc\.cluster\.local:7002",classification="failure".*`,
-	)
+	skipPortsNs         = "skip-ports-test"
+	booksappDeployments = []string{"books", "traffic", "authors", "webapp"}
 )
+
+func secureRequestMatcher(dst string) *prommatch.Matcher {
+	return prommatch.NewMatcher("request_total", prommatch.Labels{
+		"direction":   prommatch.Equals("outbound"),
+		"tls":         prommatch.Equals("true"),
+		"dst_service": prommatch.Equals(dst),
+	})
+}
+
+func insecureRequestMatcher(dst string) *prommatch.Matcher {
+	return prommatch.NewMatcher("request_total", prommatch.Labels{
+		"direction":   prommatch.Equals("outbound"),
+		"tls":         prommatch.Equals("no_identity"),
+		"dst_service": prommatch.Equals(dst),
+	})
+}
 
 func TestMain(m *testing.M) {
 	TestHelper = testutil.NewTestHelper()
@@ -62,7 +75,7 @@ func TestSkipInboundPorts(t *testing.T) {
 			}
 		}
 
-		t.Run("expect webapp to not have any 5xx response errors", func(t *testing.T) {
+		t.Run("check webapp metrics", func(t *testing.T) {
 			// Wait for slow-cookers to start sending requests by using a short
 			// time window through RetryFor.
 			err := TestHelper.RetryFor(30*time.Second, func() error {
@@ -78,11 +91,14 @@ func TestSkipInboundPorts(t *testing.T) {
 				if err != nil {
 					return fmt.Errorf("error getting metrics for pod\n%w", err)
 				}
-
-				if httpResponseTotalMetricRE.MatchString(metrics) {
-					return fmt.Errorf("expected not to find HTTP outbound requests when pod is skipping inbound port\n%s", metrics)
+				s := prommatch.Suite{}.
+					MustContain("secure requests to authors", secureRequestMatcher("authors")).
+					MustContain("insecure requests to books", insecureRequestMatcher("books")).
+					MustNotContain("insecure requests to authors", insecureRequestMatcher("authors")).
+					MustNotContain("secure requests to books", secureRequestMatcher("books"))
+				if err := s.CheckString(metrics); err != nil {
+					return fmt.Errorf("error matching metrics\n%w", err)
 				}
-
 				return nil
 			})
 

--- a/test/integration/deep/skipports/skip_ports_test.go
+++ b/test/integration/deep/skipports/skip_ports_test.go
@@ -19,19 +19,21 @@ var (
 )
 
 func secureRequestMatcher(dst string) *prommatch.Matcher {
-	return prommatch.NewMatcher("request_total", prommatch.Labels{
-		"direction":   prommatch.Equals("outbound"),
-		"tls":         prommatch.Equals("true"),
-		"dst_service": prommatch.Equals(dst),
-	})
+	return prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":   prommatch.Equals("outbound"),
+			"tls":         prommatch.Equals("true"),
+			"dst_service": prommatch.Equals(dst),
+		})
 }
 
 func insecureRequestMatcher(dst string) *prommatch.Matcher {
-	return prommatch.NewMatcher("request_total", prommatch.Labels{
-		"direction":   prommatch.Equals("outbound"),
-		"tls":         prommatch.Equals("no_identity"),
-		"dst_service": prommatch.Equals(dst),
-	})
+	return prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":   prommatch.Equals("outbound"),
+			"tls":         prommatch.Equals("no_identity"),
+			"dst_service": prommatch.Equals(dst),
+		})
 }
 
 func TestMain(m *testing.M) {

--- a/testutil/prommatch/common.go
+++ b/testutil/prommatch/common.go
@@ -1,0 +1,18 @@
+package prommatch
+
+import "regexp"
+
+var (
+	addressRe = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+`)
+	iPRe      = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+	portRe    = regexp.MustCompile(`\d+`)
+)
+
+// TargetAddrLabels match series with proper target_addr, target_port, and target_ip.
+func TargetAddrLabels() Labels {
+	return Labels{
+		"target_addr": Like(addressRe),
+		"target_ip":   Like(iPRe),
+		"target_port": Like(portRe),
+	}
+}

--- a/testutil/prommatch/prommatch.go
+++ b/testutil/prommatch/prommatch.go
@@ -118,10 +118,24 @@ func Absent() LabelMatcher {
 	}
 }
 
+// Any is when you want to select a series which has a certain label, but don't care about the value.
+func Any() LabelMatcher {
+	return func(s string) bool {
+		return s != ""
+	}
+}
+
 // HasValueLike is used for selecting time series based on value.
 func HasValueLike(f func(float64) bool) Expression {
 	return funcMatcher(func(sp *model.Sample) bool {
 		return f(float64(sp.Value))
+	})
+}
+
+// HasValueOf is used for selecting time series based on a specific value.
+func HasValueOf(f float64) Expression {
+	return funcMatcher(func(sp *model.Sample) bool {
+		return f == float64(sp.Value)
 	})
 }
 

--- a/testutil/prommatch/suite.go
+++ b/testutil/prommatch/suite.go
@@ -1,0 +1,49 @@
+package prommatch
+
+import (
+	"fmt"
+)
+
+type matcherAndMessage struct {
+	matcher *Matcher
+	message string
+	present bool
+}
+
+// Suite is a list of matchers and messages to check against a string of metrics.
+type Suite []matcherAndMessage
+
+// MustContain a series which will match the provided matcher.
+func (ms Suite) MustContain(message string, m *Matcher) Suite {
+	return append(ms, matcherAndMessage{
+		matcher: m,
+		message: message,
+		present: true,
+	})
+}
+
+// MustNotContain a series which will match the provided matcher.
+func (ms Suite) MustNotContain(message string, m *Matcher) Suite {
+	return append(ms, matcherAndMessage{
+		matcher: m,
+		message: message,
+		present: false,
+	})
+}
+
+// CheckString will run each assertion in the suite against the provided metrics.
+func (ms Suite) CheckString(metrics string) error {
+	for _, m := range ms {
+		ok, err := m.matcher.HasMatchInString(metrics)
+		if err != nil {
+			return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+		}
+		if m.present && !ok {
+			return fmt.Errorf("expected to find %s\n%s", m.message, metrics)
+		}
+		if !m.present && ok {
+			return fmt.Errorf("expected not to find %s\n%s", m.message, metrics)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Introduce prommatch.Suite to simplify checking against multiple matchers. Also, added labels for a common scenario of target_addr