### PR TITLE
dev: Update to use Kubernetes v1.24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,13 +30,13 @@ RUN scurl -vo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/downlo
     && chmod +x /usr/local/bin/yq
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as kubectl
-ARG KUBECTL_VERSION=v1.23.6
+ARG KUBECTL_VERSION=v1.24.2
 COPY bin/scurl /usr/local/bin/scurl
 RUN scurl -vo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
     && chmod 755 /usr/local/bin/kubectl
 
 FROM docker.io/golang:${GO_VERSION}-bullseye as k3d
-ARG K3D_VERSION=v5.4.1
+ARG K3D_VERSION=v5.4.3
 COPY bin/scurl /usr/local/bin/scurl
 RUN scurl -v https://raw.githubusercontent.com/rancher/k3d/$K3D_VERSION/install.sh \
     | USE_SUDO=false K3D_INSTALL_DIR=/usr/local/bin bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v16",
+    "image": "ghcr.io/linkerd/dev:v17",
     // "dockerFile": "./Dockerfile",
     // "context": "..",
     "extensions": [
@@ -18,8 +18,8 @@
     "runArgs": [
         "--init",
         // Limit container memory usage.
-        "--memory=8g",
-        "--memory-swap=8g",
+        "--memory=12g",
+        "--memory-swap=12g",
         // Use the host network so we can access k3d, etc.
         "--net=host",
         // For lldb

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -19,7 +19,7 @@ permissions:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  K3D_VERSION: v5.4.1
+  K3D_VERSION: v5.4.3
   PROTOC_NO_VENDOR: 1
   PROXY_INIT_VERSION: v1.5.3
   RUST_BACKTRACE: short
@@ -99,7 +99,7 @@ jobs:
       matrix:
         k8s:
           - v1.21
-          - v1.23
+          - latest # v1.24 isn't yet its own channel https://github.com/k3s-io/k3s/issues/5746
     name: Policy controller integration (k8s ${{ matrix.k8s }})
 
     needs: [docker-build, integration-build]

--- a/bin/k3d
+++ b/bin/k3d
@@ -2,7 +2,7 @@
 
 set -eu
 
-K3D_VERSION=v5.4.1
+K3D_VERSION=v5.4.3
 
 bindir=$( cd "${0%/*}" && pwd )
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin

--- a/policy-test/README.md
+++ b/policy-test/README.md
@@ -29,6 +29,7 @@ with:
     wait && \
     bin/image-load --k3d policy-controller controller proxy && \
     rm -rf target/cli && \
+    bin/linkerd install --crds | kubectl apply -f - && \
     bin/linkerd install --set 'policyController.logLevel=info\,linkerd=trace\,kubert=trace' \
         | kubectl apply -f -
 ```

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -169,39 +169,14 @@ where
     }
 }
 
-pub async fn await_service_account(client: &kube::Client, ns: &str, name: &str) {
-    use futures::StreamExt;
-    let secret_name = await_service_account_secret(client, ns, name).await;
-
-    tracing::trace!(name = %secret_name, "Waiting for secret");
-    tokio::pin! {
-        let secrets = kube::runtime::watcher(
-            kube::Api::<k8s::api::core::v1::Secret>::namespaced(client.clone(), ns),
-            kube::api::ListParams::default().fields(&format!("metadata.name={}", secret_name)),
-        );
-    }
-    loop {
-        match secrets
-            .next()
-            .await
-            .expect("secret watch must not end")
-            .expect("secret watch must not fail")
-        {
-            kube::runtime::watcher::Event::Restarted(secrets) if !secrets.is_empty() => break,
-            kube::runtime::watcher::Event::Applied(_) => break,
-            _ => {}
-        }
-    }
-}
-
-async fn await_service_account_secret(client: &kube::Client, ns: &str, name: &str) -> String {
+async fn await_service_account(client: &kube::Client, ns: &str, name: &str) {
     use futures::StreamExt;
 
-    tracing::trace!(%name, "Waiting for serviceaccount");
+    tracing::trace!(%name, %ns, "Waiting for serviceaccount");
     tokio::pin! {
         let sas = kube::runtime::watcher(
             kube::Api::<k8s::ServiceAccount>::namespaced(client.clone(), ns),
-            kube::api::ListParams::default().fields(&format!("metadata.name={}", name)),
+            kube::api::ListParams::default(),
         );
     }
     loop {
@@ -213,24 +188,22 @@ async fn await_service_account_secret(client: &kube::Client, ns: &str, name: &st
         tracing::info!(?ev);
         match ev {
             kube::runtime::watcher::Event::Restarted(sas) => {
-                if let Some(sa) = sas.get(0) {
-                    if let Some(sec) = sa.secrets.iter().flatten().next() {
-                        if let Some(name) = sec.name.as_ref() {
-                            return name.clone();
-                        }
-                    }
+                if sas.iter().any(|sa| sa.name() == name) {
+                    return;
                 }
             }
             kube::runtime::watcher::Event::Applied(sa) => {
-                if let Some(sec) = sa.secrets.iter().flatten().next() {
-                    if let Some(name) = sec.name.as_ref() {
-                        return name.clone();
-                    }
+                if sa.name() == name {
+                    return;
                 }
             }
             _ => {}
         }
     }
+
+    // XXX In some versions of k8s, it may be appropriate to wait for the
+    // ServiceAccount's secret to be created, but, as of v1.24,
+    // ServiceAccounts don't have secrets.
 }
 
 pub fn random_suffix(len: usize) -> String {
@@ -248,8 +221,11 @@ fn init_tracing() -> tracing::subscriber::DefaultGuard {
         tracing_subscriber::fmt()
             .with_test_writer()
             .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "trace,hyper=info,kube=info,h2=info".parse().unwrap()),
+                tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                    "trace,tower=info,hyper=info,kube=info,h2=info"
+                        .parse()
+                        .unwrap()
+                }),
             )
             .finish(),
     )


### PR DESCRIPTION
Kubernetes v1.24 is the latest stable release. This change updates
`kubectl` and `k3d`. The policy controller test is updated to use the
`latest` channel, since [v1.24 doesn't yet have its own channel][k3s].

[k3s]: https://github.com/k3s-io/k3s/issues/5746

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
