### PR TITLE
policy: Use `NonZeroU16` to represent ports

### DIFF
--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -5,6 +5,7 @@ pub use http::{
     Method, StatusCode,
 };
 use regex::Regex;
+use std::num::NonZeroU16;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InboundHttpRoute {
@@ -43,7 +44,7 @@ pub struct RequestRedirectFilter {
     pub scheme: Option<Scheme>,
     pub host: Option<String>,
     pub path: Option<PathModifier>,
-    pub port: Option<u32>,
+    pub port: Option<NonZeroU16>,
     pub status: Option<StatusCode>,
 }
 

--- a/policy-controller/grpc/src/http_route.rs
+++ b/policy-controller/grpc/src/http_route.rs
@@ -130,7 +130,7 @@ pub(crate) fn convert_redirect_filter(
                 PathModifier::Prefix(p) => proto::path_modifier::Replace::Prefix(p),
             }),
         }),
-        port: port.unwrap_or_default(),
+        port: port.map(u16::from).map(u32::from).unwrap_or_default(),
         status: u32::from(status.unwrap_or_default().as_u16()),
     }
 }

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -19,7 +19,7 @@ use linkerd_policy_controller_core::{
     ServerRef,
 };
 use maplit::*;
-use std::sync::Arc;
+use std::{num::NonZeroU16, sync::Arc};
 use tracing::trace;
 
 #[derive(Clone, Debug)]
@@ -33,7 +33,7 @@ pub struct Server<T> {
 
 impl<T> Server<T>
 where
-    T: DiscoverInboundServer<(String, String, u16)> + Send + Sync + 'static,
+    T: DiscoverInboundServer<(String, String, NonZeroU16)> + Send + Sync + 'static,
 {
     pub fn new(discover: T, cluster_networks: Vec<IpNet>, drain: drain::Watch) -> Self {
         Self {
@@ -62,7 +62,7 @@ where
     fn check_target(
         &self,
         proto::PortSpec { workload, port }: proto::PortSpec,
-    ) -> Result<(String, String, u16), tonic::Status> {
+    ) -> Result<(String, String, NonZeroU16), tonic::Status> {
         // Parse a workload name in the form namespace:name.
         let (ns, name) = match workload.split_once(':') {
             None => {
@@ -81,15 +81,10 @@ where
         };
 
         // Ensure that the port is in the valid range.
-        let port = {
-            if port == 0 || port > std::u16::MAX as u32 {
-                return Err(tonic::Status::invalid_argument(format!(
-                    "Invalid port: {}",
-                    port
-                )));
-            }
-            port as u16
-        };
+        let port = u16::try_from(port)
+            .ok()
+            .and_then(|p| NonZeroU16::try_from(p).ok())
+            .ok_or_else(|| tonic::Status::invalid_argument(format!("Invalid port: {}", port)))?;
 
         Ok((ns.to_string(), name.to_string(), port))
     }
@@ -98,7 +93,7 @@ where
 #[async_trait::async_trait]
 impl<T> InboundServerPolicies for Server<T>
 where
-    T: DiscoverInboundServer<(String, String, u16)> + Send + Sync + 'static,
+    T: DiscoverInboundServer<(String, String, NonZeroU16)> + Send + Sync + 'static,
 {
     async fn get_port(
         &self,

--- a/policy-controller/k8s/api/src/policy/server.rs
+++ b/policy-controller/k8s/api/src/policy/server.rs
@@ -2,6 +2,7 @@ use super::super::labels;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU16;
 
 /// Describes a server interface exposed by a set of pods.
 #[derive(Clone, Debug, PartialEq, Eq, CustomResource, Deserialize, Serialize, JsonSchema)]
@@ -22,7 +23,7 @@ pub struct ServerSpec {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum Port {
-    Number(u16),
+    Number(NonZeroU16),
     Name(String),
 }
 

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -241,7 +241,7 @@ impl InboundRouteBinding {
                         http_route::PathModifier::Prefix(s)
                     }
                 }),
-                port: port.map(Into::into),
+                port: port.and_then(|p| p.try_into().ok()),
                 status: status_code.map(TryFrom::try_from).transpose()?,
             }),
 

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -24,7 +24,7 @@ fn pod_must_exist_for_lookup() {
     let test = TestConfig::default();
     test.index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect_err("pod-0.ns-0 must not exist");
 }
 

--- a/policy-controller/k8s/index/src/tests/annotation.rs
+++ b/policy-controller/k8s/index/src/tests/annotation.rs
@@ -27,7 +27,7 @@ fn default_policy_annotated() {
         let mut rx = test
             .index
             .write()
-            .pod_server_rx("ns-0", "pod-0", 2222)
+            .pod_server_rx("ns-0", "pod-0", 2222.try_into().unwrap())
             .expect("pod-0.ns-0 should exist");
         assert_eq!(
             rx.borrow_and_update().reference,
@@ -66,7 +66,7 @@ async fn default_policy_annotated_invalid() {
     let rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 2222)
+        .pod_server_rx("ns-0", "pod-0", 2222.try_into().unwrap())
         .expect("pod must exist in lookups");
     assert_eq!(*rx.borrow(), test.default_server());
 }
@@ -87,7 +87,7 @@ fn opaque_annotated() {
         let rx = test
             .index
             .write()
-            .pod_server_rx("ns-0", "pod-0", 2222)
+            .pod_server_rx("ns-0", "pod-0", 2222.try_into().unwrap())
             .expect("pod-0.ns-0 should exist");
         assert_eq!(*rx.borrow(), server);
     }
@@ -126,7 +126,7 @@ fn authenticated_annotated() {
         let rx = test
             .index
             .write()
-            .pod_server_rx("ns-0", "pod-0", 2222)
+            .pod_server_rx("ns-0", "pod-0", 2222.try_into().unwrap())
             .expect("pod-0.ns-0 should exist");
         assert_eq!(*rx.borrow(), config);
     }

--- a/policy-controller/k8s/index/src/tests/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/tests/authorization_policy.rs
@@ -12,14 +12,14 @@ fn links_authorization_policy_with_mtls_name() {
     let mut rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect("pod-0.ns-0 should exist");
     assert_eq!(*rx.borrow_and_update(), test.default_server());
 
     test.index.write().apply(mk_server(
         "ns-0",
         "srv-8080",
-        Port::Number(8080),
+        Port::Number(8080.try_into().unwrap()),
         None,
         Some(("app", "app-0")),
         Some(k8s::policy::server::ProxyProtocol::Http1),
@@ -102,14 +102,14 @@ fn authorization_targets_namespace() {
     let mut rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect("pod-0.ns-0 should exist");
     assert_eq!(*rx.borrow_and_update(), test.default_server());
 
     test.index.write().apply(mk_server(
         "ns-0",
         "srv-8080",
-        Port::Number(8080),
+        Port::Number(8080.try_into().unwrap()),
         None,
         Some(("app", "app-0")),
         Some(k8s::policy::server::ProxyProtocol::Http1),
@@ -192,14 +192,14 @@ fn links_authorization_policy_with_service_account() {
     let mut rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect("pod-0.ns-0 should exist");
     assert_eq!(*rx.borrow_and_update(), test.default_server());
 
     test.index.write().apply(mk_server(
         "ns-0",
         "srv-8080",
-        Port::Number(8080),
+        Port::Number(8080.try_into().unwrap()),
         None,
         Some(("app", "app-0")),
         Some(k8s::policy::server::ProxyProtocol::Http1),

--- a/policy-controller/k8s/index/src/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/tests/http_routes.rs
@@ -12,14 +12,14 @@ fn route_attaches_to_server() {
     let mut rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect("pod-0.ns-0 should exist");
     assert_eq!(*rx.borrow_and_update(), test.default_server());
 
     test.index.write().apply(mk_server(
         "ns-0",
         "srv-8080",
-        Port::Number(8080),
+        Port::Number(8080.try_into().unwrap()),
         Some(("app", "app-0")),
         Some(("app", "app-0")),
         Some(k8s::policy::server::ProxyProtocol::Http1),

--- a/policy-controller/k8s/index/src/tests/server_authorization.rs
+++ b/policy-controller/k8s/index/src/tests/server_authorization.rs
@@ -24,14 +24,14 @@ fn link_server_authz(selector: ServerSelector) {
     let mut rx = test
         .index
         .write()
-        .pod_server_rx("ns-0", "pod-0", 8080)
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
         .expect("pod-0.ns-0 should exist");
     assert_eq!(*rx.borrow_and_update(), test.default_server());
 
     test.index.write().apply(mk_server(
         "ns-0",
         "srv-8080",
-        Port::Number(8080),
+        Port::Number(8080.try_into().unwrap()),
         Some(("app", "app-0")),
         Some(("app", "app-0")),
         Some(k8s::policy::server::ProxyProtocol::Http1),

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
+use std::num::NonZeroU16;
 
 mod admission;
 
@@ -23,10 +24,10 @@ impl IndexDiscover {
 }
 
 #[async_trait::async_trait]
-impl DiscoverInboundServer<(String, String, u16)> for IndexDiscover {
+impl DiscoverInboundServer<(String, String, NonZeroU16)> for IndexDiscover {
     async fn get_inbound_server(
         &self,
-        (namespace, pod, port): (String, String, u16),
+        (namespace, pod, port): (String, String, NonZeroU16),
     ) -> Result<Option<InboundServer>> {
         let rx = match self.0.write().pod_server_rx(&namespace, &pod, port) {
             Ok(rx) => rx,
@@ -38,7 +39,7 @@ impl DiscoverInboundServer<(String, String, u16)> for IndexDiscover {
 
     async fn watch_inbound_server(
         &self,
-        (namespace, pod, port): (String, String, u16),
+        (namespace, pod, port): (String, String, NonZeroU16),
     ) -> Result<Option<InboundServerStream>> {
         match self.0.write().pod_server_rx(&namespace, &pod, port) {
             Ok(rx) => Ok(Some(Box::pin(tokio_stream::wrappers::WatchStream::new(rx)))),

--- a/policy-test/src/nginx.rs
+++ b/policy-test/src/nginx.rs
@@ -40,7 +40,7 @@ pub fn server(ns: &str) -> k8s::policy::Server {
         },
         spec: k8s::policy::ServerSpec {
             pod_selector: k8s::labels::Selector::from_iter(Some(("app", "nginx"))),
-            port: k8s::policy::server::Port::Number(80),
+            port: k8s::policy::server::Port::Number(80.try_into().unwrap()),
             proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
         },
     }

--- a/policy-test/tests/admit_server.rs
+++ b/policy-test/tests/admit_server.rs
@@ -14,7 +14,7 @@ async fn accepts_valid() {
         },
         spec: ServerSpec {
             pod_selector: api::labels::Selector::default(),
-            port: Port::Number(80),
+            port: Port::Number(80.try_into().unwrap()),
             proxy_protocol: None,
         },
     })
@@ -32,7 +32,7 @@ async fn accepts_server_updates() {
             },
             spec: ServerSpec {
                 pod_selector: api::labels::Selector::from_iter(Some(("app", "test"))),
-                port: Port::Number(80),
+                port: Port::Number(80.try_into().unwrap()),
                 proxy_protocol: None,
             },
         };
@@ -58,7 +58,7 @@ async fn rejects_identitical_pod_selector() {
     with_temp_ns(|client, ns| async move {
         let spec = ServerSpec {
             pod_selector: api::labels::Selector::from_iter(Some(("app", "test"))),
-            port: Port::Number(80),
+            port: Port::Number(80.try_into().unwrap()),
             proxy_protocol: None,
         };
 
@@ -104,7 +104,7 @@ async fn rejects_all_pods_selected() {
             },
             spec: ServerSpec {
                 pod_selector: api::labels::Selector::from_iter(Some(("app", "test"))),
-                port: Port::Number(80),
+                port: Port::Number(80.try_into().unwrap()),
                 proxy_protocol: Some(ProxyProtocol::Http2),
             },
         };
@@ -120,7 +120,7 @@ async fn rejects_all_pods_selected() {
             },
             spec: ServerSpec {
                 pod_selector: api::labels::Selector::default(),
-                port: Port::Number(80),
+                port: Port::Number(80.try_into().unwrap()),
                 // proxy protocol doesn't factor into the selection
                 proxy_protocol: Some(ProxyProtocol::Http1),
             },
@@ -172,7 +172,7 @@ async fn rejects_invalid_proxy_protocol() {
         },
         spec: ServerSpec {
             pod_selector: api::labels::Selector::default(),
-            port: Port::Number(80),
+            port: Port::Number(80.try_into().unwrap()),
             proxy_protocol: "garbanzo".to_string(),
         },
     })

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -518,7 +518,7 @@ fn mk_admin_server(ns: &str, name: &str) -> k8s::policy::Server {
         },
         spec: k8s::policy::ServerSpec {
             pod_selector: k8s::labels::Selector::default(),
-            port: k8s::policy::server::Port::Number(4191),
+            port: k8s::policy::server::Port::Number(4191.try_into().unwrap()),
             proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
         },
     }


### PR DESCRIPTION
In various places we read port configurations from external sources
(either the Kubernetes API or gRPC clients). We have manual checks in
place to ensure that port values are never zero. We can instead assert
this with the type system by using `NonZeroU16`.

This change updates the policy controller to use `NonZeroU16` for port
values. This allows us to replace our manual port value checks with
`NonZero::try_from`, etc.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
