### PR TITLE
Allow AuthorizationPolicys to reference ServiceAccounts

### DIFF
--- a/policy-controller/k8s/index/src/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/authorization_policy.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use linkerd_policy_controller_k8s_api::{
     self as k8s,
     policy::{LocalTargetRef, NamespacedTargetRef},
+    ServiceAccount,
 };
 
 #[derive(Debug, PartialEq)]
@@ -23,6 +24,10 @@ pub(crate) enum AuthenticationTarget {
         name: String,
     },
     Network {
+        namespace: Option<String>,
+        name: String,
+    },
+    ServiceAccount {
         namespace: Option<String>,
         name: String,
     },
@@ -72,6 +77,11 @@ fn authentication_ref(t: NamespacedTargetRef) -> Result<AuthenticationTarget> {
         })
     } else if t.targets_kind::<k8s::policy::NetworkAuthentication>() {
         Ok(AuthenticationTarget::Network {
+            namespace: t.namespace.map(Into::into),
+            name: t.name,
+        })
+    } else if t.targets_kind::<ServiceAccount>() {
+        Ok(AuthenticationTarget::ServiceAccount {
             namespace: t.namespace.map(Into::into),
             name: t.name,
         })

--- a/policy-controller/k8s/index/src/index.rs
+++ b/policy-controller/k8s/index/src/index.rs
@@ -1120,6 +1120,22 @@ impl PolicyIndex {
                 );
             }
         }
+        for tgt in spec.authentications.iter() {
+            if let AuthenticationTarget::ServiceAccount {
+                ref namespace,
+                ref name,
+            } = tgt
+            {
+                // There can only be a single required ServiceAccount. This is
+                // enforced by the admission controller.
+                if identities.is_some() {
+                    bail!("policy must not include multiple ServiceAccounts");
+                }
+                let namespace = namespace.as_deref().unwrap_or(&self.namespace);
+                let id = self.cluster_info.service_account_identity(namespace, name);
+                identities = Some(vec![IdentityMatch::Exact(id)])
+            }
+        }
 
         let mut networks = None;
         for tgt in spec.authentications.iter() {

--- a/policy-controller/k8s/index/src/index.rs
+++ b/policy-controller/k8s/index/src/index.rs
@@ -1100,7 +1100,8 @@ impl PolicyIndex {
                     ref name,
                 } => {
                     let namespace = namespace.as_deref().unwrap_or(&self.namespace);
-                    tracing::trace!(ns = %namespace, %name, "Finding NetworkAuthentication");
+                    let _span = tracing::trace_span!("network", ns = %namespace, %name).entered();
+                    tracing::trace!("Finding NetworkAuthentication...");
                     let authn = all_authentications
                         .by_ns
                         .get(namespace)
@@ -1112,7 +1113,7 @@ impl PolicyIndex {
                                 namespace
                             )
                         })?;
-                    tracing::trace!(ns = %namespace, %name, nets = ?authn.matches, "Found NetworkAuthentication");
+                    tracing::trace!(nets = ?authn.matches, "Found NetworkAuthentication");
                     if networks.is_some() {
                         bail!("policy must not include multiple NetworkAuthentications");
                     }
@@ -1125,7 +1126,8 @@ impl PolicyIndex {
                     ref name,
                 } => {
                     let namespace = namespace.as_deref().unwrap_or(&self.namespace);
-                    tracing::trace!(ns = %namespace, %name, "Finding MeshTLSAuthentication");
+                    let _span = tracing::trace_span!("mesh_tls", ns = %namespace, %name).entered();
+                    tracing::trace!("Finding MeshTLSAuthentication...");
                     let authn = all_authentications
                         .by_ns
                         .get(namespace)
@@ -1137,7 +1139,7 @@ impl PolicyIndex {
                                 namespace
                             )
                         })?;
-                    tracing::trace!(ns = %namespace, %name, ids = ?authn.matches, "Found MeshTLSAuthentication");
+                    tracing::trace!(ids = ?authn.matches, "Found MeshTLSAuthentication");
                     if identities.is_some() {
                         bail!("policy must not include multiple MeshTLSAuthentications");
                     }

--- a/policy-controller/k8s/index/src/index.rs
+++ b/policy-controller/k8s/index/src/index.rs
@@ -1118,7 +1118,6 @@ impl PolicyIndex {
                     }
                     let ids = authn.matches.clone();
                     identities = Some(ids);
-                    continue;
                 }
                 AuthenticationTarget::ServiceAccount {
                     ref namespace,

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -227,6 +227,10 @@ impl Validate<AuthorizationPolicySpec> for Admission {
             bail!("only a single ServiceAccount may be set");
         }
 
+        if mtls_authns_count + sa_authns_count > 1 {
+            bail!("a MeshTLSAuthentication and ServiceAccount may not be set together");
+        }
+
         let net_authns_count = spec
             .required_authentication_refs
             .iter()
@@ -234,10 +238,6 @@ impl Validate<AuthorizationPolicySpec> for Admission {
             .count();
         if net_authns_count > 1 {
             bail!("only a single NetworkAuthentication may be set");
-        }
-
-        if mtls_authns_count + sa_authns_count > 1 {
-            bail!("only MeshTLSAuthentication or ServiceAccount may be set");
         }
 
         if mtls_authns_count + sa_authns_count + net_authns_count


### PR DESCRIPTION
Closes #8565.

With this change, AuthorizationPolicys can now reference ServiceAccounts for their target authentications. This allows users to avoid the requirement of creating  a MeshTLSAuthentication resource that references a single ServiceAccount.

The policy admission controller only allows an AuthorizationPolicy to reference a single MeshTLSAuthentication _or_ a ServiceAccount; it cannot reference both. Additionally, if a ServiceAccount is reference it can onl be a single one — similar to MeshTLSAuthentications.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>