### PR TITLE
policy: Ignore case when comparing resource kinds

### DIFF
--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -160,7 +160,8 @@ where
     T::DynamicType: Default,
 {
     let dt = Default::default();
-    *req.kind.group == *T::group(&dt) && *req.kind.kind == *T::kind(&dt)
+    req.kind.group.eq_ignore_ascii_case(&*T::group(&dt))
+        && req.kind.kind.eq_ignore_ascii_case(&*T::kind(&dt))
 }
 
 fn json_response(rsp: AdmissionReview) -> Result<Response<Body>, Error> {
@@ -413,14 +414,22 @@ impl Validate<ServerAuthorizationSpec> for Admission {
 #[async_trait::async_trait]
 impl Validate<HttpRouteSpec> for Admission {
     async fn validate(self, _ns: &str, _name: &str, spec: HttpRouteSpec) -> Result<()> {
-        // Only validate HttpRoutes which have a Server as a parent_ref.
-        if spec.inner.parent_refs.iter().flatten().any(|parent_ref| {
-            parent_ref.kind.as_deref() == Some("Server")
-                && parent_ref.group.as_deref() == Some("policy.linkerd.io")
-        }) {
-            for rule in spec.rules.iter().flatten() {
-                validate_http_route_rule(rule)?;
+        let targets_server = spec.inner.parent_refs.iter().flatten().any(|parent_ref| {
+            if let Some(p) = parent_ref.group.as_deref() {
+                if let Some(k) = parent_ref.kind.as_deref() {
+                    return p.eq_ignore_ascii_case("policy.linkerd.io")
+                        && k.eq_ignore_ascii_case("server");
+                }
             }
+            false
+        });
+        // Only validate HttpRoutes which have a Server as a parent_ref.
+        if !targets_server {
+            return Ok(());
+        }
+
+        for rule in spec.rules.iter().flatten() {
+            validate_http_route_rule(rule)?;
         }
 
         Ok(())


### PR DESCRIPTION
Kubernetes resource type names are not case-sensitive. This change
updates `kind` and `group` comparisons to ignore case.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
