### PR TITLE
Allow disabling `linkerd-await` on control plane pods

### DIFF
--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.5.4-edge
+version: 1.6.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.5.4-edge](https://img.shields.io/badge/Version-1.5.4--edge-informational?style=flat-square)
+![Version: 1.6.0-edge](https://img.shields.io/badge/Version-1.6.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -173,7 +173,7 @@ spec:
       {{- $r := merge .Values.destinationProxyResources .Values.proxy.resources }}
       {{- $_ := set $tree.Values.proxy "resources" $r }}
       {{- end }}
-      {{- $_ := set $tree.Values.proxy "await" true }}
+      {{- $_ := set $tree.Values.proxy "await" $tree.Values.proxy.await }}
       {{- $_ := set $tree.Values.proxy "loadTrustBundleFromConfigMap" true }}
       {{- $_ := set $tree.Values.proxy "podInboundPorts" "8086,8090,8443,9443,9990,9996,9997" }}
       {{- /*

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -59,7 +59,7 @@ spec:
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.proxy.resources }}
       {{- $_ := set $tree.Values.proxy "resources" $r }}
       {{- end }}
-      {{- $_ := set $tree.Values.proxy "await" true }}
+      {{- $_ := set $tree.Values.proxy "await" $tree.Values.proxy.await }}
       {{- $_ := set $tree.Values.proxy "loadTrustBundleFromConfigMap" true }}
       {{- $_ := set $tree.Values.proxy "podInboundPorts" "8443,9995" }}
       {{- /*


### PR DESCRIPTION
In some circumstances, the `lifecycle.postStart` hook can cause the
`linkerd-proxy` container to get stuck waiting for identity verification.
After the `linkerd-await` timeout, the container will be restarted and the
proxy starts without further incident. The `linkerd-control-plane` helm chart
currently has a way to disable the lifecycle hook for injected proxies, but not
for proxies on the control plane pods.

This commit adds a new value to the `linkerd-control-plane` chart of
`proxy.controlPlaneAwait` that can be used to disable the postStart
lifecycle hook on the destination and proxy-injector pods. This is
defaulted to `true` to maintain current behavior.

The linkerd-control-plane chart was templated, setting
`proxy.controlPlaneAwait` to `true` and `false`, verifying that the
postStart lifecycle hook was either present or absent depending on the
`proxy.controlPlaneAwait` value.

Fixes #8738

Signed-off-by: Jacob Lambert <calrisian777@gmail.com>
