### PR TITLE
Add DOCKER_BUILDX_CACHE path to release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,8 @@ jobs:
       # so we manually do that to avoid bloating the cache
       shell: bash
       run: bin/docker-cache-prune
+      env:
+        DOCKER_BUILDKIT_CACHE: "${{ runner.temp }}/.buildx-cache"
 
   policy_controller_manifest:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Currently, when rust code is built, we use a GitHub action that calls
the relevant scripts and logic to build images. The last step when
building an image in the release workflow is to prune the cache layers.

The script that prunes layers expects to have an environment variable
set with the path of the docker cache. During a refactor, we changed how
env variables are set for rust builds and the environment variable is no
longer set. This change adds the cache path to the prune step; missing
path results in errors when attempting to read from an inexistent file.

Signed-off-by: Matei David <matei@buoyant.io>

Current release run:

```
Run bin/docker-cache-prune

  bin/docker-cache-prune
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_ANNOTATION: true
    DOCKER_REGISTRY: ghcr.io/linkerd
    TAG: edge-22.6.2
```

Previous run, that worked:

```
  bin/docker-cache-prune
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_ANNOTATION: true
    DOCKER_REGISTRY: ghcr.io/linkerd
    TAG: edge-22.6.1
    DOCKER_BUILDKIT_CACHE: /home/runner/work/_temp/.buildx-cache
```

We seem to be missing the cache path, which in turn hits us with:

```
bin/docker-cache-prune: line 10: /index.json: No such file or directory
[9](https://github.com/linkerd/linkerd2/runs/6973063693?check_suite_focus=true#step:7:10)
Error: Process completed with exit code 1.
```

Run: https://github.com/linkerd/linkerd2/runs/6973063693?check_suite_focus=true
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
