### PR TITLE
Render partials in `linkerd multicluster allow`

### DIFF
--- a/multicluster/cmd/allow.go
+++ b/multicluster/cmd/allow.go
@@ -65,7 +65,7 @@ func newAllowCommand() *cobra.Command {
 				Files:     files,
 				Fs:        static.Templates,
 			}
-			buf, err := chart.RenderNoPartials()
+			buf, err := chart.Render()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Closes #8430

Change the chart rendering from `RenderNoPartials` to `Render` so that the partials are properly rendered.

```shell
$ bin/build-cli-bin
$ bin/linkerd multicluster allow --service-account-name foo
...
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>