### PR TITLE
Fix CNI plugin event processing

### DIFF
--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -308,7 +308,7 @@ monitor() {
         sync "$filename" "$action" "$cni_conf_sha"
         # When file exists (i.e we didn't deal with a DELETE ev)
         # then calculate its sha to be used the next turn.
-        if [ -e "$directory/$filename" ]; then
+        if [[ -e "$directory/$filename" && "$action" != 'DELETE' ]]; then
           cni_conf_sha="$(sha256sum "$directory/$filename" | while read -r s _; do echo "$s"; done)"
         fi
       fi


### PR DESCRIPTION
The CNI plugin watches for file changes and reacts accordingly. To
append our CNI plugin configuration to an existing configuration file,
we keep a watch on the config file directory, and whenever a new file is
created (or modified) we append to it. To avoid redundancy and infinite
loops, after a file has been processed, we save its SHA in-memory.
Whenever a new update is received, we calculate the file's SHA, and if
it differs from the previous one, we update it (since the file hasn't
been 'seen' by our script yet). The in-memory SHA is continously
overridden as updates are received and processed.

In our processing logic, we override the SHA only if the file exists (in
short, we want to avoid processing the SHA on 'DELETE' events). However,
when a different CNI plugin deletes the file, it typically re-creates it
immediately after. Since we do not check for the event type and instead
rely only on file existence, we end up calculating the SHA for a new
file before the file has had a chance to be processed when its
associated 'CREATE' event is picked up. This means that new files will
essentially be skipped from being updated, since the script considers
them to have been processed already (since their SHA was calculated when
the previous file was deleted).

This change fixes the bug by introducing a type check for the event in
addition to checking the file's existence. This allows us to be sure
that new files are only processed when the 'CREATE' event is picked up,
ensuring we do not skip them.

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
