### PR TITLE
Add correct match properties to link CRD to fix mirroring

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
@@ -52,6 +52,9 @@ spec:
                 description: Kubernetes Label Selector
                 type: object
                 properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   matchExpressions:
                     description: List of selector requirements
                     type: array
@@ -68,6 +71,11 @@ spec:
                         operator:
                           description: Evaluation of a label in relation to set
                           type: string
+                          enum: [In, NotIn, Exists, DoesNotExist]
+                        values:
+                          type: array
+                          items:
+                            type: string
               targetClusterName:
                 description: Name of target cluster to link to
                 type: string

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -378,7 +378,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 		dockerRegistry:          defaultDockerRegistry,
 		serviceMirrorRetryLimit: defaults.ServiceMirrorRetryLimit,
 		logLevel:                defaults.LogLevel,
-		selector:                k8s.DefaultExportedServiceSelector,
+		selector:                fmt.Sprintf("%s=%s", k8s.DefaultExportedServiceSelector, "true"),
 		gatewayAddresses:        "",
 		gatewayPort:             0,
 	}, nil

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -302,6 +302,9 @@ spec:
                 description: Kubernetes Label Selector
                 type: object
                 properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   matchExpressions:
                     description: List of selector requirements
                     type: array
@@ -318,6 +321,11 @@ spec:
                         operator:
                           description: Evaluation of a label in relation to set
                           type: string
+                          enum: [In, NotIn, Exists, DoesNotExist]
+                        values:
+                          type: array
+                          items:
+                            type: string
               targetClusterName:
                 description: Name of target cluster to link to
                 type: string

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -370,6 +370,9 @@ spec:
                 description: Kubernetes Label Selector
                 type: object
                 properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   matchExpressions:
                     description: List of selector requirements
                     type: array
@@ -386,6 +389,11 @@ spec:
                         operator:
                           description: Evaluation of a label in relation to set
                           type: string
+                          enum: [In, NotIn, Exists, DoesNotExist]
+                        values:
+                          type: array
+                          items:
+                            type: string
               targetClusterName:
                 description: Name of target cluster to link to
                 type: string

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -333,6 +333,9 @@ spec:
                 description: Kubernetes Label Selector
                 type: object
                 properties:
+                  matchLabels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   matchExpressions:
                     description: List of selector requirements
                     type: array
@@ -349,6 +352,11 @@ spec:
                         operator:
                           description: Evaluation of a label in relation to set
                           type: string
+                          enum: [In, NotIn, Exists, DoesNotExist]
+                        values:
+                          type: array
+                          items:
+                            type: string
               targetClusterName:
                 description: Name of target cluster to link to
                 type: string


### PR DESCRIPTION
The Link created by `linkerd multicluster link` has a match expression that checks for the existance of the `mirror.linkerd.io/exported` label on services; if the label exists then the service is mirrored. This is not always correct because if `mirror.linkerd.io/exported: false`, the service mirror still mirrors the service even though it should not.

The fix for this was not related to label matching — it is already handled correctly. What needed to be fixed was the actual Link CRD to allow for `matchLabels` and `matchExpressions.values`.

The default `matchLabel` is now `mirror.linkerd.io/exported: "true"` as changed in `newLinkOptionsWithDefault`.

Users can now also properly set match properties with the `-l` flag. Before these resulted in parsing errors since the Link CRD did not support these properly

```shell
$ bin/linkerd --context k3d-x multicluster link --cluster-name k3d-x -l 'mirror.linkerd.io/exported in (true)' |kubectl --context k3d-y apply -f -
...
$ bin/linkerd --context k3d-x mc link --cluster-name k3d-x --api-server-address https://172.18.0.3:6443 -l 'foo.bar=mirror-me' > link-x.yaml
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
