### PR TITLE
Pin cosign-installer to `v1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         docker-ghcr-pat: ${{ secrets.DOCKER_GHCR_PAT }}
         component: ${{ matrix.component }}
     - name: Install Cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@v1
     - name: Sign the images with Cosign
       env:
         COSIGN_EXPERIMENTAL: 1
@@ -98,7 +98,7 @@ jobs:
         arch: ${{ matrix.arch }}
         tag: ${{ env.TAG }}
     - name: Install Cosign
-      uses: sigstore/cosign-installer@main
+      uses: sigstore/cosign-installer@v1
     - name: Sign the image with Cosign
       env:
         COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
We now have tags available in the cosign-installer, which allows us to pin the latest release via `v1`.
