### PR TITLE
Disable `upgrade-edge` test in `release.yaml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         - external
         - helm-upgrade
         - uninstall
-        - upgrade-edge
+          #- upgrade-edge
         - upgrade-stable
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})


### PR DESCRIPTION
In anticipation to `2.11.3`'s release, we should disable `upgrade-edge` because that'll naturally fail.