### PR TITLE
Add unit test for `linkerd multicluster link` command

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -252,6 +252,9 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 			}
 
 			values, err := buildServiceMirrorValues(opts)
+			if err != nil {
+				return err
+			}
 
 			// Create values override
 			valuesOverrides, err := valuesOptions.MergeValues(nil)
@@ -260,6 +263,9 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 			}
 
 			serviceMirrorOut, err := renderServiceMirror(values, valuesOverrides, opts.namespace)
+			if err != nil {
+				return err
+			}
 
 			stdout.Write(credsOut)
 			stdout.Write([]byte("---\n"))

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -253,91 +253,19 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 
 			values, err := buildServiceMirrorValues(opts)
 
-			if err != nil {
-				return err
-			}
-
-			// Render raw values and create chart config
-			rawValues, err := yaml.Marshal(values)
-			if err != nil {
-				return err
-			}
-
-			files := []*chartloader.BufferedFile{
-				{Name: chartutil.ChartfileName},
-				{Name: "templates/service-mirror.yaml"},
-				{Name: "templates/psp.yaml"},
-				{Name: "templates/gateway-mirror.yaml"},
-			}
-
-			var partialFiles []*chartloader.BufferedFile
-			for _, template := range charts.L5dPartials {
-				partialFiles = append(partialFiles,
-					&chartloader.BufferedFile{Name: template},
-				)
-			}
-
-			// Load all multicluster link chart files into buffer
-			if err := charts.FilesReader(static.Templates, helmMulticlusterLinkDefaultChartName+"/", files); err != nil {
-				return err
-			}
-
-			// Load all partial chart files into buffer
-			if err := charts.FilesReader(partials.Templates, "", partialFiles); err != nil {
-				return err
-			}
-
-			// Create a Chart obj from the files
-			chart, err := chartloader.LoadFiles(append(files, partialFiles...))
-			if err != nil {
-				return err
-			}
-
-			// Store final Values generated from values.yaml and CLI flags
-			err = yaml.Unmarshal(rawValues, &chart.Values)
-			if err != nil {
-				return err
-			}
-
 			// Create values override
 			valuesOverrides, err := valuesOptions.MergeValues(nil)
 			if err != nil {
 				return err
 			}
 
-			vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
-			if err != nil {
-				return err
-			}
-
-			fullValues := map[string]interface{}{
-				"Values": vals,
-				"Release": map[string]interface{}{
-					"Namespace": opts.namespace,
-					"Service":   "CLI",
-				},
-			}
-
-			// Attach the final values into the `Values` field for rendering to work
-			renderedTemplates, err := engine.Render(chart, fullValues)
-			if err != nil {
-				return err
-			}
-
-			// Merge templates and inject
-			var serviceMirrorOut bytes.Buffer
-			for _, tmpl := range chart.Templates {
-				t := path.Join(chart.Metadata.Name, tmpl.Name)
-				if _, err := serviceMirrorOut.WriteString(renderedTemplates[t]); err != nil {
-					return err
-				}
-			}
+			serviceMirrorOut, err := renderServiceMirror(values, valuesOverrides, opts.namespace)
 
 			stdout.Write(credsOut)
 			stdout.Write([]byte("---\n"))
 			stdout.Write(linkOut)
 			stdout.Write([]byte("---\n"))
-			stdout.Write(serviceMirrorOut.Bytes())
+			stdout.Write(serviceMirrorOut)
 			stdout.Write([]byte("---\n"))
 
 			return nil
@@ -364,6 +292,80 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 		cmd, []string{"namespace", "gateway-namespace"},
 		kubeconfigPath, impersonate, impersonateGroup, kubeContext)
 	return cmd
+}
+
+func renderServiceMirror(values *multicluster.Values, valuesOverrides map[string]interface{}, namespace string) ([]byte, error) {
+	files := []*chartloader.BufferedFile{
+		{Name: chartutil.ChartfileName},
+		{Name: "templates/service-mirror.yaml"},
+		{Name: "templates/psp.yaml"},
+		{Name: "templates/gateway-mirror.yaml"},
+	}
+
+	var partialFiles []*chartloader.BufferedFile
+	for _, template := range charts.L5dPartials {
+		partialFiles = append(partialFiles,
+			&chartloader.BufferedFile{Name: template},
+		)
+	}
+
+	// Load all multicluster link chart files into buffer
+	if err := charts.FilesReader(static.Templates, helmMulticlusterLinkDefaultChartName+"/", files); err != nil {
+		return nil, err
+	}
+
+	// Load all partial chart files into buffer
+	if err := charts.FilesReader(partials.Templates, "", partialFiles); err != nil {
+		return nil, err
+	}
+
+	// Create a Chart obj from the files
+	chart, err := chartloader.LoadFiles(append(files, partialFiles...))
+	if err != nil {
+		return nil, err
+	}
+
+	// Render raw values and create chart config
+	rawValues, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store final Values generated from values.yaml and CLI flags
+	err = yaml.Unmarshal(rawValues, &chart.Values)
+	if err != nil {
+		return nil, err
+	}
+
+	vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
+	if err != nil {
+		return nil, err
+	}
+
+	fullValues := map[string]interface{}{
+		"Values": vals,
+		"Release": map[string]interface{}{
+			"Namespace": namespace,
+			"Service":   "CLI",
+		},
+	}
+
+	// Attach the final values into the `Values` field for rendering to work
+	renderedTemplates, err := engine.Render(chart, fullValues)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge templates and inject
+	var out bytes.Buffer
+	for _, tmpl := range chart.Templates {
+		t := path.Join(chart.Metadata.Name, tmpl.Name)
+		if _, err := out.WriteString(renderedTemplates[t]); err != nil {
+			return nil, err
+		}
+	}
+
+	return out.Bytes(), nil
 }
 
 func newLinkOptionsWithDefault() (*linkOptions, error) {

--- a/multicluster/cmd/link_test.go
+++ b/multicluster/cmd/link_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	multicluster "github.com/linkerd/linkerd2/multicluster/values"
+	"github.com/linkerd/linkerd2/pkg/charts"
+)
+
+func TestServiceMirrorRender(t *testing.T) {
+	defaultValues := map[string]interface{}{}
+	linkValues, _ := multicluster.NewLinkValues()
+	linkValues.TargetClusterName = "test-cluster"
+	testCases := []struct {
+		serviceMirrorValues *multicluster.Values
+		overrides           map[string]interface{}
+		goldenFileName      string
+	}{
+		{
+			linkValues,
+			nil,
+			"serivce_mirror_default.golden",
+		},
+	}
+	for i, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
+			out, err := renderServiceMirror(tc.serviceMirrorValues, charts.MergeMaps(defaultValues, tc.overrides), "test")
+			if err != nil {
+				t.Fatalf("Failed to render templates: %v", err)
+			}
+			fmt.Println(string(out))
+			if err = testDataDiffer.DiffTestYAML(tc.goldenFileName, string(out)); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/multicluster/cmd/testdata/serivce_mirror_default.golden
+++ b/multicluster/cmd/testdata/serivce_mirror_default.golden
@@ -1,0 +1,133 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+subjects:
+- kind: ServiceAccount
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+  namespace: test
+  labels:
+      linkerd.io/extension: multicluster
+      component: service-mirror
+      mirror.linkerd.io/cluster-name: test-cluster
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cluster-credentials-test-cluster"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["multicluster.linkerd.io"]
+    resources: ["links"]
+    verbs: ["list", "get", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+  namespace: test
+  labels:
+      linkerd.io/extension: multicluster
+      component: service-mirror
+      mirror.linkerd.io/cluster-name: test-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+subjects:
+  - kind: ServiceAccount
+    name: linkerd-service-mirror-test-cluster
+    namespace: test
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: linkerd-service-mirror
+      mirror.linkerd.io/cluster-name: test-cluster
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        component: linkerd-service-mirror
+        mirror.linkerd.io/cluster-name: test-cluster
+    spec:
+      containers:
+      - args:
+        - service-mirror
+        - -log-level=info
+        - -event-requeue-limit=3
+        - -namespace=test
+        - -enable-pprof=false
+        - test-cluster
+        image: cr.l5d.io/linkerd/controller:dev-undefined
+        name: service-mirror
+        securityContext:
+          runAsUser: 2103
+        ports:
+        - containerPort: 9999
+          name: admin-http
+      serviceAccountName: linkerd-service-mirror-test-cluster
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: probe-gateway-test-cluster
+  namespace: test
+  labels:
+    mirror.linkerd.io/mirrored-gateway: "true"
+    mirror.linkerd.io/cluster-name: test-cluster
+spec:
+  ports:
+  - name: mc-probe
+    port: 4191
+    protocol: TCP


### PR DESCRIPTION
As part of #7082 we need to add HA mode to linkerd-multicluster's service mirror component. Before adding configuration for it, we should have a basic unit test that asserts the output of `linkerd multicluster link`.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
