### PR TITLE
stable-2.11.3: Cherry pick 8322

### DIFF
--- a/charts/linkerd2/templates/policy-crd.yaml
+++ b/charts/linkerd2/templates/policy-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Values.namespace}}
 spec:
   group: policy.linkerd.io
@@ -152,6 +152,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Values.namespace}}
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: l5d
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -401,6 +401,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_helm_output.golden
+++ b/cli/cmd/testdata/install_helm_output.golden
@@ -480,6 +480,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
   labels:
+    helm.sh/chart: linkerd2-
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_helm_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_output_ha.golden
@@ -480,6 +480,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
   labels:
+    helm.sh/chart: linkerd2-
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -480,6 +480,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
   labels:
+    helm.sh/chart: linkerd2-
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -480,6 +480,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
   labels:
+    helm.sh/chart: linkerd2-
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: CliVersion
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -470,6 +470,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -456,6 +456,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
+    helm.sh/chart: linkerd2-0.1.0
     linkerd.io/control-plane-ns: l5d
 spec:
   group: policy.linkerd.io


### PR DESCRIPTION
#8322 

Closes #8719 
Part of #8779 

2.11 only has the Server and ServerAuthorization policy CRDs. This fixes the Helm label for Server and adds the label for ServerAuthorization.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
