### PR TITLE
policy: Index authorization policies with no authentications

### DIFF
--- a/policy-controller/k8s/index/src/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/authorization_policy.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use linkerd_policy_controller_k8s_api::{
     self as k8s,
     policy::{LocalTargetRef, NamespacedTargetRef},
@@ -33,6 +33,12 @@ pub(crate) enum AuthenticationTarget {
     },
 }
 
+#[inline]
+pub fn validate(ap: k8s::policy::AuthorizationPolicySpec) -> Result<()> {
+    Spec::try_from(ap)?;
+    Ok(())
+}
+
 impl TryFrom<k8s::policy::AuthorizationPolicySpec> for Spec {
     type Error = anyhow::Error;
 
@@ -44,9 +50,6 @@ impl TryFrom<k8s::policy::AuthorizationPolicySpec> for Spec {
             .into_iter()
             .map(authentication_ref)
             .collect::<Result<Vec<_>>>()?;
-        if authentications.is_empty() {
-            bail!("No authentication targets");
-        }
 
         Ok(Self {
             target,

--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -23,7 +23,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-mod authorization_policy;
+pub mod authorization_policy;
 mod defaults;
 mod index;
 mod meshtls_authentication;

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -2,8 +2,9 @@ use crate::k8s::{
     labels,
     policy::{
         AuthorizationPolicy, AuthorizationPolicySpec, LocalTargetRef, MeshTLSAuthentication,
-        MeshTLSAuthenticationSpec, NetworkAuthentication, NetworkAuthenticationSpec, Server,
-        ServerAuthorization, ServerAuthorizationSpec, ServerSpec,
+        MeshTLSAuthenticationSpec, NamespacedTargetRef, NetworkAuthentication,
+        NetworkAuthenticationSpec, Server, ServerAuthorization, ServerAuthorizationSpec,
+        ServerSpec,
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -12,7 +13,7 @@ use hyper::{body::Buf, http, Body, Request, Response};
 use k8s_gateway_api::{HttpRoute, HttpRouteFilter, HttpRouteRule, HttpRouteSpec};
 use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
 use kube::{core::DynamicObject, Resource, ResourceExt};
-use linkerd_policy_controller_k8s_api::policy::NamespacedTargetRef;
+use linkerd_policy_controller_k8s_index as index;
 use serde::de::DeserializeOwned;
 use std::task;
 use thiserror::Error;
@@ -260,6 +261,9 @@ impl Validate<AuthorizationPolicySpec> for Admission {
                 .collect::<Vec<_>>();
             bail!("unsupported authentication kind(s): {}", kinds.join(", "));
         }
+
+        // Confirm that the index will be able to read this spec.
+        index::authorization_policy::validate(spec)?;
 
         Ok(())
     }


### PR DESCRIPTION
In 1a0c1c31 we updated the admission controller to allow
`AuthorizationPolicy` resources with an empty
`requiredAuthenticationRefs`. But we did NOT update the indexer, so we
would allow these resources to be created but then fail to honor them in
the API.

To fix this:

1. The `AuthorizationPolicy` admission controller is updated to exercise
   the indexer's validation so that it is impossible to admit resources
   that will be discarded by the indexer;
2. An e2e test is added to exercise this configuration;
3. The indexer's validation is updated to accept resources with no
   authentications.

---

We probably want to follow this pattern elsewhere--having the admission controller exercise the indexer's validation; but these changes should be made in separate PRs.