### PR TITLE
Bump proxy-init version to v1.6.1

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -226,7 +226,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyInit.ignoreOutboundPorts | string | `"4567,4568"` | Default set of outbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container Docker image |
-| proxyInit.image.version | string | `"v1.5.3"` | Tag for the proxy-init container Docker image |
+| proxyInit.image.version | string | `"v1.6.1"` | Tag for the proxy-init container Docker image |
 | proxyInit.logFormat | string | plain | Log format (`plain` or `json`) for the proxy-init |
 | proxyInit.logLevel | string | info | Log level for the proxy-init |
 | proxyInit.resources.cpu.limit | string | `"100m"` | Maximum amount of CPU units that the proxy-init container can use |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -194,7 +194,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container Docker image
-    version: v1.5.3
+    version: v1.6.1
   resources:
     cpu:
       # -- Maximum amount of CPU units that the proxy-init container can use

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -159,7 +159,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -159,7 +159,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -357,7 +357,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -159,7 +159,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -199,7 +199,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -170,7 +170,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -379,7 +379,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -588,7 +588,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -797,7 +797,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -170,7 +170,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -173,7 +173,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -162,7 +162,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -183,7 +183,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -187,7 +187,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -170,7 +170,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -379,7 +379,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -175,7 +175,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -170,7 +170,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -171,7 +171,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -171,7 +171,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -171,7 +171,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -172,7 +172,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+          image: cr.l5d.io/linkerd/proxy-init:v1.6.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -375,7 +375,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+          image: cr.l5d.io/linkerd/proxy-init:v1.6.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -172,7 +172,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+          image: cr.l5d.io/linkerd/proxy-init:v1.6.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -375,7 +375,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+          image: cr.l5d.io/linkerd/proxy-init:v1.6.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -154,7 +154,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+    image: cr.l5d.io/linkerd/proxy-init:v1.6.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -157,7 +157,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+    image: cr.l5d.io/linkerd/proxy-init:v1.6.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -156,7 +156,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+    image: cr.l5d.io/linkerd/proxy-init:v1.6.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -165,7 +165,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+    image: cr.l5d.io/linkerd/proxy-init:v1.6.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -171,7 +171,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -172,7 +172,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -383,7 +383,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment.input.yml
+++ b/cli/cmd/testdata/inject_tap_deployment.input.yml
@@ -198,7 +198,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568,443
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -224,7 +224,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -901,7 +901,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1316,7 +1316,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1617,7 +1617,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.5.3
+        image: my.custom.registry/linkerd-io/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.5.3
+        image: my.custom.registry/linkerd-io/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: my.custom.registry/linkerd-io/proxy-init:v1.5.3
+        image: my.custom.registry/linkerd-io/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -898,7 +898,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1303,7 +1303,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1595,7 +1595,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -600,7 +600,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -982,7 +982,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1442,7 +1442,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1779,7 +1779,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -600,7 +600,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -982,7 +982,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1442,7 +1442,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1779,7 +1779,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -504,7 +504,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -831,7 +831,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1245,7 +1245,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1496,7 +1496,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -573,7 +573,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v1.5.3
+        version: v1.6.1
       logFormat: ""
       logLevel: ""
       resources:
@@ -900,7 +900,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1314,7 +1314,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1615,7 +1615,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "4567,4568"
-        image: cr.l5d.io/linkerd/proxy-init:v1.5.3
+        image: cr.l5d.io/linkerd/proxy-init:v1.6.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cni-plugin/main.go
+++ b/cni-plugin/main.go
@@ -201,6 +201,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 				SimulateOnly:          conf.ProxyInit.Simulate,
 				NetNs:                 args.Netns,
 				UseWaitFlag:           conf.ProxyInit.UseWaitFlag,
+				FirewallBinPath:       "iptables",
+				FirewallSaveBinPath:   "iptables-save",
 			}
 
 			// Check if there are any overridden ports to be skipped

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -53,7 +53,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.5.3",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.6.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -63,7 +63,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.5.3",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.6.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -53,7 +53,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v1.5.3",
+      "image": "cr.l5d.io/linkerd/proxy-init:v1.6.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/imdario/mergo v0.3.13
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/linkerd/linkerd2-proxy-api v0.6.0
-	github.com/linkerd/linkerd2-proxy-init v1.5.3
+	github.com/linkerd/linkerd2-proxy-init v1.6.1
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-runewidth v0.0.13
 	github.com/nsf/termbox-go v0.0.0-20180613055208-5c94acc5e6eb

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/linkerd/linkerd2-proxy-api v0.6.0 h1:oeJMxEGAfB2gJSs3TdzL+Efbiz+i5Zhr
 github.com/linkerd/linkerd2-proxy-api v0.6.0/go.mod h1:kiFDmEXotfjhIz3lGOa/EyQ13phLMDtmvU9VuE3kAYc=
 github.com/linkerd/linkerd2-proxy-init v1.5.3 h1:Fc5CKnWXB1Xxh+a44ENqABzbI6l5FdxZiqphjimbPT4=
 github.com/linkerd/linkerd2-proxy-init v1.5.3/go.mod h1:IpDk113zEAQY7p8OuTP+yqyZ4APlkpJkJrSRLR0MWpw=
+github.com/linkerd/linkerd2-proxy-init v1.6.1 h1:zrnqN5qnzPni0CE5eHXU258FORkqhU9ocKmCFBLGT90=
+github.com/linkerd/linkerd2-proxy-init v1.6.1/go.mod h1:qmQcEqgaXU7iUPjzEuLyUXdYs/C1co0IqXEmmUPtcy4=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1746,7 +1746,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.5.3","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.6.1","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |
@@ -1899,7 +1899,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.5.3","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v1.6.1","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init
 // This has to be kept in sync with the constraint version for
 // github.com/linkerd/linkerd2-proxy-init in /go.mod
-var ProxyInitVersion = "v1.5.3"
+var ProxyInitVersion = "v1.6.1"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
Release v1.6.1 of proxy-init adds support for iptables-nft. This change
bumps up the proxy-init version used in code, chart values, and golden
files.

* Update go.mod dep
* Update CNI plugin with new opts
* Update proxy-init ref in golden files and chart values

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
