### PR TITLE
Add changes for edge-22.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,53 @@
 # Changes
 
+## edge-22.6.3
+
+This release includes a security improvement. When a user manually specified the
+`policyValidator.keyPEM` setting, the value was incorrectly included in the
+`linkerd-config` configmap. This means that this private key was erroneously
+exposed to service accounts with read access to this configmap. Practically,
+this means that the Linkerd `proxy-injector`, `identity`, and `heartbeat` pods
+could read this value. This should **not** have exposed this private key to
+other unauthorized users unless additional role bindings were added outside of
+Linkerd. Nevertheless, we recommend that users who manually set control plane
+certificates update the credentials for the policy validator after upgrading
+Linkerd.
+
+Additionally, the linkerd-multicluster extensions has several fixes related to
+fail fast errors during link watch restarts, improper label matching for
+mirrored services, and properly cleaning up mirrored endpoints in certain
+situations.
+
+Lastly, the proxy can now retry gRPC requests that have responses with a
+TRAILERS frame. A fix to reduce redundant load balancer updates should also
+result in less connection churn.
+
+* Changed unit tests to use newly introduced `prommatch` package for asserting
+  expected metrics (thanks @krzysztofdrys!)
+* Fixed Docker container runtime check to only during `linkerd install` rather
+  than `linkerd check --pre`
+* Changed linkerd-multicluster's remote cluster watcher to assume the gateway is
+  alive when starting—fixing fail fast errors from occurring during restarts
+  (thanks @chenaoxd!)
+* Added `matchLabels` and `matchExpressions` to linkerd-multicluster's Link CRD
+* Fixed linkerd-multicluster's label selector to properly select resources that
+  match the expected label value, rather than just the presence of the label
+* Fixed linkerd-multicluster's cluster watcher to properly clean up endpoints
+  belonging to remote headless services that are no longer mirrored
+* Added the HttpRoute CRD which will be used by future policy features
+* Fixed CNI plugin event processing where file updates could sometimes be
+  skipped leading to the update not being acknowledged
+* Fixed redundant load balancer updates in the proxy that could cause
+  unnecessary connection churn
+* Fixed gRPC request retries for responses that contain a TRAILERS frame
+* Fixed the dashboard's `linkerd check` due to missing RBAC for listing pods in
+  the cluster
+* Fixed API check that ensures access to the Server CRD (thanks @aatarasoff!)
+* Changed `linkerd authz` to match the labels of pre-fetched Pods rather than
+  the multiple API calls it was doing—resulting in significant speed-up (thanks
+  @aatarasoff!)
+* Unset `policyValidtor.keyPEM` in `linkerd-config` ConfigMap
+
 ## edge-22.6.2
 
 This edge release bumps the minimum supported Kubernetes version from `v1.20`

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.5.3-edge
+version: 1.5.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.5.3-edge](https://img.shields.io/badge/Version-1.5.3--edge-informational?style=flat-square)
+![Version: 1.5.4-edge](https://img.shields.io/badge/Version-1.5.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.1.5-edge
+version: 30.1.6-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.1.5-edge](https://img.shields.io/badge/Version-30.1.5--edge-informational?style=flat-square)
+![Version: 30.1.6-edge](https://img.shields.io/badge/Version-30.1.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.5-edge
+version: 30.3.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.5-edge](https://img.shields.io/badge/Version-30.3.5--edge-informational?style=flat-square)
+![Version: 30.3.6-edge](https://img.shields.io/badge/Version-30.3.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.5-edge
+version: 30.1.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.1.5-edge](https://img.shields.io/badge/Version-30.1.5--edge-informational?style=flat-square)
+![Version: 30.1.6-edge](https://img.shields.io/badge/Version-30.1.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.5-edge
+version: 30.2.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.5-edge](https://img.shields.io/badge/Version-30.2.5--edge-informational?style=flat-square)
+![Version: 30.2.6-edge](https://img.shields.io/badge/Version-30.2.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This release includes a security improvement. When a user manually specified the
`policyValidator.keyPEM` setting, the value was incorrectly included in the
`linkerd-config` configmap. This means that this private key was erroneously
exposed to service accounts with read access to this configmap. Practically,
this means that the Linkerd `proxy-injector`, `identity`, and `heartbeat` pods
could read this value. This should **not** have exposed this private key to
other unauthorized users unless additional role bindings were added outside of
Linkerd. Nevertheless, we recommend that users who manually set control plane
certificates update the credentials for the policy validator after upgrading
Linkerd.

Additionally, the linkerd-multicluster extensions has several fixes related to
fail fast errors during link watch restarts, improper label matching for
mirrored services, and properly cleaning up mirrored endpoints in certain
situations.

Lastly, the proxy can now retry gRPC requests that have responses with a
TRAILERS frame. A fix to reduce redundant load balancer updates should also
result in less connection churn.

* Changed unit tests to use newly introduced `prommatch` package for asserting
  expected metrics (thanks @krzysztofdrys!)
* Fixed Docker container runtime check to only during `linkerd install` rather
  than `linkerd check --pre`
* Changed linkerd-multicluster's remote cluster watcher to assume the gateway is
  alive when starting—fixing fail fast errors from occurring during restarts
  (thanks @chenaoxd!)
* Added `matchLabels` and `matchExpressions` to linkerd-multicluster's Link CRD
* Fixed linkerd-multicluster's label selector to properly select resources that
  match the expected label value, rather than just the presence of the label
* Fixed linkerd-multicluster's cluster watcher to properly clean up endpoints
  belonging to remote headless services that are no longer mirrored
* Added the HttpRoute CRD which will be used by future policy features
* Fixed CNI plugin event processing where file updates could sometimes be
  skipped leading to the update not being acknowledged
* Fixed redundant load balancer updates in the proxy that could cause
  unnecessary connection churn
* Fixed gRPC request retries for responses that contain a TRAILERS frame
* Fixed the dashboard's `linkerd check` due to missing RBAC for listing pods in
  the cluster
* Fixed API check that ensures access to the Server CRD (thanks @aatarasoff!)
* Changed `linkerd authz` to match the labels of pre-fetched Pods rather than
  the multiple API calls it was doing—resulting in significant speed-up (thanks
  @aatarasoff!)
* Unset `policyValidtor.keyPEM` in `linkerd-config` ConfigMap

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
