### PR TITLE
Backport 'Fix PSP when proxyInit.runAsRoot is true'

### DIFF
--- a/charts/linkerd2/templates/psp.yaml
+++ b/charts/linkerd2/templates/psp.yaml
@@ -10,7 +10,11 @@ metadata:
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
 spec:
+  {{- if or .Values.proxyInit.closeWaitTimeoutSecs .Values.proxyInit.runAsRoot }}
+  allowPrivilegeEscalation: true
+  {{- else }}
   allowPrivilegeEscalation: false
+  {{- end }}
   readOnlyRootFilesystem: true
   {{- if empty .Values.cniEnabled }}
   allowedCapabilities:


### PR DESCRIPTION
Backports #8402 to the `stable/2.11` branch

Using `stable-2.11.3` in a PSP cluster yields:

```
$ linkerd install --set enablePSP=true --set proxyInit.runAsRoot=true | k apply -f -

$ k -n linkerd describe rs linkerd-identity-569cfff464

Events:
  Type     Reason        Age                From                   Message
  ----     ------        ----               ----                   -------
  Warning  FailedCreate  4s (x13 over 25s)  replicaset-controller  Error creating: pods "linkerd-identity-569cfff464-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.initContainers[0].securityContext.allowPrivilegeEscalation: Invalid value: true: Allowing privilege escalation for containers is not allowed]
```

And with this branch the pods gets scheduled without issues.
