### PR TITLE
Revert "feat: use direct image import in policy controller tests"

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -147,7 +147,7 @@ jobs:
           docker image ls | grep -F -e bitnami/kubectl -e curlimages/curl -e nginx -e ghcr.io/linkerd
           tag="$(CI_FORCE_CLEAN=1 bin/root-tag)"
           # Image loading is flakey in CI, so retry!
-          until k3d image import -m direct \
+          until k3d image import \
                   bitnami/kubectl:latest \
                   curlimages/curl:latest \
                   nginx:latest \

--- a/bin/image-load
+++ b/bin/image-load
@@ -149,5 +149,5 @@ fi
 
 if [ "$k3d" ]; then
   printf 'Importing %s...\n' "${images[@]}"
-  "$bin" "${image_sub_cmd[@]}" "${images[@]}" -m auto
+  "$bin" "${image_sub_cmd[@]}" "${images[@]}" -m tools-node
 fi


### PR DESCRIPTION
We have seen frequent CI failure related to failing to load images which may be related to #8771.  We revert that change to see if this improves CI reliability.

This reverts commit a57ee67fd748d8cd9e6e2bcca20f82ba894068b8.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
