### PR TITLE
multicluster: Provide High Availability mode for service mirror

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -29,9 +29,11 @@ Kubernetes: `>=1.21.0-0`
 | controllerImageVersion | string | `"linkerdVersionValue"` | Tag for the Service Mirror container Docker image |
 | enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
 | enablePSP | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
+| enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | nodeSelector | object | `{}` | Node selectors for the Service mirror pod |
+| replicas | int | `1` |  |
 | resources | object | `{}` | Resources for the Service mirror container |
 | serviceMirrorRetryLimit | int | `3` | Number of times update from the remote cluster is allowed to be requeued (retried) |
 | serviceMirrorUID | int | `2103` | User id under which the Service Mirror shall be ran |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -88,11 +88,16 @@ metadata:
   name: linkerd-service-mirror-{{.Values.targetClusterName}}
   {{ include "partials.namespace" . }}
 spec:
-  replicas: 1
+  replicas: {{.Values.replicas}}
   selector:
     matchLabels:
       component: linkerd-service-mirror
       mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
+  {{- if .Values.enablePodAntiAffinity }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -129,3 +134,20 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 6 }}
       {{- end }}
+{{- if .Values.enablePodAntiAffinity }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: linkerd-service-mirror-{{.Values.targetClusterName}}
+  {{ include "partials.namespace" . }}
+  labels:
+    component: linkerd-service-mirror
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: linkerd-service-mirror
+{{- end }}

--- a/multicluster/charts/linkerd-multicluster-link/values-ha.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values-ha.yaml
@@ -1,0 +1,2 @@
+enablePodAntiAffinity: true
+replicas: 3

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -5,14 +5,22 @@ controllerImage: cr.l5d.io/linkerd/controller
 controllerImageVersion: linkerdVersionValue
 # -- Toggle support for mirroring headless services
 enableHeadlessServices: false
+# -- Enables Pod Anti Affinity logic to balance the placement of replicas
+# across hosts and zones for High Availability.
+# Enable this only when you have multiple replicas of components.
+enablePodAntiAffinity: false
+
 gateway:
   probe:
     # -- The port used for liveliness probing
     port: 4191
+
 # -- Log level for the Multicluster components
 logLevel: info
 # -- Node selectors for the Service mirror pod
 nodeSelector: {}
+# --- Number of service mirror replicas
+replicas: 1
 # -- Resources for the Service mirror container
 resources: {}
 # -- Number of times update from the remote cluster is allowed to be requeued

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -52,6 +52,7 @@ type (
 func newLinkCommand() *cobra.Command {
 	opts, err := newLinkOptionsWithDefault()
 	var valuesOptions valuespkg.Options
+	var ha bool
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -305,6 +306,13 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				return err
 			}
 
+			if ha {
+				valuesOverrides, err = charts.OverrideFromFile(valuesOverrides, static.Templates, helmMulticlusterLinkDefaultChartName, "values-ha.yaml")
+				if err != nil {
+					return err
+				}
+			}
+
 			vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
 			if err != nil {
 				return err
@@ -359,6 +367,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
 	cmd.Flags().StringVar(&opts.gatewayAddresses, "gateway-addresses", opts.gatewayAddresses, "If specified, overwrites gateway addresses when gateway service is not type LoadBalancer (comma separated list)")
 	cmd.Flags().Uint32Var(&opts.gatewayPort, "gateway-port", opts.gatewayPort, "If specified, overwrites gateway port when gateway service is not type LoadBalancer")
+	cmd.Flags().BoolVar(&ha, "ha", false, "Link cluster in High Availability mode")
 
 	pkgcmd.ConfigureNamespaceFlagCompletion(
 		cmd, []string{"namespace", "gateway-namespace"},


### PR DESCRIPTION
Closes #7082.

Depends on #8757 to add a unit test.

Provide a High Availability mode linkerd-multicluster's serivce-mirror. #7186 added HA mode to the gateway component, but the service-mirror was left remaining.

This adds an `--ha` flag to `linkerd multicluster link` which scales the service-mirror replicas to `3` and adds a PodDisruptionBudget for the component.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
