### PR TITLE
Instantiate the RemoteClusterWatcher with gatewayAlive=true (#8590)

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -196,6 +196,8 @@ func NewRemoteClusterServiceWatcher(
 		repairPeriod:            repairPeriod,
 		liveness:                liveness,
 		headlessServicesEnabled: enableHeadlessSvc,
+		// always instantiate the gatewayAlive=true to prevent unexpected service fail fast
+		gatewayAlive: true,
 	}, nil
 }
 


### PR DESCRIPTION
If we don't instantiate the RemoteClusterWatcher
with gatewayAlive=true, then there will be a small
period all services will fail fast unexpectedly.

Simply Instantiate the RemoteClusterWatcher with
gatewayAlive=true.

Fix#8590

Signed-off-by: Ao Chen <chenao3220@gmail.com>
