### PR TITLE
policy: Simplify port conversion syntax

### DIFF
--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -83,7 +83,7 @@ where
         // Ensure that the port is in the valid range.
         let port = u16::try_from(port)
             .and_then(NonZeroU16::try_from)
-            .map_err(|_| tonic::Status::invalid_argument(format!("Invalid port: {}", port)))?;
+            .map_err(|_| tonic::Status::invalid_argument(format!("Invalid port: {port}")))?;
 
         Ok((ns.to_string(), name.to_string(), port))
     }

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -82,9 +82,8 @@ where
 
         // Ensure that the port is in the valid range.
         let port = u16::try_from(port)
-            .ok()
-            .and_then(|p| NonZeroU16::try_from(p).ok())
-            .ok_or_else(|| tonic::Status::invalid_argument(format!("Invalid port: {}", port)))?;
+            .and_then(NonZeroU16::try_from)
+            .map_err(|_| tonic::Status::invalid_argument(format!("Invalid port: {}", port)))?;
 
         Ok((ns.to_string(), name.to_string(), port))
     }

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Error, Result};
 use k8s_gateway_api as api;
 use linkerd_policy_controller_core::http_route;
+use std::num::NonZeroU16;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct InboundRouteBinding {
@@ -241,8 +242,10 @@ impl InboundRouteBinding {
                         http_route::PathModifier::Prefix(s)
                     }
                 }),
-                port: port.and_then(|p| p.try_into().ok()),
-                status: status_code.map(TryFrom::try_from).transpose()?,
+                port: port.and_then(|p| NonZeroU16::try_from(p).ok()),
+                status: status_code
+                    .map(http_route::StatusCode::try_from)
+                    .transpose()?,
             }),
 
             api::HttpRouteFilter::RequestMirror { .. } => {

--- a/policy-controller/k8s/index/src/pod.rs
+++ b/policy-controller/k8s/index/src/pod.rs
@@ -53,9 +53,8 @@ pub(crate) fn tcp_port_names(spec: Option<k8s::PodSpec>) -> HashMap<String, Port
             if let Some(ports) = container.ports {
                 for port in ports.into_iter() {
                     if let None | Some("TCP") = port.protocol.as_deref() {
-                        if let Some(cp) = u16::try_from(port.container_port)
-                            .ok()
-                            .and_then(|p| NonZeroU16::try_from(p).ok())
+                        if let Ok(cp) =
+                            u16::try_from(port.container_port).and_then(NonZeroU16::try_from)
                         {
                             if let Some(name) = port.name {
                                 port_names.entry(name).or_default().insert(cp);
@@ -194,8 +193,9 @@ mod tests {
         ($($x:expr),+ $(,)?) => (
             vec![$($x),+]
                 .into_iter()
-                .map(|p| NonZeroU16::try_from(p).unwrap())
-                .collect::<PortSet>()
+                .map(NonZeroU16::try_from)
+                .collect::<Result<PortSet, _>>()
+                .unwrap()
         );
     }
 


### PR DESCRIPTION
This is a superficial change that simplifies the syntax used for integer
conversion.